### PR TITLE
Fixed the wrong grid points in the printed outputs.

### DIFF
--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -908,7 +908,7 @@
             # Test presence of all required fields
             @test contains(output, "MLattice{2, SquareLattice}")
             @test contains(output, "lattice_vectors      : [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]")
-            @test contains(output, "positions            : 48 grid points")
+            @test contains(output, "positions            : 16 grid points")
             @test contains(output, "supercell_dimensions : (4, 4, 1)")
             @test contains(output, "basis                : [(0.0, 0.0, 0.0)]")
             @test contains(output, "periodicity          : (true, true, false)")


### PR DESCRIPTION
This pull request includes a minor change to the `test/test-AbstractWalkers.jl` file. The change updates the expected output for the `positions` field in the test to reflect a new value.

* [`test/test-AbstractWalkers.jl`](diffhunk://#diff-ff0f1efa0a27f29a7003d1044d09326489b8decc078ba556764a2c202e3819beL911-R911): Updated the expected number of grid points in the `positions` field from 48 to 16.