### PR TITLE
Hotfix/update ps for mc wl

### DIFF
--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -275,7 +275,7 @@ end
 """
     monte_carlo_sampling(
         at::AtomWalker,
-        lj::LennardJonesParameterSets,
+        pot::AbstractPotential,
         mc_params::MetropolisMCParameters;
         kb::Float64 = 8.617333262e-5 # eV/K
     )
@@ -287,7 +287,7 @@ should be in Kelvin, and the units of the energy should be in eV.
 
 # Arguments
 - `at::AtomWalker`: The initial atom walker configuration.
-- `lj::LennardJonesParameterSets`: The Lennard-Jones parameters.
+- `pot::AbstractPotential`: The potential energy function for the atoms.
 - `mc_params::MetropolisMCParameters`: The parameters for the Metropolis Monte Carlo algorithm.
 
 # Returns
@@ -298,7 +298,7 @@ should be in Kelvin, and the units of the energy should be in eV.
 """
 function monte_carlo_sampling(
     at::AtomWalker,
-    lj::LennardJonesParameterSets,
+    pot::AbstractPotential,
     mc_params::MetropolisMCParameters;
     kb::Float64 = 8.617333262e-5 # eV/K
 )
@@ -314,7 +314,7 @@ function monte_carlo_sampling(
         # Equilibrate the lattice
         equilibration_energies, equilibration_configurations, equilibration_accepted_steps = nvt_monte_carlo(
             at,
-            lj,
+            pot,
             temp,
             mc_params.equilibrium_steps,
             mc_params.step_size,
@@ -333,7 +333,7 @@ function monte_carlo_sampling(
         # Sample the lattice
         sampling_energies, sampling_configurations, sampling_accepted_steps = nvt_monte_carlo(
             equilibration_configurations[end],
-            lj,
+            pot,
             temp,
             mc_params.sampling_steps,
             mc_params.step_size,
@@ -360,7 +360,7 @@ function monte_carlo_sampling(
         @info "Temperature: $temp K, Energy: $E, Variance: $(round(E_var.val; sigdigits=4)), Cv: $(round(Cv.val; sigdigits=4)), Acceptance rate: $(round(acceptance_rate; sigdigits=4)), Step size: $(round(mc_params.step_size; sigdigits=4))"
     end
 
-    ls = LJAtomWalkers(configs, lj)
+    ls = LJAtomWalkers(configs, pot)
 
     return energies, ls, cvs, acceptance_rates
 end

--- a/src/SamplingSchemes/wang_landau.jl
+++ b/src/SamplingSchemes/wang_landau.jl
@@ -86,7 +86,7 @@ end
 
     wang_landau(
         walker::AtomWalker,
-        lj::LennardJonesParameterSets,
+        pot::AbstractPotential,
         wl_params::WangLandauParameters
     )
 
@@ -94,7 +94,7 @@ Perform the Wang-Landau sampling scheme for a lattice or an atomistic system.
 
 # Arguments
 - `lattice::AbstractLattice`/`walker::AtomWalker`: The initial lattice/atomistic configuration.
-- `h::ClassicalHamiltonian`/`lj::LennardJonesParameterSets`: The Hamiltonian parameters for the lattice/atomistic system.
+- `h::ClassicalHamiltonian`/`pot::AbstractPotential`: The Hamiltonian parameters for the lattice/atomistic system.
 - `wl_params::WangLandauParameters`: The parameters for the Wang-Landau sampling scheme.
 
 # Returns
@@ -204,7 +204,7 @@ end
 
 function wang_landau(
     walker::AtomWalker,
-    lj::LennardJonesParameterSets,
+    pot::AbstractPotential,
     wl_params::WangLandauParameters
     )
 
@@ -232,7 +232,7 @@ function wang_landau(
     f = wl_params.f_initial
 
     current_walker = deepcopy(walker)
-    current_energy = interacting_energy(current_walker.configuration, lj, current_walker.list_num_par, current_walker.frozen) + current_walker.energy_frozen_part
+    current_energy = interacting_energy(current_walker.configuration, pot, current_walker.list_num_par, current_walker.frozen) + current_walker.energy_frozen_part
     current_walker.energy = current_energy
     println("Initial energy: ", current_energy)
     push!(energies, current_energy.val)
@@ -250,10 +250,10 @@ function wang_landau(
             # Propose a swap in occupation state (only if it maintains constant N)
             proposed_walker = deepcopy(current_walker)
 
-            proposed_walker, ΔE = single_atom_random_walk!(proposed_walker, lj, wl_params.step_size)
+            proposed_walker, ΔE = single_atom_random_walk!(proposed_walker, pot, wl_params.step_size)
 
             # Calculate the proposed energy
-            # proposed_energy = interacting_energy(proposed_walker.configuration, lj, proposed_walker.list_num_par, proposed_walker.frozen) + proposed_walker.energy_frozen_part
+            # proposed_energy = interacting_energy(proposed_walker.configuration, pot, proposed_walker.list_num_par, proposed_walker.frozen) + proposed_walker.energy_frozen_part
             # proposed_walker.energy = proposed_energy
             proposed_energy = current_energy + ΔE
             proposed_walker.energy = proposed_energy


### PR DESCRIPTION
This pull request generalizes the Monte Carlo and Wang-Landau sampling schemes to work with any potential energy function, rather than being limited to Lennard-Jones potentials. The main changes involve replacing the `LennardJonesParameterSets` argument with a more generic `AbstractPotential` type throughout the relevant functions and their documentation.

**Generalization of potential energy handling:**

* Changed function signatures and documentation in `nvt_monte_carlo.jl` and `wang_landau.jl` to accept `pot::AbstractPotential` instead of `lj::LennardJonesParameterSets`, allowing for broader applicability to different potential models. [[1]](diffhunk://#diff-d0ded30ee3f1fdcace6077333f597437e3d73a0da0a3bb7f183a7a33c1999cf6L278-R278) [[2]](diffhunk://#diff-d0ded30ee3f1fdcace6077333f597437e3d73a0da0a3bb7f183a7a33c1999cf6L290-R290) [[3]](diffhunk://#diff-d0ded30ee3f1fdcace6077333f597437e3d73a0da0a3bb7f183a7a33c1999cf6L301-R301) [[4]](diffhunk://#diff-d19350c3e11bc8be6e541c921b78b68f414ea10c92a95716101b62f14cfff19bL89-R97) [[5]](diffhunk://#diff-d19350c3e11bc8be6e541c921b78b68f414ea10c92a95716101b62f14cfff19bL207-R207)

* Updated all internal calls and usages within `monte_carlo_sampling` and `wang_landau` functions to use the new `pot` argument, ensuring consistency and correct computation with arbitrary potentials. [[1]](diffhunk://#diff-d0ded30ee3f1fdcace6077333f597437e3d73a0da0a3bb7f183a7a33c1999cf6L317-R317) [[2]](diffhunk://#diff-d0ded30ee3f1fdcace6077333f597437e3d73a0da0a3bb7f183a7a33c1999cf6L336-R336) [[3]](diffhunk://#diff-d0ded30ee3f1fdcace6077333f597437e3d73a0da0a3bb7f183a7a33c1999cf6L363-R363) [[4]](diffhunk://#diff-d19350c3e11bc8be6e541c921b78b68f414ea10c92a95716101b62f14cfff19bL235-R235) [[5]](diffhunk://#diff-d19350c3e11bc8be6e541c921b78b68f414ea10c92a95716101b62f14cfff19bL253-R256)