### PR TITLE
Hotfix/remove swap chemsymbols

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,9 +50,6 @@ jobs:
           fail-on-error: false
           parallel: true
         continue-on-error: true
-      - uses: julia-actions/julia-uploadcoveralls@v1
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
   finish:
     needs: test

--- a/src/MonteCarloMoves/atomistic_swaps.jl
+++ b/src/MonteCarloMoves/atomistic_swaps.jl
@@ -14,7 +14,6 @@ Swap the positions of two atoms in the `AtomWalker`.
 function two_atoms_swap!(at::AtomWalker{C}, ind1, ind2) where C
     config = at.configuration
     config.position[ind1], config.position[ind2] = config.position[ind2], config.position[ind1]
-    config.species[ind1], config.species[ind2] = config.species[ind2], config.species[ind1]
     return at
 end
 

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -428,8 +428,6 @@
             atw_new = MonteCarloMoves.two_atoms_swap!(deepcopy(atw), 1, 2)
             
             # Tests
-            @test atw_new.configuration.species[1] == :O
-            @test atw_new.configuration.species[2] == :H
             @test atw_new.configuration.position[1] == atw.configuration.position[2]
             @test atw_new.configuration.position[2] == atw.configuration.position[1]
         end
@@ -445,8 +443,6 @@
             accepted, rate, atw_new = MonteCarloMoves.MC_random_swap!(1, deepcopy(atw), lj, Inf*u"eV") # Inf energy limit, so always accept
             
             # Tests
-            @test atw_new.configuration.species[1] == :O
-            @test atw_new.configuration.species[2] == :H
             @test atw_new.configuration.position[1] == atw.configuration.position[2]
             @test atw_new.configuration.position[2] == atw.configuration.position[1]
             @test atw_new.configuration.position[3] == atw.configuration.position[3] # Check if other atoms are unchanged
@@ -457,8 +453,6 @@
 
             accepted, rate, atw_new = MonteCarloMoves.MC_random_swap!(1, deepcopy(atw), lj, -Inf*u"eV") # -Inf energy limit, so always reject
 
-            @test atw_new.configuration.species[1] == :H # Check if species are unchanged
-            @test atw_new.configuration.species[2] == :O # Check if species are unchanged
             @test atw_new.configuration.position[1] == atw.configuration.position[1] # Check if positions are unchanged
             @test atw_new.configuration.position[2] == atw.configuration.position[2] # Check if positions are unchanged
             @test atw_new.configuration.position[3] == atw.configuration.position[3] # Check if other atoms are unchanged


### PR DESCRIPTION
This pull request makes several changes related to atom swap operations and continuous integration configuration. The most significant update is the modification of the atom swap logic, which now only swaps atom positions and leaves their species unchanged. Corresponding tests have been updated to reflect this new behavior. Additionally, a coverage upload step has been removed from the CI workflow.

### Atom swap logic changes

* The `two_atoms_swap!` function in `atomistic_swaps.jl` now only swaps the positions of two atoms, without swapping their species.

### Test updates

* Removed assertions checking species swapping in tests for `two_atoms_swap!` and `MC_random_swap!` to align with the new behavior where only positions are swapped. [[1]](diffhunk://#diff-9185005c8dc0cff86be81c555a9108ff3612a0d90a29f8ad585e0d22b91bdaf2L431-L432) [[2]](diffhunk://#diff-9185005c8dc0cff86be81c555a9108ff3612a0d90a29f8ad585e0d22b91bdaf2L448-L449) [[3]](diffhunk://#diff-9185005c8dc0cff86be81c555a9108ff3612a0d90a29f8ad585e0d22b91bdaf2L460-L461)

### CI configuration

* Removed the Coveralls coverage upload step from the GitHub Actions workflow in `.github/workflows/CI.yml`.