### PR TITLE
Grand-canonical nested sampling for lattice systems

### DIFF
--- a/src/AbstractLiveSets/AbstractLiveSets.jl
+++ b/src/AbstractLiveSets/AbstractLiveSets.jl
@@ -21,6 +21,7 @@ export LJAtomWalkers, LatticeGasWalkers
 export LJSurfaceWalkers
 export MLIPAtomWalkers
 export GuptaAtomWalkers
+export assign_energy!
 
 abstract type AbstractLiveSet end
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -10,6 +10,7 @@ using CSV, Arrow
 
 export read_output
 export ωᵢ, partition_function, internal_energy, cv
+export gc_thermodynamic_stats
 
 """
     read_output(filename::String)
@@ -206,6 +207,133 @@ function cv(Ts::Vector{Float64}, dof::Int, energy_bins::Vector{Float64}, entropy
         Cv[i] = (E2_avg[i] .- E_avg[i].^2) ./ (kb * temp.^2) .+ dof*kb/2
     end
     return Cv
+end
+
+
+"""
+    gc_thermodynamic_stats(β::Float64, ωi::Vector{Float64},
+                           grand_energies::Vector{Float64},
+                           energies::Vector{Float64},
+                           numbers::Vector{Int},
+                           μ::Float64;
+                           kb::Float64=8.617333262e-5)
+
+Compute grand-canonical thermodynamic averages from nested sampling output.
+
+The log-sum-exp trick is used for numerical stability. The grand-canonical
+heat capacity at constant μ is:
+
+    C_{V,μ} = k_B β² [Var(E) − μ Cov(E, N)]
+
+# Arguments
+- `β::Float64`: Inverse temperature 1/(k_B T).
+- `ωi::Vector{Float64}`: Phase-space volume weights from NS.
+- `grand_energies::Vector{Float64}`: Ω_i = E_i − μ N_i values.
+- `energies::Vector{Float64}`: E_i values.
+- `numbers::Vector{Int}`: N_i values.
+- `μ::Float64`: Chemical potential.
+- `kb::Float64`: Boltzmann constant (default: eV/K).
+
+# Returns
+- `(⟨E⟩, C_{V,μ}, ⟨N⟩)`: Mean energy, GC heat capacity, mean particle number.
+"""
+function gc_thermodynamic_stats(β::Float64,
+                                 ωi::Vector{Float64},
+                                 grand_energies::Vector{Float64},
+                                 energies::Vector{Float64},
+                                 numbers::Vector{Int},
+                                 μ::Float64;
+                                 kb::Float64=8.617333262e-5)
+    n = length(ωi)
+    if n != length(grand_energies) || n != length(energies) || n != length(numbers)
+        throw(DimensionMismatch("All input vectors must have the same length"))
+    end
+    if n == 0
+        return NaN, NaN, NaN
+    end
+
+    # Log-sum-exp for numerical stability
+    log_terms = [log(ωi[i]) - β * grand_energies[i] for i in 1:n]
+    max_log = maximum(log_terms)
+
+    z = 0.0
+    u = 0.0   # ⟨E⟩
+    u2 = 0.0  # ⟨E²⟩
+    n_sum = 0.0  # ⟨N⟩
+    en_sum = 0.0 # ⟨EN⟩
+
+    for i in 1:n
+        w = exp(log_terms[i] - max_log)
+        z += w
+        u += w * energies[i]
+        u2 += w * energies[i]^2
+        n_sum += w * numbers[i]
+        en_sum += w * energies[i] * numbers[i]
+    end
+
+    if z == 0.0
+        return NaN, NaN, NaN
+    end
+
+    u /= z
+    u2 /= z
+    n_avg = n_sum / z
+    en_avg = en_sum / z
+
+    var_e = u2 - u^2
+    cov_en = en_avg - u * n_avg
+
+    cv = kb * β^2 * (var_e - μ * cov_en)
+
+    return u, cv, n_avg
+end
+
+"""
+    gc_thermodynamic_stats(df::DataFrame, βs::Vector{Float64},
+                           n_walkers::Int, μ::Float64;
+                           n_cull::Int=1, ω0::Float64=1.0,
+                           kb::Float64=8.617333262e-5)
+
+Compute grand-canonical thermodynamic stats from a GC-NS output DataFrame.
+
+The DataFrame must have columns `:iter`, `:omega`, `:energy`, `:num_particles`.
+Adds the live-walker contribution to the end of the recorded samples for correct
+normalization.
+
+# Arguments
+- `df::DataFrame`: GC-NS output with columns `[:iter, :omega, :energy, :num_particles]`.
+- `βs::Vector{Float64}`: Inverse temperatures at which to evaluate.
+- `n_walkers::Int`: Number of walkers used in the NS run.
+- `μ::Float64`: Chemical potential.
+- `n_cull::Int=1`: Number of walkers culled per iteration.
+- `ω0::Float64=1.0`: Initial phase-space volume.
+- `kb::Float64`: Boltzmann constant (default: eV/K).
+
+# Returns
+- `(mean_E, Cv, mean_N)`: Vectors of ⟨E⟩, C_{V,μ}, and ⟨N⟩ at each β.
+"""
+function gc_thermodynamic_stats(df::DataFrame,
+                                 βs::Vector{Float64},
+                                 n_walkers::Int,
+                                 μ::Float64;
+                                 n_cull::Int=1,
+                                 ω0::Float64=1.0,
+                                 kb::Float64=8.617333262e-5)
+    ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
+    grand_es = df.omega
+    Es = df.energy
+    Ns = df.num_particles
+
+    mean_Es = Vector{Float64}(undef, length(βs))
+    Cvs = Vector{Float64}(undef, length(βs))
+    mean_Ns = Vector{Float64}(undef, length(βs))
+
+    Threads.@threads for (i, b) in collect(enumerate(βs))
+        mean_Es[i], Cvs[i], mean_Ns[i] = gc_thermodynamic_stats(
+            b, ωi, grand_es, Es, Ns, μ; kb=kb)
+    end
+
+    return mean_Es, Cvs, mean_Ns
 end
 
 

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -25,6 +25,9 @@ export generate_random_new_lattice_sample!
 export MC_mixed_moves!
 export MC_cluster_walk!
 export geometric_cluster_swap!
+export random_microstate!
+export lattice_insert_particle!, lattice_delete_particle!
+export MC_grand_canonical_walk!
 
 export free_component_index, free_par_index
 

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -33,12 +33,12 @@ export free_component_index, free_par_index
 
 include("helpers.jl")
 
+include("cluster_moves.jl")
+
 include("random_walks.jl")
 
 include("atomistic_swaps.jl")
 
 include("mixed_moves.jl")
-
-include("cluster_moves.jl")
 
 end # module MonteCarloMoves

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -749,13 +749,17 @@ end
                              h::ClassicalHamiltonian, omega_max::Float64,
                              mu::Float64;
                              p_move::Float64=0.5, p_insert::Float64=0.25,
-                             energy_perturb::Float64=0.0)
+                             energy_perturb::Float64=0.0, n_max::Int=typemax(Int),
+                             clusters_freq::Int=0, swaps_freq::Int=1,
+                             cluster_p::Float64=0.3)
 
 Perform grand-canonical MCMC on a single-component lattice, mixing fixed-N
-swap moves with single-site insertion and deletion.
+moves (local swaps and/or geometric cluster moves) with single-site insertion
+and deletion.
 
 Each step:
-- With probability `p_move`: propose a fixed-N local swap.
+- With probability `p_move`: propose a fixed-N move (local swap or cluster move,
+  selected by `swaps_freq:clusters_freq` ratio).
 - With probability `p_insert`: propose inserting one particle.
 - With probability `1 - p_move - p_insert`: propose deleting one particle.
 
@@ -763,6 +767,8 @@ Insert/delete proposals use a Metropolis correction to preserve the uniform
 prior over all microstates with Ω < Ω_max:
 - Insert ratio: `(p_delete / p_insert) * (M - N) / (N + 1)`
 - Delete ratio: `(p_insert / p_delete) * N / (M - N + 1)`
+
+Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 
 # Arguments
 - `n_steps::Int`: Number of MCMC steps.
@@ -773,11 +779,17 @@ prior over all microstates with Ω < Ω_max:
 - `p_move::Float64=0.5`: Probability of a fixed-N move.
 - `p_insert::Float64=0.25`: Probability of an insertion move.
 - `energy_perturb::Float64=0.0`: Energy perturbation for degeneracy breaking.
+- `n_max::Int=typemax(Int)`: Upper bound on particle count.
+- `clusters_freq::Int=0`: Relative weight of cluster moves within fixed-N branch (0 = disabled).
+- `swaps_freq::Int=1`: Relative weight of local swaps within fixed-N branch.
+- `cluster_p::Float64=0.3`: Current cluster growth probability.
 
 # Returns
 - `accept_this_walker::Bool`: Whether at least one move was accepted.
 - `accept_rate::Float64`: Fraction of accepted moves.
 - `lattice::LatticeWalker{1}`: The updated walker.
+- `cluster_accepted_count::Int`: Number of accepted cluster moves (for adaptive tuning).
+- `cluster_total_count::Int`: Number of attempted cluster moves (for adaptive tuning).
 """
 function MC_grand_canonical_walk!(n_steps::Int,
                                   lattice::LatticeWalker{1},
@@ -787,7 +799,10 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   p_move::Float64=0.5,
                                   p_insert::Float64=0.25,
                                   energy_perturb::Float64=0.0,
-                                  n_max::Int=typemax(Int))
+                                  n_max::Int=typemax(Int),
+                                  clusters_freq::Int=0,
+                                  swaps_freq::Int=1,
+                                  cluster_p::Float64=0.3)
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
@@ -799,15 +814,30 @@ function MC_grand_canonical_walk!(n_steps::Int,
     n_cap = min(n_sites, n_max)
     omega_max_u = omega_max * unit(lattice.energy)
 
+    # Cluster move mixing: compute probability of cluster vs local swap within fixed-N branch
+    total_fixed_n_freq = clusters_freq + swaps_freq
+    p_cluster_in_move = total_fixed_n_freq > 0 ? clusters_freq / total_fixed_n_freq : 0.0
+
+    cluster_accepted_count = 0
+    cluster_total_count = 0
+
     for _ in 1:n_steps
         r = rand()
         proposed_lattice = deepcopy(lattice.configuration)
         n = sum(proposed_lattice.components[1])
 
         if r < p_move
-            # Fixed-N local swap
-            lattice_random_walk!(proposed_lattice)
-            move_type = :move
+            # Fixed-N branch: choose cluster or local swap
+            if p_cluster_in_move > 0.0 && rand() < p_cluster_in_move
+                # Geometric cluster move
+                geometric_cluster_swap!(proposed_lattice, cluster_p)
+                move_type = :cluster
+                cluster_total_count += 1
+            else
+                # Local swap
+                lattice_random_walk!(proposed_lattice)
+                move_type = :move
+            end
         elseif r < p_move + p_insert
             # Insertion
             if n >= n_cap || p_insert <= 0.0
@@ -840,6 +870,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
         end
 
         # Metropolis correction for insert/delete detailed balance
+        # Cluster and local swap moves are symmetric — no correction needed
         accept = true
         if move_type == :insert
             ratio = (p_delete / p_insert) * (n_sites - n) / (n + 1)
@@ -858,8 +889,12 @@ function MC_grand_canonical_walk!(n_steps::Int,
             lattice.energy = proposed_energy
             n_accept += 1
             accept_this_walker = true
+            if move_type == :cluster
+                cluster_accepted_count += 1
+            end
         end
     end
 
-    return accept_this_walker, n_accept / max(n_steps, 1), lattice
+    return accept_this_walker, n_accept / max(n_steps, 1), lattice,
+           cluster_accepted_count, cluster_total_count
 end

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -786,7 +786,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   mu::Float64;
                                   p_move::Float64=0.5,
                                   p_insert::Float64=0.25,
-                                  energy_perturb::Float64=0.0)
+                                  energy_perturb::Float64=0.0,
+                                  n_max::Int=typemax(Int))
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
@@ -795,6 +796,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
     accept_this_walker = false
     p_delete = 1.0 - p_move - p_insert
     n_sites = num_sites(lattice.configuration)
+    n_cap = min(n_sites, n_max)
     omega_max_u = omega_max * unit(lattice.energy)
 
     for _ in 1:n_steps
@@ -808,7 +810,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
             move_type = :move
         elseif r < p_move + p_insert
             # Insertion
-            if n >= n_sites || p_insert <= 0.0
+            if n >= n_cap || p_insert <= 0.0
                 continue
             end
             success, proposed_lattice = lattice_insert_particle!(proposed_lattice)

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -668,3 +668,196 @@ function MC_cluster_walk!(n_steps::Int,
     end
     return accept_this_walker, n_accept / max(n_steps, 1), lattice
 end
+
+
+# ======================================================================
+# Grand-canonical move primitives
+# ======================================================================
+
+"""
+    random_microstate!(lattice::SLattice; p::Float64=0.5)
+
+Set each site occupied independently with probability `p`, producing a
+variable-N configuration suitable for grand-canonical sampling.
+
+# Arguments
+- `lattice::SLattice`: The single-component lattice to randomize.
+- `p::Float64=0.5`: Per-site occupation probability.
+
+# Returns
+- `lattice::SLattice`: The mutated lattice with a random microstate.
+"""
+function random_microstate!(lattice::SLattice; p::Float64=0.5)
+    for i in eachindex(lattice.components[1])
+        lattice.components[1][i] = rand() < p
+    end
+    return lattice
+end
+
+"""
+    lattice_insert_particle!(lattice::SLattice)
+
+Insert a particle at a random empty site. Returns `true` if successful,
+`false` if the lattice is full.
+
+# Arguments
+- `lattice::SLattice`: The single-component lattice.
+
+# Returns
+- `success::Bool`: Whether a particle was inserted.
+- `lattice::SLattice`: The mutated lattice.
+"""
+function lattice_insert_particle!(lattice::SLattice)
+    n_sites = num_sites(lattice)
+    n_occ = sum(lattice.components[1])
+    if n_occ >= n_sites
+        return false, lattice
+    end
+    # Collect empty site indices
+    empty_sites = findall(.!lattice.components[1])
+    site = rand(empty_sites)
+    lattice.components[1][site] = true
+    return true, lattice
+end
+
+"""
+    lattice_delete_particle!(lattice::SLattice)
+
+Delete a particle from a random occupied site. Returns `true` if successful,
+`false` if the lattice is empty.
+
+# Arguments
+- `lattice::SLattice`: The single-component lattice.
+
+# Returns
+- `success::Bool`: Whether a particle was deleted.
+- `lattice::SLattice`: The mutated lattice.
+"""
+function lattice_delete_particle!(lattice::SLattice)
+    n_occ = sum(lattice.components[1])
+    if n_occ == 0
+        return false, lattice
+    end
+    occupied_sites = findall(lattice.components[1])
+    site = rand(occupied_sites)
+    lattice.components[1][site] = false
+    return true, lattice
+end
+
+"""
+    MC_grand_canonical_walk!(n_steps::Int, lattice::LatticeWalker{1},
+                             h::ClassicalHamiltonian, omega_max::Float64,
+                             mu::Float64;
+                             p_move::Float64=0.5, p_insert::Float64=0.25,
+                             energy_perturb::Float64=0.0)
+
+Perform grand-canonical MCMC on a single-component lattice, mixing fixed-N
+swap moves with single-site insertion and deletion.
+
+Each step:
+- With probability `p_move`: propose a fixed-N local swap.
+- With probability `p_insert`: propose inserting one particle.
+- With probability `1 - p_move - p_insert`: propose deleting one particle.
+
+Insert/delete proposals use a Metropolis correction to preserve the uniform
+prior over all microstates with Ω < Ω_max:
+- Insert ratio: `(p_delete / p_insert) * (M - N) / (N + 1)`
+- Delete ratio: `(p_insert / p_delete) * N / (M - N + 1)`
+
+# Arguments
+- `n_steps::Int`: Number of MCMC steps.
+- `lattice::LatticeWalker{1}`: The walker (single component).
+- `h::ClassicalHamiltonian`: The lattice Hamiltonian.
+- `omega_max::Float64`: Upper bound on grand potential Ω = E − μN (unitless).
+- `mu::Float64`: Chemical potential (unitless, in same energy units as Hamiltonian).
+- `p_move::Float64=0.5`: Probability of a fixed-N move.
+- `p_insert::Float64=0.25`: Probability of an insertion move.
+- `energy_perturb::Float64=0.0`: Energy perturbation for degeneracy breaking.
+
+# Returns
+- `accept_this_walker::Bool`: Whether at least one move was accepted.
+- `accept_rate::Float64`: Fraction of accepted moves.
+- `lattice::LatticeWalker{1}`: The updated walker.
+"""
+function MC_grand_canonical_walk!(n_steps::Int,
+                                  lattice::LatticeWalker{1},
+                                  h::ClassicalHamiltonian,
+                                  omega_max::Float64,
+                                  mu::Float64;
+                                  p_move::Float64=0.5,
+                                  p_insert::Float64=0.25,
+                                  energy_perturb::Float64=0.0)
+    if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
+        throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+    end
+
+    n_accept = 0
+    accept_this_walker = false
+    p_delete = 1.0 - p_move - p_insert
+    n_sites = num_sites(lattice.configuration)
+    omega_max_u = omega_max * unit(lattice.energy)
+
+    for _ in 1:n_steps
+        r = rand()
+        proposed_lattice = deepcopy(lattice.configuration)
+        n = sum(proposed_lattice.components[1])
+
+        if r < p_move
+            # Fixed-N local swap
+            lattice_random_walk!(proposed_lattice)
+            move_type = :move
+        elseif r < p_move + p_insert
+            # Insertion
+            if n >= n_sites || p_insert <= 0.0
+                continue
+            end
+            success, proposed_lattice = lattice_insert_particle!(proposed_lattice)
+            if !success
+                continue
+            end
+            move_type = :insert
+        else
+            # Deletion
+            if n == 0 || p_delete <= 0.0
+                continue
+            end
+            success, proposed_lattice = lattice_delete_particle!(proposed_lattice)
+            if !success
+                continue
+            end
+            move_type = :delete
+        end
+
+        perturbation_energy = energy_perturb * (rand() - 0.5) * unit(lattice.energy)
+        proposed_energy = interacting_energy(proposed_lattice, h) + perturbation_energy
+        n_new = sum(proposed_lattice.components[1])
+        proposed_omega = proposed_energy - mu * n_new * unit(lattice.energy)
+
+        if proposed_omega >= omega_max_u
+            continue
+        end
+
+        # Metropolis correction for insert/delete detailed balance
+        accept = true
+        if move_type == :insert
+            ratio = (p_delete / p_insert) * (n_sites - n) / (n + 1)
+            if ratio < 1.0 && rand() >= ratio
+                accept = false
+            end
+        elseif move_type == :delete
+            ratio = (p_insert / p_delete) * n / (n_sites - n + 1)
+            if ratio < 1.0 && rand() >= ratio
+                accept = false
+            end
+        end
+
+        if accept
+            lattice.configuration = proposed_lattice
+            lattice.energy = proposed_energy
+            n_accept += 1
+            accept_this_walker = true
+        end
+    end
+
+    return accept_this_walker, n_accept / max(n_steps, 1), lattice
+end

--- a/src/SamplingSchemes/SamplingSchemes.jl
+++ b/src/SamplingSchemes/SamplingSchemes.jl
@@ -40,6 +40,11 @@ export MCRoutine, MCRandomWalkMaxE, MCRandomWalkClone, MCNewSample, MCRejectionS
 
 export MCRandomWalkMaxEParallel, MCRandomWalkCloneParallel, MCDistributed
 
+# grand-canonical nested sampling
+export GrandCanonicalNestedSamplingParameters
+export MCGrandCanonicalMoves
+export grand_canonical_nested_sampling
+
 # other sampling schemes
 export exact_enumeration
 export wang_landau

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -263,21 +263,52 @@ struct MCRejectionSampling <: MCRoutine end
     struct MCGrandCanonicalMoves <: MCRoutine
 
 A type for generating a new walker using grand-canonical MCMC moves that mix
-fixed-N local swaps with single-site particle insertion and deletion.
+fixed-N moves (local swaps and/or geometric cluster moves) with single-site
+particle insertion and deletion.
 
 # Fields
-- `p_move::Float64`: Probability of a fixed-N swap move per MCMC step (default 0.5).
+- `p_move::Float64`: Probability of a fixed-N move per MCMC step (default 0.5).
 - `p_insert::Float64`: Probability of a particle insertion per step (default 0.25).
   The deletion probability is `1 - p_move - p_insert`.
+- `clusters_freq::Int`: Relative weight of cluster moves within the fixed-N branch (default 0 = disabled).
+- `swaps_freq::Int`: Relative weight of local swaps within the fixed-N branch (default 1).
+- `initial_cluster_p::Float64`: Starting growth probability for geometric cluster moves (default 0.3).
+- `target_cluster_accept::Float64`: Target acceptance rate for adaptive cluster p tuning (default 0.3).
+- `cluster_adjust_interval::Int`: Number of NS iterations between cluster p adjustments (default 50).
+- `cluster_p_floor::Float64`: Lower bound for adaptive cluster p (default 0.01).
+- `cluster_p_ceiling::Float64`: Upper bound for adaptive cluster p (default 1.0).
+
+When `clusters_freq == 0` (the default), the fixed-N branch uses only local swaps
+(`lattice_random_walk!`), preserving backward compatibility with existing scripts.
+When `clusters_freq > 0`, the fixed-N branch mixes geometric cluster moves with
+local swaps according to the `clusters_freq:swaps_freq` ratio.
 """
 struct MCGrandCanonicalMoves <: MCRoutine
     p_move::Float64
     p_insert::Float64
-    function MCGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25)
+    clusters_freq::Int
+    swaps_freq::Int
+    initial_cluster_p::Float64
+    target_cluster_accept::Float64
+    cluster_adjust_interval::Int
+    cluster_p_floor::Float64
+    cluster_p_ceiling::Float64
+    function MCGrandCanonicalMoves(;
+            p_move::Float64=0.5,
+            p_insert::Float64=0.25,
+            clusters_freq::Int=0,
+            swaps_freq::Int=1,
+            initial_cluster_p::Float64=0.3,
+            target_cluster_accept::Float64=0.3,
+            cluster_adjust_interval::Int=50,
+            cluster_p_floor::Float64=0.01,
+            cluster_p_ceiling::Float64=1.0)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
         end
-        new(p_move, p_insert)
+        new(p_move, p_insert, clusters_freq, swaps_freq,
+            initial_cluster_p, target_cluster_accept, cluster_adjust_interval,
+            cluster_p_floor, cluster_p_ceiling)
     end
 end
 
@@ -298,6 +329,13 @@ for thermodynamic reweighting.
 - `fail_count::Int64`: Consecutive failed replacements.
 - `allowed_fail_count::Int64`: Maximum consecutive failures before warning.
 - `init_occupation_p::Float64`: Per-site occupation probability for initial walkers.
+- `n_max::Int64`: Upper bound on particle count per walker.
+- `cluster_p::Float64`: Current cluster growth probability (mutable runtime state).
+- `cluster_accepted::Float64`: Accepted cluster moves in current adjustment window.
+- `cluster_total::Float64`: Total cluster moves attempted in current adjustment window.
+- `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p after each adjustment.
+- `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adjustment.
+- `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adjustment.
 """
 mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     mc_steps::Int64
@@ -308,18 +346,31 @@ mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     allowed_fail_count::Int64
     init_occupation_p::Float64
     n_max::Int64
+    cluster_p::Float64
+    cluster_accepted::Float64
+    cluster_total::Float64
+    cluster_p_history::Vector{Float64}
+    cluster_accept_history::Vector{Float64}
+    cluster_adjust_iterations::Vector{Int}
 end
 
 """
     GrandCanonicalNestedSamplingParameters(;
         mc_steps=100, chemical_potential=0.0, energy_perturbation=1e-12,
         random_seed=1234, fail_count=0, allowed_fail_count=10,
-        init_occupation_p=0.5, n_max=typemax(Int64))
+        init_occupation_p=0.5, n_max=typemax(Int64),
+        cluster_p=0.3, cluster_accepted=0.0, cluster_total=0.0,
+        cluster_p_history=Float64[], cluster_accept_history=Float64[],
+        cluster_adjust_iterations=Int[])
 
 Convenience constructor for `GrandCanonicalNestedSamplingParameters`.
 
 The `n_max` parameter sets an upper bound on the number of particles per walker.
 Insertions are rejected when N ≥ n_max. Default is `typemax(Int64)` (no cap).
+
+The `cluster_*` fields are mutable runtime state for adaptive cluster move tuning.
+They are initialized from the static configuration on `MCGrandCanonicalMoves` at
+the start of `grand_canonical_nested_sampling` when `clusters_freq > 0`.
 """
 function GrandCanonicalNestedSamplingParameters(;
     mc_steps::Int64=100,
@@ -330,11 +381,19 @@ function GrandCanonicalNestedSamplingParameters(;
     allowed_fail_count::Int64=10,
     init_occupation_p::Float64=0.5,
     n_max::Int64=typemax(Int64),
+    cluster_p::Float64=0.3,
+    cluster_accepted::Float64=0.0,
+    cluster_total::Float64=0.0,
+    cluster_p_history::Vector{Float64}=Float64[],
+    cluster_accept_history::Vector{Float64}=Float64[],
+    cluster_adjust_iterations::Vector{Int}=Int[],
 )
     GrandCanonicalNestedSamplingParameters(
         mc_steps, chemical_potential, energy_perturbation,
         random_seed, fail_count, allowed_fail_count,
         init_occupation_p, n_max,
+        cluster_p, cluster_accepted, cluster_total,
+        cluster_p_history, cluster_accept_history, cluster_adjust_iterations,
     )
 end
 
@@ -1127,11 +1186,14 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     to_walk = deepcopy(ats[parent_idx])
 
     # Decorrelate via GC MCMC
-    accept, rate, to_walk = MC_grand_canonical_walk!(
+    accept, rate, to_walk, cl_accepted, cl_total = MC_grand_canonical_walk!(
         gc_params.mc_steps, to_walk, h, omega_max_val, mu;
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         energy_perturb=gc_params.energy_perturbation,
-        n_max=gc_params.n_max)
+        n_max=gc_params.n_max,
+        clusters_freq=mc_routine.clusters_freq,
+        swaps_freq=mc_routine.swaps_freq,
+        cluster_p=gc_params.cluster_p)
 
     if accept
         push!(ats, to_walk)
@@ -1144,6 +1206,22 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
         energy_worst = missing
         n_worst = missing
         gc_params.fail_count += 1
+    end
+
+    # Accumulate cluster acceptance stats and adapt cluster_p
+    if cl_total > 0
+        gc_params.cluster_accepted += cl_accepted
+        gc_params.cluster_total += cl_total
+        if mc_routine.cluster_adjust_interval > 0 &&
+           gc_params.cluster_total >= mc_routine.cluster_adjust_interval
+            window_rate = gc_params.cluster_accepted / max(gc_params.cluster_total, 1.0)
+            adjust_cluster_p(gc_params, window_rate, ns_iteration;
+                             target=mc_routine.target_cluster_accept,
+                             floor=mc_routine.cluster_p_floor,
+                             ceiling=mc_routine.cluster_p_ceiling)
+            gc_params.cluster_accepted = 0.0
+            gc_params.cluster_total = 0.0
+        end
     end
 
     return iter, omega_worst, energy_worst, n_worst, liveset, gc_params
@@ -1180,6 +1258,16 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
                                          save_strategy::DataSavingStrategy)
     # Initialize walkers with random microstates
     _init_gc_walkers!(liveset, gc_params)
+
+    # Initialize cluster_p and reset counters from MCGrandCanonicalMoves if applicable
+    if mc_routine.clusters_freq > 0
+        gc_params.cluster_p = mc_routine.initial_cluster_p
+        gc_params.cluster_accepted = 0.0
+        gc_params.cluster_total = 0.0
+        empty!(gc_params.cluster_p_history)
+        empty!(gc_params.cluster_accept_history)
+        empty!(gc_params.cluster_adjust_iterations)
+    end
 
     df = DataFrame(iter=Int[], omega=Float64[], energy=Float64[], num_particles=Int[])
 

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -307,15 +307,19 @@ mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     fail_count::Int64
     allowed_fail_count::Int64
     init_occupation_p::Float64
+    n_max::Int64
 end
 
 """
     GrandCanonicalNestedSamplingParameters(;
         mc_steps=100, chemical_potential=0.0, energy_perturbation=1e-12,
         random_seed=1234, fail_count=0, allowed_fail_count=10,
-        init_occupation_p=0.5)
+        init_occupation_p=0.5, n_max=typemax(Int64))
 
 Convenience constructor for `GrandCanonicalNestedSamplingParameters`.
+
+The `n_max` parameter sets an upper bound on the number of particles per walker.
+Insertions are rejected when N ≥ n_max. Default is `typemax(Int64)` (no cap).
 """
 function GrandCanonicalNestedSamplingParameters(;
     mc_steps::Int64=100,
@@ -325,11 +329,12 @@ function GrandCanonicalNestedSamplingParameters(;
     fail_count::Int64=0,
     allowed_fail_count::Int64=10,
     init_occupation_p::Float64=0.5,
+    n_max::Int64=typemax(Int64),
 )
     GrandCanonicalNestedSamplingParameters(
         mc_steps, chemical_potential, energy_perturbation,
         random_seed, fail_count, allowed_fail_count,
-        init_occupation_p,
+        init_occupation_p, n_max,
     )
 end
 
@@ -1057,8 +1062,18 @@ Each site is occupied independently with probability `gc_params.init_occupation_
 """
 function _init_gc_walkers!(liveset::LatticeGasWalkers, gc_params::GrandCanonicalNestedSamplingParameters)
     h = liveset.hamiltonian
+    n_max = gc_params.n_max
     for walker in liveset.walkers
         random_microstate!(walker.configuration; p=gc_params.init_occupation_p)
+        # Enforce n_max: if too many particles, randomly delete until N ≤ n_max
+        n_occ = sum(walker.configuration.components[1])
+        if n_occ > n_max
+            occupied = findall(walker.configuration.components[1])
+            shuffle!(occupied)
+            for i in 1:(n_occ - n_max)
+                walker.configuration.components[1][occupied[i]] = false
+            end
+        end
         assign_energy!(walker, h; perturb_energy=gc_params.energy_perturbation)
     end
     return liveset
@@ -1115,7 +1130,8 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     accept, rate, to_walk = MC_grand_canonical_walk!(
         gc_params.mc_steps, to_walk, h, omega_max_val, mu;
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
-        energy_perturb=gc_params.energy_perturbation)
+        energy_perturb=gc_params.energy_perturbation,
+        n_max=gc_params.n_max)
 
     if accept
         push!(ats, to_walk)

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -254,6 +254,85 @@ A type for generating a new walker by performing rejection sampling. Currently, 
 """
 struct MCRejectionSampling <: MCRoutine end
 
+
+# ======================================================================
+# Grand-canonical nested sampling types
+# ======================================================================
+
+"""
+    struct MCGrandCanonicalMoves <: MCRoutine
+
+A type for generating a new walker using grand-canonical MCMC moves that mix
+fixed-N local swaps with single-site particle insertion and deletion.
+
+# Fields
+- `p_move::Float64`: Probability of a fixed-N swap move per MCMC step (default 0.5).
+- `p_insert::Float64`: Probability of a particle insertion per step (default 0.25).
+  The deletion probability is `1 - p_move - p_insert`.
+"""
+struct MCGrandCanonicalMoves <: MCRoutine
+    p_move::Float64
+    p_insert::Float64
+    function MCGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25)
+        if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
+            throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+        end
+        new(p_move, p_insert)
+    end
+end
+
+"""
+    mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
+
+Parameters for grand-canonical nested sampling on lattice systems.
+
+The grand potential Ω = E − μN is used as the sorting quantity. Walkers have
+variable particle count N, and the NS loop records (Ω, E, N) per iteration
+for thermodynamic reweighting.
+
+# Fields
+- `mc_steps::Int64`: MCMC steps per replacement walker.
+- `chemical_potential::Float64`: Chemical potential μ (unitless, in energy units of the Hamiltonian).
+- `energy_perturbation::Float64`: Perturbation to break energy degeneracies.
+- `random_seed::Int64`: Seed for the random number generator.
+- `fail_count::Int64`: Consecutive failed replacements.
+- `allowed_fail_count::Int64`: Maximum consecutive failures before warning.
+- `init_occupation_p::Float64`: Per-site occupation probability for initial walkers.
+"""
+mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
+    mc_steps::Int64
+    chemical_potential::Float64
+    energy_perturbation::Float64
+    random_seed::Int64
+    fail_count::Int64
+    allowed_fail_count::Int64
+    init_occupation_p::Float64
+end
+
+"""
+    GrandCanonicalNestedSamplingParameters(;
+        mc_steps=100, chemical_potential=0.0, energy_perturbation=1e-12,
+        random_seed=1234, fail_count=0, allowed_fail_count=10,
+        init_occupation_p=0.5)
+
+Convenience constructor for `GrandCanonicalNestedSamplingParameters`.
+"""
+function GrandCanonicalNestedSamplingParameters(;
+    mc_steps::Int64=100,
+    chemical_potential::Float64=0.0,
+    energy_perturbation::Float64=1e-12,
+    random_seed::Int64=1234,
+    fail_count::Int64=0,
+    allowed_fail_count::Int64=10,
+    init_occupation_p::Float64=0.5,
+)
+    GrandCanonicalNestedSamplingParameters(
+        mc_steps, chemical_potential, energy_perturbation,
+        random_seed, fail_count, allowed_fail_count,
+        init_occupation_p,
+    )
+end
+
 """
     sort_by_energy!(liveset::LJAtomWalkers)
 
@@ -954,4 +1033,167 @@ function print_message(i, iter, emax, step_size, print_info, liveset::AtomWalker
         @info "MC move failed, step: $(i), emax: $(liveset.walkers[1].energy.val), step_size: $(round(step_size; sigdigits=4))"
     end
 end
-    
+
+
+# ======================================================================
+# Grand-canonical nested sampling
+# ======================================================================
+
+"""
+    _grand_potential(walker::LatticeWalker{1}, mu::Float64) -> typeof(0.0u"eV")
+
+Compute Ω = E − μN for a single-component lattice walker.
+"""
+function _grand_potential(walker::LatticeWalker{1}, mu::Float64)
+    n = sum(walker.configuration.components[1])
+    return walker.energy - mu * n * unit(walker.energy)
+end
+
+"""
+    _init_gc_walkers!(liveset::LatticeGasWalkers, gc_params::GrandCanonicalNestedSamplingParameters)
+
+Initialize walkers with random microstates for grand-canonical NS.
+Each site is occupied independently with probability `gc_params.init_occupation_p`.
+"""
+function _init_gc_walkers!(liveset::LatticeGasWalkers, gc_params::GrandCanonicalNestedSamplingParameters)
+    h = liveset.hamiltonian
+    for walker in liveset.walkers
+        random_microstate!(walker.configuration; p=gc_params.init_occupation_p)
+        assign_energy!(walker, h; perturb_energy=gc_params.energy_perturbation)
+    end
+    return liveset
+end
+
+"""
+    nested_sampling_step!(liveset::LatticeGasWalkers,
+                          gc_params::GrandCanonicalNestedSamplingParameters,
+                          mc_routine::MCGrandCanonicalMoves;
+                          ns_iteration::Int=0)
+
+Perform one step of grand-canonical nested sampling.
+
+Sorts walkers by Ω = E − μN, removes the worst (highest Ω), clones a parent
+with Ω < Ω_worst, and decorrelates the clone via grand-canonical MCMC.
+
+# Returns
+- `iter`: Iteration number (or `missing` if the step failed).
+- `omega_max`: The Ω value of the removed walker (with units).
+- `energy`: The E value of the removed walker.
+- `num_particles`: The N value of the removed walker.
+- `liveset`: The updated liveset.
+- `gc_params`: The updated parameters.
+"""
+function nested_sampling_step!(liveset::LatticeGasWalkers,
+                               gc_params::GrandCanonicalNestedSamplingParameters,
+                               mc_routine::MCGrandCanonicalMoves;
+                               ns_iteration::Int=0)
+    ats = liveset.walkers
+    h = liveset.hamiltonian
+    mu = gc_params.chemical_potential
+    n_walkers = length(ats)
+
+    # Sort by grand potential (descending — worst first)
+    sort!(ats, by = w -> _grand_potential(w, mu), rev=true)
+
+    iter::Union{Missing,Int} = missing
+    worst = ats[1]
+    omega_worst = _grand_potential(worst, mu)
+    energy_worst = worst.energy
+    n_worst = sum(worst.configuration.components[1])
+
+    # Select parent: prefer walkers strictly below omega_worst
+    omega_max_val = omega_worst.val  # unitless for the MC function
+    eligible = [k for k in 2:n_walkers if _grand_potential(ats[k], mu) < omega_worst]
+    if !isempty(eligible)
+        parent_idx = rand(eligible)
+    else
+        parent_idx = rand(2:n_walkers)
+    end
+    to_walk = deepcopy(ats[parent_idx])
+
+    # Decorrelate via GC MCMC
+    accept, rate, to_walk = MC_grand_canonical_walk!(
+        gc_params.mc_steps, to_walk, h, omega_max_val, mu;
+        p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
+        energy_perturb=gc_params.energy_perturbation)
+
+    if accept
+        push!(ats, to_walk)
+        popfirst!(ats)
+        update_iter!(liveset)
+        gc_params.fail_count = 0
+        iter = liveset.walkers[1].iter
+    else
+        omega_worst = missing
+        energy_worst = missing
+        n_worst = missing
+        gc_params.fail_count += 1
+    end
+
+    return iter, omega_worst, energy_worst, n_worst, liveset, gc_params
+end
+
+"""
+    grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
+                                    gc_params::GrandCanonicalNestedSamplingParameters,
+                                    n_steps::Int64,
+                                    mc_routine::MCGrandCanonicalMoves,
+                                    save_strategy::DataSavingStrategy)
+
+Run the grand-canonical nested sampling loop.
+
+Initializes walkers with random microstates, then iterates: remove the
+highest-Ω walker, record (Ω, E, N), replace with a decorrelated clone.
+
+# Arguments
+- `liveset::LatticeGasWalkers`: The initial liveset (walkers will be re-initialized).
+- `gc_params::GrandCanonicalNestedSamplingParameters`: GC-NS parameters including μ.
+- `n_steps::Int64`: Number of NS iterations.
+- `mc_routine::MCGrandCanonicalMoves`: The GC move routine.
+- `save_strategy::DataSavingStrategy`: Strategy for periodic output.
+
+# Returns
+- `df::DataFrame`: Columns `[:iter, :omega, :energy, :num_particles]`.
+- `liveset::LatticeGasWalkers`: The final liveset (surviving walkers).
+- `gc_params::GrandCanonicalNestedSamplingParameters`: Updated parameters.
+"""
+function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
+                                         gc_params::GrandCanonicalNestedSamplingParameters,
+                                         n_steps::Int64,
+                                         mc_routine::MCGrandCanonicalMoves,
+                                         save_strategy::DataSavingStrategy)
+    # Initialize walkers with random microstates
+    _init_gc_walkers!(liveset, gc_params)
+
+    df = DataFrame(iter=Int[], omega=Float64[], energy=Float64[], num_particles=Int[])
+
+    for i in 1:n_steps
+        print_info = i % save_strategy.n_info == 0
+        write_walker_every_n(liveset.walkers[1], i, save_strategy)
+
+        iter, omega, energy, n_par, liveset, gc_params = nested_sampling_step!(
+            liveset, gc_params, mc_routine; ns_iteration=i)
+
+        @debug "GC-NS step $i, iter: $iter, omega: $omega, energy: $energy, N: $n_par"
+
+        if gc_params.fail_count >= gc_params.allowed_fail_count
+            @warn "GC-NS: Failed $(gc_params.allowed_fail_count) times in a row."
+            gc_params.fail_count = 0
+        end
+
+        if !(iter isa typeof(missing))
+            push!(df, (iter, omega.val, energy.val, n_par))
+        end
+
+        if print_info && !(iter isa typeof(missing))
+            @info "GC-NS iter: $(iter), Ω: $(omega), E: $(energy), N: $(n_par)"
+        elseif print_info && iter isa typeof(missing)
+            @info "GC-NS MC move failed, step: $(i)"
+        end
+
+        write_df_every_n(df, i, save_strategy)
+        write_ls_every_n(liveset, i, save_strategy)
+    end
+
+    return df, liveset, gc_params
+end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -8,5 +8,7 @@
     include("test-nvt_monte_carlo.jl")
     # test Wang-Landau
     include("test-wang_landau.jl")
+    # test grand-canonical nested sampling
+    include("test-grand_canonical_ns.jl")
 
 end

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -25,6 +25,7 @@
         @test gc_params.fail_count == 0
         @test gc_params.allowed_fail_count == 10
         @test gc_params.init_occupation_p == 0.5
+        @test gc_params.n_max == typemax(Int64)
  
         gc_params2 = GrandCanonicalNestedSamplingParameters(
             mc_steps=200, chemical_potential=-0.05,
@@ -32,7 +33,11 @@
         @test gc_params2.mc_steps == 200
         @test gc_params2.chemical_potential == -0.05
         @test gc_params2.init_occupation_p == 0.3
- 
+        @test gc_params2.n_max == typemax(Int64)
+
+        gc_params3 = GrandCanonicalNestedSamplingParameters(n_max=Int64(5))
+        @test gc_params3.n_max == 5
+
         # Test mutability
         gc_params.fail_count = 5
         @test gc_params.fail_count == 5
@@ -328,5 +333,35 @@
         rm("test_val.csv", force=true)
         rm("test_val.traj", force=true)
         rm("test_val.ls", force=true)
+    end
+
+    # ================================================================
+    @testset "n_max enforcement" begin
+        n_max_val = Int64(5)
+        walkers_nm = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:10]
+        liveset_nm = LatticeGasWalkers(walkers_nm, ham; assign_energy=false)
+
+        gc_params_nm = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05,
+            init_occupation_p=0.5, n_max=n_max_val)
+        mc_routine_nm = MCGrandCanonicalMoves()
+        save_nm = SaveEveryN("test_nmax_df.csv", "test_nmax.traj", "test_nmax.ls", 10000, 10000, 10000)
+
+        df_nm, updated_liveset_nm, _ = grand_canonical_nested_sampling(
+            liveset_nm, gc_params_nm, Int64(50), mc_routine_nm, save_nm)
+
+        # After initialization, all walkers must respect n_max
+        for w in updated_liveset_nm.walkers
+            @test sum(w.configuration.components[1]) <= n_max_val
+        end
+
+        # All recorded samples must respect n_max
+        if nrow(df_nm) > 0
+            @test all(df_nm.num_particles .<= n_max_val)
+        end
+
+        rm("test_nmax_df.csv", force=true)
+        rm("test_nmax.traj", force=true)
+        rm("test_nmax.ls", force=true)
     end
 end

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -41,6 +41,18 @@
         # Test mutability
         gc_params.fail_count = 5
         @test gc_params.fail_count == 5
+
+        # Cluster field defaults
+        @test gc_params.cluster_p == 0.3
+        @test gc_params.cluster_accepted == 0.0
+        @test gc_params.cluster_total == 0.0
+        @test gc_params.cluster_p_history == Float64[]
+        @test gc_params.cluster_accept_history == Float64[]
+        @test gc_params.cluster_adjust_iterations == Int[]
+
+        # Cluster field mutability
+        gc_params.cluster_p = 0.5
+        @test gc_params.cluster_p == 0.5
     end
  
     # ================================================================
@@ -53,7 +65,23 @@
         mc2 = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
         @test mc2.p_move == 0.4
         @test mc2.p_insert == 0.3
- 
+
+        # Cluster field defaults
+        @test mc.clusters_freq == 0
+        @test mc.swaps_freq == 1
+        @test mc.initial_cluster_p == 0.3
+        @test mc.target_cluster_accept == 0.3
+        @test mc.cluster_adjust_interval == 50
+        @test mc.cluster_p_floor == 0.01
+        @test mc.cluster_p_ceiling == 1.0
+
+        # Cluster-enabled construction
+        mc3 = MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25,
+            clusters_freq=3, swaps_freq=1, initial_cluster_p=0.5)
+        @test mc3.clusters_freq == 3
+        @test mc3.swaps_freq == 1
+        @test mc3.initial_cluster_p == 0.5
+
         # Invalid probabilities
         @test_throws ArgumentError MCGrandCanonicalMoves(p_move=0.8, p_insert=0.3)
         @test_throws ArgumentError MCGrandCanonicalMoves(p_move=-0.1, p_insert=0.3)
@@ -138,14 +166,17 @@
         n_init = sum(walker.configuration.components[1])
         omega_max = walker.energy.val - mu * n_init + 1.0  # generous upper bound
  
-        accept, rate, updated_walker = MC_grand_canonical_walk!(
+        accept, rate, updated_walker, cl_acc, cl_tot = MC_grand_canonical_walk!(
             100, walker, ham, omega_max, mu;
             p_move=0.5, p_insert=0.25, energy_perturb=0.0)
- 
+
         @test accept isa Bool
         @test 0.0 <= rate <= 1.0
         @test updated_walker isa LatticeWalker{1}
- 
+        # No cluster moves when clusters_freq=0 (default)
+        @test cl_acc == 0
+        @test cl_tot == 0
+
         # Energy should be consistent with the configuration
         expected_energy = interacting_energy(updated_walker.configuration, ham)
         @test updated_walker.energy ≈ expected_energy
@@ -159,7 +190,34 @@
         @test_throws ArgumentError MC_grand_canonical_walk!(
             10, walker, ham, omega_max, mu; p_move=0.8, p_insert=0.3)
     end
- 
+
+    # ================================================================
+    @testset "MC_grand_canonical_walk! with cluster moves" begin
+        walker = LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0)
+        assign_energy!(walker, ham)
+
+        mu = -0.05
+        n_init = sum(walker.configuration.components[1])
+        omega_max = walker.energy.val - mu * n_init + 1.0
+
+        accept, rate, updated_walker, cl_acc, cl_tot = MC_grand_canonical_walk!(
+            200, walker, ham, omega_max, mu;
+            p_move=0.5, p_insert=0.25, energy_perturb=0.0,
+            clusters_freq=1, swaps_freq=1, cluster_p=0.3)
+
+        @test accept isa Bool
+        @test 0.0 <= rate <= 1.0
+        @test updated_walker isa LatticeWalker{1}
+        # Should have attempted some cluster moves
+        @test cl_tot > 0
+        @test cl_acc >= 0
+        @test cl_acc <= cl_tot
+
+        # Energy should be consistent
+        expected_energy = interacting_energy(updated_walker.configuration, ham)
+        @test updated_walker.energy ≈ expected_energy
+    end
+
     # ================================================================
     @testset "nested_sampling_step! for GC" begin
         walkers = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:5]
@@ -363,5 +421,112 @@
         rm("test_nmax_df.csv", force=true)
         rm("test_nmax.traj", force=true)
         rm("test_nmax.ls", force=true)
+    end
+
+    # ================================================================
+    @testset "GC-NS with cluster moves: basic functionality" begin
+        walkers_cl = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:10]
+        liveset_cl = LatticeGasWalkers(walkers_cl, ham; assign_energy=false)
+
+        gc_params_cl = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05)
+        mc_routine_cl = MCGrandCanonicalMoves(
+            p_move=0.5, p_insert=0.25,
+            clusters_freq=1, swaps_freq=1, initial_cluster_p=0.3,
+            cluster_adjust_interval=20)
+        save_cl = SaveEveryN("test_gc_cl_df.csv", "test_gc_cl.traj", "test_gc_cl.ls", 10000, 10000, 10000)
+
+        df_cl, updated_liveset_cl, updated_params_cl = grand_canonical_nested_sampling(
+            liveset_cl, gc_params_cl, Int64(50), mc_routine_cl, save_cl)
+
+        @test df_cl isa DataFrame
+        @test names(df_cl) == ["iter", "omega", "energy", "num_particles"]
+        @test nrow(df_cl) > 0
+        @test length(updated_liveset_cl.walkers) == 10
+
+        # Cluster adaptation should have been active
+        @test length(updated_params_cl.cluster_p_history) >= 0
+        # cluster_p should be within bounds
+        @test updated_params_cl.cluster_p >= mc_routine_cl.cluster_p_floor
+        @test updated_params_cl.cluster_p <= mc_routine_cl.cluster_p_ceiling
+
+        rm("test_gc_cl_df.csv", force=true)
+        rm("test_gc_cl.traj", force=true)
+        rm("test_gc_cl.ls", force=true)
+    end
+
+    # ================================================================
+    @testset "GC-NS with cluster moves: validation against exact enumeration" begin
+        # Reuse the 4x4 lattice and Hamiltonian from Study B
+        L = 4
+        lattice_template_cl = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(L, L, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:L*L]],
+            adsorptions=:full
+        )
+        ham_cl = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        n_sites_cl = L * L
+
+        mu_cl = -0.05
+        kb = 8.617333262e-5
+        T_cl = 300.0
+        beta_cl = 1.0 / (kb * T_cl)
+
+        # Exact enumeration
+        exact_z_cl = 0.0
+        exact_N_cl = 0.0
+        for mask in 0:(2^n_sites_cl - 1)
+            lat = deepcopy(lattice_template_cl)
+            for site in 1:n_sites_cl
+                lat.components[1][site] = ((mask >> (site - 1)) & 1) == 1
+            end
+            E_v = interacting_energy(lat, ham_cl).val
+            N_v = sum(lat.components[1])
+            omega_v = E_v - mu_cl * N_v
+            boltz = exp(-beta_cl * omega_v)
+            exact_z_cl += boltz
+            exact_N_cl += boltz * N_v
+        end
+        exact_mean_N_cl = exact_N_cl / exact_z_cl
+        exact_ln_z_cl = log(exact_z_cl)
+
+        # Run GC-NS with cluster moves
+        n_walkers_cl = 100
+        n_steps_cl = Int64(3000)
+        walkers_val_cl = [LatticeWalker(deepcopy(lattice_template_cl), energy=0.0u"eV", iter=0)
+                          for _ in 1:n_walkers_cl]
+        liveset_val_cl = LatticeGasWalkers(walkers_val_cl, ham_cl; assign_energy=false)
+
+        gc_params_val_cl = GrandCanonicalNestedSamplingParameters(
+            mc_steps=100, chemical_potential=mu_cl,
+            energy_perturbation=1e-12, init_occupation_p=0.5)
+        mc_routine_val_cl = MCGrandCanonicalMoves(
+            p_move=0.5, p_insert=0.25,
+            clusters_freq=3, swaps_freq=1, initial_cluster_p=0.3,
+            cluster_adjust_interval=50)
+        save_val_cl = SaveEveryN("test_val_cl.csv", "test_val_cl.traj", "test_val_cl.ls", 10000, 10000, 10000)
+
+        df_val_cl, _, params_val_cl = grand_canonical_nested_sampling(
+            liveset_val_cl, gc_params_val_cl, n_steps_cl, mc_routine_val_cl, save_val_cl)
+
+        @test nrow(df_val_cl) > 0
+
+        # Compute NS thermodynamic stats
+        mean_E_cl, Cv_cl, mean_N_ns_cl = gc_thermodynamic_stats(
+            df_val_cl, [beta_cl], n_walkers_cl, mu_cl)
+
+        # Compare ⟨N⟩ with exact (|error| < 0.5)
+        @test abs(mean_N_ns_cl[1] - exact_mean_N_cl) < 0.5
+
+        # Cluster adaptation should have fired
+        @test length(params_val_cl.cluster_p_history) > 0
+
+        rm("test_val_cl.csv", force=true)
+        rm("test_val_cl.traj", force=true)
+        rm("test_val_cl.ls", force=true)
     end
 end

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -1,0 +1,332 @@
+@testset "Grand-canonical nested sampling tests" begin
+ 
+    # ================================================================
+    # Shared lattice and Hamiltonian for all GC tests
+    # ================================================================
+    square_lattice = MLattice{1,SquareLattice}(
+        lattice_constant=1.0,
+        basis=[(0.0, 0.0, 0.0)],
+        supercell_dimensions=(4, 4, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1, 1.5],
+        components=:equal,
+        adsorptions=:full
+    )
+    ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+ 
+    # ================================================================
+    @testset "GrandCanonicalNestedSamplingParameters" begin
+        gc_params = GrandCanonicalNestedSamplingParameters()
+        @test gc_params isa SamplingSchemes.SamplingParameters
+        @test gc_params.mc_steps == 100
+        @test gc_params.chemical_potential == 0.0
+        @test gc_params.energy_perturbation == 1e-12
+        @test gc_params.random_seed == 1234
+        @test gc_params.fail_count == 0
+        @test gc_params.allowed_fail_count == 10
+        @test gc_params.init_occupation_p == 0.5
+ 
+        gc_params2 = GrandCanonicalNestedSamplingParameters(
+            mc_steps=200, chemical_potential=-0.05,
+            init_occupation_p=0.3)
+        @test gc_params2.mc_steps == 200
+        @test gc_params2.chemical_potential == -0.05
+        @test gc_params2.init_occupation_p == 0.3
+ 
+        # Test mutability
+        gc_params.fail_count = 5
+        @test gc_params.fail_count == 5
+    end
+ 
+    # ================================================================
+    @testset "MCGrandCanonicalMoves" begin
+        mc = MCGrandCanonicalMoves()
+        @test mc isa MCRoutine
+        @test mc.p_move == 0.5
+        @test mc.p_insert == 0.25
+ 
+        mc2 = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+        @test mc2.p_move == 0.4
+        @test mc2.p_insert == 0.3
+ 
+        # Invalid probabilities
+        @test_throws ArgumentError MCGrandCanonicalMoves(p_move=0.8, p_insert=0.3)
+        @test_throws ArgumentError MCGrandCanonicalMoves(p_move=-0.1, p_insert=0.3)
+    end
+ 
+    # ================================================================
+    @testset "random_microstate!" begin
+        lattice = deepcopy(square_lattice)
+ 
+        # p=0 gives empty lattice
+        random_microstate!(lattice; p=0.0)
+        @test sum(lattice.components[1]) == 0
+ 
+        # p=1 gives full lattice
+        random_microstate!(lattice; p=1.0)
+        @test sum(lattice.components[1]) == num_sites(lattice)
+ 
+        # p=0.5 gives variable occupancy (statistical — just check it runs)
+        counts = Int[]
+        for _ in 1:50
+            random_microstate!(lattice; p=0.5)
+            push!(counts, sum(lattice.components[1]))
+        end
+        # With 16 sites and p=0.5, we should see variation
+        @test minimum(counts) < maximum(counts)
+        # Mean should be roughly 8
+        @test 4 < mean(counts) < 12
+    end
+ 
+    # ================================================================
+    @testset "lattice_insert_particle!" begin
+        lattice = deepcopy(square_lattice)
+        lattice.components[1] .= false
+        n_sites = num_sites(lattice)
+ 
+        # Insert into empty lattice
+        success, _ = lattice_insert_particle!(lattice)
+        @test success
+        @test sum(lattice.components[1]) == 1
+ 
+        # Fill the lattice
+        for _ in 2:n_sites
+            lattice_insert_particle!(lattice)
+        end
+        @test sum(lattice.components[1]) == n_sites
+ 
+        # Insert into full lattice should fail
+        success, _ = lattice_insert_particle!(lattice)
+        @test !success
+        @test sum(lattice.components[1]) == n_sites
+    end
+ 
+    # ================================================================
+    @testset "lattice_delete_particle!" begin
+        lattice = deepcopy(square_lattice)
+        lattice.components[1] .= true
+        n_sites = num_sites(lattice)
+ 
+        # Delete from full lattice
+        success, _ = lattice_delete_particle!(lattice)
+        @test success
+        @test sum(lattice.components[1]) == n_sites - 1
+ 
+        # Empty the lattice
+        lattice.components[1] .= false
+        lattice.components[1][1] = true
+        success, _ = lattice_delete_particle!(lattice)
+        @test success
+        @test sum(lattice.components[1]) == 0
+ 
+        # Delete from empty lattice should fail
+        success, _ = lattice_delete_particle!(lattice)
+        @test !success
+    end
+ 
+    # ================================================================
+    @testset "MC_grand_canonical_walk!" begin
+        walker = LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0)
+        assign_energy!(walker, ham)
+ 
+        mu = -0.05  # in eV
+        n_init = sum(walker.configuration.components[1])
+        omega_max = walker.energy.val - mu * n_init + 1.0  # generous upper bound
+ 
+        accept, rate, updated_walker = MC_grand_canonical_walk!(
+            100, walker, ham, omega_max, mu;
+            p_move=0.5, p_insert=0.25, energy_perturb=0.0)
+ 
+        @test accept isa Bool
+        @test 0.0 <= rate <= 1.0
+        @test updated_walker isa LatticeWalker{1}
+ 
+        # Energy should be consistent with the configuration
+        expected_energy = interacting_energy(updated_walker.configuration, ham)
+        @test updated_walker.energy ≈ expected_energy
+ 
+        # Omega should be below omega_max
+        n_final = sum(updated_walker.configuration.components[1])
+        omega_final = updated_walker.energy.val - mu * n_final
+        @test omega_final < omega_max
+ 
+        # Invalid probability should throw
+        @test_throws ArgumentError MC_grand_canonical_walk!(
+            10, walker, ham, omega_max, mu; p_move=0.8, p_insert=0.3)
+    end
+ 
+    # ================================================================
+    @testset "nested_sampling_step! for GC" begin
+        walkers = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:5]
+        liveset = LatticeGasWalkers(walkers, ham)
+ 
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05)
+        mc_routine = MCGrandCanonicalMoves()
+ 
+        # Initialize walkers with random microstates
+        SamplingSchemes._init_gc_walkers!(liveset, gc_params)
+ 
+        e_type = typeof(walkers[1].energy)
+        iter, omega, energy, n_par, updated_liveset, updated_params = nested_sampling_step!(
+            liveset, gc_params, mc_routine)
+ 
+        @test iter isa Union{Missing,Int}
+        @test omega isa Union{Missing,e_type}
+        @test energy isa Union{Missing,e_type}
+        @test n_par isa Union{Missing,Int}
+        @test length(updated_liveset.walkers) == 5
+        @test updated_params.fail_count >= 0
+    end
+ 
+    # ================================================================
+    @testset "grand_canonical_nested_sampling loop" begin
+        walkers = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:10]
+        liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
+ 
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05)
+        mc_routine = MCGrandCanonicalMoves()
+        save_strategy = SaveEveryN("test_gc_df.csv", "test_gc.traj", "test_gc.ls", 1000, 1000, 1000)
+ 
+        df, updated_liveset, updated_params = grand_canonical_nested_sampling(
+            liveset, gc_params, Int64(20), mc_routine, save_strategy)
+ 
+        @test df isa DataFrame
+        @test names(df) == ["iter", "omega", "energy", "num_particles"]
+        @test nrow(df) <= 20
+        @test nrow(df) > 0  # At least some steps should succeed
+        @test eltype(df.iter) == Int
+        @test eltype(df.omega) == Float64
+        @test eltype(df.energy) == Float64
+        @test eltype(df.num_particles) == Int
+        @test length(updated_liveset.walkers) == 10
+ 
+        # Omega should be monotonically non-increasing (each recorded Ω <= previous)
+        if nrow(df) > 1
+            for i in 2:nrow(df)
+                @test df.omega[i] <= df.omega[1] + 1e-10
+            end
+        end
+ 
+        rm("test_gc_df.csv", force=true)
+        rm("test_gc.traj", force=true)
+        rm("test_gc.ls", force=true)
+    end
+ 
+    # ================================================================
+    @testset "gc_thermodynamic_stats basic" begin
+        # Hand-crafted test: 2 microstates
+        # Microstate 1: E=0, N=0, Ω=0
+        # Microstate 2: E=-1, N=1, Ω=-1-μ*1
+        μ = -0.5
+        ωi = [0.5, 0.5]
+        grand_es = [0.0, -1.0 - μ * 1.0]  # Ω = E - μN
+        Es = [0.0, -1.0]
+        Ns = [0, 1]
+ 
+        # At β=0 (infinite T), equal weights
+        u, cv_val, n_avg = gc_thermodynamic_stats(
+            0.001, ωi, grand_es, Es, Ns, μ; kb=1.0)
+        @test isfinite(u)
+        @test isfinite(cv_val)
+        @test isfinite(n_avg)
+        # At very low β, should be roughly equal mixture
+        @test n_avg ≈ 0.5 atol=0.1
+ 
+        # Dimension mismatch should throw
+        @test_throws DimensionMismatch gc_thermodynamic_stats(
+            1.0, [0.5], [0.0, 1.0], [0.0, 1.0], [0, 1], 0.0)
+    end
+ 
+    # ================================================================
+    @testset "Validation against exact grand-canonical enumeration" begin
+        # 4x4 lattice, NN interactions only, single component
+        # Exact: sum over all 2^16 = 65536 microstates
+        L = 4
+        lattice_template = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(L, L, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:L*L]],
+            adsorptions=:full
+        )
+        ham_val = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        n_sites = L * L
+ 
+        # Exact grand-canonical enumeration
+        mu_val = -0.05  # eV
+        kb = 8.617333262e-5  # eV/K
+        T_test = 300.0  # K
+        beta_test = 1.0 / (kb * T_test)
+ 
+        # Enumerate all 2^16 microstates
+        exact_z = 0.0
+        exact_E = 0.0
+        exact_E2 = 0.0
+        exact_N = 0.0
+        exact_EN = 0.0
+ 
+        for mask in 0:(2^n_sites - 1)
+            lattice = deepcopy(lattice_template)
+            for site in 1:n_sites
+                lattice.components[1][site] = ((mask >> (site - 1)) & 1) == 1
+            end
+            E_val = interacting_energy(lattice, ham_val).val
+            N_val = sum(lattice.components[1])
+            omega_val = E_val - mu_val * N_val
+ 
+            boltz = exp(-beta_test * omega_val)
+            exact_z += boltz
+            exact_E += boltz * E_val
+            exact_E2 += boltz * E_val^2
+            exact_N += boltz * N_val
+            exact_EN += boltz * E_val * N_val
+        end
+ 
+        exact_mean_E = exact_E / exact_z
+        exact_mean_N = exact_N / exact_z
+        exact_mean_E2 = exact_E2 / exact_z
+        exact_mean_EN = exact_EN / exact_z
+        exact_var_E = exact_mean_E2 - exact_mean_E^2
+        exact_cov_EN = exact_mean_EN - exact_mean_E * exact_mean_N
+        exact_Cv = kb * beta_test^2 * (exact_var_E - mu_val * exact_cov_EN)
+ 
+        # Run GC-NS with enough walkers and iterations
+        n_walkers = 100
+        n_steps = Int64(3000)
+ 
+        walkers = [LatticeWalker(deepcopy(lattice_template), energy=0.0u"eV", iter=0)
+                   for _ in 1:n_walkers]
+        liveset = LatticeGasWalkers(walkers, ham_val; assign_energy=false)
+ 
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=100, chemical_potential=mu_val,
+            energy_perturbation=1e-12, init_occupation_p=0.5)
+        mc_routine = MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25)
+        save_strategy = SaveEveryN("test_val.csv", "test_val.traj", "test_val.ls", 10000, 10000, 10000)
+ 
+        df, _, _ = grand_canonical_nested_sampling(
+            liveset, gc_params, n_steps, mc_routine, save_strategy)
+ 
+        @test nrow(df) > 0
+ 
+        # Compute NS thermodynamic stats
+        mean_E_ns, Cv_ns, mean_N_ns = gc_thermodynamic_stats(
+            df, [beta_test], n_walkers, mu_val)
+ 
+        # Compare with exact values (generous tolerances for stochastic algorithm)
+        @test mean_E_ns[1] ≈ exact_mean_E rtol=0.3
+        @test mean_N_ns[1] ≈ exact_mean_N rtol=0.3
+        # Cv is harder to converge; just check it's in the right ballpark
+        if isfinite(Cv_ns[1]) && isfinite(exact_Cv) && exact_Cv > 0
+            @test Cv_ns[1] > 0
+        end
+ 
+        rm("test_val.csv", force=true)
+        rm("test_val.traj", force=true)
+        rm("test_val.ls", force=true)
+    end
+end


### PR DESCRIPTION
This PR introduces a complete grand-canonical nested sampling (GC-NS) implementation for lattice systems, enabling sampling at fixed chemical potential μ with variable particle number N. It builds on the geometric cluster move infrastructure already present in `dev` and extends it to the variable-N regime.

**What's new**

GC-NS sorts walkers by the grand potential `Ω = E − μN` rather than energy alone. Each MCMC step mixes three move types: fixed-N moves (local swaps and/or geometric cluster moves), single-site insertions, and single-site deletions, with configurable probabilities. Insert and delete proposals carry the appropriate Metropolis correction for detailed balance under the uniform-microstate prior; fixed-N moves remain symmetric and require only the `Ω < Ω_max` check.

New types and functions:
- **`MCGrandCanonicalMoves`**: Static configuration struct specifying move probabilities (`p_move`, `p_insert`), the cluster/swap mixing ratio (`clusters_freq`, `swaps_freq`), and adaptive cluster-tuning parameters. Defaults to swap-only behavior (`clusters_freq=0`).
- **`GrandCanonicalNestedSamplingParameters`**: Mutable runtime state, including `mc_steps`, `chemical_potential`, `init_occupation_p`, and `n_max`, plus cluster adaptation accumulators (`cluster_p`, `cluster_accepted`, `cluster_total`) and full diagnostic histories (`cluster_p_history`, `cluster_accept_history`, `cluster_adjust_iterations`).
- **`MC_grand_canonical_walk!`**: The inner MCMC kernel. Branches between fixed-N moves (cluster vs. local swap by frequency ratio) and insert/delete; applies the Metropolis correction to particle-changing moves and returns cluster acceptance counts for adaptive tuning.
- **`grand_canonical_nested_sampling`**: The outer NS loop. Initializes walkers with random microstates (respecting `n_max`), then iterates remove-worst-Ω, clone, decorrelate, recording `(iter, Ω, E, N)` per step.
- **`gc_thermodynamic_stats`**: Post-processing for grand-canonical thermodynamic averages from a GC-NS DataFrame, computing `⟨E⟩`, `⟨N⟩`, and `C_{V,μ} = k_B β² [Var(E) − μ Cov(E, N)]` at arbitrary β via log-sum-exp reweighting. Both a low-level method (operating on raw vectors) and a DataFrame convenience method are provided; the DataFrame version threads over β values.

Supporting additions:
- New move primitives in `MonteCarloMoves`: `random_microstate!`, `lattice_insert_particle!`, and `lattice_delete_particle!`.
- Internal helpers in `SamplingSchemes`: `_grand_potential` (which computes `Ω = E − μN` per walker) and `_init_gc_walkers!` (which performs random initialization with `n_max` enforcement via random deletion).
- `assign_energy!` is now exported from `AbstractLiveSets`.

**Cluster move integration**

When `clusters_freq > 0` is set on `MCGrandCanonicalMoves`, the fixed-N branch mixes existing `geometric_cluster_swap!` calls with `lattice_random_walk!` according to the configured ratio. The adaptive `cluster_p` tuning machinery already on `dev` (via `adjust_cluster_p`) is reused: `MC_grand_canonical_walk!` returns cluster accept/total counters, and the GC-NS step accumulates them and triggers adjustments at the configured interval. Defaults preserve swap-only behavior, so existing call sites are unaffected.

**`n_max` parameter**

`GrandCanonicalNestedSamplingParameters` includes an `n_max` cap on per-walker particle count (default `typemax(Int64)`). Insertions are rejected when `N ≥ n_max`, and `_init_gc_walkers!` enforces the cap on the initial random microstates by random deletion.

**Tests**

A new `test-grand_canonical_ns.jl` file with 12 testsets covers:
- Constructor defaults and validation for both new structs (including all cluster-related fields and the `ArgumentError` paths)
- Move primitives (`random_microstate!`, `lattice_insert_particle!`, `lattice_delete_particle!`), including edge cases such as full and empty lattices
- `MC_grand_canonical_walk!` with and without cluster moves: energy/configuration consistency, Ω bounds, return-tuple shape
- Single-step `nested_sampling_step!` for GC and the full `grand_canonical_nested_sampling` loop: DataFrame schema, Ω monotonicity, and walker count preservation
- `gc_thermodynamic_stats` basic correctness and `DimensionMismatch` handling
- **Validation against exact enumeration** on a 4×4 lattice (2¹⁶ microstates) for both swap-only and cluster-enabled GC-NS runs: `⟨E⟩` and `⟨N⟩` match the analytic grand-canonical averages within tolerance
- `n_max` enforcement: every initial walker and every recorded sample respects the cap