### PR TITLE
Lattice fixed-N grand-canonical post-processing

### DIFF
--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -362,6 +362,75 @@ function _log_factorial(n::Integer)
 end
 
 """
+    _log_binomial(M::Integer, N::Integer) -> Float64
+
+Return `log(binomial(M, N))` in floating point, computed from `_log_factorial`
+so that it does not overflow for lattice sizes where `binomial(M, N)` exceeds
+`typemax(Int64)`.
+"""
+function _log_binomial(M::Integer, N::Integer)
+    0 <= N <= M || throw(ArgumentError("require 0 ≤ N ≤ M, got N=$N, M=$M"))
+    return _log_factorial(M) - _log_factorial(N) - _log_factorial(M - N)
+end
+
+"""
+    _fixed_N_log_evidence(df, T_grid; n_walkers, n_cull, ω0, live_energies, kb)
+        -> (log_Z_NS::Vector{Float64}, mean_E::Vector{Float64})
+
+Canonical NS evidence `log Z_NS(β) = log Σᵢ ωᵢ exp(−βEᵢ)` and canonical mean
+energy at each temperature in `T_grid`, evaluated by log-sum-exp. When
+`live_energies` is supplied, each of the `n_walkers` live walkers contributes
+the residual prior weight `ω0 · (K/(K+n_cull))^{n_iters} / K` at its energy
+(the live-set tail correction). Internal helper shared by the
+`gc_thermodynamic_stats_fixed_N` methods.
+"""
+function _fixed_N_log_evidence(
+    df::DataFrame,
+    T_grid::AbstractVector{<:Unitful.Temperature};
+    n_walkers::Int,
+    n_cull::Int,
+    ω0::Float64,
+    live_energies::Union{Nothing,AbstractVector{<:Real}},
+    kb::Float64,
+)
+    Es = collect(Float64, df.emax)
+    n_iters = length(Es)
+    if isempty(Es) && (live_energies === nothing || isempty(live_energies))
+        throw(ArgumentError(
+            "a sector has no discarded samples and no live-set tail; for " *
+            "single-configuration sectors supply an empty DataFrame plus a " *
+            "live_emax entry carrying the sector energy"))
+    end
+    ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
+    # Each live walker carries weight ω0 · (K/(K+n_cull))^n_iters / K,
+    # accounting for the prior volume that finite termination leaves in
+    # the live set.
+    log_tail = log(ω0) + n_iters * log(n_walkers / (n_walkers + n_cull)) -
+               log(n_walkers)
+    if live_energies === nothing
+        Es_all = Es
+        log_ws = log.(ωi)
+    else
+        Es_live = collect(Float64, live_energies)
+        Es_all = vcat(Es, Es_live)
+        log_ws = vcat(log.(ωi), fill(log_tail, length(Es_live)))
+    end
+
+    log_Z_NS = Vector{Float64}(undef, length(T_grid))
+    mean_E = Vector{Float64}(undef, length(T_grid))
+    for (j, T) in enumerate(T_grid)
+        β = 1.0 / (kb * ustrip(u"K", T))
+        log_terms = log_ws .- β .* Es_all
+        max_log = maximum(log_terms)
+        ws = exp.(log_terms .- max_log)
+        sum_w = sum(ws)
+        log_Z_NS[j] = max_log + log(sum_w)
+        mean_E[j] = sum(ws .* Es_all) / sum_w
+    end
+    return log_Z_NS, mean_E
+end
+
+"""
     gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
                                    n_walkers=120, n_cull=1, ω0=1.0,
                                    live_emax=nothing, kb=8.617333262e-5)
@@ -479,31 +548,11 @@ function gc_thermodynamic_stats_fixed_N(
             continue
         end
 
-        ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
-        Es = collect(Float64, df.emax)
-        n_iters = length(df.iter)
-        # Each live walker carries weight ω0 · (K/(K+n_cull))^n_iters / K,
-        # accounting for the prior volume that finite termination leaves in
-        # the live set.
-        log_tail = log(ω0) + n_iters * log(n_walkers / (n_walkers + n_cull)) -
-                   log(n_walkers)
-        for (j, T) in enumerate(T_grid)
-            β = 1.0 / (kb * ustrip(u"K", T))
-            if live_emax === nothing
-                log_terms = log.(ωi) .- β .* Es
-                Es_all = Es
-            else
-                Es_live = collect(Float64, live_emax[i])
-                log_terms = vcat(log.(ωi) .- β .* Es,
-                                 log_tail .- β .* Es_live)
-                Es_all = vcat(Es, Es_live)
-            end
-            max_log = maximum(log_terms)
-            ws = exp.(log_terms .- max_log)
-            sum_w = sum(ws)
-            log_Z_NS[i, j] = max_log + log(sum_w)
-            mean_E_N[i, j] = sum(ws .* Es_all) / sum_w
-        end
+        live = live_emax === nothing ? nothing : live_emax[i]
+        log_Z_NS[i, :], mean_E_N[i, :] = _fixed_N_log_evidence(
+            df, T_grid;
+            n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
+            live_energies=live, kb=kb)
     end
 
     log_fact = [_log_factorial(N) for N in N_int]
@@ -535,6 +584,159 @@ function gc_thermodynamic_stats_fixed_N(
     end
 
     return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
+end
+
+"""
+    gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, n_sites, μ_grid, T_grid;
+                                   n_walkers=120, n_cull=1, ω0=1.0,
+                                   live_emax=nothing, kb=8.617333262e-5)
+
+Lattice-gas method: compute grand-canonical thermodynamic averages from a
+stack of canonical (fixed-`N`) lattice nested-sampling outputs, one per
+particle count `N`, on a lattice with `n_sites` sites.
+
+Fixed-`N` lattice NS samples the uniform prior over the `binomial(n_sites, N)`
+occupation patterns, so the absolute canonical partition function is
+`Z_N(β) = binomial(M, N) · Z_NS^{(N)}(β)` with `M = n_sites` and
+
+```math
+\\Xi(\\mu, T) = \\sum_N z^N \\binom{M}{N} Z_{\\mathrm{NS}}^{(N)}(\\beta),
+\\qquad z = \\exp(\\beta\\mu).
+```
+
+A lattice gas has no momentum integral, so `z = exp(βμ)` directly — no volume
+argument and no thermal wavelength enter (contrast the atomistic method of
+this function). The sum runs over the supplied `N_values`, which must include
+`0`; truncating `N_values` below `n_sites` truncates Ξ accordingly, which is
+safe only when `⟨N⟩` at the requested `(μ, T)` sits well below the largest
+supplied `N`.
+
+## Special sectors
+
+- `N = 0`: the empty lattice is a single configuration with `E = 0`, so
+  `Z_NS^{(0)} = 1`; the corresponding DataFrame contents are ignored.
+- `N = n_sites` (and any other single-configuration sector): NS cannot make
+  progress because every walker holds the same configuration. Supply an empty
+  DataFrame (`DataFrame(iter=Int[], emax=Float64[])`) together with a
+  `live_emax` entry holding `n_walkers` copies of the sector energy — the
+  live-set tail then carries the sector's entire prior mass (exactly `ω0`,
+  so pair this with `ω0 = 1.0` semantics in mind; see below).
+
+## Live-set tail and normalization
+
+As for the atomistic method, the recorded weights `ωᵢ` carry only part of the
+prior volume after finite NS termination. Supplying `live_emax` (one vector of
+`n_walkers` live-walker energies per `N`) adds the residual
+`ω0 · (K/(K+n_cull))^{n_iters} / K` per live walker to each sector evidence.
+For fully-normalized absolute `Ξ`, pass `ω0 = (n_walkers + n_cull)/n_walkers`
+(Skilling weights) together with `live_emax`; with the defaults, `logXi` is
+biased low by a uniform-in-`N` factor that cancels in the ratio observables
+`mean_N`, `var_N`, and `mean_U`.
+
+# Arguments
+- `ns_outputs::AbstractVector{<:DataFrame}`: one canonical lattice-NS output
+  per `N`, each with columns `[:iter, :emax]` (energies in eV, as produced by
+  `nested_sampling` on a `LatticeGasWalkers` liveset).
+- `N_values::AbstractVector{<:Integer}`: particle counts corresponding to each
+  DataFrame. Must include `0`, and every entry must lie in `0:n_sites`.
+- `n_sites::Integer`: number of lattice sites `M`.
+- `μ_grid::AbstractVector{<:typeof(1.0u"eV")}`: chemical potentials.
+- `T_grid::AbstractVector{<:Unitful.Temperature}`: temperatures.
+
+# Keyword arguments
+- `n_walkers::Int=120`: number of NS walkers used to produce each DataFrame.
+  Must be uniform across `ns_outputs`.
+- `n_cull::Int=1`: NS culls per iteration.
+- `ω0::Float64=1.0`: initial prior weight, passed to `ωᵢ`.
+- `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
+  when supplied, one vector of `n_walkers` live-walker energies (in eV) per
+  `N`. The entry for `N=0` is ignored.
+- `kb::Float64`: Boltzmann constant in eV/K.
+
+# Returns
+A `NamedTuple` `(logXi, mean_N, var_N, mean_U)`. Each field is a
+`Matrix{Float64}` of size `(length(μ_grid), length(T_grid))` indexed
+`[i_μ, i_T]`. `logXi` is the natural log of the absolute grand partition
+function — returned in log space (unlike the atomistic method's `Xi`) because
+the binomial prior mass grows like `2^M` and `Ξ` overflows `Float64` for
+modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`, and `mean_U`
+is `⟨E⟩` (grand-canonical, in eV).
+"""
+function gc_thermodynamic_stats_fixed_N(
+    ns_outputs::AbstractVector{<:DataFrame},
+    N_values::AbstractVector{<:Integer},
+    n_sites::Integer,
+    μ_grid::AbstractVector{<:typeof(1.0u"eV")},
+    T_grid::AbstractVector{<:Unitful.Temperature};
+    n_walkers::Int=120,
+    n_cull::Int=1,
+    ω0::Float64=1.0,
+    live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
+    kb::Float64=8.617333262e-5,
+)
+    if length(ns_outputs) != length(N_values)
+        throw(DimensionMismatch("ns_outputs and N_values must have the same length"))
+    end
+    if !(0 in N_values)
+        throw(ArgumentError("N_values must include 0 (the empty lattice)"))
+    end
+    if !all(0 .<= N_values .<= n_sites)
+        throw(ArgumentError("every entry of N_values must lie in 0:n_sites"))
+    end
+    if live_emax !== nothing && length(live_emax) != length(N_values)
+        throw(DimensionMismatch("live_emax and N_values must have the same length"))
+    end
+
+    N_int = collect(Int, N_values)
+    n_N = length(N_int)
+    n_mu = length(μ_grid)
+    n_T = length(T_grid)
+
+    log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
+    mean_E_N = Matrix{Float64}(undef, n_N, n_T)
+
+    for (i, df) in enumerate(ns_outputs)
+        # The N = 0 sector is the empty lattice: a single configuration with
+        # E = 0, so Z_NS^{(0)} = 1. The corresponding DataFrame is ignored.
+        if N_int[i] == 0
+            log_Z_NS[i, :] .= 0.0
+            mean_E_N[i, :] .= 0.0
+            continue
+        end
+
+        live = live_emax === nothing ? nothing : live_emax[i]
+        log_Z_NS[i, :], mean_E_N[i, :] = _fixed_N_log_evidence(
+            df, T_grid;
+            n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
+            live_energies=live, kb=kb)
+    end
+
+    log_binom = [_log_binomial(n_sites, N) for N in N_int]
+
+    logXi = Matrix{Float64}(undef, n_mu, n_T)
+    mean_N = Matrix{Float64}(undef, n_mu, n_T)
+    var_N = Matrix{Float64}(undef, n_mu, n_T)
+    mean_U = Matrix{Float64}(undef, n_mu, n_T)
+
+    for (j, T) in enumerate(T_grid)
+        β = 1.0 / (kb * ustrip(u"K", T))
+        for (k, μ) in enumerate(μ_grid)
+            μ_val = ustrip(u"eV", μ)
+
+            log_w = log_Z_NS[:, j] .+ N_int .* (β * μ_val) .+ log_binom
+            max_log = maximum(log_w)
+            ws = exp.(log_w .- max_log)
+            sum_w = sum(ws)
+
+            logXi[k, j] = max_log + log(sum_w)
+            mean_N[k, j] = sum(ws .* N_int) / sum_w
+            mean_N2 = sum(ws .* (N_int .^ 2)) / sum_w
+            var_N[k, j] = mean_N2 - mean_N[k, j]^2
+            mean_U[k, j] = sum(ws .* view(mean_E_N, :, j)) / sum_w
+        end
+    end
+
+    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -502,8 +502,9 @@ end
 """
     _log_factorial(n::Integer) -> Float64
 
-Return `log(n!)` for small non-negative `n`, computed by summing `log(k)` to
-keep the result exact in floating point for `n` up to several dozen.
+Return `log(n!)` for non-negative `n`, computed by summing `log(k)`. Accurate
+to roundoff accumulation (absolute error ~1e-11 at `n ~ 10^4`), which covers
+both the small-`n` atomistic use and the large-`M` `_log_binomial` use.
 """
 function _log_factorial(n::Integer)
     n < 0 && throw(ArgumentError("n must be non-negative"))
@@ -528,11 +529,16 @@ end
         -> (log_Z_NS::Vector{Float64}, mean_E::Vector{Float64})
 
 Canonical NS evidence `log Z_NS(β) = log Σᵢ ωᵢ exp(−βEᵢ)` and canonical mean
-energy at each temperature in `T_grid`, evaluated by log-sum-exp. When
-`live_energies` is supplied, each of the `n_walkers` live walkers contributes
-the residual prior weight `ω0 · (K/(K+n_cull))^{n_iters} / K` at its energy
-(the live-set tail correction). Internal helper shared by the
-`gc_thermodynamic_stats_fixed_N` methods.
+energy at each temperature in `T_grid`, evaluated by log-sum-exp. The discarded
+weights `ωᵢ` are built directly in log space, so deep ladders (`iter` beyond
+~`700 · n_walkers`, where the linear-space `ωᵢ` underflows Float64) keep their
+low-energy samples. When `live_energies` is supplied, the residual prior mass
+`ω0 · (K/(K+n_cull))^{n_iters}` (with `n_iters = maximum(df.iter)`) is split
+evenly among the supplied energies — the live-set tail correction. An empty
+ladder records no compression, so its tail carries the sector's entire prior
+mass, exactly 1 and independent of `ω0` (matching the internally-handled
+`N = 0` sector). Internal helper shared by the `gc_thermodynamic_stats_fixed_N`
+methods.
 """
 function _fixed_N_log_evidence(
     df::DataFrame,
@@ -544,26 +550,34 @@ function _fixed_N_log_evidence(
     kb::Float64,
 )
     Es = collect(Float64, df.emax)
-    n_iters = length(Es)
     if isempty(Es) && (live_energies === nothing || isempty(live_energies))
         throw(ArgumentError(
             "a sector has no discarded samples and no live-set tail; for " *
             "single-configuration sectors supply an empty DataFrame plus a " *
-            "live_emax entry carrying the sector energy"))
+            "live_emax entry carrying the sector energy (e.g. n_walkers " *
+            "copies of it)"))
     end
-    ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
-    # Each live walker carries weight ω0 · (K/(K+n_cull))^n_iters / K,
-    # accounting for the prior volume that finite termination leaves in
-    # the live set.
-    log_tail = log(ω0) + n_iters * log(n_walkers / (n_walkers + n_cull)) -
-               log(n_walkers)
+    # Log-space weights: the linear-space ωᵢ underflows Float64 for
+    # iter ≳ 700·K, silently dropping the low-energy samples that dominate
+    # at low T.
+    log_r = log(n_walkers / (n_walkers + n_cull))
+    log_ωi = (log(ω0) + log(n_cull / (n_walkers + n_cull))) .+ df.iter .* log_r
     if live_energies === nothing
         Es_all = Es
-        log_ws = log.(ωi)
+        log_ws = log_ωi
     else
         Es_live = collect(Float64, live_energies)
+        # The live set carries the residual prior mass ω0 · r^n_iters, split
+        # evenly among the supplied energies. n_iters comes from the recorded
+        # iter values (not the row count), so continuation ladders whose iter
+        # does not start at 1 stay consistent with their ωᵢ. An empty ladder
+        # records no compression: its tail is the sector's entire prior mass,
+        # exactly 1, independent of ω0.
+        n_iters = isempty(df.iter) ? 0 : maximum(df.iter)
+        log_tail_total = n_iters == 0 ? 0.0 : log(ω0) + n_iters * log_r
+        log_tail = log_tail_total - log(length(Es_live))
         Es_all = vcat(Es, Es_live)
-        log_ws = vcat(log.(ωi), fill(log_tail, length(Es_live)))
+        log_ws = vcat(log_ωi, fill(log_tail, length(Es_live)))
     end
 
     log_Z_NS = Vector{Float64}(undef, length(T_grid))
@@ -585,8 +599,11 @@ end
                                    n_walkers=120, n_cull=1, ω0=1.0,
                                    live_emax=nothing, kb=8.617333262e-5)
 
-Compute grand-canonical thermodynamic averages from a stack of canonical
-nested-sampling outputs, one per fixed particle number `N`.
+Atomistic method: compute grand-canonical thermodynamic averages from a stack
+of canonical nested-sampling outputs, one per fixed particle number `N`, using
+the simulation-box volume `V` and the thermal wavelength. Returns `Xi` in
+linear space (contrast the lattice-gas method of this function, which takes
+`n_sites` and returns `logXi`).
 
 For each `N`, the canonical NS evidence at inverse temperature `β` is
 
@@ -617,12 +634,15 @@ grand sum for numerical stability.
 
 After a finite number of NS iterations `n_iters` the recorded weights `ωᵢ` carry
 only `1 − (K/(K+n_cull))^{n_iters}` of the prior volume (times `ω0`); the remainder
-sits in the `K` surviving live walkers. Supplying `live_emax` (one vector of K live
-walker energies per `N`) adds the live-set tail to each per-N evidence: each live
-walker contributes weight `ω0 · (K/(K+n_cull))^{n_iters} / K` at its current energy.
-When omitted, the live-set tail is neglected — for ratio observables (`⟨N⟩`, `⟨U⟩`)
-the resulting bias is small but visible at low T or shallow NS; for the absolute
-`Ξ` it appears as a uniform-in-N prefactor that does not cancel.
+sits in the `K` surviving live walkers. Supplying `live_emax` (one vector of live
+walker energies per `N`, normally the K live energies) adds the live-set tail to
+each per-N evidence: the residual mass `ω0 · (K/(K+n_cull))^{n_iters}` is split
+evenly among the supplied energies. A sector supplied as an empty DataFrame plus
+live energies carries mass exactly `1`, independent of `ω0` (see the lattice-gas
+method's "Special sectors"). When omitted, the live-set tail is neglected — for
+ratio observables (`⟨N⟩`, `⟨U⟩`) the resulting bias is small but visible at low T
+or shallow NS; for the absolute `Ξ` it appears as a uniform-in-N prefactor that
+does not cancel.
 
 # Arguments
 - `ns_outputs::AbstractVector{<:DataFrame}`: one canonical-NS output per `N`,
@@ -676,8 +696,14 @@ function gc_thermodynamic_stats_fixed_N(
     if !(0 in N_values)
         throw(ArgumentError("N_values must include 0 (the empty configuration)"))
     end
+    if !allunique(N_values)
+        throw(ArgumentError("N_values must not contain duplicate entries"))
+    end
     if live_emax !== nothing && length(live_emax) != length(N_values)
         throw(DimensionMismatch("live_emax and N_values must have the same length"))
+    end
+    if !all(T -> ustrip(u"K", T) > 0, T_grid)
+        throw(ArgumentError("every temperature in T_grid must be positive"))
     end
 
     N_int = collect(Int, N_values)
@@ -768,20 +794,26 @@ supplied `N`.
 - `N = n_sites` (and any other single-configuration sector): NS cannot make
   progress because every walker holds the same configuration. Supply an empty
   DataFrame (`DataFrame(iter=Int[], emax=Float64[])`) together with a
-  `live_emax` entry holding `n_walkers` copies of the sector energy — the
-  live-set tail then carries the sector's entire prior mass (exactly `ω0`,
-  so pair this with `ω0 = 1.0` semantics in mind; see below).
+  `live_emax` entry holding the sector energy (conventionally `n_walkers`
+  copies of it; any count works) — the live-set tail then carries the
+  sector's entire prior mass, exactly `1` and independent of `ω0`, matching
+  the internally-handled `N = 0` sector. Because such sectors require a
+  `live_emax` entry, covering the full range `0:n_sites` in `N_values` is
+  only possible with `live_emax` supplied.
 
 ## Live-set tail and normalization
 
 As for the atomistic method, the recorded weights `ωᵢ` carry only part of the
 prior volume after finite NS termination. Supplying `live_emax` (one vector of
-`n_walkers` live-walker energies per `N`) adds the residual
-`ω0 · (K/(K+n_cull))^{n_iters} / K` per live walker to each sector evidence.
-For fully-normalized absolute `Ξ`, pass `ω0 = (n_walkers + n_cull)/n_walkers`
-(Skilling weights) together with `live_emax`; with the defaults, `logXi` is
-biased low by a uniform-in-`N` factor that cancels in the ratio observables
-`mean_N`, `var_N`, and `mean_U`.
+live-walker energies per `N`, normally the `n_walkers` live energies) splits
+the residual prior mass `ω0 · (K/(K+n_cull))^{n_iters}` evenly among the
+supplied entries of each sector. For fully-normalized absolute `Ξ`, pass
+`ω0 = (n_walkers + n_cull)/n_walkers` (Skilling weights) together with
+`live_emax`; with the defaults (`ω0 = 1.0`, no tail), `logXi` is biased low,
+and the omitted tail additionally leaves an `N`-dependent bias — small but
+visible at low `T` or for shallow NS runs, and not exactly cancelling in the
+ratio observables `mean_N`, `var_N`, and `mean_U` when per-`N` ladders differ
+in length or convergence.
 
 # Arguments
 - `ns_outputs::AbstractVector{<:DataFrame}`: one canonical lattice-NS output
@@ -797,10 +829,11 @@ biased low by a uniform-in-`N` factor that cancels in the ratio observables
 - `n_walkers::Int=120`: number of NS walkers used to produce each DataFrame.
   Must be uniform across `ns_outputs`.
 - `n_cull::Int=1`: NS culls per iteration.
-- `ω0::Float64=1.0`: initial prior weight, passed to `ωᵢ`.
+- `ω0::Float64=1.0`: initial prior weight for the discarded-sample ladder.
 - `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
-  when supplied, one vector of `n_walkers` live-walker energies (in eV) per
-  `N`. The entry for `N=0` is ignored.
+  when supplied, one vector of live-walker energies (in eV) per `N` —
+  normally the `n_walkers` live energies; the sector's residual prior mass is
+  split evenly among the supplied entries. The entry for `N=0` is ignored.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
@@ -833,8 +866,14 @@ function gc_thermodynamic_stats_fixed_N(
     if !all(0 .<= N_values .<= n_sites)
         throw(ArgumentError("every entry of N_values must lie in 0:n_sites"))
     end
+    if !allunique(N_values)
+        throw(ArgumentError("N_values must not contain duplicate entries"))
+    end
     if live_emax !== nothing && length(live_emax) != length(N_values)
         throw(DimensionMismatch("live_emax and N_values must have the same length"))
+    end
+    if !all(T -> ustrip(u"K", T) > 0, T_grid)
+        throw(ArgumentError("every temperature in T_grid must be positive"))
     end
 
     N_int = collect(Int, N_values)

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -12,5 +12,7 @@
     include("test-grand_canonical_ns.jl")
     # test atomistic GC-NS fixed-N post-processing (ideal gas reference)
     include("test-atomistic-gcns-fixed-n.jl")
+    # test lattice GC-NS fixed-N post-processing
+    include("test-lattice-gcns-fixed-n.jl")
 
 end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -128,6 +128,20 @@
             [-0.25u"eV"], [300.0u"K"];
             n_walkers=K,
             live_emax=[Float64[], Float64[]])
+
+        # Duplicate entries in N_values
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [0, 1, 1],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [300.0u"K"];
+            n_walkers=K)
+
+        # Non-positive temperature
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [0, 1, 2],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [0.0u"K"];
+            n_walkers=K)
     end
 
 end

--- a/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
@@ -81,6 +81,12 @@
 
     # ================================================================
     @testset "exact-enumeration validation (3x3 lattice, real NS runs)" begin
+        using Random
+        # The NS tolerance checks below are statistical: seed the global RNG
+        # so they do not depend on which test files ran before this one.
+        # (The random_seed field on the NS parameters is not consumed.)
+        Random.seed!(1000)
+
         M = 9
         ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
 

--- a/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
@@ -38,6 +38,33 @@
         # a nonzero-N sector with no discarded samples and no live tail
         @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
             [empty_df(), empty_df()], [0, 1], 4, μs, Ts)
+        # duplicate entries in N_values
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [empty_df(), good_df(), good_df()], [0, 1, 1], 4, μs, Ts)
+        # non-positive temperature
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            dfs, [0, 1], 4, μs, [0.0u"K"])
+    end
+
+    # ================================================================
+    @testset "_fixed_N_log_evidence: single-configuration sectors" begin
+        # An empty ladder plus a live tail carries the sector's entire prior
+        # mass, exactly 1 — independent of ω0 and of how many live energies
+        # are supplied — so log_Z_NS = -βE exactly.
+        fe = FreeBird.AnalysisTools._fixed_N_log_evidence
+        empty_df = DataFrame(iter=Int[], emax=Float64[])
+        Ts = [200.0, 400.0] .* u"K"
+        E = -0.3
+        K = 25
+        for ω0 in (1.0, (K + 1) / K), live in (fill(E, K), [E])
+            logZ, meanE = fe(empty_df, Ts;
+                n_walkers=K, n_cull=1, ω0=ω0, live_energies=live, kb=kb)
+            for (j, T) in enumerate(Ts)
+                β = 1.0 / (kb * ustrip(u"K", T))
+                @test isapprox(logZ[j], -β * E, rtol=1e-12)
+                @test isapprox(meanE[j], E, rtol=1e-12)
+            end
+        end
     end
 
     # ================================================================
@@ -58,6 +85,11 @@
         dfs = [DataFrame(iter=collect(1:n_iters), emax=fill(N * ε, n_iters))
                for N in N_values]
         live = [fill(N * ε, K) for N in N_values]
+        # The N = M sector uses the documented single-configuration recipe
+        # (empty DataFrame + live tail), pinning it at tight tolerance: the
+        # tail carries exactly the sector's prior mass 1, matching the flat
+        # ladders' 1 + O(r^n/K) closure within rtol.
+        dfs[end] = DataFrame(iter=Int[], emax=Float64[])
 
         μ_grid = [-0.08, -0.04, 0.0] .* u"eV"
         T_grid = [250.0, 300.0, 400.0] .* u"K"
@@ -160,7 +192,6 @@
             liveset = LatticeGasWalkers(walkers, ham, perturb_energy=1e-12)
             ns_params = LatticeNestedSamplingParameters(
                 mc_steps=60,
-                random_seed=1000 + N,
                 allowed_fail_count=100_000)
             df, final_ls, _ = nested_sampling(
                 liveset, ns_params, n_iters, MCRandomWalkClone(), save_strategy)

--- a/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
@@ -1,0 +1,196 @@
+@testset "Lattice GC-NS, fixed-N construction" begin
+
+    kb = 8.617333262e-5 # eV/K
+
+    # ================================================================
+    @testset "_log_binomial" begin
+        lb = FreeBird.AnalysisTools._log_binomial
+        @test lb(16, 0) == 0.0
+        @test lb(16, 16) == 0.0
+        @test isapprox(lb(16, 8), log(binomial(16, 8)), rtol=1e-12)
+        # Beyond Int64 overflow of binomial(M, N)
+        @test isapprox(lb(200, 100),
+                       Float64(log(binomial(big(200), big(100)))), rtol=1e-10)
+        @test_throws ArgumentError lb(4, 5)
+        @test_throws ArgumentError lb(4, -1)
+    end
+
+    # ================================================================
+    @testset "argument validation" begin
+        μs = [0.0u"eV"]
+        Ts = [300.0u"K"]
+        empty_df() = DataFrame(iter=Int[], emax=Float64[])
+        good_df() = DataFrame(iter=[1, 2], emax=[-0.1, -0.1])
+        dfs = [empty_df(), good_df()]
+
+        # ns_outputs / N_values length mismatch
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            dfs, [0, 1, 2], 4, μs, Ts)
+        # N_values must include 0
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            dfs, [1, 2], 4, μs, Ts)
+        # N_values must lie in 0:n_sites
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            dfs, [0, 5], 4, μs, Ts)
+        # live_emax length mismatch
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            dfs, [0, 1], 4, μs, Ts; live_emax=[Float64[]])
+        # a nonzero-N sector with no discarded samples and no live tail
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [empty_df(), empty_df()], [0, 1], 4, μs, Ts)
+    end
+
+    # ================================================================
+    @testset "Langmuir closed form from synthetic ladders" begin
+        # On-site-only lattice gas: every N-particle configuration has
+        # E = N ε_ads, so each per-N NS ladder is exactly flat and can be
+        # synthesized without running a sampler. With Skilling weights
+        # ω0 = (K+1)/K plus the live-set tail, Σω = 1 per sector (up to
+        # O(r^n/K)) and the assembly must reproduce the Langmuir closed form
+        # Ξ = (1 + z e^{-βε})^M to floating-point accuracy.
+        M = 16
+        ε = -0.04
+        K = 25
+        n_iters = 600
+        ω0 = (K + 1) / K
+        N_values = collect(0:M)
+
+        dfs = [DataFrame(iter=collect(1:n_iters), emax=fill(N * ε, n_iters))
+               for N in N_values]
+        live = [fill(N * ε, K) for N in N_values]
+
+        μ_grid = [-0.08, -0.04, 0.0] .* u"eV"
+        T_grid = [250.0, 300.0, 400.0] .* u"K"
+
+        stats = gc_thermodynamic_stats_fixed_N(dfs, N_values, M, μ_grid, T_grid;
+            n_walkers=K, n_cull=1, ω0=ω0, live_emax=live)
+
+        @test stats.logXi isa Matrix{Float64}
+        @test size(stats.logXi) == (length(μ_grid), length(T_grid))
+
+        for (j, T) in enumerate(T_grid), (k, μ) in enumerate(μ_grid)
+            β = 1.0 / (kb * ustrip(u"K", T))
+            zeff = exp(β * (ustrip(u"eV", μ) - ε))
+            θ = zeff / (1 + zeff)
+            @test isapprox(stats.logXi[k, j], M * log1p(zeff), rtol=1e-8)
+            @test isapprox(stats.mean_N[k, j], M * θ, rtol=1e-8)
+            @test isapprox(stats.var_N[k, j], M * θ / (1 + zeff), rtol=1e-8)
+            @test isapprox(stats.mean_U[k, j], ε * M * θ, rtol=1e-8)
+        end
+    end
+
+    # ================================================================
+    @testset "exact-enumeration validation (3x3 lattice, real NS runs)" begin
+        M = 9
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+
+        # A 3x3 periodic square lattice with the first N sites occupied.
+        function lattice_at(N::Int)
+            lat = MLattice{1,SquareLattice}(
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(3, 3, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1, 1.5],
+                components=:equal,
+                adsorptions=:full)
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            return lat
+        end
+
+        # Exact per-N energy lists from fixed-N enumeration (512 configs total).
+        exact_E = Dict{Int,Vector{Float64}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(lattice_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            @test length(exact_E[N]) == binomial(M, N)
+        end
+
+        # Exact grand-canonical reference from the full spectrum.
+        function exact_stats(μ_val::Float64, T_val::Float64)
+            β = 1.0 / (kb * T_val)
+            log_terms = Float64[]
+            Ns = Int[]
+            Es = Float64[]
+            for N in 0:M, E in exact_E[N]
+                push!(log_terms, N * β * μ_val - β * E)
+                push!(Ns, N)
+                push!(Es, E)
+            end
+            max_log = maximum(log_terms)
+            w = exp.(log_terms .- max_log)
+            sw = sum(w)
+            logXi = max_log + log(sw)
+            mean_N = sum(w .* Ns) / sw
+            var_N = sum(w .* (Ns .^ 2)) / sw - mean_N^2
+            mean_U = sum(w .* Es) / sw
+            return logXi, mean_N, var_N, mean_U
+        end
+
+        # Canonical NS at each intermediate N; the walk (site hops) conserves N.
+        K = 100
+        n_iters = 800
+        save_strategy = SaveEveryN(
+            df_filename="test_lfn_df.csv",
+            wk_filename="test_lfn.traj.extxyz",
+            ls_filename="test_lfn.ls.extxyz",
+            n_traj=1_000_000, n_snap=1_000_000, n_info=1_000_000)
+
+        dfs = Vector{DataFrame}(undef, M + 1)
+        live = Vector{Vector{Float64}}(undef, M + 1)
+
+        # N = 0: empty lattice, handled internally (DataFrame ignored).
+        dfs[1] = DataFrame(iter=Int[], emax=Float64[])
+        live[1] = Float64[]
+
+        for N in 1:(M - 1)
+            walkers = [
+                begin
+                    lat = lattice_at(N)
+                    generate_random_new_lattice_sample!(lat)
+                    LatticeWalker(lat)
+                end for _ in 1:K]
+            liveset = LatticeGasWalkers(walkers, ham, perturb_energy=1e-12)
+            ns_params = LatticeNestedSamplingParameters(
+                mc_steps=60,
+                random_seed=1000 + N,
+                allowed_fail_count=100_000)
+            df, final_ls, _ = nested_sampling(
+                liveset, ns_params, n_iters, MCRandomWalkClone(), save_strategy)
+            dfs[N + 1] = df
+            live[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
+        end
+
+        # N = M: a single configuration, so NS cannot progress; the live-set
+        # tail carries the whole sector (empty DataFrame + K copies of E_full).
+        dfs[M + 1] = DataFrame(iter=Int[], emax=Float64[])
+        live[M + 1] = fill(only(exact_E[M]), K)
+
+        rm("test_lfn_df.csv", force=true)
+        rm("test_lfn.traj.extxyz", force=true)
+        rm("test_lfn.ls.extxyz", force=true)
+
+        μ_grid = [-0.10, -0.06, -0.03] .* u"eV"
+        T_grid = [300.0, 500.0] .* u"K"
+
+        stats = gc_thermodynamic_stats_fixed_N(dfs, collect(0:M), M,
+            μ_grid, T_grid;
+            n_walkers=K, n_cull=1, ω0=(K + 1) / K, live_emax=live)
+
+        for (j, T) in enumerate(T_grid), (k, μ) in enumerate(μ_grid)
+            ref_logXi, ref_mean_N, ref_var_N, ref_mean_U = exact_stats(
+                ustrip(u"eV", μ), ustrip(u"K", T))
+            @test isapprox(stats.logXi[k, j], ref_logXi, atol=0.1)
+            @test isapprox(stats.mean_N[k, j], ref_mean_N, rtol=0.05, atol=0.1)
+            @test isapprox(stats.var_N[k, j], ref_var_N, rtol=0.25, atol=0.2)
+            @test isapprox(stats.mean_U[k, j], ref_mean_U, rtol=0.05, atol=0.02)
+        end
+
+        # Monotonicity: ⟨N⟩ increases with μ at fixed T.
+        for j in eachindex(T_grid)
+            @test issorted(stats.mean_N[:, j])
+        end
+    end
+
+end


### PR DESCRIPTION
## Summary

Adds the lattice mirror of the atomistic fixed-N grand-canonical composition (#131): a second method of `gc_thermodynamic_stats_fixed_N` that dispatches on `n_sites::Integer`. Canonical lattice NS conserves N (site hops) and samples the uniform prior over the binomial(M, N) occupation patterns, so the grand partition function assembles as

    Ξ(μ, T) = Σ_N z^N · C(M, N) · Z_NS^(N)(β),   z = exp(βμ)

The binomial replaces the atomistic (zV)^N/N!, and no thermal wavelength enters.

## Design points

- Returns `logXi` in log space (the binomial prior mass grows like 2^M, so Ξ overflows Float64 for modest lattices).
- The N = 0 sector is handled internally (Z_NS^(0) = 1).
- Single-configuration sectors (e.g., N = M), where NS cannot progress, are supplied as an empty DataFrame plus a `live_emax` entry carrying the sector energy (conventionally `n_walkers` copies; any count works after the post-review hardening), so the live tail carries the whole sector.
- The per-N log-sum-exp evidence assembly is extracted into `_fixed_N_log_evidence`, shared with the atomistic method (no behavior change there at extraction; see post-review hardening).
- No new exports; single-component (`SLattice`) only, like the other grand-canonical constructions.

## Validation

- Langmuir closed form Ξ = (1 + z·e^(−βε))^M from synthetic flat ladders at rtol 1e-8 (logXi, mean_N, var_N, mean_U).
- 512-configuration exact enumeration on a 3×3 lattice against real canonical NS runs at each N (K = 100), including both special-case sectors and a ⟨N⟩-monotonicity check.
- Argument validation and `_log_binomial` unit tests (including beyond-Int64 binomials).
- 103 tests pass in the new file (85 at initial submission). Full test suite passes after merging `dev` (SamplingSchemes 715/715, all other testsets clean).

## Review note

The branch forked from `dev` at the #131 merge and cleanly merges `dev` (now including #133 and #134) back in; the `AnalysisTools.jl` diff against `dev` includes only additions and the `_fixed_N_log_evidence` extraction. Known follow-up: reconcile the live-tail ω₀ convention with `gc_thermodynamic_stats_ideal_ref`, and add a fixed-N vs ideal-gas-referenced cross-validation test now that both constructions coexist.

## Post-review hardening (2026-07-28)

Commits d0de0a8 and c82fbb7 implement the review follow-ups. The shared helper `_fixed_N_log_evidence` now computes the discarded-sample weights directly in log space (the linear-space `ωᵢ` underflows Float64 once `iter` exceeds roughly 700·K, silently zeroing the deepest samples in exactly the large-lattice regime `logXi` targets), takes the live-set tail exponent from `maximum(df.iter)`, and splits the residual mass evenly among the supplied live energies; an empty-ladder single-configuration sector therefore carries its exact prior mass 1, independent of ω₀. Both methods now reject duplicate `N_values` entries and nonpositive temperatures. New unit tests pin the empty-DataFrame + live-tail recipe at rtol 1e-12, and the Langmuir test's N = M sector now exercises that recipe at rtol 1e-8; the test file has 103 tests, and the full suite passes (SamplingSchemes 715/715), with CI green. This settles the empty-ladder half of the ω₀-convention reconciliation named in the review note; the ladder-weight convention relative to `gc_thermodynamic_stats_ideal_ref` remains the open follow-up.
