### PR TITLE
Add microcanonical inflection-point analysis to AnalysisTools

### DIFF
--- a/docs/src/AnalysisTools.md
+++ b/docs/src/AnalysisTools.md
@@ -13,7 +13,7 @@ free. Along the contiguous cull index ``i`` the enclosed prior volume is
 energy ladder ``E(i)``,
 
 ```math
-S(E) = i\,\ln\!\frac{K}{K+1} - \ln\left|\frac{dE}{di}\right| ,
+S(E) = i\,\ln\!\frac{K}{K+1} - \ln\left|\frac{dE}{di}\right| + \mathrm{const} ,
 ```
 
 where derivatives are taken against the dense, uniform ``i``-axis (local cubic
@@ -23,7 +23,7 @@ Phys. Rev. E **84**, 011127 (2011) and Qi & Bachmann, Phys. Rev. Lett. **120**,
 the inverse caloric temperature ``\beta(E) = dS/dE``, and their **order** follows
 from the higher derivatives:
 
-| transition order | signature in ``S^{(n)}(E)`` |
+| transition order | *independent* signature in ``S^{(n)}(E)`` |
 |:--|:--|
 | 1 (first-order)  | ``\beta = S'`` has a positive local **minimum** (``\beta`` backbends; latent heat) |
 | 2 (second-order) | ``\gamma = S''`` has a negative local **maximum** |
@@ -31,10 +31,14 @@ from the higher derivatives:
 | odd ``n``        | positive local minimum of ``S^{(n)}`` |
 | even ``n``       | negative local maximum of ``S^{(n)}`` |
 
-The transition temperature is ``T_\mathrm{tr} = 1/\beta(E_\mathrm{tr})``. This is a
-purely microcanonical route: it needs no temperature grid, returns transition
-**energies and orders** directly, and can resolve transitions that broad canonical
-`cv(T)` peaks blur.
+*Dependent* transitions carry the swapped signatures (odd ``n``: negative local
+maximum; even ``n``: positive local minimum) and are reported with
+`kind = :dependent` when accompanied by an independent transition of lower order
+at lower energy. The transition temperature is
+``T_\mathrm{tr} = 1/(k_B\,\beta(E_\mathrm{tr}))`` — in Kelvin with the default
+`kb` in eV/K, or in energy units with `kb = 1`. This is a purely microcanonical
+route: it needs no temperature grid, returns transition **energies and orders**
+directly, and can resolve transitions that broad canonical `cv(T)` peaks blur.
 
 ### Workflow
 
@@ -70,6 +74,7 @@ conv = transition_convergence(dfs, [320, 640, 1280])   # flags drifting transiti
     divergence as ``E \to E_\mathrm{ground}``.
 
 ## Functions
+
 ```@autodocs
 Modules = [AnalysisTools]
 ```

--- a/docs/src/AnalysisTools.md
+++ b/docs/src/AnalysisTools.md
@@ -1,5 +1,74 @@
 # Analysis Tools
 
+The `AnalysisTools` module post-processes sampling output into thermodynamic
+quantities: phase-space weights (`ωᵢ`), the partition function, internal energy,
+constant-volume heat capacity (`cv`), grand-canonical reweighting, and — described
+below — microcanonical inflection-point analysis of phase transitions.
+
+## Microcanonical inflection-point analysis
+
+Nested sampling yields the microcanonical entropy ``S(E) = \ln g(E)`` almost for
+free. Along the contiguous cull index ``i`` the enclosed prior volume is
+``X_i = (K/(K+1))^i``, so ``\ln X_i = i\,\ln(K/(K+1))`` and, with the recorded
+energy ladder ``E(i)``,
+
+```math
+S(E) = i\,\ln\!\frac{K}{K+1} - \ln\left|\frac{dE}{di}\right| ,
+```
+
+where derivatives are taken against the dense, uniform ``i``-axis (local cubic
+fits) rather than a binned ``\ln g`` in energy space. Following Schnabel *et al.*,
+Phys. Rev. E **84**, 011127 (2011) and Qi & Bachmann, Phys. Rev. Lett. **120**,
+180601 (2018), phase transitions in finite systems appear as *inflection points* of
+the inverse caloric temperature ``\beta(E) = dS/dE``, and their **order** follows
+from the higher derivatives:
+
+| transition order | signature in ``S^{(n)}(E)`` |
+|:--|:--|
+| 1 (first-order)  | ``\beta = S'`` has a positive local **minimum** (``\beta`` backbends; latent heat) |
+| 2 (second-order) | ``\gamma = S''`` has a negative local **maximum** |
+| 3                | ``\delta = S'''`` has a positive local minimum |
+| odd ``n``        | positive local minimum of ``S^{(n)}`` |
+| even ``n``       | negative local maximum of ``S^{(n)}`` |
+
+The transition temperature is ``T_\mathrm{tr} = 1/\beta(E_\mathrm{tr})``. This is a
+purely microcanonical route: it needs no temperature grid, returns transition
+**energies and orders** directly, and can resolve transitions that broad canonical
+`cv(T)` peaks blur.
+
+### Workflow
+
+```julia
+using FreeBird
+
+df = read_output("ladder.csv")            # canonical NS output (columns :iter, :emax)
+K  = 320                                   # number of live walkers used to produce it
+
+E, S = microcanonical_entropy(df, K)               # S(E) = ln g(E)
+d    = caloric_derivatives(df, K; max_order = 2)   # d.E, d.β, d.γ
+ts   = inflection_transitions(df, K; max_order = 2) # → (E_tr, T_tr, order, kind, strength)
+
+# Recommended: confirm each transition is converged in the walker count K
+dfs = [read_output("ladder_K320.csv"),
+       read_output("ladder_K640.csv"),
+       read_output("ladder_K1280.csv")]
+conv = transition_convergence(dfs, [320, 640, 1280])   # flags drifting transitions
+```
+
+### Convergence and smoothing
+
+!!! warning "Use enough walkers, and check convergence"
+    The derivative ``\gamma = d^2S/dE^2`` amplifies the finite-walker "staircase"
+    granularity of the NS ladder (step ``\sim 1/(K\,g)``). This roughness is
+    *deterministic* in the walker count ``K`` — it does **not** average out over
+    independent runs — so a transition should only be trusted once its temperature
+    and order stop drifting as ``K`` grows; use [`transition_convergence`](@ref).
+    Near-ground transitions converge last. The light internal smoothing
+    (`halfwidth`) is a necessary differentiation aid, **not** a substitute for
+    adequate ``K``: smoothing heavily to mask too-few walkers biases the transition
+    temperatures. Energy-window/`ground_trim` controls remove the ``\beta``
+    divergence as ``E \to E_\mathrm{ground}``.
+
 ## Functions
 ```@autodocs
 Modules = [AnalysisTools]

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -11,6 +11,7 @@ using CSV, Arrow
 export read_output
 export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
+export microcanonical_entropy, caloric_derivatives
 
 """
     read_output(filename::String)
@@ -336,5 +337,7 @@ function gc_thermodynamic_stats(df::DataFrame,
     return mean_Es, Cvs, mean_Ns
 end
 
+
+include("microcanonical_inflection.jl")
 
 end # module AnalysisTools

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -12,6 +12,7 @@ export read_output
 export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
 export microcanonical_entropy, caloric_derivatives, inflection_transitions
+export transition_convergence
 
 """
     read_output(filename::String)

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -11,7 +11,7 @@ using CSV, Arrow
 export read_output
 export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
-export microcanonical_entropy, caloric_derivatives
+export microcanonical_entropy, caloric_derivatives, inflection_transitions
 
 """
     read_output(filename::String)

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -65,11 +65,11 @@ function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     W = min(W, (n - 3) ÷ 2)
     nodes = unique(round.(Int, range(W + 1, n - W; length = min(n_nodes, n - 2W))))
 
-    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]
+    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]; slope = Float64[]
     for idx in nodes
         _, ep, epp = _local_cubic(i, e, idx, W)        # dE/di, d²E/di²
         ep < 0 || continue                              # ladder must descend
-        push!(E, e[idx])
+        push!(E, e[idx]); push!(slope, ep)
         push!(Svol, cc * i[idx])                        # volume entropy ln G = ln X
         push!(Scal, cc * i[idx] - log(-ep))             # caloric entropy ln g (+const)
         push!(β, cc / ep - epp / ep^2)                  # β = dS/dE (caloric)
@@ -77,10 +77,10 @@ function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     length(E) >= 5 || throw(ArgumentError("too few usable nodes; check the ladder/halfwidth"))
 
     o = sortperm(E)                                     # ascending in energy
-    E, Svol, Scal, β = E[o], Svol[o], Scal[o], β[o]
+    E, Svol, Scal, β, slope = E[o], Svol[o], Scal[o], β[o], slope[o]
     γ = max_order >= 2 ? _derivative(E, β) : Float64[]
     δ = max_order >= 3 ? _derivative(E, γ) : Float64[]
-    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ)
+    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ, slope = slope)
 end
 
 """
@@ -148,4 +148,143 @@ function caloric_derivatives(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     max_order == 1 && return (E = r.E, β = r.β)
     max_order == 2 && return (E = r.E, β = r.β, γ = r.γ)
     return (E = r.E, β = r.β, γ = r.γ, δ = r.δ)
+end
+
+# median / linear-interpolated quantile without a Statistics dependency
+function _median(v::AbstractVector)
+    s = sort(v); m = length(s)
+    m == 0 && return zero(eltype(s))
+    iseven(m) ? (s[m÷2] + s[m÷2+1]) / 2 : s[m÷2+1]
+end
+function _quantile(v::AbstractVector, q::Real)
+    s = sort(collect(v)); m = length(s)
+    m == 1 && return float(s[1])
+    h = (m - 1) * q + 1
+    lo = floor(Int, h); hi = min(lo + 1, m)
+    return s[lo] + (h - lo) * (s[hi] - s[lo])
+end
+
+# Local extrema of the order-n entropy derivative `Sn` carrying the Qi–Bachmann
+# transition signature: odd order → positive local minimum, even order → negative
+# local maximum. Prominence-filtered (relative to the interior range) and merged by
+# a minimum energy separation. Returns node indices into `E`/`Sn`.
+function _order_extrema(E::Vector{Float64}, Sn::Vector{Float64}, order::Int;
+                        prominence::Float64, edge::Int, min_sep::Float64)
+    n = length(Sn)
+    lo, hi = 1 + edge, n - edge
+    lo < hi || return Int[]
+    interior = view(Sn, lo:hi)
+    rng = _quantile(interior, 0.9) - _quantile(interior, 0.1)   # robust to divergence outliers
+    rng > 0 || return Int[]
+    thr = prominence * rng
+    odd = isodd(order)
+    cands = Tuple{Int,Float64}[]
+    for i in lo:hi
+        if odd                                            # positive local minimum
+            (Sn[i] < Sn[i-1] && Sn[i] <= Sn[i+1] && Sn[i] > 0) || continue
+            l = i; while l > 1 && Sn[l-1] >= Sn[i]; l -= 1; end
+            r = i; while r < n && Sn[r+1] >= Sn[i]; r += 1; end
+            prom = min(maximum(view(Sn, l:i)), maximum(view(Sn, i:r))) - Sn[i]
+        else                                              # negative local maximum
+            (Sn[i] > Sn[i-1] && Sn[i] >= Sn[i+1] && Sn[i] < 0) || continue
+            l = i; while l > 1 && Sn[l-1] <= Sn[i]; l -= 1; end
+            r = i; while r < n && Sn[r+1] <= Sn[i]; r += 1; end
+            prom = Sn[i] - max(minimum(view(Sn, l:i)), minimum(view(Sn, i:r)))
+        end
+        prom >= thr && push!(cands, (i, prom))
+    end
+    sort!(cands, by = c -> -c[2])
+    chosen = Int[]
+    for (i, _) in cands
+        all(abs(E[i] - E[j]) > min_sep for j in chosen) && push!(chosen, i)
+    end
+    return sort(chosen)
+end
+
+"""
+    inflection_transitions(df::DataFrame, n_walkers::Int;
+        n_cull=1, max_order=2, n_nodes=400, halfwidth=0,
+        kb=8.617333262e-5, prominence=0.05, edge=4,
+        min_separation=nothing, energy_window=nothing, beta_max=nothing)
+
+Identify and classify phase transitions in a nested-sampling output `df` by
+microcanonical inflection-point analysis (Schnabel et al. 2011; Qi & Bachmann
+2018). Returns one entry per transition, ordered by energy.
+
+A transition of order `n` is a "least-sensitive" inflection point of the entropy,
+detected as an extremum of the `n`-th derivative `Sⁿ(E)` with the Qi–Bachmann sign:
+**odd order → a positive local minimum** of `Sⁿ` (order 1 = β backbending,
+first-order), **even order → a negative local maximum** of `Sⁿ` (order 2 = γ peak,
+second-order). Orders `1…max_order` are searched. The transition temperature is
+`T_tr = 1/(kb·β(E_tr))`.
+
+# Arguments
+- `max_order`: highest transition order to search (1–3).
+- `kb`: Boltzmann constant; default `8.617333262e-5` eV/K gives `T_tr` in Kelvin
+  when `:emax` is in eV. Pass `kb=1.0` for the microcanonical temperature in energy
+  units (`kT`).
+- `prominence`: peak prominence threshold as a fraction of the (robust 10–90
+  percentile) derivative range (default 0.20). Raise it to keep only strong
+  transitions.
+- `ground_trim`: fraction of the energy span (above the ground state) to discard
+  before differentiating, removing the `β → ∞` divergence as `dE/di → 0` (default
+  0.05). γ/δ are recomputed on the trimmed window so transitions are not
+  contaminated by the divergence.
+- `edge`, `min_separation`, `energy_window`, `beta_max`: numerical controls;
+  `min_separation` defaults to 3% of the (trimmed) energy span, and `beta_max`
+  optionally adds an explicit β ceiling.
+- `n_cull`, `n_nodes`, `halfwidth`: as in [`caloric_derivatives`].
+
+# Returns
+`Vector{NamedTuple}` with fields `E_tr`, `T_tr`, `order::Int`, `kind`
+(`:independent` or `:dependent`), and `strength` (the `Sⁿ` extremum value).
+`kind` uses the Qi–Bachmann heuristic: a transition accompanied by a lower-order
+transition at lower energy is `:dependent`, otherwise `:independent`.
+
+!!! note
+    γ and higher derivatives are sensitive to NS statistics. The ladder roughness
+    is finite-walker granularity (it does **not** average out over seeds), so use
+    enough walkers `K`; verify with [`transition_convergence`](@ref). Heavy
+    smoothing (large `halfwidth`) on under-converged ladders biases `T_tr`.
+"""
+function inflection_transitions(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
+        max_order::Int = 2, n_nodes::Int = 400, halfwidth::Int = 0,
+        kb::Float64 = 8.617333262e-5, prominence::Float64 = 0.20, edge::Int = 4,
+        ground_trim::Float64 = 0.05,
+        min_separation::Union{Nothing,Float64} = nothing,
+        energy_window::Union{Nothing,Tuple{<:Real,<:Real}} = nothing,
+        beta_max::Union{Nothing,Float64} = nothing)
+    1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
+    0 <= ground_trim < 0.5 || throw(ArgumentError("ground_trim must be in [0, 0.5)"))
+    r = _microcanonical_core(df, n_walkers; n_cull = n_cull, n_nodes = n_nodes,
+                             halfwidth = halfwidth, max_order = 1)
+    E, β = r.E, r.β
+    # Trim the ground-state β divergence (the ladder flattens, dE/di → 0, β → ∞)
+    # BEFORE differentiating, so γ/δ near the transitions are not contaminated.
+    Emin, Emax = extrema(E)
+    Elo = Emin + ground_trim * (Emax - Emin)
+    keep = (β .> 0) .& (E .>= Elo)
+    beta_max === nothing || (keep = keep .& (β .< beta_max))
+    if energy_window !== nothing
+        keep = keep .& (E .>= energy_window[1]) .& (E .<= energy_window[2])
+    end
+    idx = findall(keep)
+    length(idx) >= 2edge + 5 || return NamedTuple[]
+    Ew, βw = E[idx], β[idx]
+    # derivatives recomputed on the windowed β (free of the ground divergence)
+    γw = max_order >= 2 ? _derivative(Ew, βw) : Float64[]
+    δw = max_order >= 3 ? _derivative(Ew, γw) : Float64[]
+    derivs = (βw, γw, δw)
+    msep = min_separation === nothing ? 0.03 * (maximum(Ew) - minimum(Ew)) : min_separation
+    found = NamedTuple[]
+    for n in 1:max_order
+        Sn = derivs[n]
+        for i in _order_extrema(Ew, Sn, n; prominence = prominence, edge = edge, min_sep = msep)
+            push!(found, (E_tr = Ew[i], T_tr = 1 / (kb * βw[i]), order = n, strength = Sn[i]))
+        end
+    end
+    sort!(found, by = t -> t.E_tr)
+    return [(E_tr = t.E_tr, T_tr = t.T_tr, order = t.order,
+             kind = any(s.order < t.order && s.E_tr < t.E_tr for s in found) ? :dependent : :independent,
+             strength = t.strength) for t in found]
 end

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -53,23 +53,36 @@ function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
                               n_nodes::Int = 400, halfwidth::Int = 0, max_order::Int = 2)
     n_walkers > 0 || throw(ArgumentError("n_walkers must be positive"))
     1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
+    halfwidth == 0 || halfwidth >= 2 ||
+        throw(ArgumentError("halfwidth must be 0 (automatic) or ≥ 2 (a cubic fit needs ≥ 5 points)"))
     hasproperty(df, :iter) && hasproperty(df, :emax) ||
         throw(ArgumentError("df must have :iter and :emax columns (nested_sampling output)"))
     i = Float64.(df.iter)
     e = Float64.(df.emax)
     n = length(i)
-    n >= 9 || throw(ArgumentError("NS ladder too short (need ≥ 9 recorded iterations)"))
 
     cc = log(n_walkers / (n_walkers + n_cull))         # ln(K/(K+n_cull)) < 0
     W = halfwidth > 0 ? halfwidth : clamp(n ÷ 55, 25, 2000)
     W = min(W, (n - 3) ÷ 2)
+    n - 2W >= 5 || throw(ArgumentError(halfwidth > 0 ?
+        "NS ladder too short: halfwidth = $halfwidth needs ≥ $(2halfwidth + 5) recorded iterations (got $n)" :
+        "NS ladder too short: the automatic halfwidth needs ≥ 55 recorded iterations (got $n); pass an explicit halfwidth ≥ 2 to analyze shorter ladders"))
     nodes = unique(round.(Int, range(W + 1, n - W; length = min(n_nodes, n - 2W))))
 
-    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]; slope = Float64[]
-    for idx in nodes
-        _, ep, epp = _local_cubic(i, e, idx, W)        # dE/di, d²E/di²
-        ep < 0 || continue                              # ladder must descend
-        push!(E, e[idx]); push!(slope, ep)
+    # Fit every node first: the slope floor below needs the typical ladder slope.
+    fits = [(idx, _local_cubic(i, e, idx, W)) for idx in nodes]
+    descending = [-ep for (_, (_, ep, _)) in fits if ep < 0]
+    isempty(descending) &&
+        throw(ArgumentError("too few usable nodes; check the ladder/halfwidth"))
+    # Drop nodes whose slope is at rounding level relative to the typical slope: on
+    # emax plateaus (exactly degenerate lattice levels, or the default 1e-12 energy
+    # perturbation) the fitted slope is ~0 and β = cc/ep − epp/ep² would spike.
+    slope_floor = 1e-8 * _median(descending)
+
+    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]
+    for (idx, (_, ep, epp)) in fits
+        ep < -slope_floor || continue                   # ladder must genuinely descend
+        push!(E, e[idx])
         push!(Svol, cc * i[idx])                        # volume entropy ln G = ln X
         push!(Scal, cc * i[idx] - log(-ep))             # caloric entropy ln g (+const)
         push!(β, cc / ep - epp / ep^2)                  # β = dS/dE (caloric)
@@ -77,10 +90,10 @@ function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     length(E) >= 5 || throw(ArgumentError("too few usable nodes; check the ladder/halfwidth"))
 
     o = sortperm(E)                                     # ascending in energy
-    E, Svol, Scal, β, slope = E[o], Svol[o], Scal[o], β[o], slope[o]
+    E, Svol, Scal, β = E[o], Svol[o], Scal[o], β[o]
     γ = max_order >= 2 ? _derivative(E, β) : Float64[]
     δ = max_order >= 3 ? _derivative(E, γ) : Float64[]
-    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ, slope = slope)
+    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ)
 end
 
 """
@@ -103,7 +116,9 @@ uniform `i`-axis.
 - `n_cull`: NS culls per iteration (default 1).
 - `n_nodes`: number of smoothed output nodes (default 400).
 - `halfwidth`: half-window (in iterations) of the local cubic smoother; `0` (default)
-  picks `clamp(n÷55, 25, 2000)`.
+  picks `clamp(n÷55, 25, 2000)`, which requires a ladder of ≥ 55 recorded
+  iterations. Explicit values must be ≥ 2; pass a small one to analyze shorter
+  ladders.
 
 # Returns
 `(E, S)` — energies (ascending, same units as `:emax`) and entropy (dimensionless,
@@ -138,7 +153,11 @@ and then differentiated against energy with local cubic fits.
 A `NamedTuple` with `E` (ascending energies, same units as `:emax`) and `β` (units
 of inverse energy), plus `γ` and `δ` as requested by `max_order`. Note `γ`, `δ` are
 sensitive to NS statistics — increase the walker count `K` (not the number of seeds)
-for cleaner higher derivatives; see [`transition_convergence`](@ref).
+for cleaner higher derivatives; see [`transition_convergence`](@ref). They are also
+computed over the *full* energy range, including the near-ground region where the
+ladder flattens and the `β` estimate diverges — [`inflection_transitions`](@ref)
+trims that region (`ground_trim`) before differentiating; do the same before
+interpreting low-energy `γ`/`δ` features.
 """
 function caloric_derivatives(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
                              max_order::Int = 2, n_nodes::Int = 400, halfwidth::Int = 0)
@@ -150,7 +169,7 @@ function caloric_derivatives(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     return (E = r.E, β = r.β, γ = r.γ, δ = r.δ)
 end
 
-# median / linear-interpolated quantile without a Statistics dependency
+# median / linear-interpolated (type-7) quantile helpers
 function _median(v::AbstractVector)
     s = sort(v); m = length(s)
     m == 0 && return zero(eltype(s))
@@ -164,58 +183,79 @@ function _quantile(v::AbstractVector, q::Real)
     return s[lo] + (h - lo) * (s[hi] - s[lo])
 end
 
-# Local extrema of the order-n entropy derivative `Sn` carrying the Qi–Bachmann
-# transition signature: odd order → positive local minimum, even order → negative
-# local maximum. Prominence-filtered (relative to the interior range) and merged by
-# a minimum energy separation. Returns node indices into `E`/`Sn`.
+# Local extrema of the order-n entropy derivative `Sn` carrying a Qi–Bachmann
+# transition signature. Independent transitions: odd order → positive local
+# minimum, even order → negative local maximum. Dependent transitions carry the
+# swapped signatures (Qi & Bachmann 2018): odd order → negative local maximum,
+# even order → positive local minimum. Prominence-filtered against the robust
+# range of the linearly detrended interior (so the threshold tracks the size of
+# the transition features, not the global cooling trend of β over however much
+# ladder is analyzed) and merged by a minimum energy separation. Returns
+# (node index, kind) pairs sorted by index.
 function _order_extrema(E::Vector{Float64}, Sn::Vector{Float64}, order::Int;
-                        prominence::Float64, edge::Int, min_sep::Float64)
+                        prominence::Float64, edge::Int, min_sep::Float64,
+                        prominence_abs::Union{Nothing,Float64} = nothing)
     n = length(Sn)
     lo, hi = 1 + edge, n - edge
-    lo < hi || return Int[]
-    interior = view(Sn, lo:hi)
-    rng = _quantile(interior, 0.9) - _quantile(interior, 0.1)   # robust to divergence outliers
-    rng > 0 || return Int[]
-    thr = prominence * rng
+    lo < hi || return Tuple{Int,Symbol}[]
+    thr = if prominence_abs === nothing
+        xs, ys = view(E, lo:hi), view(Sn, lo:hi)
+        mx = sum(xs) / length(xs); my = sum(ys) / length(ys)
+        sxx = sum(abs2, xs .- mx)
+        b = sxx > 0 ? sum((xs .- mx) .* (ys .- my)) / sxx : 0.0
+        resid = ys .- my .- b .* (xs .- mx)
+        rng = _quantile(resid, 0.9) - _quantile(resid, 0.1)     # robust to divergence outliers
+        rng > 0 || return Tuple{Int,Symbol}[]
+        prominence * rng
+    else
+        prominence_abs
+    end
     odd = isodd(order)
-    cands = Tuple{Int,Float64}[]
+    cands = Tuple{Int,Float64,Symbol}[]
     for i in lo:hi
-        if odd                                            # positive local minimum
-            (Sn[i] < Sn[i-1] && Sn[i] <= Sn[i+1] && Sn[i] > 0) || continue
+        if Sn[i] < Sn[i-1] && Sn[i] <= Sn[i+1] && Sn[i] > 0        # positive local minimum
             l = i; while l > 1 && Sn[l-1] >= Sn[i]; l -= 1; end
             r = i; while r < n && Sn[r+1] >= Sn[i]; r += 1; end
             prom = min(maximum(view(Sn, l:i)), maximum(view(Sn, i:r))) - Sn[i]
-        else                                              # negative local maximum
-            (Sn[i] > Sn[i-1] && Sn[i] >= Sn[i+1] && Sn[i] < 0) || continue
+            kind = odd ? :independent : :dependent
+        elseif Sn[i] > Sn[i-1] && Sn[i] >= Sn[i+1] && Sn[i] < 0    # negative local maximum
             l = i; while l > 1 && Sn[l-1] <= Sn[i]; l -= 1; end
             r = i; while r < n && Sn[r+1] <= Sn[i]; r += 1; end
             prom = Sn[i] - max(minimum(view(Sn, l:i)), minimum(view(Sn, i:r)))
+            kind = odd ? :dependent : :independent
+        else
+            continue
         end
-        prom >= thr && push!(cands, (i, prom))
+        prom >= thr && push!(cands, (i, prom, kind))
     end
     sort!(cands, by = c -> -c[2])
-    chosen = Int[]
-    for (i, _) in cands
-        all(abs(E[i] - E[j]) > min_sep for j in chosen) && push!(chosen, i)
+    chosen = Tuple{Int,Symbol}[]
+    for (i, _, kind) in cands
+        all(abs(E[i] - E[j]) > min_sep for (j, _) in chosen) && push!(chosen, (i, kind))
     end
-    return sort(chosen)
+    return sort!(chosen, by = first)
 end
 
 """
     inflection_transitions(df::DataFrame, n_walkers::Int;
         n_cull=1, max_order=2, n_nodes=400, halfwidth=0,
-        kb=8.617333262e-5, prominence=0.05, edge=4,
-        min_separation=nothing, energy_window=nothing, beta_max=nothing)
+        kb=8.617333262e-5, prominence=0.20, prominence_abs=nothing, edge=4,
+        ground_trim=0.05, min_separation=nothing, energy_window=nothing,
+        beta_max=nothing)
 
 Identify and classify phase transitions in a nested-sampling output `df` by
 microcanonical inflection-point analysis (Schnabel et al. 2011; Qi & Bachmann
 2018). Returns one entry per transition, ordered by energy.
 
 A transition of order `n` is a "least-sensitive" inflection point of the entropy,
-detected as an extremum of the `n`-th derivative `Sⁿ(E)` with the Qi–Bachmann sign:
-**odd order → a positive local minimum** of `Sⁿ` (order 1 = β backbending,
-first-order), **even order → a negative local maximum** of `Sⁿ` (order 2 = γ peak,
-second-order). Orders `1…max_order` are searched. The transition temperature is
+detected as an extremum of the `n`-th derivative `Sⁿ(E)` with a Qi–Bachmann sign
+signature. **Independent** transitions: odd order → a positive local minimum of
+`Sⁿ` (order 1 = β backbending, first-order), even order → a negative local
+maximum (order 2 = γ peak, second-order). **Dependent** transitions carry the
+swapped signatures (odd order → negative local maximum, even order → positive
+local minimum) and are reported only when accompanied by an independent
+transition of lower order at lower energy — Qi & Bachmann's necessary condition.
+Orders `1…max_order` are searched. The transition temperature is
 `T_tr = 1/(kb·β(E_tr))`.
 
 # Arguments
@@ -223,39 +263,51 @@ second-order). Orders `1…max_order` are searched. The transition temperature i
 - `kb`: Boltzmann constant; default `8.617333262e-5` eV/K gives `T_tr` in Kelvin
   when `:emax` is in eV. Pass `kb=1.0` for the microcanonical temperature in energy
   units (`kT`).
-- `prominence`: peak prominence threshold as a fraction of the (robust 10–90
-  percentile) derivative range (default 0.20). Raise it to keep only strong
-  transitions.
+- `prominence`: peak prominence threshold as a fraction of the robust (10–90
+  percentile) range of the **linearly detrended** derivative over the analysis
+  window (default 0.20). Detrending ties the threshold to the size of the
+  transition features rather than to how much ladder is analyzed. Raise it to
+  keep only strong transitions.
+- `prominence_abs`: absolute prominence threshold in the units of `Sⁿ`; when set,
+  it replaces the relative `prominence` criterion (default `nothing`).
 - `ground_trim`: fraction of the energy span (above the ground state) to discard
   before differentiating, removing the `β → ∞` divergence as `dE/di → 0` (default
   0.05). γ/δ are recomputed on the trimmed window so transitions are not
   contaminated by the divergence.
 - `edge`, `min_separation`, `energy_window`, `beta_max`: numerical controls;
-  `min_separation` defaults to 3% of the (trimmed) energy span, and `beta_max`
-  optionally adds an explicit β ceiling.
+  `edge ≥ 1` nodes are skipped at each window boundary, `min_separation` defaults
+  to 3% of the (trimmed) energy span, and `beta_max` optionally adds an explicit
+  β ceiling. Nodes removed by `beta_max` (or the `β > 0` filter) can split the
+  window into disjoint energy segments; derivatives and extrema are then computed
+  per contiguous segment, never across a gap.
 - `n_cull`, `n_nodes`, `halfwidth`: as in [`caloric_derivatives`](@ref).
 
 # Returns
 `Vector{NamedTuple}` with fields `E_tr`, `T_tr`, `order::Int`, `kind`
-(`:independent` or `:dependent`), and `strength` (the `Sⁿ` extremum value).
-`kind` uses the Qi–Bachmann heuristic: a transition accompanied by a lower-order
-transition at lower energy is `:dependent`, otherwise `:independent`.
+(`:independent` or `:dependent`, assigned from the sign signatures above), and
+`strength` (the `Sⁿ` extremum value).
 
 !!! note
     γ and higher derivatives are sensitive to NS statistics. The ladder roughness
     is finite-walker granularity (it does **not** average out over seeds), so use
     enough walkers `K`; verify with [`transition_convergence`](@ref). Heavy
     smoothing (large `halfwidth`) on under-converged ladders biases `T_tr`.
+    On lattice ladders with exactly (or near-exactly) degenerate levels, plateau
+    stretches of `emax` are dropped by an internal slope floor before `β` is
+    formed; a plateau longer than the smoothing window leaves a gap in the
+    analyzed energy range.
 """
 function inflection_transitions(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
         max_order::Int = 2, n_nodes::Int = 400, halfwidth::Int = 0,
-        kb::Float64 = 8.617333262e-5, prominence::Float64 = 0.20, edge::Int = 4,
+        kb::Float64 = 8.617333262e-5, prominence::Float64 = 0.20,
+        prominence_abs::Union{Nothing,Float64} = nothing, edge::Int = 4,
         ground_trim::Float64 = 0.05,
         min_separation::Union{Nothing,Float64} = nothing,
         energy_window::Union{Nothing,Tuple{<:Real,<:Real}} = nothing,
         beta_max::Union{Nothing,Float64} = nothing)
     1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
     0 <= ground_trim < 0.5 || throw(ArgumentError("ground_trim must be in [0, 0.5)"))
+    edge >= 1 || throw(ArgumentError("edge must be ≥ 1"))
     r = _microcanonical_core(df, n_walkers; n_cull = n_cull, n_nodes = n_nodes,
                              halfwidth = halfwidth, max_order = 1)
     E, β = r.E, r.β
@@ -269,24 +321,42 @@ function inflection_transitions(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
         keep = keep .& (E .>= energy_window[1]) .& (E .<= energy_window[2])
     end
     idx = findall(keep)
-    length(idx) >= 2edge + 5 || return NamedTuple[]
-    Ew, βw = E[idx], β[idx]
-    # derivatives recomputed on the windowed β (free of the ground divergence)
-    γw = max_order >= 2 ? _derivative(Ew, βw) : Float64[]
-    δw = max_order >= 3 ? _derivative(Ew, γw) : Float64[]
-    derivs = (βw, γw, δw)
-    msep = min_separation === nothing ? 0.03 * (maximum(Ew) - minimum(Ew)) : min_separation
+    isempty(idx) && return NamedTuple[]
+    msep = min_separation === nothing ? 0.03 * (E[idx[end]] - E[idx[1]]) : min_separation
+    # The β-based filters can excise interior nodes (e.g. beta_max cutting the top
+    # of a backbend); differentiate and search each contiguous segment separately
+    # so no local fit ever spans a gap.
+    runs = UnitRange{Int}[]
+    s = 1
+    for k in 2:length(idx)
+        idx[k] == idx[k-1] + 1 || (push!(runs, s:(k - 1)); s = k)
+    end
+    push!(runs, s:length(idx))
     found = NamedTuple[]
-    for n in 1:max_order
-        Sn = derivs[n]
-        for i in _order_extrema(Ew, Sn, n; prominence = prominence, edge = edge, min_sep = msep)
-            push!(found, (E_tr = Ew[i], T_tr = 1 / (kb * βw[i]), order = n, strength = Sn[i]))
+    for run in runs
+        length(run) >= 2edge + 5 || continue
+        Ew, βw = E[idx[run]], β[idx[run]]
+        # derivatives recomputed on the windowed β (free of the ground divergence)
+        γw = max_order >= 2 ? _derivative(Ew, βw) : Float64[]
+        δw = max_order >= 3 ? _derivative(Ew, γw) : Float64[]
+        derivs = (βw, γw, δw)
+        for n in 1:max_order
+            Sn = derivs[n]
+            for (i, kind) in _order_extrema(Ew, Sn, n; prominence = prominence,
+                                            edge = edge, min_sep = msep,
+                                            prominence_abs = prominence_abs)
+                push!(found, (E_tr = Ew[i], T_tr = 1 / (kb * βw[i]), order = n,
+                              kind = kind, strength = Sn[i]))
+            end
         end
     end
+    # Qi–Bachmann necessary condition: a dependent transition accompanies an
+    # independent one of lower order at lower energy; drop unaccompanied ones.
+    indep = [t for t in found if t.kind === :independent]
+    filter!(t -> t.kind === :independent ||
+                 any(s.order < t.order && s.E_tr < t.E_tr for s in indep), found)
     sort!(found, by = t -> t.E_tr)
-    return [(E_tr = t.E_tr, T_tr = t.T_tr, order = t.order,
-             kind = any(s.order < t.order && s.E_tr < t.E_tr for s in found) ? :dependent : :independent,
-             strength = t.strength) for t in found]
+    return found
 end
 
 # closest same-order transition to `t` within `match_tol` (relative in T_tr); else nothing

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -127,12 +127,12 @@ Microcanonical entropy derivatives from a nested-sampling output `df`:
 ``β(E)=dS/dE`` (inverse caloric temperature; the microcanonical temperature is
 ``k_BT=1/β``), ``γ(E)=d^2S/dE^2``, and optionally ``δ(E)=d^3S/dE^3``.
 
-Derivatives are computed in iteration-index space (see [`microcanonical_entropy`])
+Derivatives are computed in iteration-index space (see [`microcanonical_entropy`](@ref))
 and then differentiated against energy with local cubic fits.
 
 # Arguments
 - `max_order`: highest derivative to return (1 → β only; 2 → β, γ; 3 → β, γ, δ).
-- `n_cull`, `n_nodes`, `halfwidth`: as in [`microcanonical_entropy`].
+- `n_cull`, `n_nodes`, `halfwidth`: as in [`microcanonical_entropy`](@ref).
 
 # Returns
 A `NamedTuple` with `E` (ascending energies, same units as `:emax`) and `β` (units
@@ -233,7 +233,7 @@ second-order). Orders `1…max_order` are searched. The transition temperature i
 - `edge`, `min_separation`, `energy_window`, `beta_max`: numerical controls;
   `min_separation` defaults to 3% of the (trimmed) energy span, and `beta_max`
   optionally adds an explicit β ceiling.
-- `n_cull`, `n_nodes`, `halfwidth`: as in [`caloric_derivatives`].
+- `n_cull`, `n_nodes`, `halfwidth`: as in [`caloric_derivatives`](@ref).
 
 # Returns
 `Vector{NamedTuple}` with fields `E_tr`, `T_tr`, `order::Int`, `kind`
@@ -321,7 +321,7 @@ and order stop drifting as `K` increases. Near-ground transitions converge last.
   is flagged `converged` (default 0.1).
 - `match_tol`: relative `T_tr` window for matching the same transition across `K`
   (default 0.25).
-- `kwargs...`: forwarded to [`inflection_transitions`] (e.g. `max_order`, `prominence`,
+- `kwargs...`: forwarded to [`inflection_transitions`](@ref) (e.g. `max_order`, `prominence`,
   `ground_trim`, `kb`).
 
 # Returns

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -1,0 +1,151 @@
+# =============================================================================
+# Microcanonical inflection-point analysis of nested-sampling output.
+#
+# Implements the microcanonical entropy and its energetic derivatives following
+# Schnabel et al., Phys. Rev. E 84, 011127 (2011) and Qi & Bachmann, Phys. Rev.
+# Lett. 120, 180601 (2018). Transitions appear as inflection points of the
+# inverse microcanonical temperature β(E)=dS/dE; the order is read from the
+# higher derivatives (see `inflection_transitions`).
+#
+# Nested sampling gives the entropy essentially exactly along the (contiguous)
+# cull index i: the enclosed prior volume is X_i = (K/(K+1))^i, so
+# ln X_i = i·ln(K/(K+1)). With the energy ladder E(i) (E = `emax`), the caloric
+# entropy is S(E) = ln g(E) = i·ln(K/(K+1)) − ln|dE/di| (+const), and derivatives
+# are taken against the dense, uniform i-axis (local cubic fits) — far more stable
+# than differentiating a binned ln g in energy space.
+#
+# NUMERICS NOTE: γ=d²S/dE² amplifies the finite-walker "staircase" granularity of
+# the NS ladder (step ~ 1/(K·g)). That roughness shrinks with the NUMBER OF
+# WALKERS K (not with more independent runs — the ladder is reproducible across
+# seeds). Smoothing here is a light, necessary differentiation aid, NOT a
+# substitute for adequate K: heavy smoothing on under-converged ladders biases the
+# transition temperatures. Use `transition_convergence` to check K-convergence.
+# =============================================================================
+
+# Local cubic least-squares fit of `y` vs `x` over the window [idx-W, idx+W];
+# returns the value, first, and second derivative at node `idx`.
+function _local_cubic(x::AbstractVector, y::AbstractVector, idx::Int, W::Int)
+    lo = max(firstindex(x), idx - W)
+    hi = min(lastindex(x), idx + W)
+    dx = x[lo:hi] .- x[idx]
+    V = [dx[k]^p for k in eachindex(dx), p in 0:3]
+    c = V \ y[lo:hi]
+    return c[1], c[2], 2 * c[3]
+end
+
+# First derivative of `y` w.r.t. `x` at every point, via local cubic fits.
+function _derivative(x::AbstractVector, y::AbstractVector; W::Int = 12)
+    d = similar(float.(y))
+    @inbounds for j in eachindex(x)
+        lo = max(firstindex(x), j - W)
+        hi = min(lastindex(x), j + W)
+        dx = x[lo:hi] .- x[j]
+        V = [dx[k]^p for k in eachindex(dx), p in 0:3]
+        d[j] = (V \ y[lo:hi])[2]
+    end
+    return d
+end
+
+# Core: build the smoothed microcanonical curves on a set of i-space nodes.
+# Returns a NamedTuple with energies `E` (ascending) and, as requested,
+# `S_vol`, `S_caloric`, `β`, `γ`, `δ`.
+function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
+                              n_nodes::Int = 400, halfwidth::Int = 0, max_order::Int = 2)
+    n_walkers > 0 || throw(ArgumentError("n_walkers must be positive"))
+    1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
+    hasproperty(df, :iter) && hasproperty(df, :emax) ||
+        throw(ArgumentError("df must have :iter and :emax columns (nested_sampling output)"))
+    i = Float64.(df.iter)
+    e = Float64.(df.emax)
+    n = length(i)
+    n >= 9 || throw(ArgumentError("NS ladder too short (need ≥ 9 recorded iterations)"))
+
+    cc = log(n_walkers / (n_walkers + n_cull))         # ln(K/(K+n_cull)) < 0
+    W = halfwidth > 0 ? halfwidth : clamp(n ÷ 55, 25, 2000)
+    W = min(W, (n - 3) ÷ 2)
+    nodes = unique(round.(Int, range(W + 1, n - W; length = min(n_nodes, n - 2W))))
+
+    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]
+    for idx in nodes
+        _, ep, epp = _local_cubic(i, e, idx, W)        # dE/di, d²E/di²
+        ep < 0 || continue                              # ladder must descend
+        push!(E, e[idx])
+        push!(Svol, cc * i[idx])                        # volume entropy ln G = ln X
+        push!(Scal, cc * i[idx] - log(-ep))             # caloric entropy ln g (+const)
+        push!(β, cc / ep - epp / ep^2)                  # β = dS/dE (caloric)
+    end
+    length(E) >= 5 || throw(ArgumentError("too few usable nodes; check the ladder/halfwidth"))
+
+    o = sortperm(E)                                     # ascending in energy
+    E, Svol, Scal, β = E[o], Svol[o], Scal[o], β[o]
+    γ = max_order >= 2 ? _derivative(E, β) : Float64[]
+    δ = max_order >= 3 ? _derivative(E, γ) : Float64[]
+    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ)
+end
+
+"""
+    microcanonical_entropy(df::DataFrame, n_walkers::Int;
+                           n_cull=1, kind=:caloric, n_nodes=400, halfwidth=0)
+
+Estimate the microcanonical entropy ``S(E)`` from a canonical nested-sampling
+output `df` (columns `:iter`, `:emax`) produced with `n_walkers` live points.
+
+Along the contiguous cull index ``i`` the enclosed prior volume is
+``X_i=(K/(K+n_{cull}))^i``, so the volume entropy is ``S_{vol}=\\ln X_i=i\\ln(K/(K+n_{cull}))``
+and the caloric entropy is ``S(E)=\\ln g(E)=i\\ln(K/(K+n_{cull}))-\\ln|dE/di|``,
+with the ladder slope ``dE/di`` obtained from local cubic fits against the dense,
+uniform `i`-axis.
+
+# Arguments
+- `kind`: `:caloric` for ``S=\\ln g`` (matches Schnabel/Qi–Bachmann; default) or
+  `:volume` for the Hertz/Gibbs volume entropy ``S_{vol}=\\ln G`` (one fewer
+  derivative, slightly cleaner).
+- `n_cull`: NS culls per iteration (default 1).
+- `n_nodes`: number of smoothed output nodes (default 400).
+- `halfwidth`: half-window (in iterations) of the local cubic smoother; `0` (default)
+  picks `clamp(n÷55, 25, 2000)`.
+
+# Returns
+`(E, S)` — energies (ascending, same units as `:emax`) and entropy (dimensionless,
+up to an additive constant).
+
+See also [`caloric_derivatives`](@ref), [`inflection_transitions`](@ref).
+"""
+function microcanonical_entropy(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
+                                kind::Symbol = :caloric, n_nodes::Int = 400, halfwidth::Int = 0)
+    kind in (:caloric, :volume) || throw(ArgumentError("kind must be :caloric or :volume"))
+    r = _microcanonical_core(df, n_walkers; n_cull = n_cull, n_nodes = n_nodes,
+                             halfwidth = halfwidth, max_order = 1)
+    return r.E, kind === :caloric ? r.S_caloric : r.S_vol
+end
+
+"""
+    caloric_derivatives(df::DataFrame, n_walkers::Int;
+                        n_cull=1, max_order=2, n_nodes=400, halfwidth=0)
+
+Microcanonical entropy derivatives from a nested-sampling output `df`:
+``β(E)=dS/dE`` (inverse caloric temperature; the microcanonical temperature is
+``k_BT=1/β``), ``γ(E)=d^2S/dE^2``, and optionally ``δ(E)=d^3S/dE^3``.
+
+Derivatives are computed in iteration-index space (see [`microcanonical_entropy`])
+and then differentiated against energy with local cubic fits.
+
+# Arguments
+- `max_order`: highest derivative to return (1 → β only; 2 → β, γ; 3 → β, γ, δ).
+- `n_cull`, `n_nodes`, `halfwidth`: as in [`microcanonical_entropy`].
+
+# Returns
+A `NamedTuple` with `E` (ascending energies, same units as `:emax`) and `β` (units
+of inverse energy), plus `γ` and `δ` as requested by `max_order`. Note `γ`, `δ` are
+sensitive to NS statistics — increase the walker count `K` (not the number of seeds)
+for cleaner higher derivatives; see [`transition_convergence`](@ref).
+"""
+function caloric_derivatives(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
+                             max_order::Int = 2, n_nodes::Int = 400, halfwidth::Int = 0)
+    1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
+    r = _microcanonical_core(df, n_walkers; n_cull = n_cull, n_nodes = n_nodes,
+                             halfwidth = halfwidth, max_order = max_order)
+    max_order == 1 && return (E = r.E, β = r.β)
+    max_order == 2 && return (E = r.E, β = r.β, γ = r.γ)
+    return (E = r.E, β = r.β, γ = r.γ, δ = r.δ)
+end

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -288,3 +288,69 @@ function inflection_transitions(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
              kind = any(s.order < t.order && s.E_tr < t.E_tr for s in found) ? :dependent : :independent,
              strength = t.strength) for t in found]
 end
+
+# closest same-order transition to `t` within `match_tol` (relative in T_tr); else nothing
+function _closest(transitions, t, match_tol::Float64)
+    best = nothing; bestd = Inf
+    for s in transitions
+        s.order == t.order || continue
+        d = abs(s.T_tr - t.T_tr)
+        if d <= match_tol * t.T_tr && d < bestd
+            best, bestd = s, d
+        end
+    end
+    return best
+end
+
+"""
+    transition_convergence(dfs, n_walkers; tol=0.1, match_tol=0.25, kwargs...)
+
+Assess walker-count (`K`) convergence of microcanonical inflection-point
+transitions. `dfs` is a collection of nested-sampling outputs at the walker counts
+`n_walkers` (any order; they are sorted ascending internally). `inflection_transitions`
+is run at each `K` and the results from the **largest `K`** are taken as the current
+best estimate, then traced down the `K`-ladder.
+
+This is the recommended way to use the inflection analysis: the γ (and higher)
+derivatives carry finite-`K` "staircase" granularity that does **not** average out
+over independent runs, so a transition should only be trusted once its temperature
+and order stop drifting as `K` increases. Near-ground transitions converge last.
+
+# Arguments
+- `tol`: relative `T_tr` drift between the two largest `K` below which a transition
+  is flagged `converged` (default 0.1).
+- `match_tol`: relative `T_tr` window for matching the same transition across `K`
+  (default 0.25).
+- `kwargs...`: forwarded to [`inflection_transitions`] (e.g. `max_order`, `prominence`,
+  `ground_trim`, `kb`).
+
+# Returns
+`Vector{NamedTuple}`, one per transition found at the largest `K`, with fields
+`T_tr`, `order`, `kind`, `converged::Bool`, `T_drift` (relative change from the
+second-largest `K`, `Inf` if it has no match there), `T_by_K` (the matched `T_tr`
+at each `K`, `missing` where unmatched), and `n_walkers` (the sorted `K` values).
+"""
+function transition_convergence(dfs, n_walkers; tol::Float64 = 0.1,
+                                match_tol::Float64 = 0.25, kwargs...)
+    length(dfs) == length(n_walkers) ||
+        throw(DimensionMismatch("dfs and n_walkers must have the same length"))
+    length(dfs) >= 2 ||
+        throw(ArgumentError("need at least two walker counts to assess convergence"))
+    perm = sortperm(collect(n_walkers))
+    dfv = collect(dfs)[perm]
+    Ks = collect(n_walkers)[perm]
+    per_K = [inflection_transitions(dfv[k], Ks[k]; kwargs...) for k in eachindex(dfv)]
+    ref = per_K[end]
+    out = NamedTuple[]
+    for t in ref
+        T_by_K = Union{Missing,Float64}[
+            (c = _closest(per_K[k], t, match_tol); c === nothing ? missing : c.T_tr)
+            for k in eachindex(per_K)]
+        prevc = _closest(per_K[end-1], t, match_tol)
+        drift = prevc === nothing ? Inf : abs(prevc.T_tr - t.T_tr) / t.T_tr
+        push!(out, (T_tr = t.T_tr, order = t.order, kind = t.kind,
+                    converged = drift <= tol, T_drift = drift,
+                    T_by_K = T_by_K, n_walkers = Ks))
+    end
+    return out
+end

--- a/test/test-AnalysisTools.jl
+++ b/test/test-AnalysisTools.jl
@@ -87,15 +87,16 @@
     @testset "microcanonical inflection-point analysis" begin
         # Synthesize an NS ladder whose density of states has a prescribed caloric
         # temperature β(E)=dS/dE: build g=exp(∫β), its normalized CDF G, and invert
-        # G at the NS prior volumes X_i=(K/(K+1))^i so emax(i)=G⁻¹(X_i).
-        function synth_ladder(βfun; Emin=0.0, Emax=10.0, K=200, n=4000, ng=20001)
+        # G at the NS prior volumes X_i=(K/(K+n_cull))^i so emax(i)=G⁻¹(X_i).
+        # Also returns the (Eg, G) grid so tests can check S_vol = ln G exactly.
+        function synth_ladder(βfun; Emin=0.0, Emax=10.0, K=200, n=4000, ng=20001, n_cull=1)
             Eg = collect(range(Emin, Emax; length=ng)); dE = Eg[2] - Eg[1]
             βg = βfun.(Eg)
             S = zeros(ng); for j in 2:ng; S[j] = S[j-1] + 0.5*(βg[j]+βg[j-1])*dE; end
             g = exp.(S .- maximum(S))
             G = zeros(ng); for j in 2:ng; G[j] = G[j-1] + 0.5*(g[j]+g[j-1])*dE; end
             G ./= G[end]
-            c = K/(K+1); Es = Float64[]
+            c = K/(K+n_cull); Es = Float64[]
             for i in 1:n
                 Xi = c^i
                 if Xi <= G[1]; push!(Es, Eg[1]); continue; end
@@ -103,16 +104,25 @@
                 jj = searchsortedfirst(G, Xi)
                 push!(Es, Eg[jj-1] + (Xi-G[jj-1])/(G[jj]-G[jj-1])*(Eg[jj]-Eg[jj-1]))
             end
-            return DataFrame(iter = collect(1:n), emax = Es), K
+            return DataFrame(iter = collect(1:n), emax = Es), K, Eg, G
+        end
+        # linear interpolation of the CDF grid at energy x
+        function cdf_at(Eg, G, x)
+            jj = clamp(searchsortedfirst(Eg, x), 2, length(Eg))
+            G[jj-1] + (x - Eg[jj-1])/(Eg[jj] - Eg[jj-1])*(G[jj] - G[jj-1])
         end
         Etr = 5.0; w = 0.8
 
         @testset "entropy/β recovery, no spurious transition" begin
             βfun(E) = 2.0 - 0.10*E - 0.005*E^2          # β>0, γ strictly monotonic
-            df, K = synth_ladder(βfun)
+            df, K, Eg, G = synth_ladder(βfun)
             E, S = microcanonical_entropy(df, K)
             @test issorted(E)
             @test all(isfinite, S)
+            # volume entropy is exact by construction: S_vol = ln X_i = ln G(E_i)
+            Ev, Sv = microcanonical_entropy(df, K; kind=:volume)
+            @test all(abs(Sv[k] - log(cdf_at(Eg, G, Ev[k]))) < 1e-6
+                      for k in eachindex(Ev) if 0.5 < Ev[k] < 9.5)
             d = caloric_derivatives(df, K; max_order=2)
             mid = findall(e -> 3.0 < e < 7.0, d.E)
             @test !isempty(mid)
@@ -121,14 +131,24 @@
             @test isempty(inflection_transitions(df, K; kb=1.0, energy_window=(2.0, 9.0)))
         end
 
+        @testset "n_cull ≠ 1 prior-volume factor" begin
+            βfun(E) = 2.0 - 0.12*E
+            df, K = synth_ladder(βfun; n_cull=4)
+            d = caloric_derivatives(df, K; n_cull=4)
+            mid = findall(e -> 3.0 < e < 7.0, d.E)
+            @test !isempty(mid)
+            @test all(abs(d.β[i] - βfun(d.E[i])) < 0.15 for i in mid)   # cc = ln(K/(K+4))
+        end
+
         @testset "second-order transition (γ negative peak)" begin
             βfun(E) = 2.0 - 0.15*E + 0.10*tanh((E-Etr)/w)   # C/w=0.125 < 0.15 (concave)
             df, K = synth_ladder(βfun)
             ts = inflection_transitions(df, K; kb=1.0, max_order=2)
-            @test !isempty(ts)
-            t = ts[argmin([abs(s.E_tr - Etr) for s in ts])]
+            @test length(ts) == 1                       # exactly one transition reported
+            t = ts[1]
             @test abs(t.E_tr - Etr) < 1.0
             @test t.order == 2
+            @test t.kind == :independent
             @test isapprox(t.T_tr, 1/βfun(Etr); rtol=0.25)              # T_tr ≈ 1/β(Etr)
         end
 
@@ -136,10 +156,11 @@
             βfun(E) = 2.0 - 0.15*E + 0.40*tanh((E-Etr)/w)   # C/w=0.50 > 0.15 → backbend
             df, K = synth_ladder(βfun)
             ts = inflection_transitions(df, K; kb=1.0, max_order=2)
-            @test !isempty(ts)
-            t = ts[argmin([abs(s.E_tr - Etr) for s in ts])]
+            @test length(ts) == 1                       # exactly one transition reported
+            t = ts[1]
             @test abs(t.E_tr - Etr) < 1.5
             @test t.order == 1
+            @test t.kind == :independent
         end
 
         @testset "transition_convergence" begin
@@ -150,6 +171,14 @@
             @test res isa Vector
             @test all(r -> haskey(r, :converged) && haskey(r, :T_by_K) && length(r.T_by_K) == 2, res)
             @test any(r -> r.converged, res)        # deterministic DOS → stable across K
+            # negative paths: zero tolerance flags any finite drift as unconverged
+            res0 = transition_convergence([df1, df2], [150, 300]; kb=1.0, tol=0.0)
+            @test !isempty(res0) && all(r -> !r.converged, res0)
+            # an impossibly tight matching window leaves the lower-K ladder unmatched
+            resm = transition_convergence([df1, df2], [150, 300]; kb=1.0, match_tol=1e-12)
+            @test !isempty(resm)
+            @test all(r -> r.T_drift == Inf && !r.converged, resm)
+            @test all(r -> ismissing(r.T_by_K[1]) && !ismissing(r.T_by_K[2]), resm)
         end
 
         @testset "argument validation" begin
@@ -161,6 +190,11 @@
             @test_throws ArgumentError transition_convergence([df], [K])
             @test_throws DimensionMismatch transition_convergence([df, df], [K])
             @test_throws ArgumentError microcanonical_entropy(DataFrame(iter=Int[], emax=Float64[]), K)
+            @test_throws ArgumentError microcanonical_entropy(df, 0)
+            @test_throws ArgumentError microcanonical_entropy(DataFrame(a=collect(1:100)), K)
+            @test_throws ArgumentError microcanonical_entropy(df, K; halfwidth=1)
+            @test_throws ArgumentError microcanonical_entropy(df, K; halfwidth=-3)
+            @test_throws ArgumentError inflection_transitions(df, K; edge=0)
         end
     end
 end

--- a/test/test-AnalysisTools.jl
+++ b/test/test-AnalysisTools.jl
@@ -83,4 +83,84 @@
         rm("test_output_df.csv")
         rm("test_output_df.arrow")
     end
+
+    @testset "microcanonical inflection-point analysis" begin
+        # Synthesize an NS ladder whose density of states has a prescribed caloric
+        # temperature β(E)=dS/dE: build g=exp(∫β), its normalized CDF G, and invert
+        # G at the NS prior volumes X_i=(K/(K+1))^i so emax(i)=G⁻¹(X_i).
+        function synth_ladder(βfun; Emin=0.0, Emax=10.0, K=200, n=4000, ng=20001)
+            Eg = collect(range(Emin, Emax; length=ng)); dE = Eg[2] - Eg[1]
+            βg = βfun.(Eg)
+            S = zeros(ng); for j in 2:ng; S[j] = S[j-1] + 0.5*(βg[j]+βg[j-1])*dE; end
+            g = exp.(S .- maximum(S))
+            G = zeros(ng); for j in 2:ng; G[j] = G[j-1] + 0.5*(g[j]+g[j-1])*dE; end
+            G ./= G[end]
+            c = K/(K+1); Es = Float64[]
+            for i in 1:n
+                Xi = c^i
+                if Xi <= G[1]; push!(Es, Eg[1]); continue; end
+                if Xi >= G[end]; push!(Es, Eg[end]); continue; end
+                jj = searchsortedfirst(G, Xi)
+                push!(Es, Eg[jj-1] + (Xi-G[jj-1])/(G[jj]-G[jj-1])*(Eg[jj]-Eg[jj-1]))
+            end
+            return DataFrame(iter = collect(1:n), emax = Es), K
+        end
+        Etr = 5.0; w = 0.8
+
+        @testset "entropy/β recovery, no spurious transition" begin
+            βfun(E) = 2.0 - 0.10*E - 0.005*E^2          # β>0, γ strictly monotonic
+            df, K = synth_ladder(βfun)
+            E, S = microcanonical_entropy(df, K)
+            @test issorted(E)
+            @test all(isfinite, S)
+            d = caloric_derivatives(df, K; max_order=2)
+            mid = findall(e -> 3.0 < e < 7.0, d.E)
+            @test !isempty(mid)
+            @test all(abs(d.β[i] - βfun(d.E[i])) < 0.15 for i in mid)   # β recovered
+            # no false positives in the resolved bulk (edges/low-T flattening excluded)
+            @test isempty(inflection_transitions(df, K; kb=1.0, energy_window=(2.0, 9.0)))
+        end
+
+        @testset "second-order transition (γ negative peak)" begin
+            βfun(E) = 2.0 - 0.15*E + 0.10*tanh((E-Etr)/w)   # C/w=0.125 < 0.15 (concave)
+            df, K = synth_ladder(βfun)
+            ts = inflection_transitions(df, K; kb=1.0, max_order=2)
+            @test !isempty(ts)
+            t = ts[argmin([abs(s.E_tr - Etr) for s in ts])]
+            @test abs(t.E_tr - Etr) < 1.0
+            @test t.order == 2
+            @test isapprox(t.T_tr, 1/βfun(Etr); rtol=0.25)              # T_tr ≈ 1/β(Etr)
+        end
+
+        @testset "first-order transition (β backbending)" begin
+            βfun(E) = 2.0 - 0.15*E + 0.40*tanh((E-Etr)/w)   # C/w=0.50 > 0.15 → backbend
+            df, K = synth_ladder(βfun)
+            ts = inflection_transitions(df, K; kb=1.0, max_order=2)
+            @test !isempty(ts)
+            t = ts[argmin([abs(s.E_tr - Etr) for s in ts])]
+            @test abs(t.E_tr - Etr) < 1.5
+            @test t.order == 1
+        end
+
+        @testset "transition_convergence" begin
+            βfun(E) = 2.0 - 0.15*E + 0.10*tanh((E-Etr)/w)
+            df1, _ = synth_ladder(βfun; K=150)
+            df2, _ = synth_ladder(βfun; K=300)
+            res = transition_convergence([df1, df2], [150, 300]; kb=1.0)
+            @test res isa Vector
+            @test all(r -> haskey(r, :converged) && haskey(r, :T_by_K) && length(r.T_by_K) == 2, res)
+            @test any(r -> r.converged, res)        # deterministic DOS → stable across K
+        end
+
+        @testset "argument validation" begin
+            df, K = synth_ladder(E -> 2.0 - 0.12*E)
+            @test_throws ArgumentError microcanonical_entropy(df, K; kind=:bogus)
+            @test_throws ArgumentError caloric_derivatives(df, K; max_order=5)
+            @test_throws ArgumentError inflection_transitions(df, K; max_order=0)
+            @test_throws ArgumentError inflection_transitions(df, K; ground_trim=0.6)
+            @test_throws ArgumentError transition_convergence([df], [K])
+            @test_throws DimensionMismatch transition_convergence([df, df], [K])
+            @test_throws ArgumentError microcanonical_entropy(DataFrame(iter=Int[], emax=Float64[]), K)
+        end
+    end
 end


### PR DESCRIPTION
## Summary

This PR adds microcanonical inflection-point analysis of phase transitions to `AnalysisTools`, following Schnabel et al. (Phys. Rev. E **84**, 011127, 2011) and Qi & Bachmann (Phys. Rev. Lett. **120**, 180601, 2018). Nested sampling is well suited to this analysis because it produces the microcanonical entropy `S(E) = ln g(E)` directly: along the contiguous cull index, `ln X_i = i·ln(K/(K+1))` holds exactly. The analysis therefore locates transitions and classifies them by order from a canonical NS ladder, without a temperature grid. It reports the energy and order of each transition, rather than only the peaks in the canonical heat capacity `cv(T)`.

The change is self-contained and additive. It adds one new file, `src/AnalysisTools/microcanonical_inflection.jl` (included and exported from `AnalysisTools.jl`), along with tests and documentation. No existing behavior changes.

## What's added (four exported functions)

- **`microcanonical_entropy(df, n_walkers; kind=:caloric|:volume)`**: computes `S(E)` from an NS output (the `[:iter, :emax]` columns). `kind=:caloric` returns `ln g`, and `kind=:volume` returns `ln G`.
- **`caloric_derivatives(df, n_walkers; max_order)`**: computes `β = dS/dE` and `γ = d²S/dE²`, and optionally `δ`. The derivatives are computed in the dense, uniform iteration-index space using local cubic fits, which is more stable than differentiating a binned `ln g` in energy space.
- **`inflection_transitions(df, n_walkers; max_order, …)`**: returns `(E_tr, T_tr, order, kind, strength)` for each transition. The order is determined by the Qi–Bachmann derivative-sign rule (odd order yields a positive local minimum of `S⁽ⁿ⁾`, even order yields a negative local maximum); `kind` is `:independent` or `:dependent`; and `T_tr = 1/(kb·β(E_tr))`.
- **`transition_convergence(dfs, n_walkers; …)`**: runs the analysis across a ladder of walker counts `K` and flags transitions as stable (drift below `tol`) or still moving.

## Key design point (and a non-obvious finding)

`γ = d²S/dE²` amplifies the finite-walker "staircase" granularity of the NS ladder (with a step of roughly `1/(K·g)`). We verified that this roughness is **deterministic in `K`**: the energy ladder is reproducible across independent seeds (`σ_E → 0`), so adding more walkers reduces the oscillation, whereas adding more seeds does not (the `γ`-oscillation count dropped from 35 to 30 to 21 as `K` increased from 320 to 640 to 1280). This has three consequences:

- `transition_convergence` (per-`K` stability) is the recommended starting point: treat a transition as converged only after its `T_tr` and order stop drifting with `K`. Transitions near the ground state converge last.
- Internal smoothing provides only a minor aid to differentiation and does not substitute for an adequate number of walkers. Heavy smoothing on under-converged ladders biases `T_tr`.
- The derivatives use no seed averaging because averaging over seeds would not improve them.

## Testing

- A new test set in `test/test-AnalysisTools.jl` uses an analytic density of states: it builds synthetic NS ladders from a prescribed `β(E)` and verifies `β` recovery (to within 0.15), both order classifications (a second-order `γ`-peak and a first-order backbending) at the expected `T_tr`, the structure returned by `transition_convergence`, and the argument guards.
- The full `Pkg.test()` suite passes, including the new tests.
- Cross-checked against `cv()` peaks on LJ(111) and LJ(100) NS ladders. For example, the LJ(111) N=4 ordering `T_tr` matched the heat-capacity peak to within about 1%, and the LJ(100) N=4 condensation was correctly identified as first-order.

## Docs

- Added a methods section and a worked example to `docs/src/AnalysisTools.md`. The four exported functions are recognized by the existing `@autodocs` block, so `checkdocs=:export` passes and `makedocs` builds cleanly.

## Notes/limitations

- The analysis is limited to single-component canonical NS ladders (the `[:iter, :emax]` format).
- The `kind` field (independent or dependent) is assigned using the Qi–Bachmann energy-ordering heuristic, so complex spectra may require manual review.
- A future addition could be an optional smoothing-spline backend. The per-`K` convergence caveat is documented in the function docstrings and in the manual.

## Changes

6 commits across 4 files: `microcanonical_inflection.jl` (new, +356 lines), `AnalysisTools.jl` (exports and include), `test-AnalysisTools.jl` (+80 lines), and `docs/src/AnalysisTools.md` (+71 lines).