### PR TITLE
Add ideal-gas-referenced grand-canonical nested sampling for lattice systems

### DIFF
--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -13,6 +13,7 @@ export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
 export microcanonical_entropy, caloric_derivatives, inflection_transitions
 export transition_convergence
+export gc_thermodynamic_stats_ideal_ref
 
 """
     read_output(filename::String)
@@ -336,6 +337,153 @@ function gc_thermodynamic_stats(df::DataFrame,
     end
 
     return mean_Es, Cvs, mean_Ns
+end
+
+"""
+    gc_thermodynamic_stats_ideal_ref(df::DataFrame, n_sites::Int, z0::Float64,
+                                     μs::Vector{Float64}, Ts::Vector{Float64},
+                                     n_walkers::Int;
+                                     n_cull::Int=1, ω0::Float64=1.0,
+                                     live_emax::Union{Nothing,Vector{Float64}}=nothing,
+                                     live_numbers::Union{Nothing,Vector{Int}}=nothing,
+                                     kb::Float64=8.617333262e-5)
+
+Assemble grand-canonical thermodynamics on a (μ, T) grid from a single
+ideal-gas-referenced nested sampling run (`ideal_gas_referenced_nested_sampling`
+in `SamplingSchemes`).
+
+The run samples the ideal-lattice-gas prior at reference fugacity `z0`
+(configuration weight `z0^N`, total prior mass `(1 + z0)^M` on `M = n_sites`
+sites) and culls by energy alone. The absolute grand partition function at any
+target chemical potential μ and temperature T is then
+
+```math
+\\Xi(\\mu, T) = (1 + z_0)^M \\sum_j \\omega_j \\left(\\frac{z}{z_0}\\right)^{N_j}
+               e^{-\\beta E_j}, \\qquad z = e^{\\beta\\mu},
+```
+
+where the sum runs over culled walkers (plus, when `live_emax`/`live_numbers`
+are given, the surviving live walkers, each with residual weight
+`(K/(K+n_cull))^{n_iters} / K` — no `ω0` factor, since `ω0` corrects the
+dead-sample shell weights only). There is no thermal-wavelength factor: a
+lattice gas has no momentum degrees of freedom, so `z = exp(βμ)` directly.
+All sums are evaluated with the log-sum-exp trick, and Ξ is returned as
+`log Ξ` to avoid overflow at low temperature.
+
+For a fully normalized absolute Ξ, pass `ω0 = (n_walkers + n_cull)/n_walkers`
+(Skilling weights) together with the live-walker tail — the dead weights then
+sum to `1 − (K/(K+n_cull))^{n_iters}` and the tail supplies the remainder, so
+`Σω = 1` exactly. The default `ω0 = 1.0` underestimates Ξ by a factor
+`K/(K+n_cull)` and neglects the tail (see the `ωᵢ` conventions). Ratio
+observables (`mean_N`, `var_N`, `mean_U`) are insensitive to `ω0`.
+
+The reweighting factor `(z/z0)^{N_j}` is pure importance sampling in μ: its
+reliability at each grid point is reported by the Kish effective sample size
+`N_eff = (Σ w)² / Σ w²`, which collapses as `|βμ − ln z0|` grows beyond
+roughly `1/√Var(N)`. Treat grid points with small `N_eff` (≲ 100) as
+unreliable and re-run with z0 closer to the target fugacity.
+
+# Arguments
+- `df::DataFrame`: NS output with columns `[:iter, :emax, :num_particles]`.
+- `n_sites::Int`: Number of lattice sites M.
+- `z0::Float64`: Reference fugacity of the prior used in the run (must match!).
+- `μs::Vector{Float64}`: Chemical potential grid (same energy units as `df.emax`, e.g. eV).
+- `Ts::Vector{Float64}`: Temperature grid in K.
+- `n_walkers::Int`: Number of walkers K used in the NS run.
+- `n_cull::Int=1`: Number of walkers culled per iteration.
+- `ω0::Float64=1.0`: Initial phase-space volume factor.
+- `live_emax::Union{Nothing,Vector{Float64}}=nothing`: Energies of the surviving live walkers.
+- `live_numbers::Union{Nothing,Vector{Int}}=nothing`: Particle counts of the surviving live walkers.
+- `kb::Float64`: Boltzmann constant (default: eV/K).
+
+# Returns
+A `NamedTuple` of `Matrix{Float64}` of size `(length(μs), length(Ts))`,
+indexed `[i_μ, i_T]`:
+- `logXi`: Natural log of the absolute grand partition function.
+- `mean_N`: Mean particle number ⟨N⟩.
+- `var_N`: Particle-number variance ⟨N²⟩ − ⟨N⟩².
+- `mean_U`: Mean configurational energy ⟨E⟩.
+- `N_eff`: Kish effective sample size of the reweighted estimate.
+"""
+function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
+                                          n_sites::Int,
+                                          z0::Float64,
+                                          μs::Vector{Float64},
+                                          Ts::Vector{Float64},
+                                          n_walkers::Int;
+                                          n_cull::Int=1,
+                                          ω0::Float64=1.0,
+                                          live_emax::Union{Nothing,Vector{Float64}}=nothing,
+                                          live_numbers::Union{Nothing,Vector{Int}}=nothing,
+                                          kb::Float64=8.617333262e-5)
+    if z0 <= 0.0
+        throw(ArgumentError("z0 must be positive"))
+    end
+    if n_sites <= 0
+        throw(ArgumentError("n_sites must be positive"))
+    end
+    if (live_emax === nothing) != (live_numbers === nothing)
+        throw(ArgumentError("live_emax and live_numbers must be provided together"))
+    end
+    if live_emax !== nothing && length(live_emax) != length(live_numbers)
+        throw(DimensionMismatch("live_emax and live_numbers must have the same length"))
+    end
+    n_dead = nrow(df)
+    if n_dead == 0 && (live_emax === nothing || isempty(live_emax))
+        throw(ArgumentError("df is empty and no live walkers were provided"))
+    end
+
+    # β- and μ-independent per-sample log prior-volume weights, built directly
+    # in log space: the linear ωᵢ underflows to 0.0 once iter ≳ 745·K/n_cull,
+    # which silently zeroes the deepest (lowest-energy) samples on large lattices
+    log_w0 = n_dead > 0 ?
+        (log(ω0) + log(n_cull / (n_walkers + n_cull))) .+
+        Vector{Float64}(df.iter) .* log(n_walkers / (n_walkers + n_cull)) : Float64[]
+    Es = n_dead > 0 ? Vector{Float64}(df.emax) : Float64[]
+    Ns = n_dead > 0 ? Vector{Float64}(df.num_particles) : Float64[]
+
+    if live_emax !== nothing && !isempty(live_emax)
+        # Residual prior volume after the last recorded iteration, split
+        # uniformly over the K surviving walkers. No ω0 factor here: ω0
+        # corrects the dead-sample shell weights, not the residual volume
+        # X_n = (K/(K+n_cull))^n — with ω0 = (K+n_cull)/K the dead weights sum
+        # to 1 − X_n and the tail closes the identity Σw = 1 exactly
+        n_iters = n_dead > 0 ? maximum(df.iter) : 0
+        log_tail = n_iters * log(n_walkers / (n_walkers + n_cull)) - log(n_walkers)
+        log_w0 = vcat(log_w0, fill(log_tail, length(live_emax)))
+        Es = vcat(Es, live_emax)
+        Ns = vcat(Ns, Float64.(live_numbers))
+    end
+
+    log_prior_mass = n_sites * log1p(z0)
+    log_z0 = log(z0)
+
+    n_mu = length(μs)
+    n_T = length(Ts)
+    logXi = Matrix{Float64}(undef, n_mu, n_T)
+    mean_N = Matrix{Float64}(undef, n_mu, n_T)
+    var_N = Matrix{Float64}(undef, n_mu, n_T)
+    mean_U = Matrix{Float64}(undef, n_mu, n_T)
+    N_eff = Matrix{Float64}(undef, n_mu, n_T)
+
+    Threads.@threads for j in 1:n_T
+        β = 1.0 / (kb * Ts[j])
+        for i in 1:n_mu
+            s = β * μs[i] - log_z0
+            log_w = log_w0 .+ s .* Ns .- β .* Es
+            max_log = maximum(log_w)
+            ws = exp.(log_w .- max_log)
+            sum_w = sum(ws)
+            logXi[i, j] = log_prior_mass + max_log + log(sum_w)
+            n_avg = sum(ws .* Ns) / sum_w
+            mean_N[i, j] = n_avg
+            var_N[i, j] = sum(ws .* Ns .^ 2) / sum_w - n_avg^2
+            mean_U[i, j] = sum(ws .* Es) / sum_w
+            N_eff[i, j] = sum_w^2 / sum(abs2, ws)
+        end
+    end
+
+    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff)
 end
 
 

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -751,7 +751,7 @@ end
                              p_move::Float64=0.5, p_insert::Float64=0.25,
                              energy_perturb::Float64=0.0, n_max::Int=typemax(Int),
                              clusters_freq::Int=0, swaps_freq::Int=1,
-                             cluster_p::Float64=0.3)
+                             cluster_p::Float64=0.3, z0::Float64=1.0)
 
 Perform grand-canonical MCMC on a single-component lattice, mixing fixed-N
 moves (local swaps and/or geometric cluster moves) with single-site insertion
@@ -763,10 +763,16 @@ Each step:
 - With probability `p_insert`: propose inserting one particle.
 - With probability `1 - p_move - p_insert`: propose deleting one particle.
 
-Insert/delete proposals use a Metropolis correction to preserve the uniform
-prior over all microstates with Ω < Ω_max:
-- Insert ratio: `(p_delete / p_insert) * (M - N) / (N + 1)`
-- Delete ratio: `(p_insert / p_delete) * N / (M - N + 1)`
+Insert/delete proposals use a Metropolis correction to preserve the ideal-lattice-gas
+prior at reference fugacity `z0` — the Bernoulli product measure giving each
+configuration with N particles weight `z0^N` — over all microstates with Ω < Ω_max:
+- Insert ratio: `z0 * (p_delete / p_insert) * (M - N) / (N + 1)`
+- Delete ratio: `(1 / z0) * (p_insert / p_delete) * N / (M - N + 1)`
+
+The default `z0 = 1.0` reduces to the uniform prior over all 2^M microstates,
+matching the Ω-sorted grand-canonical nested sampling construction. `z0 ≠ 1`
+is used by the ideal-gas-referenced (E-sorted) construction, where the walk
+runs with `mu = 0` so the Ω ceiling reduces to an energy ceiling.
 
 Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 
@@ -783,6 +789,8 @@ Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 - `clusters_freq::Int=0`: Relative weight of cluster moves within fixed-N branch (0 = disabled).
 - `swaps_freq::Int=1`: Relative weight of local swaps within fixed-N branch.
 - `cluster_p::Float64=0.3`: Current cluster growth probability.
+- `z0::Float64=1.0`: Reference fugacity of the prior preserved by insert/delete
+  (1.0 = uniform prior over microstates).
 
 # Returns
 - `accept_this_walker::Bool`: Whether at least one move was accepted.
@@ -802,9 +810,13 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   n_max::Int=typemax(Int),
                                   clusters_freq::Int=0,
                                   swaps_freq::Int=1,
-                                  cluster_p::Float64=0.3)
+                                  cluster_p::Float64=0.3,
+                                  z0::Float64=1.0)
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+    end
+    if z0 <= 0.0
+        throw(ArgumentError("z0 must be positive"))
     end
 
     n_accept = 0
@@ -869,16 +881,17 @@ function MC_grand_canonical_walk!(n_steps::Int,
             continue
         end
 
-        # Metropolis correction for insert/delete detailed balance
+        # Metropolis correction for insert/delete detailed balance under the
+        # z0^N-weighted prior (z0 = 1: uniform prior)
         # Cluster and local swap moves are symmetric — no correction needed
         accept = true
         if move_type == :insert
-            ratio = (p_delete / p_insert) * (n_sites - n) / (n + 1)
+            ratio = z0 * (p_delete / p_insert) * (n_sites - n) / (n + 1)
             if ratio < 1.0 && rand() >= ratio
                 accept = false
             end
         elseif move_type == :delete
-            ratio = (p_insert / p_delete) * n / (n_sites - n + 1)
+            ratio = (p_insert / p_delete) * n / (z0 * (n_sites - n + 1))
             if ratio < 1.0 && rand() >= ratio
                 accept = false
             end

--- a/src/SamplingSchemes/SamplingSchemes.jl
+++ b/src/SamplingSchemes/SamplingSchemes.jl
@@ -45,6 +45,10 @@ export GrandCanonicalNestedSamplingParameters
 export MCGrandCanonicalMoves
 export grand_canonical_nested_sampling
 
+# ideal-gas-referenced grand-canonical nested sampling
+export IdealGasReferencedGCNSParameters
+export ideal_gas_referenced_nested_sampling
+
 # other sampling schemes
 export exact_enumeration
 export wang_landau

--- a/src/SamplingSchemes/helpers.jl
+++ b/src/SamplingSchemes/helpers.jl
@@ -56,3 +56,31 @@ function adjust_cluster_p(params::SamplingParameters, rate::Float64, iteration::
     push!(params.cluster_adjust_iterations, iteration)
     return params
 end
+
+"""
+    _accumulate_cluster_stats!(params::SamplingParameters, mc_routine,
+                               cl_accepted::Int, cl_total::Int, ns_iteration::Int)
+
+Accumulate cluster-move acceptance statistics from one decorrelation walk onto
+`params` and call `adjust_cluster_p` when the adjustment window is full.
+`mc_routine` supplies the static tuning configuration (`cluster_adjust_interval`,
+`target_cluster_accept`, `cluster_p_floor`, `cluster_p_ceiling`). Shared by the
+grand-canonical `nested_sampling_step!` methods.
+"""
+function _accumulate_cluster_stats!(params::SamplingParameters, mc_routine,
+                                    cl_accepted::Int, cl_total::Int, ns_iteration::Int)
+    cl_total > 0 || return params
+    params.cluster_accepted += cl_accepted
+    params.cluster_total += cl_total
+    if mc_routine.cluster_adjust_interval > 0 &&
+       params.cluster_total >= mc_routine.cluster_adjust_interval
+        window_rate = params.cluster_accepted / max(params.cluster_total, 1.0)
+        adjust_cluster_p(params, window_rate, ns_iteration;
+                         target=mc_routine.target_cluster_accept,
+                         floor=mc_routine.cluster_p_floor,
+                         ceiling=mc_routine.cluster_p_ceiling)
+        params.cluster_accepted = 0.0
+        params.cluster_total = 0.0
+    end
+    return params
+end

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1209,20 +1209,7 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     end
 
     # Accumulate cluster acceptance stats and adapt cluster_p
-    if cl_total > 0
-        gc_params.cluster_accepted += cl_accepted
-        gc_params.cluster_total += cl_total
-        if mc_routine.cluster_adjust_interval > 0 &&
-           gc_params.cluster_total >= mc_routine.cluster_adjust_interval
-            window_rate = gc_params.cluster_accepted / max(gc_params.cluster_total, 1.0)
-            adjust_cluster_p(gc_params, window_rate, ns_iteration;
-                             target=mc_routine.target_cluster_accept,
-                             floor=mc_routine.cluster_p_floor,
-                             ceiling=mc_routine.cluster_p_ceiling)
-            gc_params.cluster_accepted = 0.0
-            gc_params.cluster_total = 0.0
-        end
-    end
+    _accumulate_cluster_stats!(gc_params, mc_routine, cl_accepted, cl_total, ns_iteration)
 
     return iter, omega_worst, energy_worst, n_worst, liveset, gc_params
 end
@@ -1300,4 +1287,297 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
     end
 
     return df, liveset, gc_params
+end
+
+# ======================================================================
+# Ideal-gas-referenced grand-canonical nested sampling
+# ======================================================================
+
+"""
+    mutable struct IdealGasReferencedGCNSParameters <: SamplingParameters
+
+Parameters for ideal-gas-referenced grand-canonical nested sampling on
+lattice systems.
+
+The prior is the non-interacting (ideal) lattice gas at reference fugacity
+`z0`: a Bernoulli product measure in which each site is occupied independently
+with probability `p0 = z0/(1 + z0)`, so a configuration with N particles
+carries prior weight `z0^N` and the total prior mass on M sites is
+`(1 + z0)^M`. Nested sampling culls on the energy E alone — the chemical
+potential does not enter the sampler. Both μ and T are recovered in
+post-processing (see `gc_thermodynamic_stats_ideal_ref` in `AnalysisTools`),
+so a single run yields Ξ(μ, T) over a continuous temperature range and a
+neighborhood of μ around `μ_ref(T) = k_B T ln z0`.
+
+Setting `reference_fugacity = 1` makes the prior the uniform measure over all
+2^M microstates — the same prior as the Ω-sorted construction in
+`GrandCanonicalNestedSamplingParameters`, which instead bakes a single μ into
+the sort quantity Ω = E − μN.
+
+Unlike the Ω-sorted construction there is deliberately no `n_max` field: the
+post-processing normalization `(1 + z0)^M` is the prior mass of the *full*
+occupation range N ∈ {0, …, M}, and capping insertions would silently
+truncate the prior support and bias Ξ.
+
+# Fields
+- `mc_steps::Int64`: MCMC steps per replacement walker.
+- `reference_fugacity::Float64`: Reference fugacity z0 of the ideal-lattice-gas prior.
+- `energy_perturbation::Float64`: Perturbation to break energy degeneracies.
+  Required to be nonzero on lattices (degenerate levels stall the strict `<`
+  ceiling and bias the evidence — enforced by the keyword constructor); must
+  remain ≪ k_B·T at the lowest temperature targeted in post-processing, since
+  perturbed energies are recorded.
+- `random_seed::Int64`: Kept for parity with `GrandCanonicalNestedSamplingParameters`;
+  **not currently consumed** by the NS loop — call `Random.seed!` before
+  `ideal_gas_referenced_nested_sampling` for reproducible runs.
+- `fail_count::Int64`: Consecutive failed replacements.
+- `allowed_fail_count::Int64`: Maximum consecutive failures before warning.
+- `cluster_p::Float64`: Current cluster growth probability (mutable runtime state).
+- `cluster_accepted::Float64`: Accepted cluster moves in current adjustment window.
+- `cluster_total::Float64`: Total cluster moves attempted in current adjustment window.
+- `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p after each adjustment.
+- `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adjustment.
+- `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adjustment.
+"""
+mutable struct IdealGasReferencedGCNSParameters <: SamplingParameters
+    mc_steps::Int64
+    reference_fugacity::Float64
+    energy_perturbation::Float64
+    random_seed::Int64
+    fail_count::Int64
+    allowed_fail_count::Int64
+    cluster_p::Float64
+    cluster_accepted::Float64
+    cluster_total::Float64
+    cluster_p_history::Vector{Float64}
+    cluster_accept_history::Vector{Float64}
+    cluster_adjust_iterations::Vector{Int}
+end
+
+"""
+    IdealGasReferencedGCNSParameters(;
+        mc_steps=100, reference_fugacity=1.0, energy_perturbation=1e-12,
+        random_seed=1234, fail_count=0, allowed_fail_count=10,
+        cluster_p=0.3, cluster_accepted=0.0, cluster_total=0.0,
+        cluster_p_history=Float64[], cluster_accept_history=Float64[],
+        cluster_adjust_iterations=Int[])
+
+Convenience constructor for `IdealGasReferencedGCNSParameters`.
+
+`reference_fugacity` (z0) must be positive. Choose z0 near the target
+fugacity range `exp(βμ)` of interest: post-run reweighting to a target (μ, T)
+carries a factor `(exp(βμ)/z0)^N` per sample, and its effective sample size
+degrades as `|βμ − ln z0|` grows (roughly beyond `1/√Var(N)`).
+
+The `cluster_*` fields are mutable runtime state for adaptive cluster move
+tuning, initialized from the static configuration on `MCGrandCanonicalMoves`
+at the start of `ideal_gas_referenced_nested_sampling` when `clusters_freq > 0`.
+"""
+function IdealGasReferencedGCNSParameters(;
+    mc_steps::Int64=100,
+    reference_fugacity::Float64=1.0,
+    energy_perturbation::Float64=1e-12,
+    random_seed::Int64=1234,
+    fail_count::Int64=0,
+    allowed_fail_count::Int64=10,
+    cluster_p::Float64=0.3,
+    cluster_accepted::Float64=0.0,
+    cluster_total::Float64=0.0,
+    cluster_p_history::Vector{Float64}=Float64[],
+    cluster_accept_history::Vector{Float64}=Float64[],
+    cluster_adjust_iterations::Vector{Int}=Int[],
+)
+    if reference_fugacity <= 0.0
+        throw(ArgumentError("reference_fugacity must be positive"))
+    end
+    if energy_perturbation == 0.0
+        throw(ArgumentError("energy_perturbation must be nonzero: degenerate " *
+            "lattice energy levels stall the strict < ceiling and bias the evidence"))
+    end
+    IdealGasReferencedGCNSParameters(
+        mc_steps, reference_fugacity, energy_perturbation,
+        random_seed, fail_count, allowed_fail_count,
+        cluster_p, cluster_accepted, cluster_total,
+        cluster_p_history, cluster_accept_history, cluster_adjust_iterations,
+    )
+end
+
+"""
+    _init_ideal_gas_ref_walkers!(liveset::LatticeGasWalkers,
+                                 params::IdealGasReferencedGCNSParameters)
+
+Initialize walkers as exact i.i.d. draws from the ideal-lattice-gas prior:
+each site occupied independently with probability `z0/(1 + z0)`.
+"""
+function _init_ideal_gas_ref_walkers!(liveset::LatticeGasWalkers,
+                                      params::IdealGasReferencedGCNSParameters)
+    h = liveset.hamiltonian
+    z0 = params.reference_fugacity
+    p0 = z0 / (1.0 + z0)
+    for walker in liveset.walkers
+        random_microstate!(walker.configuration; p=p0)
+        assign_energy!(walker, h; perturb_energy=params.energy_perturbation)
+        # Reset the iteration counter: df.iter feeds the ωᵢ prior-volume
+        # weights, so a stale counter from a reused liveset corrupts them
+        walker.iter = 0
+    end
+    return liveset
+end
+
+"""
+    nested_sampling_step!(liveset::LatticeGasWalkers,
+                          params::IdealGasReferencedGCNSParameters,
+                          mc_routine::MCGrandCanonicalMoves;
+                          ns_iteration::Int=0)
+
+Perform one step of ideal-gas-referenced grand-canonical nested sampling.
+
+Sorts walkers by energy E (not Ω — the chemical potential plays no role in
+the sampler), removes the worst (highest E), clones a parent with E < E_worst,
+and decorrelates the clone via grand-canonical MCMC that preserves the
+`z0^N`-weighted prior below the energy ceiling.
+
+# Returns
+- `iter`: Iteration number (or `missing` if the step failed).
+- `emax`: The E value of the removed walker (with units).
+- `num_particles`: The N value of the removed walker.
+- `liveset`: The updated liveset.
+- `params`: The updated parameters.
+"""
+function nested_sampling_step!(liveset::LatticeGasWalkers,
+                               params::IdealGasReferencedGCNSParameters,
+                               mc_routine::MCGrandCanonicalMoves;
+                               ns_iteration::Int=0)
+    ats = liveset.walkers
+    h = liveset.hamiltonian
+    n_walkers = length(ats)
+
+    # Sort by energy (descending — worst first); the z0^N prior weighting is
+    # maintained by the MC walk, not by the sort
+    sort_by_energy!(liveset)
+
+    iter::Union{Missing,Int} = missing
+    worst = ats[1]
+    emax_worst = worst.energy
+    n_worst = sum(worst.configuration.components[1])
+
+    emax_val = emax_worst.val  # unitless for the MC function
+    eligible = [k for k in 2:n_walkers if ats[k].energy < emax_worst]
+    if !isempty(eligible)
+        parent_idx = rand(eligible)
+    else
+        parent_idx = rand(2:n_walkers)
+    end
+    to_walk = deepcopy(ats[parent_idx])
+
+    # Decorrelate via GC MCMC: with mu = 0 the Ω ceiling reduces to an energy
+    # ceiling, and z0 weights the insert/delete acceptance to preserve the
+    # Bernoulli(z0/(1+z0)) prior
+    accept, rate, to_walk, cl_accepted, cl_total = MC_grand_canonical_walk!(
+        params.mc_steps, to_walk, h, emax_val, 0.0;
+        p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
+        energy_perturb=params.energy_perturbation,
+        z0=params.reference_fugacity,
+        clusters_freq=mc_routine.clusters_freq,
+        swaps_freq=mc_routine.swaps_freq,
+        cluster_p=params.cluster_p)
+
+    if accept
+        push!(ats, to_walk)
+        popfirst!(ats)
+        update_iter!(liveset)
+        params.fail_count = 0
+        iter = liveset.walkers[1].iter
+    else
+        emax_worst = missing
+        n_worst = missing
+        params.fail_count += 1
+    end
+
+    # Accumulate cluster acceptance stats and adapt cluster_p
+    _accumulate_cluster_stats!(params, mc_routine, cl_accepted, cl_total, ns_iteration)
+
+    return iter, emax_worst, n_worst, liveset, params
+end
+
+"""
+    ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
+                                         params::IdealGasReferencedGCNSParameters,
+                                         n_steps::Int64,
+                                         mc_routine::MCGrandCanonicalMoves,
+                                         save_strategy::DataSavingStrategy)
+
+Run the ideal-gas-referenced grand-canonical nested sampling loop.
+
+Walkers are initialized as exact i.i.d. draws from the ideal-lattice-gas
+prior at reference fugacity z0 (each site occupied with probability
+`z0/(1 + z0)`), then the loop iterates: remove the highest-energy walker,
+record (E, N), replace with a clone decorrelated below the energy ceiling
+under the `z0^N`-weighted prior. The chemical potential never enters the
+run; a single run is post-processed to Ξ(μ, T) on an arbitrary (μ, T) grid
+by `gc_thermodynamic_stats_ideal_ref` in `AnalysisTools`, which also needs
+the surviving live walkers' (E, N) for the live-set tail closure —
+extract them from the returned liveset.
+
+# Arguments
+- `liveset::LatticeGasWalkers`: The initial liveset (walkers will be re-initialized).
+- `params::IdealGasReferencedGCNSParameters`: Parameters including the reference fugacity z0.
+- `n_steps::Int64`: Number of NS iterations.
+- `mc_routine::MCGrandCanonicalMoves`: The GC move routine (reused from the Ω-sorted construction).
+- `save_strategy::DataSavingStrategy`: Strategy for periodic output.
+
+# Returns
+- `df::DataFrame`: Columns `[:iter, :emax, :num_particles]`.
+- `liveset::LatticeGasWalkers`: The final liveset (surviving walkers).
+- `params::IdealGasReferencedGCNSParameters`: Updated parameters.
+"""
+function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
+                                              params::IdealGasReferencedGCNSParameters,
+                                              n_steps::Int64,
+                                              mc_routine::MCGrandCanonicalMoves,
+                                              save_strategy::DataSavingStrategy)
+    # Initialize walkers as i.i.d. draws from the Bernoulli(z0/(1+z0)) prior
+    _init_ideal_gas_ref_walkers!(liveset, params)
+
+    # Initialize cluster_p and reset counters from MCGrandCanonicalMoves if applicable
+    if mc_routine.clusters_freq > 0
+        params.cluster_p = mc_routine.initial_cluster_p
+        params.cluster_accepted = 0.0
+        params.cluster_total = 0.0
+        empty!(params.cluster_p_history)
+        empty!(params.cluster_accept_history)
+        empty!(params.cluster_adjust_iterations)
+    end
+
+    df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
+
+    for i in 1:n_steps
+        print_info = i % save_strategy.n_info == 0
+        write_walker_every_n(liveset.walkers[1], i, save_strategy)
+
+        iter, emax, n_par, liveset, params = nested_sampling_step!(
+            liveset, params, mc_routine; ns_iteration=i)
+
+        @debug "IG-ref GC-NS step $i, iter: $iter, emax: $emax, N: $n_par"
+
+        if params.fail_count >= params.allowed_fail_count
+            @warn "IG-ref GC-NS: Failed $(params.allowed_fail_count) times in a row."
+            params.fail_count = 0
+        end
+
+        if !(iter isa typeof(missing))
+            push!(df, (iter, emax.val, n_par))
+        end
+
+        if print_info && !(iter isa typeof(missing))
+            @info "IG-ref GC-NS iter: $(iter), E: $(emax), N: $(n_par)"
+        elseif print_info && iter isa typeof(missing)
+            @info "IG-ref GC-NS MC move failed, step: $(i)"
+        end
+
+        write_df_every_n(df, i, save_strategy)
+        write_ls_every_n(liveset, i, save_strategy)
+    end
+
+    return df, liveset, params
 end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -10,5 +10,7 @@
     include("test-wang_landau.jl")
     # test grand-canonical nested sampling
     include("test-grand_canonical_ns.jl")
+    # test ideal-gas-referenced grand-canonical nested sampling
+    include("test-ideal-gas-ref-gcns.jl")
 
 end

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -1,0 +1,329 @@
+@testset "Ideal-gas-referenced GC-NS" begin
+    using Random
+
+    kb = 8.617333262e-5  # eV/K
+
+    # Shared 4x4 single-component square lattice template
+    igref_L = 4
+    igref_n_sites = igref_L * igref_L
+    igref_template = MLattice{1,SquareLattice}(
+        lattice_constant=1.0,
+        basis=[(0.0, 0.0, 0.0)],
+        supercell_dimensions=(igref_L, igref_L, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1, 1.5],
+        components=[[false for _ in 1:igref_L*igref_L]],
+        adsorptions=:full
+    )
+
+    function igref_run(template, ham, z0, n_walkers, n_steps; seed=7, mc_steps=100)
+        Random.seed!(seed)
+        walkers = [LatticeWalker(deepcopy(template), energy=0.0u"eV", iter=0)
+                   for _ in 1:n_walkers]
+        liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(mc_steps=mc_steps, reference_fugacity=z0)
+        mc_routine = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+        save = SaveEveryN("test_igref.csv", "test_igref.traj", "test_igref.ls",
+                          100000, 100000, 100000)
+        df, final_ls, params = ideal_gas_referenced_nested_sampling(
+            liveset, params, Int64(n_steps), mc_routine, save)
+        rm("test_igref.csv", force=true)
+        rm("test_igref.traj", force=true)
+        rm("test_igref.ls", force=true)
+        live_E = [w.energy.val for w in final_ls.walkers]
+        live_N = [sum(w.configuration.components[1]) for w in final_ls.walkers]
+        return df, live_E, live_N
+    end
+
+    # ================================================================
+    @testset "IdealGasReferencedGCNSParameters constructor" begin
+        params = IdealGasReferencedGCNSParameters()
+        @test params.mc_steps == 100
+        @test params.reference_fugacity == 1.0
+        @test params.energy_perturbation == 1e-12
+        @test params.fail_count == 0
+        @test params.allowed_fail_count == 10
+        @test params.cluster_p == 0.3
+        @test isempty(params.cluster_p_history)
+
+        params2 = IdealGasReferencedGCNSParameters(reference_fugacity=0.25, mc_steps=50)
+        @test params2.reference_fugacity == 0.25
+        @test params2.mc_steps == 50
+
+        @test_throws ArgumentError IdealGasReferencedGCNSParameters(reference_fugacity=0.0)
+        @test_throws ArgumentError IdealGasReferencedGCNSParameters(reference_fugacity=-1.0)
+        # Tie-breaking is a correctness requirement on degenerate lattice spectra
+        @test_throws ArgumentError IdealGasReferencedGCNSParameters(energy_perturbation=0.0)
+    end
+
+    # ================================================================
+    @testset "nested_sampling_step! for IG-ref GC-NS" begin
+        Random.seed!(3)
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        walkers = [LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+                   for _ in 1:5]
+        liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
+
+        params = IdealGasReferencedGCNSParameters(mc_steps=50, reference_fugacity=0.5)
+        mc_routine = MCGrandCanonicalMoves()
+
+        # Initialize walkers as draws from the Bernoulli(z0/(1+z0)) prior
+        SamplingSchemes._init_ideal_gas_ref_walkers!(liveset, params)
+        @test all(w.iter == 0 for w in liveset.walkers)
+
+        e_type = typeof(walkers[1].energy)
+        iter, emax, n_par, updated_liveset, updated_params = nested_sampling_step!(
+            liveset, params, mc_routine)
+
+        @test iter isa Union{Missing,Int}
+        @test emax isa Union{Missing,e_type}
+        @test n_par isa Union{Missing,Int}
+        @test length(updated_liveset.walkers) == 5
+        @test updated_params.fail_count >= 0
+        if !(iter isa Missing)
+            # The culled walker had the highest energy: all survivors sit
+            # strictly below the recorded ceiling (perturbation breaks ties)
+            @test all(w.energy < emax for w in updated_liveset.walkers)
+        end
+    end
+
+    # ================================================================
+    @testset "MC_grand_canonical_walk! z0 prior stationarity" begin
+        # With a zero Hamiltonian (E ≡ 0) and a non-binding ceiling, the walk
+        # must sample the Bernoulli(z0/(1+z0)) prior: ⟨N⟩ = M z0/(1+z0),
+        # Var(N) = M z0/(1+z0)².
+        ham0 = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        for z0 in (0.5, 2.0)
+            Random.seed!(42)
+            walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+            MC_grand_canonical_walk!(500, walker, ham0, 1e3, 0.0;
+                                     p_move=0.2, p_insert=0.4, z0=z0)
+            acc_N = 0.0
+            n_samples = 3000
+            for _ in 1:n_samples
+                MC_grand_canonical_walk!(10, walker, ham0, 1e3, 0.0;
+                                         p_move=0.2, p_insert=0.4, z0=z0)
+                acc_N += sum(walker.configuration.components[1])
+            end
+            p0 = z0 / (1 + z0)
+            @test isapprox(acc_N / n_samples, igref_n_sites * p0; atol=0.5)
+        end
+
+        # z0 must be positive
+        walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+        @test_throws ArgumentError MC_grand_canonical_walk!(
+            1, walker, ham0, 1e3, 0.0; z0=0.0)
+    end
+
+    # ================================================================
+    @testset "Langmuir closed form (non-interacting reference)" begin
+        # Zero neighbor interactions, on-site adsorption only: E = ε_ads·N, so
+        # Ξ(μ,T) = (1 + z·e^{-βε})^M exactly (Langmuir isotherm) — the lattice
+        # analog of the atomistic IdealGasParameters validation.
+        eps_ads = -0.04
+        ham_ni = GenericLatticeHamiltonian(eps_ads, [0.0, 0.0], u"eV")
+        n_walkers = 100
+
+        df, live_E, live_N = igref_run(igref_template, ham_ni, 1.0, n_walkers, 3000)
+        @test nrow(df) > 0
+        @test names(df) == ["iter", "emax", "num_particles"]
+        # E-sorted NS: recorded energy ceilings are non-increasing
+        @test issorted(df.emax, rev=true)
+
+        # μ grid spans the reliable reweighting window around μ_ref(T) = kT·ln z0 = 0
+        # plus one deliberately out-of-window point (μ = -0.08) for the N_eff check
+        μs = [-0.08, -0.04, -0.03, -0.02]
+        Ts = [200.0, 300.0, 500.0]
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, 1.0, μs, Ts, n_walkers;
+            ω0=(n_walkers + 1) / n_walkers, live_emax=live_E, live_numbers=live_N)
+        stats_notail = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, 1.0, μs, Ts, n_walkers)
+
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            i == 1 && continue  # skip the out-of-window point
+            β = 1 / (kb * T)
+            x = exp(β * μ) * exp(-β * eps_ads)
+            logXi_exact = igref_n_sites * log1p(x)
+            meanN_exact = igref_n_sites * x / (1 + x)
+            @test isapprox(stats.logXi[i, j], logXi_exact; atol=0.5)
+            @test isapprox(stats.mean_N[i, j], meanN_exact; rtol=0.10)
+            @test isapprox(stats.mean_U[i, j], eps_ads * meanN_exact; rtol=0.10)
+        end
+
+        # The live-set tail adds positive prior mass: logΞ strictly increases
+        @test all(stats.logXi .> stats_notail.logXi)
+
+        # N_eff collapses out of the reweighting window: the far point
+        # (μ = -0.08 at T = 200 K, |βμ - ln z0| ≈ 4.6) must have a much
+        # smaller effective sample size than an in-window point
+        @test stats.N_eff[1, 1] < stats.N_eff[4, 1] / 10
+        @test all(stats.N_eff .<= nrow(df) + length(live_E))
+    end
+
+    # ================================================================
+    @testset "Interacting lattice vs exact enumeration (z0 ≠ 1)" begin
+        # NN + NNN attractive lattice gas; reference fugacity centered on the
+        # target (μ = -0.05 eV, T = 300 K), i.e. z0 = exp(βμ) ≈ 0.145. This
+        # exercises the z0-weighted insert/delete ratios, the Bernoulli(p0)
+        # initialization, and the (1+z0)^M absolute normalization end to end.
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        μ_center = -0.05
+        T_center = 300.0
+        z0 = exp(μ_center / (kb * T_center))
+        n_walkers = 100
+
+        df, live_E, live_N = igref_run(igref_template, ham, z0, n_walkers, 4000; seed=11)
+        @test nrow(df) > 0
+        @test issorted(df.emax, rev=true)
+        # The energy ladder must reach deep order (ground state E = -1.04 eV:
+        # full lattice, 16·(-0.04) + 32·(-0.01) + 32·(-0.0025))
+        @test minimum(df.emax) < -1.0
+
+        μs = [-0.06, -0.05]
+        Ts = [300.0, 400.0]
+
+        # Exact grand-canonical reference: enumerate all 2^16 microstates once
+        E_vals = Vector{Float64}(undef, 2^igref_n_sites)
+        N_vals = Vector{Int}(undef, 2^igref_n_sites)
+        lattice = deepcopy(igref_template)
+        for mask in 0:(2^igref_n_sites - 1)
+            for site in 1:igref_n_sites
+                lattice.components[1][site] = ((mask >> (site - 1)) & 1) == 1
+            end
+            E_vals[mask+1] = interacting_energy(lattice, ham).val
+            N_vals[mask+1] = sum(lattice.components[1])
+        end
+
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, z0, μs, Ts, n_walkers;
+            ω0=(n_walkers + 1) / n_walkers, live_emax=live_E, live_numbers=live_N)
+
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            β = 1 / (kb * T)
+            log_w = β .* μ .* N_vals .- β .* E_vals
+            max_log = maximum(log_w)
+            w = exp.(log_w .- max_log)
+            Z = sum(w)
+            logXi_exact = max_log + log(Z)
+            meanN_exact = sum(w .* N_vals) / Z
+            meanU_exact = sum(w .* E_vals) / Z
+            varN_exact = sum(w .* N_vals .^ 2) / Z - meanN_exact^2
+
+            # Tolerances: logΞ atol = 1.5 ≈ 2.7x the observed worst
+            # seed-to-seed error (±0.55 over 6 seeds), kept below the ≈2.2
+            # shift a missing (1+z0)^M normalization would cause so the test
+            # still discriminates; ⟨N⟩/⟨U⟩ rtol = 0.10 ≈ 4x the ±0.27 spread.
+            # This is the first absolute-Ξ check in the test suite.
+            @test isapprox(stats.logXi[i, j], logXi_exact; atol=1.5)
+            @test isapprox(stats.mean_N[i, j], meanN_exact; rtol=0.10)
+            @test isapprox(stats.mean_U[i, j], meanU_exact; rtol=0.10)
+            @test isapprox(stats.var_N[i, j], varN_exact; rtol=0.25)
+        end
+    end
+
+    # ================================================================
+    @testset "Exact Skilling closure (E ≡ 0)" begin
+        # With a zero Hamiltonian every configuration has E = 0 (up to the
+        # 1e-12 tie-breaking tags), so at z = z0 the reweighting factor is 1
+        # and logΞ must equal M·ln(1+z0) EXACTLY when the dead weights use
+        # ω0 = (K+n_cull)/K and the live-set tail closes the ladder:
+        # Σω = (1 - r^n) + r^n = 1, independent of n and of the sampled N_j.
+        # This is an algebraic identity test of the weight bookkeeping — it
+        # would catch any ω0/tail double counting.
+        ham0 = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        n_walkers = 50
+        df, live_E, live_N = igref_run(igref_template, ham0, 1.0, n_walkers, 300;
+                                       seed=17, mc_steps=30)
+        @test nrow(df) > 0
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, 1.0, [0.0], [300.0], n_walkers;
+            ω0=(n_walkers + 1) / n_walkers, live_emax=live_E, live_numbers=live_N)
+        # β|E| ≲ 4e-11 from the tie-breaking tags; atol dominated by that
+        @test isapprox(stats.logXi[1, 1], igref_n_sites * log(2.0); atol=1e-6)
+    end
+
+    # ================================================================
+    @testset "gc_thermodynamic_stats_ideal_ref argument validation" begin
+        df_ok = DataFrame(iter=[1, 2], emax=[-0.1, -0.2], num_particles=[3, 4])
+        μs = [-0.05]
+        Ts = [300.0]
+
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 0.0, μs, Ts, 100)
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_ok, 0, 1.0, μs, Ts, 100)
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 1.0, μs, Ts, 100; live_emax=[-0.1])
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 1.0, μs, Ts, 100; live_numbers=[1])
+        @test_throws DimensionMismatch gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 1.0, μs, Ts, 100; live_emax=[-0.1], live_numbers=[1, 2])
+
+        df_empty = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_empty, 16, 1.0, μs, Ts, 100)
+
+        # Live walkers alone are a valid input (a run that never culled:
+        # n_iters = 0, each live walker carries weight 1/K) — check the
+        # closed form logΞ = M·ln(1+z0) + logsumexp(-ln K + N·βμ - β·E)
+        live_E = [-0.1, -0.2]
+        live_N = [1, 2]
+        stats_live = gc_thermodynamic_stats_ideal_ref(
+            df_empty, 16, 1.0, μs, Ts, 100;
+            live_emax=live_E, live_numbers=live_N)
+        β = 1 / (kb * Ts[1])
+        terms = [exp(-log(100) + live_N[k] * β * μs[1] - β * live_E[k]) for k in 1:2]
+        logXi_expected = 16 * log(2.0) + log(sum(terms))
+        @test isapprox(stats_live.logXi[1, 1], logXi_expected; rtol=1e-10)
+        @test isapprox(stats_live.mean_N[1, 1],
+                       sum(terms .* live_N) / sum(terms); rtol=1e-10)
+
+        # Output shape
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 1.0, [-0.05, -0.04, -0.03], [200.0, 300.0], 100)
+        @test size(stats.logXi) == (3, 2)
+        @test size(stats.var_N) == (3, 2)
+        @test size(stats.N_eff) == (3, 2)
+    end
+
+    # ================================================================
+    @testset "Cluster moves through the IG-ref step" begin
+        # Exercise the clusters_freq > 0 path: geometric cluster moves inside
+        # MC_grand_canonical_walk! plus the adaptive cluster_p machinery on
+        # IdealGasReferencedGCNSParameters
+        Random.seed!(21)
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        walkers = [LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+                   for _ in 1:20]
+        liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(mc_steps=50, reference_fugacity=0.5)
+        mc_routine = MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25,
+                                           clusters_freq=1, swaps_freq=1)
+        save = SaveEveryN("test_igref_cl.csv", "test_igref_cl.traj", "test_igref_cl.ls",
+                          100000, 100000, 100000)
+        df, _, params_out = ideal_gas_referenced_nested_sampling(
+            liveset, params, Int64(400), mc_routine, save)
+        rm("test_igref_cl.csv", force=true)
+        rm("test_igref_cl.traj", force=true)
+        rm("test_igref_cl.ls", force=true)
+
+        @test nrow(df) > 0
+        # Adaptation must have fired: history populated, cluster_p in bounds
+        @test !isempty(params_out.cluster_p_history)
+        @test all(mc_routine.cluster_p_floor .<= params_out.cluster_p_history
+                  .<= mc_routine.cluster_p_ceiling)
+        @test length(params_out.cluster_accept_history) ==
+              length(params_out.cluster_p_history)
+    end
+
+    # ================================================================
+    @testset "Same-seed reproducibility" begin
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        df1, live_E1, _ = igref_run(igref_template, ham, 2.0, 30, 300; seed=99, mc_steps=50)
+        df2, live_E2, _ = igref_run(igref_template, ham, 2.0, 30, 300; seed=99, mc_steps=50)
+        @test df1.emax == df2.emax
+        @test df1.num_particles == df2.num_particles
+        @test live_E1 == live_E2
+    end
+end


### PR DESCRIPTION
## Summary

Adds an E-sorted, ideal-gas-referenced construction of grand-canonical nested sampling for single-component lattice gases. Whereas the existing Ω-sorted GC-NS (#129) targets a single chemical potential per run, this construction removes μ from the sampler entirely: the prior is the non-interacting lattice gas at a reference fugacity z₀ (a Bernoulli product measure — per-site occupation probability z₀/(1+z₀), configuration weight z₀^N, total prior mass (1+z₀)^M), and NS sorts and culls on E alone. One run then yields the absolute grand partition function Ξ(μ, T) on an arbitrary (μ, T) grid in post-processing: all temperatures exactly (the prior is T-independent), and a μ-neighborhood around μ_ref(T) = k_B·T·ln z₀ by importance reweighting.

## What's included

- **`MC_grand_canonical_walk!` gains a `z0` keyword** (default 1.0): the insert ratio is scaled by z₀, and the delete ratio by 1/z₀, preserving the z₀^N prior. At z₀ = 1, this reduces exactly to the existing uniform-prior behavior.
- **`IdealGasReferencedGCNSParameters` + `ideal_gas_referenced_nested_sampling`**: E-sorted GC-NS. Walkers are initialized as exact i.i.d. Bernoulli(z₀/(1+z₀)) draws; decorrelation reuses `MC_grand_canonical_walk!` with `mu = 0` (the Ω ceiling reduces to an E ceiling). Output columns are `[:iter, :emax, :num_particles]`. This deliberately has **no `n_max`**: the (1+z₀)^M normalization is the prior mass over the full occupation range, and a cap would silently truncate the prior support and bias Ξ.
- **`gc_thermodynamic_stats_ideal_ref`** in `AnalysisTools`: assembles Ξ(μ, T) = (1+z₀)^M · Σⱼ ωⱼ (z/z₀)^{Nⱼ} exp(−βEⱼ) with z = exp(βμ) (no Λ³ — a lattice gas has no momentum integral), in log space (overflow-safe). Returns `logXi`, `mean_N`, `var_N`, `mean_U`, and a Kish `N_eff` reliability diagnostic. Supports `ω0` and a live-walker (E, N) tail for fully normalized absolute Ξ.

## Usage caveats (documented in the docstrings)

1. **μ is importance reweighting, not ladder coverage** — the (z/z₀)^N factor degrades once |βμ − ln z₀| exceeds ~1/√Var(N). Check the returned `N_eff` (4×4-lattice validation: errors of 0.7 in logΞ at N_eff ≈ 3 vs < 0.05 at N_eff ≳ 200). Choose z₀ near exp(βμ_target).
2. **Energy tie-breaking is a correctness requirement** for degenerate lattice spectra; the default `energy_perturbation = 1e-12` handles it, but it must remain ≪ k_B·T at the lowest targeted temperature.
3. For **absolute** Ξ, pass `ω0 = (K + n_cull)/K` and the live-set tail. With the defaults, logΞ is biased low (ratio observables are unaffected).

## Validation (`test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl`, +329 lines)

- z₀-walk stationarity against the Bernoulli product prior.
- Langmuir closed form Ξ = (1 + z·e^{−βε_ads})^M (adsorption-only Hamiltonian).
- Absolute logΞ against the full 2^16 exact enumeration on a 4×4 lattice at z₀ ≠ 1.
- `N_eff` diagnostic behavior, live-set tail closure, argument validation, and same-seed reproducibility.