### PR TITLE
CI: replace Codecov action with Coveralls for coverage reporting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,3 +52,14 @@ jobs:
       - uses: julia-actions/julia-uploadcoveralls@v1
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+  finish:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true
+        # carryforward: "run-1,run-2"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,12 +41,14 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v2
         with:
           files: lcov.info
-          token: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          fail_ci_if_error: false
-        if: ${{ matrix.julia-version == '1' }}
+          flag-name: run-${{ join(matrix.*, '-') }}
+          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          fail-on-error: false
+          parallel: true
       - uses: julia-actions/julia-uploadcoveralls@v1
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
This pull request includes a change to the CI configuration to switch from using Codecov to Coveralls for test coverage reporting. 

Changes in CI configuration:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L44-R51): Replaced the `codecov/codecov-action` with `coverallsapp/github-action` for parallel coverage reporting. Updated the configuration to include necessary parameters for Coveralls, such as `flag-name`, `github-token`, `fail-on-error`, and `parallel`.