### PR TITLE
fix: correct type name from LennardJonesParametersSets to LennardJonesParameterSets across multiple files

### DIFF
--- a/src/AbstractLiveSets/atomistic_livesets.jl
+++ b/src/AbstractLiveSets/atomistic_livesets.jl
@@ -2,53 +2,53 @@
 abstract type AtomWalkers <: AbstractLiveSet end
 
 """
-    assign_energy!(walker::AtomWalker, lj::LennardJonesParametersSets)
+    assign_energy!(walker::AtomWalker, lj::LennardJonesParameterSets)
 
 Assigns the energy to the given `walker` using the Lennard-Jones parameters `lj`.
 
 # Arguments
 - `walker::AtomWalker`: The walker object to assign the energy to.
-- `lj::LennardJonesParametersSets`: The Lennard-Jones parameters.
+- `lj::LennardJonesParameterSets`: The Lennard-Jones parameters.
 
 # Returns
 - `walker::AtomWalker`: The walker object with the assigned energy.
 
 """
-function assign_energy!(walker::AtomWalker, lj::LennardJonesParametersSets)
+function assign_energy!(walker::AtomWalker, lj::LennardJonesParameterSets)
     # walker.energy_frozen_part = frozen_energy(walker.configuration, lj, walker.list_num_par, walker.frozen)
     walker.energy = interacting_energy(walker.configuration, lj, walker.list_num_par, walker.frozen) + walker.energy_frozen_part
     return walker
 end
 
 """
-    assign_frozen_energy!(walker::AtomWalker, lj::LennardJonesParametersSets)
+    assign_frozen_energy!(walker::AtomWalker, lj::LennardJonesParameterSets)
 
 Assigns the frozen energy to the given `walker` using the Lennard-Jones parameters `lj`.
 
 # Arguments
 - `walker::AtomWalker`: The walker object to assign the energy to.
-- `lj::LennardJonesParametersSets`: The Lennard-Jones parameters.
+- `lj::LennardJonesParameterSets`: The Lennard-Jones parameters.
 
 # Returns
 - `walker::AtomWalker`: The walker object with the assigned energy.
 
 """
-function assign_frozen_energy!(walker::AtomWalker, lj::LennardJonesParametersSets)
+function assign_frozen_energy!(walker::AtomWalker, lj::LennardJonesParameterSets)
     walker.energy_frozen_part = frozen_energy(walker.configuration, lj, walker.list_num_par, walker.frozen)
     return walker
 end
 
 """
-    assign_energy!(walker::AtomWalker, lj::LennardJonesParametersSets, surface::AtomWalker)
+    assign_energy!(walker::AtomWalker, lj::LennardJonesParameterSets, surface::AtomWalker)
 Assigns the energy to the given `walker` using the Lennard-Jones parameters `lj` with an external surface.
 # Arguments
 - `walker::AtomWalker`: The walker object to assign the energy to.
-- `lj::LennardJonesParametersSets`: The Lennard-Jones parameters.
+- `lj::LennardJonesParameterSets`: The Lennard-Jones parameters.
 - `surface::AtomWalker`: The surface walker object to consider in the energy calculation.
 # Returns
 - `walker::AtomWalker`: The walker object with the assigned energy.
 """
-function assign_energy!(walker::AtomWalker, lj::LennardJonesParametersSets, surface::AtomWalker)
+function assign_energy!(walker::AtomWalker, lj::LennardJonesParameterSets, surface::AtomWalker)
     walker.energy =  interacting_energy(walker.configuration, lj, walker.list_num_par, walker.frozen, surface.configuration) + walker.energy_frozen_part
     return walker
 end
@@ -61,18 +61,18 @@ The `LJAtomWalkers` struct represents a collection of atom walkers that interact
 
 # Fields
 - `walkers::Vector{AtomWalker{C}}`: A vector of atom walkers, where `C` is the number of components.
-- `lj_potential::LennardJonesParametersSets`: The Lennard-Jones potential parameters. See `LennardJonesParametersSets`.
+- `lj_potential::LennardJonesParameterSets`: The Lennard-Jones potential parameters. See `LennardJonesParameterSets`.
 
 # Constructor
-- `LJAtomWalkers(walkers::Vector{AtomWalker{C}}, lj_potential::LennardJonesParametersSets; assign_energy=true)`: 
+- `LJAtomWalkers(walkers::Vector{AtomWalker{C}}, lj_potential::LennardJonesParameterSets; assign_energy=true)`: 
     Constructs a new `LJAtomWalkers` object with the given walkers and Lennard-Jones potential parameters. If `assign_energy=true`,
     the energy of each walker is assigned using the Lennard-Jones potential.
 
 """
 struct LJAtomWalkers <: AtomWalkers
     walkers::Vector{AtomWalker{C}} where C
-    lj_potential::LennardJonesParametersSets
-    function LJAtomWalkers(walkers::Vector{AtomWalker{C}}, lj_potential::LennardJonesParametersSets; assign_energy=true, const_frozen_part=true) where C
+    lj_potential::LennardJonesParameterSets
+    function LJAtomWalkers(walkers::Vector{AtomWalker{C}}, lj_potential::LennardJonesParameterSets; assign_energy=true, const_frozen_part=true) where C
         if const_frozen_part && !isempty(walkers)
             frozen_part_energy = frozen_energy(walkers[1].configuration, lj_potential, walkers[1].list_num_par, walkers[1].frozen)
         end
@@ -98,19 +98,19 @@ with the presence of an external surface object wrapped in an `AtomWalker`.
 
 # Fields
 - `walkers::Vector{AtomWalker{C}}`: A vector of atom walkers, where `C` is the number of components.
-- `lj_potential::LennardJonesParametersSets`: The Lennard-Jones potential parameters.
+- `lj_potential::LennardJonesParameterSets`: The Lennard-Jones potential parameters.
 - `surface::AtomWalker{CS}`: An atom walker representing the surface, where `CS` is the number of components of the surface.
 
 # Constructor
 - `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                    lj_potential::LennardJonesParametersSets, 
+                    lj_potential::LennardJonesParameterSets, 
                     surface::AtomWalker{CS}; assign_energy=true)`
 
     Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones potential parameters, and a single surface walker. 
     If `assign_energy=true`, the energy of each walker is assigned using the Lennard-Jones potential and the surface.
 
 - `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                            lj_potential::LennardJonesParametersSets, 
+                            lj_potential::LennardJonesParameterSets, 
                             surface::AtomWalker{CS}, 
                             assign_energy_parallel::Symbol,
                             ) where C where CS`
@@ -121,10 +121,10 @@ with the presence of an external surface object wrapped in an `AtomWalker`.
 """
 struct LJSurfaceWalkers <: AtomWalkers
     walkers::Vector{AtomWalker{C}} where C
-    lj_potential::LennardJonesParametersSets
+    lj_potential::LennardJonesParameterSets
     surface::AtomWalker{CS} where CS
     function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                                lj_potential::LennardJonesParametersSets, 
+                                lj_potential::LennardJonesParameterSets, 
                                 surface::AtomWalker{CS}; 
                                 assign_energy = true,
                                 ) where C where CS
@@ -141,7 +141,7 @@ struct LJSurfaceWalkers <: AtomWalkers
 end
 
 function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                            lj_potential::LennardJonesParametersSets, 
+                            lj_potential::LennardJonesParameterSets, 
                             surface::AtomWalker{CS}, 
                             assign_energy_parallel::Symbol,
                             ) where C where CS

--- a/src/AbstractPotentials/AbstractPotentials.jl
+++ b/src/AbstractPotentials/AbstractPotentials.jl
@@ -10,7 +10,7 @@ using Unitful
 export AbstractPotential
 export LJParameters, lj_energy
 export CompositeLJParameters
-export LennardJonesParametersSets
+export LennardJonesParameterSets
 
 abstract type AbstractPotential end
 

--- a/src/AbstractPotentials/lennardjones.jl
+++ b/src/AbstractPotentials/lennardjones.jl
@@ -1,4 +1,4 @@
-abstract type LennardJonesParametersSets <: AbstractPotential end
+abstract type LennardJonesParameterSets <: AbstractPotential end
 
 
 """
@@ -13,7 +13,7 @@ The `LJParameters` struct represents the parameters for the Lennard-Jones potent
 - `shift::typeof(0.0u"eV")`: The energy shift applied to the potential, calculated at the cutoff distance.
 
 """
-struct LJParameters <: LennardJonesParametersSets
+struct LJParameters <: LennardJonesParameterSets
     epsilon::typeof(1.0u"eV")
     sigma::typeof(1.0u"Å")
     cutoff::Float64
@@ -110,7 +110,7 @@ end
 
 
 """
-    struct CompositeLJParameters{C} <: LennardJonesParametersSets
+    struct CompositeLJParameters{C} <: LennardJonesParameterSets
 
 CompositeLJParameters is a struct that represents a set of composite Lennard-Jones parameters.
 
@@ -121,7 +121,7 @@ CompositeLJParameters is a struct that represents a set of composite Lennard-Jon
 - `C::Int`: The number of composite parameter sets.
 
 """
-struct CompositeLJParameters{C} <: LennardJonesParametersSets
+struct CompositeLJParameters{C} <: LennardJonesParameterSets
     lj_param_sets::Matrix{LJParameters}
     function CompositeLJParameters{C}(lj_param_sets::Matrix{LJParameters}) where C
         if size(lj_param_sets) != (C, C)

--- a/src/MonteCarloMoves/atomistic_swaps.jl
+++ b/src/MonteCarloMoves/atomistic_swaps.jl
@@ -19,14 +19,14 @@ function two_atoms_swap!(at::AtomWalker{C}, ind1, ind2) where C
 end
 
 """
-    MC_random_swap!(n_steps::Int, at::AtomWalker{C}, lj::LennardJonesParametersSets, emax::typeof(0.0u"eV"))
+    MC_random_swap!(n_steps::Int, at::AtomWalker{C}, lj::LennardJonesParameterSets, emax::typeof(0.0u"eV"))
 
 Perform a Monte Carlo random swap of two atoms in the `AtomWalker`. Only works when there are two or more non-frozen components.
 
 # Arguments
 - `n_steps::Int`: The number of Monte Carlo steps to perform.
 - `at::AtomWalker{C}`: The `AtomWalker` object.
-- `lj::LennardJonesParametersSets`: The Lennard-Jones parameters.
+- `lj::LennardJonesParameterSets`: The Lennard-Jones parameters.
 - `emax::typeof(0.0u"eV")`: The maximum energy allowed for accepting a move.
 
 # Returns
@@ -36,7 +36,7 @@ Perform a Monte Carlo random swap of two atoms in the `AtomWalker`. Only works w
 """
 function MC_random_swap!(n_steps::Int, 
                          at::AtomWalker{C}, 
-                         lj::LennardJonesParametersSets, 
+                         lj::LennardJonesParameterSets, 
                          emax::typeof(0.0u"eV")
                          ) where C
     n_accept = 0

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -274,7 +274,7 @@ end
 """
     monte_carlo_sampling(
         at::AtomWalker,
-        lj::LennardJonesParametersSets,
+        lj::LennardJonesParameterSets,
         mc_params::MetropolisMCParameters;
         kb::Float64 = 8.617333262e-5 # eV/K
     )
@@ -286,7 +286,7 @@ should be in Kelvin, and the units of the energy should be in eV.
 
 # Arguments
 - `at::AtomWalker`: The initial atom walker configuration.
-- `lj::LennardJonesParametersSets`: The Lennard-Jones parameters.
+- `lj::LennardJonesParameterSets`: The Lennard-Jones parameters.
 - `mc_params::MetropolisMCParameters`: The parameters for the Metropolis Monte Carlo algorithm.
 
 # Returns
@@ -297,7 +297,7 @@ should be in Kelvin, and the units of the energy should be in eV.
 """
 function monte_carlo_sampling(
     at::AtomWalker,
-    lj::LennardJonesParametersSets,
+    lj::LennardJonesParameterSets,
     mc_params::MetropolisMCParameters;
     kb::Float64 = 8.617333262e-5 # eV/K
 )

--- a/src/SamplingSchemes/wang_landau.jl
+++ b/src/SamplingSchemes/wang_landau.jl
@@ -86,7 +86,7 @@ end
 
     wang_landau(
         walker::AtomWalker,
-        lj::LennardJonesParametersSets,
+        lj::LennardJonesParameterSets,
         wl_params::WangLandauParameters
     )
 
@@ -94,7 +94,7 @@ Perform the Wang-Landau sampling scheme for a lattice or an atomistic system.
 
 # Arguments
 - `lattice::AbstractLattice`/`walker::AtomWalker`: The initial lattice/atomistic configuration.
-- `h::ClassicalHamiltonian`/`lj::LennardJonesParametersSets`: The Hamiltonian parameters for the lattice/atomistic system.
+- `h::ClassicalHamiltonian`/`lj::LennardJonesParameterSets`: The Hamiltonian parameters for the lattice/atomistic system.
 - `wl_params::WangLandauParameters`: The parameters for the Wang-Landau sampling scheme.
 
 # Returns
@@ -203,7 +203,7 @@ end
 
 function wang_landau(
     walker::AtomWalker,
-    lj::LennardJonesParametersSets,
+    lj::LennardJonesParameterSets,
     wl_params::WangLandauParameters
     )
 


### PR DESCRIPTION
The type `LennardJonesParametersSets` has been renamed to `LennardJonesParameterSets` for consistency and clarity. This change affects function signatures, struct definitions, and documentation throughout the project.