### PR TITLE
Atomistic fixed-N grand-canonical nested sampling post-processing

### DIFF
--- a/src/AbstractPotentials/AbstractPotentials.jl
+++ b/src/AbstractPotentials/AbstractPotentials.jl
@@ -23,6 +23,7 @@ export CompositeParameterSets
 export LJParameters, lj_energy
 export LennardJonesParameterSets
 export GuptaParameters
+export IdealGasParameters
 export PyCalculator
 
 
@@ -102,6 +103,8 @@ include("composite_paramsets.jl")
 include("lennardjones.jl")
 
 include("gupta.jl")
+
+include("ideal_gas.jl")
 
 include("ase_calculators.jl")
 

--- a/src/AbstractPotentials/ideal_gas.jl
+++ b/src/AbstractPotentials/ideal_gas.jl
@@ -1,0 +1,23 @@
+"""
+    struct IdealGasParameters
+
+A zero-interaction potential representing a classical ideal gas.
+
+`IdealGasParameters` is a `SingleComponentPotential{Pairwise}` whose `pair_energy`
+is identically zero at any separation. All existing pairwise dispatch paths
+(`intra_component_energy`, `inter_component_energy`, `interacting_energy`,
+`frozen_energy`) therefore evaluate to `0.0u"eV"` without any further methods.
+
+The intended use is as an analytical reference for grand-canonical post-processing:
+the ideal-gas grand partition function has the closed form `Ξ(μ, T) = exp(zV)` with
+`z = exp(βμ)/Λ(T)³`, which provides the cleanest possible check of normalization,
+fugacity, and thermal-wavelength conventions in downstream analysis code.
+"""
+struct IdealGasParameters <: SingleComponentPotential{Pairwise} end
+
+"""
+    pair_energy(r::typeof(1.0u"Å"), ::IdealGasParameters)
+
+Return `0.0u"eV"` at any separation `r`. The ideal gas has no pair interactions.
+"""
+pair_energy(::typeof(1.0u"Å"), ::IdealGasParameters) = 0.0u"eV"

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -412,8 +412,12 @@ the resulting bias is small but visible at low T or shallow NS; for the absolute
   any DataFrame (e.g., `DataFrame(iter=Int[], emax=Float64[])`).
 - `N_values::AbstractVector{<:Integer}`: particle counts corresponding to each
   DataFrame. Must include `0`; `length(N_values) == length(ns_outputs)`.
-- `V::typeof(1.0u"Å^3")`: accessible configurational volume (explicit; for
-  surface systems this is *not* the simulation-box volume).
+- `V::typeof(1.0u"Å^3")`: the simulation-box volume, i.e. the NS prior volume
+  per particle (NS samples positions uniformly over the box). This is what
+  closes `Z_N^{config} = V^N · Z_{NS}^{(N)}`, so it must *not* be reduced to an
+  accessible or adsorption-region sub-volume. For surface systems the
+  substrate's volume exclusion is captured by the Boltzmann factor inside
+  `Z_{NS}^{(N)}`, not by shrinking `V`.
 - `atomic_mass::typeof(1.0u"u")`: per-atom mass for `Λ(T)`.
 - `μ_grid::AbstractVector{<:typeof(1.0u"eV")}`: chemical potentials.
 - `T_grid::AbstractVector{<:Unitful.Temperature}`: temperatures.

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -7,10 +7,12 @@ module AnalysisTools
 
 using DataFrames
 using CSV, Arrow
+using Unitful
 
 export read_output
 export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
+export gc_thermodynamic_stats_fixed_N
 
 """
     read_output(filename::String)
@@ -334,6 +336,158 @@ function gc_thermodynamic_stats(df::DataFrame,
     end
 
     return mean_Es, Cvs, mean_Ns
+end
+
+
+"""
+    _thermal_wavelength(atomic_mass::typeof(1.0u"u"), T::Unitful.Temperature) -> typeof(1.0u"Å")
+
+Compute the thermal de Broglie wavelength `Λ = h / sqrt(2π m k_B T)` in Å.
+Internal helper for `gc_thermodynamic_stats_fixed_N`.
+"""
+function _thermal_wavelength(atomic_mass::typeof(1.0u"u"), T::Unitful.Temperature)
+    return uconvert(u"Å", Unitful.h / sqrt(2π * atomic_mass * Unitful.k * T))
+end
+
+"""
+    _log_factorial(n::Integer) -> Float64
+
+Return `log(n!)` for small non-negative `n`, computed by summing `log(k)` to
+keep the result exact in floating point for `n` up to several dozen.
+"""
+function _log_factorial(n::Integer)
+    n < 0 && throw(ArgumentError("n must be non-negative"))
+    n == 0 && return 0.0
+    return sum(log, 1:n)
+end
+
+"""
+    gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
+                                   n_walkers=120, n_cull=1, ω0=1.0,
+                                   kb=8.617333262e-5)
+
+Compute grand-canonical thermodynamic averages from a stack of canonical
+nested-sampling outputs, one per fixed particle number `N`.
+
+For each `N`, the canonical NS evidence at inverse temperature `β` is
+
+```math
+Z_{\\mathrm{NS}}^{(N)}(\\beta) = \\sum_i \\omega_i \\exp(-\\beta E_i)
+```
+
+— the prior-volume-normalized configurational integral. The absolute
+configurational partition function is `Z_N^{config}(\\beta) = V^N \\cdot Z_{NS}^{(N)}(\\beta)`.
+The grand partition function is assembled as
+
+```math
+\\Xi(\\mu, T) = \\sum_N \\frac{(zV)^N}{N!}\\, Z_{\\mathrm{NS}}^{(N)}(\\beta),
+\\qquad z = \\frac{\\exp(\\beta\\mu)}{\\Lambda(T)^3}
+```
+
+with the thermal wavelength `Λ(T) = h / sqrt(2π m k_B T)` computed from `atomic_mass`.
+The sum runs over the supplied `N_values`, which must include `0` (the empty
+configuration, `Z_{NS}^{(0)} = 1`). Truncation error at the upper end of `N_values`
+is bounded by the tail of `(zV)^N / N!` for the largest `⟨N⟩` requested.
+
+A log-sum-exp pass is used both inside each per-N evidence and across the
+grand sum for numerical stability.
+
+# Arguments
+- `ns_outputs::AbstractVector{<:DataFrame}`: one canonical-NS output per `N`,
+  each with columns `[:iter, :emax]` (matching the schema produced by
+  `nested_sampling`).
+- `N_values::AbstractVector{<:Integer}`: particle counts corresponding to each
+  DataFrame. Must include `0`; `length(N_values) == length(ns_outputs)`.
+- `V::typeof(1.0u"Å^3")`: accessible configurational volume (explicit; for
+  surface systems this is *not* the simulation-box volume).
+- `atomic_mass::typeof(1.0u"u")`: per-atom mass for `Λ(T)`.
+- `μ_grid::AbstractVector{<:typeof(1.0u"eV")}`: chemical potentials.
+- `T_grid::AbstractVector{<:Unitful.Temperature}`: temperatures.
+
+# Keyword arguments
+- `n_walkers::Int=120`: number of NS walkers used to produce each DataFrame.
+  Must be uniform across `ns_outputs`.
+- `n_cull::Int=1`: NS culls per iteration.
+- `ω0::Float64=1.0`: initial prior weight, passed to `ωᵢ`.
+- `kb::Float64`: Boltzmann constant in eV/K.
+
+# Returns
+A `NamedTuple` `(Xi, mean_N, var_N, mean_U)`. Each field is a `Matrix{Float64}`
+of size `(length(μ_grid), length(T_grid))` indexed `[i_μ, i_T]`. `Xi` is the
+absolute grand partition function, `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
+and `mean_U` is `⟨E⟩` (grand-canonical, in eV).
+"""
+function gc_thermodynamic_stats_fixed_N(
+    ns_outputs::AbstractVector{<:DataFrame},
+    N_values::AbstractVector{<:Integer},
+    V::typeof(1.0u"Å^3"),
+    atomic_mass::typeof(1.0u"u"),
+    μ_grid::AbstractVector{<:typeof(1.0u"eV")},
+    T_grid::AbstractVector{<:Unitful.Temperature};
+    n_walkers::Int=120,
+    n_cull::Int=1,
+    ω0::Float64=1.0,
+    kb::Float64=8.617333262e-5,
+)
+    if length(ns_outputs) != length(N_values)
+        throw(DimensionMismatch("ns_outputs and N_values must have the same length"))
+    end
+    if !(0 in N_values)
+        throw(ArgumentError("N_values must include 0 (the empty configuration)"))
+    end
+
+    N_int = collect(Int, N_values)
+    n_N = length(N_int)
+    n_mu = length(μ_grid)
+    n_T = length(T_grid)
+    V_val = ustrip(u"Å^3", V)
+
+    log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
+    mean_E_N = Matrix{Float64}(undef, n_N, n_T)
+
+    for (i, df) in enumerate(ns_outputs)
+        ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
+        Es = df.emax
+        for (j, T) in enumerate(T_grid)
+            β = 1.0 / (kb * ustrip(u"K", T))
+            log_terms = log.(ωi) .- β .* Es
+            max_log = maximum(log_terms)
+            ws = exp.(log_terms .- max_log)
+            sum_w = sum(ws)
+            log_Z_NS[i, j] = max_log + log(sum_w)
+            mean_E_N[i, j] = sum(ws .* Es) / sum_w
+        end
+    end
+
+    log_fact = [_log_factorial(N) for N in N_int]
+
+    Xi = Matrix{Float64}(undef, n_mu, n_T)
+    mean_N = Matrix{Float64}(undef, n_mu, n_T)
+    var_N = Matrix{Float64}(undef, n_mu, n_T)
+    mean_U = Matrix{Float64}(undef, n_mu, n_T)
+
+    for (j, T) in enumerate(T_grid)
+        β = 1.0 / (kb * ustrip(u"K", T))
+        Λ_val = ustrip(u"Å", _thermal_wavelength(atomic_mass, T))
+        log_V_over_Λ3 = log(V_val) - 3 * log(Λ_val)
+        for (k, μ) in enumerate(μ_grid)
+            μ_val = ustrip(u"eV", μ)
+            log_zV = β * μ_val + log_V_over_Λ3
+
+            log_w = log_Z_NS[:, j] .+ N_int .* log_zV .- log_fact
+            max_log = maximum(log_w)
+            ws = exp.(log_w .- max_log)
+            sum_w = sum(ws)
+
+            Xi[k, j] = exp(max_log) * sum_w
+            mean_N[k, j] = sum(ws .* N_int) / sum_w
+            mean_N2 = sum(ws .* (N_int .^ 2)) / sum_w
+            var_N[k, j] = mean_N2 - mean_N[k, j]^2
+            mean_U[k, j] = sum(ws .* view(mean_E_N, :, j)) / sum_w
+        end
+    end
+
+    return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -364,7 +364,7 @@ end
 """
     gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
                                    n_walkers=120, n_cull=1, ω0=1.0,
-                                   kb=8.617333262e-5)
+                                   live_emax=nothing, kb=8.617333262e-5)
 
 Compute grand-canonical thermodynamic averages from a stack of canonical
 nested-sampling outputs, one per fixed particle number `N`.
@@ -385,17 +385,31 @@ The grand partition function is assembled as
 ```
 
 with the thermal wavelength `Λ(T) = h / sqrt(2π m k_B T)` computed from `atomic_mass`.
-The sum runs over the supplied `N_values`, which must include `0` (the empty
-configuration, `Z_{NS}^{(0)} = 1`). Truncation error at the upper end of `N_values`
-is bounded by the tail of `(zV)^N / N!` for the largest `⟨N⟩` requested.
+The sum runs over the supplied `N_values`, which must include `0`. The `N=0` sector
+is treated specially: `Z_{NS}^{(0)} = 1` by definition (the empty configuration has no
+spatial integral), so the corresponding DataFrame contents are ignored. Truncation
+error at the upper end of `N_values` is bounded by the tail of `(zV)^N / N!` for the
+largest `⟨N⟩` requested.
 
 A log-sum-exp pass is used both inside each per-N evidence and across the
 grand sum for numerical stability.
 
+## Live-set tail correction
+
+After a finite number of NS iterations `n_iters` the recorded weights `ωᵢ` carry
+only `1 − (K/(K+n_cull))^{n_iters}` of the prior volume (times `ω0`); the remainder
+sits in the `K` surviving live walkers. Supplying `live_emax` (one vector of K live
+walker energies per `N`) adds the live-set tail to each per-N evidence: each live
+walker contributes weight `ω0 · (K/(K+n_cull))^{n_iters} / K` at its current energy.
+When omitted, the live-set tail is neglected — for ratio observables (`⟨N⟩`, `⟨U⟩`)
+the resulting bias is small but visible at low T or shallow NS; for the absolute
+`Ξ` it appears as a uniform-in-N prefactor that does not cancel.
+
 # Arguments
 - `ns_outputs::AbstractVector{<:DataFrame}`: one canonical-NS output per `N`,
   each with columns `[:iter, :emax]` (matching the schema produced by
-  `nested_sampling`).
+  `nested_sampling`). The entry corresponding to `N=0` is ignored and may be
+  any DataFrame (e.g., `DataFrame(iter=Int[], emax=Float64[])`).
 - `N_values::AbstractVector{<:Integer}`: particle counts corresponding to each
   DataFrame. Must include `0`; `length(N_values) == length(ns_outputs)`.
 - `V::typeof(1.0u"Å^3")`: accessible configurational volume (explicit; for
@@ -409,6 +423,9 @@ grand sum for numerical stability.
   Must be uniform across `ns_outputs`.
 - `n_cull::Int=1`: NS culls per iteration.
 - `ω0::Float64=1.0`: initial prior weight, passed to `ωᵢ`.
+- `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
+  when supplied, one vector of `K = n_walkers` live walker energies (in eV) per
+  `N`. The entry for `N=0` is ignored. See "Live-set tail correction" above.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
@@ -427,6 +444,7 @@ function gc_thermodynamic_stats_fixed_N(
     n_walkers::Int=120,
     n_cull::Int=1,
     ω0::Float64=1.0,
+    live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
     kb::Float64=8.617333262e-5,
 )
     if length(ns_outputs) != length(N_values)
@@ -434,6 +452,9 @@ function gc_thermodynamic_stats_fixed_N(
     end
     if !(0 in N_values)
         throw(ArgumentError("N_values must include 0 (the empty configuration)"))
+    end
+    if live_emax !== nothing && length(live_emax) != length(N_values)
+        throw(DimensionMismatch("live_emax and N_values must have the same length"))
     end
 
     N_int = collect(Int, N_values)
@@ -446,16 +467,38 @@ function gc_thermodynamic_stats_fixed_N(
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
 
     for (i, df) in enumerate(ns_outputs)
+        # The N = 0 sector is the empty configuration: Z_NS^{(0)} = 1 by
+        # definition. The corresponding DataFrame contents are ignored.
+        if N_int[i] == 0
+            log_Z_NS[i, :] .= 0.0
+            mean_E_N[i, :] .= 0.0
+            continue
+        end
+
         ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
-        Es = df.emax
+        Es = collect(Float64, df.emax)
+        n_iters = length(df.iter)
+        # Each live walker carries weight ω0 · (K/(K+n_cull))^n_iters / K,
+        # accounting for the prior volume that finite termination leaves in
+        # the live set.
+        log_tail = log(ω0) + n_iters * log(n_walkers / (n_walkers + n_cull)) -
+                   log(n_walkers)
         for (j, T) in enumerate(T_grid)
             β = 1.0 / (kb * ustrip(u"K", T))
-            log_terms = log.(ωi) .- β .* Es
+            if live_emax === nothing
+                log_terms = log.(ωi) .- β .* Es
+                Es_all = Es
+            else
+                Es_live = collect(Float64, live_emax[i])
+                log_terms = vcat(log.(ωi) .- β .* Es,
+                                 log_tail .- β .* Es_live)
+                Es_all = vcat(Es, Es_live)
+            end
             max_log = maximum(log_terms)
             ws = exp.(log_terms .- max_log)
             sum_w = sum(ws)
             log_Z_NS[i, j] = max_log + log(sum_w)
-            mean_E_N[i, j] = sum(ws .* Es) / sum_w
+            mean_E_N[i, j] = sum(ws .* Es_all) / sum_w
         end
     end
 

--- a/src/EnergyEval/atomistic_pairwise.jl
+++ b/src/EnergyEval/atomistic_pairwise.jl
@@ -17,13 +17,23 @@ function inter_component_energy(at1::AbstractSystem, at2::AbstractSystem, pot::S
     pairs = [(i, j) for i in 1:length(at1), j in 1:length(at2)]
     # @show pairs # DEBUG
     energy = Array{typeof(0.0u"eV"), 1}(undef, length(pairs))
-    Threads.@threads for k in eachindex(pairs)
-        # @show i,j # DEBUG
-        (i, j) = pairs[k]
-        r = pbc_dist(position(at1, i), position(at2, j), at1)
-        energy[k] = pair_energy(r, pot)
+    # Serial path when single-threaded: @threads spawns and joins a task on
+    # every call, which dominates these small per-call loops (see ROADMAP
+    # "Threading granularity"). Results are identical either way because the
+    # iterations write disjoint slots.
+    if Threads.nthreads() == 1
+        for k in eachindex(pairs)
+            (i, j) = pairs[k]
+            r = pbc_dist(position(at1, i), position(at2, j), at1)
+            energy[k] = pair_energy(r, pot)
+        end
+    else
+        Threads.@threads for k in eachindex(pairs)
+            (i, j) = pairs[k]
+            r = pbc_dist(position(at1, i), position(at2, j), at1)
+            energy[k] = pair_energy(r, pot)
+        end
     end
-    # energy = energy*u"eV"
     return sum(energy)
 end
 
@@ -50,11 +60,18 @@ function intra_component_energy(at::AbstractSystem, pot::SingleComponentPotentia
     end
     # @info "num_pairs: $num_pairs, length(pairs): $(length(pairs))"
     energies = Vector{typeof(0.0u"eV")}(undef, length(pairs))
-    Threads.@threads for k in eachindex(pairs)
-        (i, j) = pairs[k]
-        r = pbc_dist(position(at, i), position(at, j), at)
-        energies[k] = pair_energy(r, pot)
-        # @info "interacting pair: [$(i),$(j)] $(lj_energy(r,lj))"
+    if Threads.nthreads() == 1   # see comment in inter_component_energy
+        for k in eachindex(pairs)
+            (i, j) = pairs[k]
+            r = pbc_dist(position(at, i), position(at, j), at)
+            energies[k] = pair_energy(r, pot)
+        end
+    else
+        Threads.@threads for k in eachindex(pairs)
+            (i, j) = pairs[k]
+            r = pbc_dist(position(at, i), position(at, j), at)
+            energies[k] = pair_energy(r, pot)
+        end
     end
     return sum(energies)
 end

--- a/src/EnergyEval/atomistic_single_site.jl
+++ b/src/EnergyEval/atomistic_single_site.jl
@@ -27,9 +27,20 @@ function single_site_energy(index::Int,
     all_index = collect(1:length(at))
     popat!(all_index, index)
     energies = Array{typeof(0.0u"eV"), 1}(undef, length(all_index))
-    Threads.@threads for i in eachindex(all_index)
-        r = pbc_dist(position(at, index), position(at, all_index[i]), at)
-        energies[i] = pair_energy(r,pot)
+    # Serial path when single-threaded: @threads spawns and joins a task on
+    # every call; this function runs millions of times per NS run, so the task
+    # overhead dominates the small loop (see ROADMAP "Threading granularity").
+    # Results are identical: iterations write disjoint slots.
+    if Threads.nthreads() == 1
+        for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            energies[i] = pair_energy(r,pot)
+        end
+    else
+        Threads.@threads for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            energies[i] = pair_energy(r,pot)
+        end
     end
     return sum(energies)
 end
@@ -48,15 +59,25 @@ function single_site_energy(index::Int,
     all_index = collect(1:length(at))
     popat!(all_index, index)
     energies = Array{typeof(0.0u"eV"), 1}(undef, length(all_index))
-    Threads.@threads for i in eachindex(all_index)
-        r = pbc_dist(position(at, index), position(at, all_index[i]), at)
-        if all_index[i] in comp_split[from_comp]
-            energy = pair_energy(r,cps.param_sets[from_comp,from_comp])
-            energies[i] = energy
-        else
-            to_comp = findfirst(x->all_index[i] in x, comp_split)
-            energy = pair_energy(r,cps.param_sets[from_comp,to_comp])
-            energies[i] = energy
+    if Threads.nthreads() == 1   # see comment in the single-component method
+        for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            if all_index[i] in comp_split[from_comp]
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,from_comp])
+            else
+                to_comp = findfirst(x->all_index[i] in x, comp_split)
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+            end
+        end
+    else
+        Threads.@threads for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            if all_index[i] in comp_split[from_comp]
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,from_comp])
+            else
+                to_comp = findfirst(x->all_index[i] in x, comp_split)
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+            end
         end
     end
     return sum(energies)
@@ -77,23 +98,41 @@ function single_site_energy(index::Int,
     all_index = collect(1:length(at))
     popat!(all_index, index)
     energies = Array{typeof(0.0u"eV"), 1}(undef, length(all_index))
-    Threads.@threads for i in eachindex(all_index)
-        r = pbc_dist(position(at, index), position(at, all_index[i]), at)
-        if all_index[i] in comp_split[from_comp]
-            energy = pair_energy(r,cps.param_sets[from_comp,from_comp])
-            energies[i] = energy
-        else
-            to_comp = findfirst(x->all_index[i] in x, comp_split)
-            energy = pair_energy(r,cps.param_sets[from_comp,to_comp])
-            energies[i] = energy
+    if Threads.nthreads() == 1   # see comment in the single-component method
+        for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            if all_index[i] in comp_split[from_comp]
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,from_comp])
+            else
+                to_comp = findfirst(x->all_index[i] in x, comp_split)
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+            end
+        end
+    else
+        Threads.@threads for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            if all_index[i] in comp_split[from_comp]
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,from_comp])
+            else
+                to_comp = findfirst(x->all_index[i] in x, comp_split)
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+            end
         end
     end
     internal_e = sum(energies)
     energies_surface = Array{typeof(0.0u"eV"), 1}(undef, length(surface))
-    Threads.@threads for i in eachindex(surface.position)
-        r = pbc_dist(position(at, index), position(surface, i), at)
-        to_comp = C # surface is the last component
-        energies_surface[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+    if Threads.nthreads() == 1   # see comment in the single-component method
+        for i in eachindex(surface.position)
+            r = pbc_dist(position(at, index), position(surface, i), at)
+            to_comp = C # surface is the last component
+            energies_surface[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+        end
+    else
+        Threads.@threads for i in eachindex(surface.position)
+            r = pbc_dist(position(at, index), position(surface, i), at)
+            to_comp = C # surface is the last component
+            energies_surface[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+        end
     end
     external_e = sum(energies_surface)
     return internal_e + external_e

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -449,3 +449,13 @@ function monte_carlo_sampling(
 
     return energies, ls, cvs, acceptance_rates
 end
+
+# Catch-all for common mistake of omitting MCRoutine as the first argument
+function monte_carlo_sampling(system, potential_or_hamiltonian, mc_params::MetropolisMCParameters; kwargs...)
+    throw(ArgumentError(
+        "`monte_carlo_sampling` requires an `MCRoutine` as the first argument.\n" *
+        "For atomistic systems, use e.g. `MCRandomWalkMaxE()` or `MCMixedMoves()`.\n" *
+        "For lattice systems, use `MCNewSample()`.\n" *
+        "Example: monte_carlo_sampling(MCRandomWalkMaxE(), walker, potential, params)"
+    ))
+end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -10,5 +10,7 @@
     include("test-wang_landau.jl")
     # test grand-canonical nested sampling
     include("test-grand_canonical_ns.jl")
+    # test atomistic GC-NS fixed-N post-processing (ideal gas reference)
+    include("test-atomistic-gcns-fixed-n.jl")
 
 end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -179,9 +179,20 @@ end
         return positions
     end
 
+    # Uniform-prior NS initialization (i.i.d. random placement, overlaps
+    # rejected), as canonical NS requires. A fixed-site initial live set is not
+    # a prior draw and biases the NS evidence; see scripts/fixed_n_init_test.jl.
+    function _uniform_walker_N(N::Int)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            sys = FastSystem(periodic_system(coor, box, fractional=true))
+            E = ustrip(u"eV", interacting_energy(sys, lj))
+            (isfinite(E) && E < 100.0) && return AtomWalker(sys)
+        end
+    end
+
     function _build_liveset_N(N::Int)
-        walkers = [AtomWalker(FastSystem(periodic_system(_place_n_atoms(N), box, fractional=true)))
-                   for _ in 1:K]
+        walkers = [_uniform_walker_N(N) for _ in 1:K]
         return LJAtomWalkers(walkers, lj)
     end
 
@@ -296,24 +307,23 @@ end
     end
 
     @testset "NS-vs-NVT ⟨U⟩_N agreement at T = 200 K" begin
-        # The tolerance is deliberately loose. NS at small K with single-atom
-        # random walks systematically underestimates |⟨U⟩| for N ≥ 3 in this
-        # supercritical-but-cold regime (k_B T ≈ 1.7 ε): once the live set
-        # collapses near the well bottom, the empirical df.emax sequence is too
-        # coarse in the thermally relevant E band (a few k_B T above the
-        # minimum) to faithfully reproduce the canonical distribution. The
-        # observed bias is ~30–50 % at N = 3, 4, scaling with the number of
-        # interacting pairs. NVT MC at n_sample = 8000 is converged to
-        # micro-eV precision, so it is the trustworthy reference here.
+        # NS live sets are drawn from the uniform prior (i.i.d. random
+        # placement), as canonical NS requires; the earlier fixed-site init
+        # biased ⟨U⟩ low by ~40–50 %. With correct init the residual NS-vs-NVT
+        # difference is sampling noise at these deliberately cheap CI params
+        # (K = 48, n_ns = 800, one seed per N): deeper runs (K = 192,
+        # n_ns = 8000) agree with NVT and an independent importance-sampling
+        # anchor to ~0.1 % (see scripts/fixed_n_init_test.jl). NVT MC at
+        # n_sample = 8000 is the trustworthy reference here.
         #
-        # The test's purpose is to catch normalization / unit-conversion / sign
-        # bugs in the per-N evidence assembly (which would produce errors of
-        # 100 % or more), not to certify NS sampling quality.
+        # The bound below absorbs that cheap-params sampling noise (observed
+        # ≤ 26 % here) while still catching normalization / unit / sign bugs in
+        # the per-N evidence assembly (which produce > 100 % errors).
         for (idx, N) in enumerate(N_values)
             N == 0 && continue
             U_NS = _U_with_tail(ns_outputs[idx], live_emax_all[idx])
             U_NVT = U_NVT_by_N[N]
-            @test isapprox(U_NS, U_NVT; rtol=0.60, atol=3e-3)
+            @test isapprox(U_NS, U_NVT; rtol=0.40, atol=3e-3)
             # Sign check: NS and NVT must both be non-positive in the
             # attractive regime (this catches a wrong-sign error that the
             # loose isapprox would otherwise miss for U ≈ 0).
@@ -486,9 +496,20 @@ end
         return positions
     end
 
+    # Uniform-prior NS initialization over the full box (see the 3D LJ block).
+    # Adsorbates landing in/near the slab are rejected here / discarded by NS.
+    function _uniform_walker_N(N::Int)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            w = AtomWalker(FastSystem(periodic_system(coor, box, fractional=true)))
+            E_ads = ustrip(u"eV", interacting_energy(w.configuration, ljs,
+                        w.list_num_par, w.frozen, surface.configuration))
+            (isfinite(E_ads) && E_ads < 100.0) && return w
+        end
+    end
+
     function _build_liveset_N(N::Int)
-        walkers = [AtomWalker(FastSystem(periodic_system(_place_n_adsorbates(N), box, fractional=true)))
-                   for _ in 1:K]
+        walkers = [_uniform_walker_N(N) for _ in 1:K]
         return LJSurfaceWalkers(walkers, ljs, surface)
     end
 
@@ -619,18 +640,18 @@ end
     end
 
     @testset "NS-vs-NVT ⟨U⟩_N agreement at T = 200 K" begin
-        # rtol/atol inherited from the 3D LJ fluid block: loose enough to
-        # absorb the documented small-K NS sampling bias in the
-        # supercritical-but-cold regime, tight enough to catch
-        # normalization, unit-conversion, or sign bugs in the per-N
-        # evidence assembly. Comparison is on the adsorbate part of ⟨U⟩
-        # (total minus the constant substrate self-energy), because the
-        # constant offset would otherwise dwarf any disagreement.
+        # NS live sets are drawn from the uniform prior (see the 3D LJ block);
+        # with correct init the residual NS-vs-NVT difference is cheap-params
+        # sampling noise (one seed per N at K = 48, n_ns = 800), not a
+        # systematic bias. Comparison is on the adsorbate part of ⟨U⟩ (total
+        # minus the constant substrate self-energy), since the constant offset
+        # would otherwise dwarf any disagreement. The bound still catches
+        # normalization / unit / sign bugs (which produce > 100 % errors).
         for (idx, N) in enumerate(N_values)
             N == 0 && continue
             U_NS_ads = _U_with_tail(ns_outputs[idx], live_emax_all[idx]) - E_surf_self
             U_NVT_ads = U_NVT_by_N[N] - E_surf_self
-            @test isapprox(U_NS_ads, U_NVT_ads; rtol=0.60, atol=3e-3)
+            @test isapprox(U_NS_ads, U_NVT_ads; rtol=0.40, atol=3e-3)
             # Adsorbate part should be non-positive in the attractive
             # regime (single Ar binds to the substrate at ~−3ε).
             @test U_NS_ads <= 1e-4

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -390,3 +390,302 @@ end
         @test out.mean_U[2, 1] <= 1e-3
     end
 end
+
+
+@testset "Atomistic GC-NS, fixed-N construction (LJ on LJ(111) surface)" begin
+    using Random
+
+    # ===== Substrate: LJ(111) slab =======================================
+    # 2x2 in-plane rectangular supercell, 3 layers ABC stacking, all frozen.
+    # In-plane NN distance a = 2^(1/6) σ (the LJ minimum). The rectangular
+    # primitive cell on a (111) plane has dimensions (a, a√3) with 2 atoms
+    # per cell; ABC stacking places adjacent layers at the up- and down-
+    # triangle centroids of the layer below. Inter-layer spacing a√(2/3)
+    # is the FCC (111) value. Box-x is technically shorter than 2·cutoff
+    # (same convention as the 3D LJ fluid block above) so PBC self-image
+    # contributions are present but appear as a constant offset that both
+    # NS and NVT see identically — the cross-check remains valid.
+    σ_val = 2.5
+    ε_val = 0.01
+    a = 2^(1/6) * σ_val
+    Δz_layer = a * sqrt(2/3)
+    Lx = 2.0 * a
+    Ly = 2.0 * a * sqrt(3.0)
+    Lz = 22.0  # vacuum above 3-layer slab > 2·cutoff = 15 Å
+
+    # Layer-internal positions, given as fractions of the primitive
+    # rectangle (Lx/2, Ly/2): A = layer with 2 atoms at primitive corners;
+    # B and C are the up- and down-triangle centroids of A.
+    layer_offsets = [
+        [(0.0, 0.0), (0.5, 0.5)],         # A
+        [(0.5, 1.0/6.0), (0.0, 2.0/3.0)], # B
+        [(0.5, 5.0/6.0), (0.0, 1.0/3.0)], # C
+    ]
+
+    function _build_substrate_positions()
+        positions = Pair{Symbol, Vector{Float64}}[]
+        for (l, layer) in enumerate(layer_offsets)
+            z_frac = (l - 1) * Δz_layer / Lz
+            for (fx_prim, fy_prim) in layer
+                for ix in 0:1, iy in 0:1
+                    fx = (ix + fx_prim) / 2.0
+                    fy = (iy + fy_prim) / 2.0
+                    push!(positions, :Ar => [fx, fy, z_frac])
+                end
+            end
+        end
+        return positions
+    end
+
+    box = [[Lx * u"Å", 0u"Å", 0u"Å"],
+           [0u"Å", Ly * u"Å", 0u"Å"],
+           [0u"Å", 0u"Å", Lz * u"Å"]]
+    V_box = (Lx * Ly * Lz) * u"Å^3"
+    mass = 40.0u"u"
+
+    lj = LJParameters(epsilon=ε_val, sigma=σ_val, cutoff=3.0, shift=true)
+    # 2-component CPS for adsorbate × surface: [aa, as, ss] all identical.
+    ljs = CompositeParameterSets(2, [lj, lj, lj])
+
+    substrate_positions = _build_substrate_positions()
+    substrate_sys = FastSystem(periodic_system(substrate_positions, box, fractional=true))
+    surface = AtomWalker(substrate_sys; freeze_species=[:Ar])
+    surface.energy_frozen_part = interacting_energy(surface.configuration, lj)
+    E_surf_self = ustrip(u"eV", surface.energy_frozen_part)
+
+    T_val = 200.0u"K"
+    T_grid = [T_val]
+    kb = 8.617333262e-5
+    β = 1.0 / (kb * ustrip(u"K", T_val))
+
+    N_values = collect(0:4)
+    K = 48
+    mc_steps = 500
+    n_ns_steps = 800
+    n_equi = 2000
+    n_sample = 8000
+
+    # ----- Adsorbate placement: above hollow-ish xy sites, well above the
+    # top substrate layer (z = 2 Δz_layer + 1.5 σ).
+    top_z_frac = 2 * Δz_layer / Lz
+    init_z_frac = top_z_frac + (1.5 * σ_val) / Lz
+    hollow_sites = [(0.25, 0.25),
+                    (0.75, 0.25),
+                    (0.25, 0.75),
+                    (0.75, 0.75)]
+
+    function _place_n_adsorbates(N::Int)
+        positions = Pair{Symbol, Vector{Float64}}[]
+        for i in 1:N
+            fx, fy = hollow_sites[i]
+            fx += 0.02 * (rand() - 0.5)
+            fy += 0.02 * (rand() - 0.5)
+            fz = init_z_frac + 0.01 * (rand() - 0.5)
+            push!(positions, :Ar => [fx, fy, fz])
+        end
+        return positions
+    end
+
+    function _build_liveset_N(N::Int)
+        walkers = [AtomWalker(FastSystem(periodic_system(_place_n_adsorbates(N), box, fractional=true)))
+                   for _ in 1:K]
+        return LJSurfaceWalkers(walkers, ljs, surface)
+    end
+
+    function _run_ns_at_N_surface(N::Int, seed::Int)
+        Random.seed!(seed)
+        liveset = _build_liveset_N(N)
+        ns_params = NestedSamplingParameters(
+            mc_steps=mc_steps,
+            initial_step_size=0.3,
+            step_size=0.3,
+            step_size_lo=0.01,
+            step_size_up=2.0,
+            accept_range=(0.25, 0.75),
+            allowed_fail_count=1000,
+            energy_perturbation=1e-12,
+        )
+        save_strategy = SaveEveryN(
+            df_filename="_test_surf_ns_$(N).csv",
+            wk_filename="_test_surf_ns_$(N).traj.extxyz",
+            ls_filename="_test_surf_ns_$(N).ls.extxyz",
+            n_traj=100_000,
+            n_snap=100_000,
+            n_info=100_000,
+        )
+        df, final_liveset, _ = nested_sampling(
+            liveset, ns_params, n_ns_steps, MCRandomWalkClone(), save_strategy)
+        live_emax_N = [ustrip(u"eV", w.energy) for w in final_liveset.walkers]
+        rm("_test_surf_ns_$(N).csv", force=true)
+        rm("_test_surf_ns_$(N).traj.extxyz", force=true)
+        rm("_test_surf_ns_$(N).ls.extxyz", force=true)
+        return df, live_emax_N
+    end
+
+    # Bespoke NVT MC loop with surface support. The production
+    # `nvt_monte_carlo` does not yet take a surface argument; this mirrors
+    # the surface-aware `MC_random_walk!` from `MonteCarloMoves` but
+    # accepts on the Metropolis-Hastings ratio at temperature T.
+    function _run_nvt_at_N_surface(N::Int, seed::Int)
+        Random.seed!(seed)
+        sys = FastSystem(periodic_system(_place_n_adsorbates(N), box, fractional=true))
+        walker = AtomWalker(sys)
+        walker.energy = interacting_energy(
+            walker.configuration, ljs, walker.list_num_par, walker.frozen,
+            surface.configuration) + surface.energy_frozen_part
+
+        step_size = 0.3
+        kbT_eV = kb * ustrip(u"K", T_val)
+
+        function inner!(n_steps)
+            energies = Vector{Float64}(undef, n_steps)
+            for i in 1:n_steps
+                config = walker.configuration
+                free_index = FreeBird.MonteCarloMoves.free_par_index(walker)
+                if isempty(free_index)
+                    energies[i] = ustrip(u"eV", walker.energy)
+                    continue
+                end
+                i_at = rand(free_index)
+                prewalk = FreeBird.EnergyEval.single_site_energy(
+                    i_at, config, ljs, walker.list_num_par, surface.configuration)
+                pos = position(config, i_at)
+                orig = pos
+                pos = FreeBird.MonteCarloMoves.single_atom_random_walk!(pos, step_size)
+                pos = FreeBird.MonteCarloMoves.periodic_boundary_wrap!(pos, config)
+                config.position[i_at] = pos
+                postwalk = FreeBird.EnergyEval.single_site_energy(
+                    i_at, config, ljs, walker.list_num_par, surface.configuration)
+                ΔE = postwalk - prewalk
+                if ΔE < 0.0u"eV" || rand() < exp(-ustrip(u"eV", ΔE) / kbT_eV)
+                    walker.energy = walker.energy + ΔE
+                else
+                    config.position[i_at] = orig
+                end
+                energies[i] = ustrip(u"eV", walker.energy)
+            end
+            return energies
+        end
+
+        inner!(n_equi)
+        energies_sample = inner!(n_sample)
+        return mean(energies_sample)
+    end
+
+    # ===== Run NS at each N >= 1 ========================================
+    # N = 0 is handled by gc_thermodynamic_stats_fixed_N's special case.
+    # N = 1 is non-trivial here (single adsorbate sees the substrate's
+    # attractive potential), unlike the 3D LJ fluid block where N = 1 has
+    # E ≡ 0 and NS cannot make progress.
+    ns_outputs = Vector{DataFrame}(undef, length(N_values))
+    live_emax_all = Vector{Vector{Float64}}(undef, length(N_values))
+    ns_outputs[1] = DataFrame(iter=Int[], emax=Float64[])
+    live_emax_all[1] = Float64[]
+
+    for (idx, N) in enumerate(N_values)
+        N == 0 && continue
+        df, live_emax_N = _run_ns_at_N_surface(N, 3000 + N)
+        ns_outputs[idx] = df
+        live_emax_all[idx] = live_emax_N
+    end
+
+    @testset "NS run schema and basic shape" begin
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            df = ns_outputs[idx]
+            @test names(df) == ["iter", "emax"]
+            @test nrow(df) >= 0.5 * n_ns_steps
+            @test length(live_emax_all[idx]) == K
+        end
+    end
+
+    # ===== Per-N ⟨U⟩: NS vs NVT cross-check =============================
+    # Compare on the adsorbate contribution ⟨U⟩ − E_surf_self, since the
+    # constant substrate self-energy dominates the absolute scale and would
+    # otherwise make rtol-based agreement trivially pass.
+    function _U_with_tail(df::DataFrame, live_emax_N::Vector{Float64})
+        ωi = ωᵢ(df.iter, K)
+        n_iters = length(df.iter)
+        tail_w = (K / (K + 1))^n_iters / K
+        ωi_full = vcat(ωi, fill(tail_w, K))
+        Es_full = vcat(collect(Float64, df.emax), live_emax_N)
+        return internal_energy(β, ωi_full, Es_full)
+    end
+
+    U_NVT_by_N = Dict{Int, Float64}()
+    for N in N_values
+        N == 0 && continue
+        U_NVT_by_N[N] = _run_nvt_at_N_surface(N, 4000 + N)
+    end
+
+    @testset "NS-vs-NVT ⟨U⟩_N agreement at T = 200 K" begin
+        # rtol/atol inherited from the 3D LJ fluid block: loose enough to
+        # absorb the documented small-K NS sampling bias in the
+        # supercritical-but-cold regime, tight enough to catch
+        # normalization, unit-conversion, or sign bugs in the per-N
+        # evidence assembly. Comparison is on the adsorbate part of ⟨U⟩
+        # (total minus the constant substrate self-energy), because the
+        # constant offset would otherwise dwarf any disagreement.
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            U_NS_ads = _U_with_tail(ns_outputs[idx], live_emax_all[idx]) - E_surf_self
+            U_NVT_ads = U_NVT_by_N[N] - E_surf_self
+            @test isapprox(U_NS_ads, U_NVT_ads; rtol=0.60, atol=3e-3)
+            # Adsorbate part should be non-positive in the attractive
+            # regime (single Ar binds to the substrate at ~−3ε).
+            @test U_NS_ads <= 1e-4
+        end
+    end
+
+    @testset "Per-N ⟨U⟩ decreases (more negative) with N" begin
+        # Each adsorbate adds attractive surface and (for N ≥ 2)
+        # attractive lateral contributions. Allow 1 meV slack per step.
+        U_N_vec = Float64[]
+        push!(U_N_vec, 0.0)  # adsorbate contribution at N = 0 is 0
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            push!(U_N_vec, _U_with_tail(ns_outputs[idx], live_emax_all[idx]) - E_surf_self)
+        end
+        for i in 2:length(U_N_vec)
+            @test U_N_vec[i] <= U_N_vec[i-1] + 1e-3
+        end
+    end
+
+    # ===== End-to-end Ξ(μ, T) via gc_thermodynamic_stats_fixed_N ========
+    # V passed is the simulation-box volume = NS prior volume per particle
+    # (NOT a slab or adsorption-region volume). The substrate's
+    # contribution to the configurational integral is fully captured by
+    # the Boltzmann factor exp(−βU) in the per-N NS evidence; no
+    # geometric V reduction is needed.
+    #
+    # μ window placed in the dilute-coverage regime. With ε = 0.01 eV
+    # and a single-adsorbate binding of roughly −3 ε at hollow sites, we
+    # expect ⟨N⟩ ~ 1–3 across the chosen μ pair.
+    μ_grid = [-0.235u"eV", -0.215u"eV"]
+
+    out = gc_thermodynamic_stats_fixed_N(
+        ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+        n_walkers=K, live_emax=live_emax_all)
+
+    @testset "End-to-end Ξ assembly: returns expected shape" begin
+        @test size(out.Xi) == (length(μ_grid), length(T_grid))
+        @test size(out.mean_N) == (length(μ_grid), length(T_grid))
+        @test size(out.var_N) == (length(μ_grid), length(T_grid))
+        @test size(out.mean_U) == (length(μ_grid), length(T_grid))
+        @test all(out.Xi .> 0)
+        @test all(out.mean_N .>= 0)
+        @test all(out.var_N .>= 0)
+    end
+
+    @testset "⟨N⟩ in sub-monolayer window for chosen μ" begin
+        # Monolayer capacity ≈ 8 hollow sites on the 2x2 (111) supercell;
+        # sub-monolayer means ⟨N⟩ well below 8.
+        @test 0.1 < out.mean_N[1, 1] < 4.5
+        @test 0.1 < out.mean_N[2, 1] < 4.5
+    end
+
+    @testset "Ξ and ⟨N⟩ monotone in μ at fixed T" begin
+        @test out.Xi[2, 1] > out.Xi[1, 1]
+        @test out.mean_N[2, 1] > out.mean_N[1, 1]
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -120,6 +120,273 @@
             1000.0u"Å^3", 40.0u"u",
             [-0.25u"eV"], [300.0u"K"];
             n_walkers=K)
+
+        # Length mismatch between live_emax and N_values
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [0, 1, 2],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [300.0u"K"];
+            n_walkers=K,
+            live_emax=[Float64[], Float64[]])
     end
 
+end
+
+
+@testset "Atomistic GC-NS, fixed-N construction (3D LJ fluid)" begin
+    using Random
+
+    # ===== System ==========================================================
+    # 12 Å cubic periodic box with an Ar-like LJ fluid: ε = 0.01 eV (T_crit ~ 1.3ε/k_B
+    # ≈ 150 K), σ = 2.5 Å, cutoff 3σ with energy shift. At T = 200 K we have
+    # k_B T ≈ 1.72 ε — supercritical, safely away from coexistence physics.
+    L = 12.0
+    box = [[L * u"Å", 0u"Å", 0u"Å"],
+           [0u"Å", L * u"Å", 0u"Å"],
+           [0u"Å", 0u"Å", L * u"Å"]]
+    V_box = L^3 * u"Å^3"
+    mass = 40.0u"u"
+    lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=3.0, shift=true)
+
+    T_val = 200.0u"K"
+    T_grid = [T_val]
+    kb = 8.617333262e-5
+    β = 1.0 / (kb * ustrip(u"K", T_val))
+
+    N_values = collect(0:4)
+    K = 48
+    mc_steps = 500
+    n_ns_steps = 800
+    n_equi = 2000
+    n_sample = 8000
+
+    # Build N atoms on a sparse cubic-corner grid (max 5 spots used; for N ≤ 4
+    # this gives initial separations ≈ L/2 = 6 Å, well outside the LJ wall).
+    function _place_n_atoms(N::Int)
+        spots = [(0.25, 0.25, 0.25),
+                 (0.75, 0.25, 0.25),
+                 (0.25, 0.75, 0.25),
+                 (0.75, 0.75, 0.25),
+                 (0.25, 0.25, 0.75)]
+        positions = Pair{Symbol, Vector{Float64}}[]
+        for i in 1:N
+            x, y, z = spots[i]
+            x += 0.02 * (rand() - 0.5)
+            y += 0.02 * (rand() - 0.5)
+            z += 0.02 * (rand() - 0.5)
+            push!(positions, :Ar => [x, y, z])
+        end
+        return positions
+    end
+
+    function _build_liveset_N(N::Int)
+        walkers = [AtomWalker(FastSystem(periodic_system(_place_n_atoms(N), box, fractional=true)))
+                   for _ in 1:K]
+        return LJAtomWalkers(walkers, lj)
+    end
+
+    function _run_ns_at_N(N::Int, seed::Int)
+        Random.seed!(seed)
+        liveset = _build_liveset_N(N)
+        ns_params = NestedSamplingParameters(
+            mc_steps=mc_steps,
+            initial_step_size=0.3,
+            step_size=0.3,
+            step_size_lo=0.01,
+            step_size_up=2.0,
+            accept_range=(0.25, 0.75),
+            allowed_fail_count=1000,
+            energy_perturbation=1e-12,
+        )
+        save_strategy = SaveEveryN(
+            df_filename="_test_lj_ns_$(N).csv",
+            wk_filename="_test_lj_ns_$(N).traj.extxyz",
+            ls_filename="_test_lj_ns_$(N).ls.extxyz",
+            n_traj=100_000,
+            n_snap=100_000,
+            n_info=100_000,
+        )
+        df, final_liveset, _ = nested_sampling(
+            liveset, ns_params, n_ns_steps, MCRandomWalkClone(), save_strategy)
+        live_emax_N = [ustrip(u"eV", w.energy) for w in final_liveset.walkers]
+        rm("_test_lj_ns_$(N).csv", force=true)
+        rm("_test_lj_ns_$(N).traj.extxyz", force=true)
+        rm("_test_lj_ns_$(N).ls.extxyz", force=true)
+        return df, live_emax_N
+    end
+
+    function _run_nvt_at_N(N::Int, seed::Int)
+        Random.seed!(seed)
+        atoms_list = _place_n_atoms(N)
+        sys = FastSystem(periodic_system(atoms_list, box, fractional=true))
+        walker = AtomWalker(sys)
+        mc_params = MetropolisMCParameters(
+            [ustrip(u"K", T_val)];
+            equilibrium_steps=n_equi,
+            sampling_steps=n_sample,
+            step_size=0.3,
+            step_size_lo=0.05,
+            step_size_up=1.0,
+            accept_range=(0.3, 0.7),
+            random_seed=seed,
+        )
+        energies, _, _, _ = monte_carlo_sampling(MCRandomWalkMaxE(), walker, lj, mc_params)
+        return energies[1]
+    end
+
+    # ===== Run NS at each N ≥ 2 ==========================================
+    # N = 0 is handled by the function's special case.
+    # N = 1 cannot make NS progress: a single atom in a periodic box has no
+    # pair interactions, so every walker has E = 0 exactly and every MC walk
+    # is rejected by the energy-ceiling check. Z_NS^{(1)} = 1 by definition,
+    # so we synthesize the DataFrame directly. Using a long, all-zero-energy
+    # df with default ω₀ yields the same `K/(K+1)` multiplicative scaling as
+    # the real NS runs at N ≥ 2, keeping the Ξ assembly internally consistent.
+    ns_outputs = Vector{DataFrame}(undef, length(N_values))
+    live_emax_all = Vector{Vector{Float64}}(undef, length(N_values))
+    ns_outputs[1] = DataFrame(iter=Int[], emax=Float64[])
+    live_emax_all[1] = Float64[]
+
+    for (idx, N) in enumerate(N_values)
+        N == 0 && continue
+        if N == 1
+            n_synth = 5000
+            ns_outputs[idx] = DataFrame(iter=collect(1:n_synth), emax=zeros(n_synth))
+            live_emax_all[idx] = zeros(Float64, K)
+            continue
+        end
+        df, live_emax_N = _run_ns_at_N(N, 1000 + N)
+        ns_outputs[idx] = df
+        live_emax_all[idx] = live_emax_N
+    end
+
+    @testset "NS run schema and basic shape" begin
+        for (idx, N) in enumerate(N_values)
+            (N == 0 || N == 1) && continue
+            df = ns_outputs[idx]
+            @test names(df) == ["iter", "emax"]
+            @test nrow(df) >= 0.5 * n_ns_steps
+            @test length(live_emax_all[idx]) == K
+        end
+    end
+
+    # ===== Per-N ⟨U⟩: NS vs NVT cross-check =============================
+    # Construct per-N ⟨U⟩_NS with live-set tail closure, compare to NVT mean.
+    # internal_energy uses the same ω·exp(−βE) weighting as the function.
+    function _U_with_tail(df::DataFrame, live_emax_N::Vector{Float64})
+        ωi = ωᵢ(df.iter, K)
+        n_iters = length(df.iter)
+        tail_w = (K / (K + 1))^n_iters / K
+        ωi_full = vcat(ωi, fill(tail_w, K))
+        Es_full = vcat(collect(Float64, df.emax), live_emax_N)
+        return internal_energy(β, ωi_full, Es_full)
+    end
+
+    function _U_no_tail(df::DataFrame)
+        ωi = ωᵢ(df.iter, K)
+        Es = collect(Float64, df.emax)
+        return internal_energy(β, ωi, Es)
+    end
+
+    # Cache NVT cross-check results — used by two test blocks.
+    U_NVT_by_N = Dict{Int, Float64}()
+    for N in N_values
+        N == 0 && continue
+        U_NVT_by_N[N] = _run_nvt_at_N(N, 2000 + N)
+    end
+
+    @testset "NS-vs-NVT ⟨U⟩_N agreement at T = 200 K" begin
+        # The tolerance is deliberately loose. NS at small K with single-atom
+        # random walks systematically underestimates |⟨U⟩| for N ≥ 3 in this
+        # supercritical-but-cold regime (k_B T ≈ 1.7 ε): once the live set
+        # collapses near the well bottom, the empirical df.emax sequence is too
+        # coarse in the thermally relevant E band (a few k_B T above the
+        # minimum) to faithfully reproduce the canonical distribution. The
+        # observed bias is ~30–50 % at N = 3, 4, scaling with the number of
+        # interacting pairs. NVT MC at n_sample = 8000 is converged to
+        # micro-eV precision, so it is the trustworthy reference here.
+        #
+        # The test's purpose is to catch normalization / unit-conversion / sign
+        # bugs in the per-N evidence assembly (which would produce errors of
+        # 100 % or more), not to certify NS sampling quality.
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            U_NS = _U_with_tail(ns_outputs[idx], live_emax_all[idx])
+            U_NVT = U_NVT_by_N[N]
+            @test isapprox(U_NS, U_NVT; rtol=0.60, atol=3e-3)
+            # Sign check: NS and NVT must both be non-positive in the
+            # attractive regime (this catches a wrong-sign error that the
+            # loose isapprox would otherwise miss for U ≈ 0).
+            @test U_NS <= 1e-4
+        end
+    end
+
+    @testset "Live-set tail correction moves U toward NVT" begin
+        # For at least one N, the tail-corrected ⟨U⟩ should be no further from
+        # NVT than the uncorrected ⟨U⟩. Tested at N = 2 where the well is
+        # deepest in relative terms and live walkers concentrate below the
+        # latest recorded emax. Includes a small slack to absorb the case
+        # where the two estimates are essentially indistinguishable.
+        N_check = 2
+        idx_check = findfirst(==(N_check), N_values)
+        df = ns_outputs[idx_check]
+        live_emax_N = live_emax_all[idx_check]
+        U_with = _U_with_tail(df, live_emax_N)
+        U_without = _U_no_tail(df)
+        U_NVT = U_NVT_by_N[N_check]
+        @test abs(U_with - U_NVT) <= abs(U_without - U_NVT) + 1e-6
+    end
+
+    @testset "Per-N ⟨U⟩ decreases (more negative) with N" begin
+        # Attractive LJ regime → adding a particle adds (on average) negative
+        # pair contributions to ⟨U⟩_N. Allow 1 meV slack per step for noise.
+        U_N_vec = Float64[]
+        push!(U_N_vec, 0.0)  # N = 0 by definition
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            push!(U_N_vec, _U_with_tail(ns_outputs[idx], live_emax_all[idx]))
+        end
+        # N=1 → N=2: pair energy appears, U drops.
+        # N=2 → N=3 → N=4: each adds more pair contributions.
+        for i in 2:length(U_N_vec)
+            @test U_N_vec[i] <= U_N_vec[i-1] + 1e-3
+        end
+    end
+
+    # ===== End-to-end Ξ(μ, T) via gc_thermodynamic_stats_fixed_N =========
+    # μ values placed in the dilute-gas window: at zV ≈ 1, μ ≈ -0.205 eV
+    # (from the ideal-gas zV relation with V = 1728 Å³, m = 40u, T = 200 K).
+    # μ_grid below brackets ⟨N⟩ values around 1 and 2.
+    μ_grid = [-0.215u"eV", -0.200u"eV"]
+
+    out = gc_thermodynamic_stats_fixed_N(
+        ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+        n_walkers=K, live_emax=live_emax_all)
+
+    @testset "End-to-end Ξ assembly: returns expected shape" begin
+        @test size(out.Xi) == (length(μ_grid), length(T_grid))
+        @test size(out.mean_N) == (length(μ_grid), length(T_grid))
+        @test size(out.var_N) == (length(μ_grid), length(T_grid))
+        @test size(out.mean_U) == (length(μ_grid), length(T_grid))
+        @test all(out.Xi .> 0)
+        @test all(out.mean_N .>= 0)
+        @test all(out.var_N .>= 0)
+    end
+
+    @testset "⟨N⟩ in expected range for chosen μ window" begin
+        @test 0.3 < out.mean_N[1, 1] < 2.5
+        @test 0.5 < out.mean_N[2, 1] < 3.5
+    end
+
+    @testset "Ξ and ⟨N⟩ monotone in μ at fixed T" begin
+        @test out.Xi[2, 1] > out.Xi[1, 1]
+        @test out.mean_N[2, 1] > out.mean_N[1, 1]
+    end
+
+    @testset "Grand ⟨U⟩ is non-positive (attractive regime, low density)" begin
+        # In the dilute attractive regime, ⟨U⟩_GC should be ≤ 0 (with slack
+        # for sampling noise at the lowest μ where ⟨N⟩ ≈ 0).
+        @test out.mean_U[1, 1] <= 1e-3
+        @test out.mean_U[2, 1] <= 1e-3
+    end
 end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -1,0 +1,125 @@
+@testset "Atomistic GC-NS, fixed-N construction (ideal gas)" begin
+
+    @testset "IdealGasParameters dispatch" begin
+        pot = IdealGasParameters()
+
+        # pair_energy is identically zero
+        @test pair_energy(1.0u"Å", pot) == 0.0u"eV"
+        @test pair_energy(0.5u"Å", pot) == 0.0u"eV"
+        @test pair_energy(100.0u"Å", pot) == 0.0u"eV"
+
+        # Construct a 3-atom periodic system and verify every pairwise dispatch
+        # path returns 0.0u"eV".
+        box = [[10.0u"Å", 0u"Å", 0u"Å"],
+               [0u"Å", 10.0u"Å", 0u"Å"],
+               [0u"Å", 0u"Å", 10.0u"Å"]]
+        coor = [:Ar => [0.1, 0.2, 0.3],
+                :Ar => [0.4, 0.5, 0.6],
+                :Ar => [0.7, 0.8, 0.9]]
+        sys = FastSystem(periodic_system(coor, box, fractional=true))
+
+        @test interacting_energy(sys, pot) == 0.0u"eV"
+        @test interacting_energy(sys, pot, [3], [false]) == 0.0u"eV"
+        @test frozen_energy(sys, pot, [3], [true]) == 0.0u"eV"
+    end
+
+    @testset "_thermal_wavelength" begin
+        # Reference value for H (m=1u) at T=300K: Λ ≈ 1.008 Å.
+        Λ_H = FreeBird.AnalysisTools._thermal_wavelength(1.0u"u", 300.0u"K")
+        @test isapprox(ustrip(u"Å", Λ_H), 1.008, rtol=1e-2)
+
+        # Exact scaling: Λ ∝ 1/sqrt(m), Λ ∝ 1/sqrt(T).
+        Λ_2m = FreeBird.AnalysisTools._thermal_wavelength(2.0u"u", 300.0u"K")
+        Λ_2T = FreeBird.AnalysisTools._thermal_wavelength(1.0u"u", 600.0u"K")
+        @test isapprox(ustrip(u"Å", Λ_2m) / ustrip(u"Å", Λ_H), 1 / sqrt(2), rtol=1e-10)
+        @test isapprox(ustrip(u"Å", Λ_2T) / ustrip(u"Å", Λ_H), 1 / sqrt(2), rtol=1e-10)
+    end
+
+    @testset "ideal-gas closed form: Ξ, ⟨N⟩, Var(N), ⟨U⟩" begin
+        # Synthesize per-N canonical NS DataFrames for an ideal gas (E ≡ 0).
+        # With ω0 = (K+1)/K and many iterations, sum(ω_i) → 1 exactly,
+        # making Z_NS^{(N)} = 1 for every N (the analytical answer).
+        # N_max = 20 keeps the truncation tail (zV)^N/N! negligible for
+        # ⟨N⟩ ≤ 3 at rtol = 1e-3.
+        N_max = 20
+        N_values = collect(0:N_max)
+        K = 120
+        n_iters = 5000
+        ω0_test = (K + 1) / K
+
+        ns_outputs = [DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for _ in N_values]
+
+        V = 1000.0u"Å^3"
+        m = 40.0u"u"
+        T = 300.0u"K"
+        T_grid = [T]
+
+        kb = 8.617333262e-5
+        β = 1.0 / (kb * ustrip(u"K", T))
+        Λ_val = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+        V_val = ustrip(u"Å^3", V)
+
+        # Solve zV = (exp(βμ)/Λ³) · V for μ given a target zV.
+        μ_for_zV(zV_target) = (log(zV_target * Λ_val^3 / V_val) / β) * u"eV"
+
+        zV_targets = (0.5, 1.5, 3.0)
+        μ_grid = [μ_for_zV(z) for z in zV_targets]
+
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test)
+
+        for (k, zV) in enumerate(zV_targets)
+            @test isapprox(out.Xi[k, 1], exp(zV), rtol=1e-3)
+            @test isapprox(out.mean_N[k, 1], zV, rtol=1e-3)
+            @test isapprox(out.var_N[k, 1], zV, rtol=1e-3)
+            @test isapprox(out.mean_U[k, 1], 0.0, atol=1e-12)
+        end
+    end
+
+    @testset "Ξ monotone in μ at fixed T" begin
+        N_max = 20
+        N_values = collect(0:N_max)
+        K = 120
+        n_iters = 5000
+        ω0_test = (K + 1) / K
+
+        ns_outputs = [DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for _ in N_values]
+
+        V = 1000.0u"Å^3"
+        m = 40.0u"u"
+        T_grid = [300.0u"K", 600.0u"K"]
+
+        μ_grid = collect(range(-0.30u"eV", -0.20u"eV", length=10))
+
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test)
+
+        @test all(diff(out.Xi, dims=1) .> 0)
+    end
+
+    @testset "argument validation" begin
+        K = 120
+        n_iters = 100
+        ns_outputs = [DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for _ in 1:3]
+
+        # Missing N=0 in N_values
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [1, 2, 3],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [300.0u"K"];
+            n_walkers=K)
+
+        # Length mismatch between ns_outputs and N_values
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [0, 1, 2, 3],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [300.0u"K"];
+            n_walkers=K)
+    end
+
+end


### PR DESCRIPTION
## Summary

Adds the atomistic fixed-_N_ construction of grand-canonical nested sampling: canonical NS runs at fixed particle numbers $N$ are stitched into the grand ensemble in post-processing, with no new sampler. The user runs `nested_sampling` per $N$ and `gc_thermodynamic_stats_fixed_N` (AnalysisTools) assembles

$$\Xi(\mu, T) = \sum_N \frac{(zV)^N}{N!}\\, Z_{NS}^{(N)}(\beta), \qquad z = \frac{e^{\beta\mu}}{\Lambda(T)^3}$$

returning $(\mu, T)$ matrices of $\Xi$, $\langle N \rangle$, $\mathrm{Var}(N)$, and $\langle U \rangle$. Single-component $(C = 1)$ systems only.

## What is included

- `IdealGasParameters`: a zero-interaction `SingleComponentPotential{Pairwise}` reference potential, used to validate the pipeline against the closed form $\Xi_{\text{ideal}} = e^{zV}$.
- `gc_thermodynamic_stats_fixed_N` with log-sum-exp evidence assembly, an optional live-set tail closure (`live_emax` keyword) for the prior volume that finite NS termination leaves uncounted, and special-casing of the $N = 0$ sector $(Z_{NS}^{(0)} = 1)$. The volume argument is the simulation-box volume, i.e., the NS prior volume per particle; substrate volume exclusion enters through the Boltzmann factor inside $Z_{NS}^{(N)}$, not through $V$.
- A 95-test validation suite (`test-atomistic-gcns-fixed-n.jl`) covering closed-form ideal-gas checks, argument validation, and per-_N_ NS-vs-NVT cross-checks for a 3D LJ fluid and an LJ adsorbate on a frozen LJ(111) slab.
- NS live sets in the tests are drawn from the uniform prior (i.i.d. random placement), which canonical NS requires; fixed-site initialization biased per-_N_ $\langle U \rangle$ low in magnitude by 36 to 52%, and is the reason the agreement tolerance is now rtol = 0.40 instead of 0.60.
- A serial path for the EnergyEval inner loops when `Threads.nthreads() == 1`: `Threads.@threads` spawns and joins a task per call, which dominated these small hot loops (~30× overhead, profiled); `single_site_energy` drops to 0.26 μs/call with identical results. Multithreaded dispatch is unchanged.
- A corrected `V` docstring for `gc_thermodynamic_stats_fixed_N` and an informative `ArgumentError` for `monte_carlo_sampling` calls that omit the `MCRoutine` first argument (the call shape used in pre-0.3 examples).

## Validation beyond the test suite

Off-PR diagnostics (scripts and datasets retained locally) verified: ideal-gas $\Xi$ to within $10^{-7}$ of $e^{zV}$ across $zV = 0.1$ to $5$; fluid per-_N_ $\langle U \rangle$ agreement with NVT MC and an independent importance-sampling anchor for $N = 1$ to $8$; and surface $\langle U \rangle(T)$ across 50 to 400 K on a 3×3 LJ(111) cell, where seed-free NS follows the gas/condensed equilibrium while single-temperature canonical MC remains trapped in whichever basin it is seeded from. The 50 K full-monolayer reweighting reproduces a bound-seeded reference to 0.3% at the published walker prescription $K = 80N$.

## Test plan

- `test-atomistic-gcns-fixed-n.jl`: 95/95 (ideal gas 25, fluid 35, surface 35)
- `test-EnergyEval.jl`: 71/71 (serial path produces identical energies)
- `test-nvt_monte_carlo.jl`: 33/33 (catch-all does not affect dispatch)