### PR TITLE
CI and installation guide update

### DIFF
--- a/.github/workflows/Documentations.yml
+++ b/.github/workflows/Documentations.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - name: Install dependencies

--- a/.github/workflows/Documentations.yml
+++ b/.github/workflows/Documentations.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - dev
+      - main
+      - 'releases/**'
       # - 'feature/*' # temporary for testing
     tags: '*'
   pull_request:

--- a/.github/workflows/Documentations.yml
+++ b/.github/workflows/Documentations.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.10'
+          version: '1'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/README.md
+++ b/README.md
@@ -16,14 +16,29 @@ Once Julia is installed, you can install the `FreeBird` package from the Julia R
 
 ```julia-repl
 julia> ] # press the "]" key on your keyboard to enter the Pkg manager
+```
+then
 
+```julia-repl
 pkg> add FreeBird
 ```
+Alternatively, you can install the package with:
+```julia
+using Pkg; Pkg.add("FreeBird")
+```
+Useful for installing the package in a script or a notebook.
+
 Or, if you want to install a specific branch from GitHub, you can do so with:
 
 ```julia-repl
 pkg> add https://github.com/wexlergroup/FreeBird.jl#branch_name
 ```
+Or, again, to install the package in a script or a notebook:
+```julia
+using Pkg; Pkg.add(url="https://github.com/wexlergroup/FreeBird.jl",rev="branch_name")
+```
+Remember to replace `branch_name` with the name of the branch you want to install.
+
 To get back to the Julia REPL, press `Ctrl+C` or backspace (when the REPL cursor is at the beginning of the input).
 
 ## References

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,6 +31,6 @@ deploydocs(
     repo = "github.com/wexlergroup/FreeBird.jl.git",
     target = "build",
     branch = "gh-pages",
-    # devbranch = "dev",
+    devbranch = "dev",
     push_preview = true,
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,13 +10,28 @@ Once Julia is installed, you can install the `FreeBird` package from the Julia R
 
 ```julia-repl
 julia> ] # press the "]" key on your keyboard to enter the Pkg manager
+```
+then
 
+```julia-repl
 pkg> add FreeBird
 ```
+Alternatively, you can install the package with:
+```julia
+using Pkg; Pkg.add("FreeBird")
+```
+Useful for installing the package in a script or a notebook.
+
 Or, if you want to install a specific branch from GitHub, you can do so with:
 
 ```julia-repl
 pkg> add https://github.com/wexlergroup/FreeBird.jl#branch_name
 ```
+Or, again, to install the package in a script or a notebook:
+```julia
+using Pkg; Pkg.add(url="https://github.com/wexlergroup/FreeBird.jl",rev="branch_name")
+```
+Remember to replace `branch_name` with the name of the branch you want to install.
+
 To get back to the Julia REPL, press `Ctrl+C` or backspace (when the REPL cursor is at the beginning of the input).
 


### PR DESCRIPTION
This pull request includes updates to the documentation workflow, improvements to the installation instructions in the documentation, and a minor change to the deployment configuration.

Updates to documentation workflow:

* [`.github/workflows/Documentations.yml`](diffhunk://#diff-2e51eb124acd9fba0cd8db3b1e11d245764bb83fa5b88f93067d11107631aadbR7-R8): Added `main` and `releases/**` branches to the `push` event triggers. Updated `julia-actions/setup-julia` to version 2 and changed the Julia version specification to '1'. [[1]](diffhunk://#diff-2e51eb124acd9fba0cd8db3b1e11d245764bb83fa5b88f93067d11107631aadbR7-R8) [[2]](diffhunk://#diff-2e51eb124acd9fba0cd8db3b1e11d245764bb83fa5b88f93067d11107631aadbL22-R26)

Improvements to installation instructions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R41): Enhanced the installation instructions by adding alternative methods to install the `FreeBird` package using `Pkg.add`.
* [`docs/src/index.md`](diffhunk://#diff-36c852523b6a7513a10b8a6bae21f1037eaa27484efc9042f75bbda46d9f529bR13-R35): Updated the installation instructions in the documentation to include alternative methods for installing the `FreeBird` package using `Pkg.add`.

Deployment configuration:

* [`docs/make.jl`](diffhunk://#diff-4aae2d1c783cade58bd2cb13748da956e568b7f2aed5fafd9e2a46fb97daf613L34-R34): Uncommented the `devbranch` configuration to enable deployment previews from the `dev` branch.