### PR TITLE
Hard-core (athermal) lattice models via the finite-J recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test*.*
 input*
 output*
 !test/*
+!test/**/*.jl
 *.extxyz
 *.swp
 .DS_Store

--- a/src/AbstractHamiltonians/AbstractHamiltonians.jl
+++ b/src/AbstractHamiltonians/AbstractHamiltonians.jl
@@ -34,6 +34,37 @@ Units of energy `U` is also specified.
 GenericLatticeHamiltonian(on_site_interaction::Float64, nth_neighbor_interactions::Vector{Float64}, energy_units::Unitful.Units)
 GenericLatticeHamiltonian(on_site_interaction::U, nth_neighbor_interactions::Vector{U}) where U
 ```
+
+All couplings must be finite; `Inf` is rejected by the constructor because it
+stalls nested sampling silently (every ceiling comparison becomes `Inf >= Inf`).
+
+## Hard-core (athermal) lattice models
+
+Nearest-neighbor exclusion models — hard squares on the square lattice, hard
+hexagons on the triangular lattice — are expressed with a *finite* repulsive
+coupling on a lattice built with a single cutoff shell, e.g.
+`GenericLatticeHamiltonian(0.0, [1.0], u"eV")` with `cutoff_radii=[1.1]`.
+The energy is then `J × (number of excluded-neighbor pairs)`, an
+integer-leveled ladder whose `E = 0` manifold is exactly the hard-core
+configuration space, and the nested-sampling descent through the violating
+levels measures the hard-core partition function against the full,
+unrestricted prior (the `(1+z0)^M` normalization stays valid). Two numerical
+windows apply:
+
+- **Sampling**: choose the NS `energy_perturbation` δ with
+  `eps(E_max) ≪ δ ≪ J`, where `E_max = J·M·c/2` is the maximal violation
+  energy on `M` sites with excluded-shell coordination `c`. Concretely, keep
+  `δ / eps(E_max)` above ~`K²` so the `K` walkers draw distinct tie-breaking
+  values on a plateau: δ = `1e-9` at `J = 1 eV` is safe through
+  `E_max ≈ 10³ eV` (hard squares near `M ≈ 500`, hard hexagons near
+  `M ≈ 330`); scale δ proportionally for larger lattices.
+- **Post-processing**: evaluate at a temperature low enough that
+  `β·J ≥ (ladder depth in nats) + ~40`, with the depth
+  `n_iters · ln((K + n_cull)/K)`, while keeping `β·δ ≪ 1`; every violating
+  level's Boltzmann factor is then an exact zero to double precision, the
+  allowed levels' deviate from 1 only by `O(β·δ)`, and all observables are
+  athermal (functions of the activity `z = exp(βμ)` alone).
+
 ## Examples
 ```jldoctest
 julia> ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
@@ -54,6 +85,13 @@ struct GenericLatticeHamiltonian{N,U} <: ClassicalHamiltonian
     function GenericLatticeHamiltonian{N,U}(on_site_interaction::U, nth_neighbor_interactions::Vector{U}) where {N,U}
         if length(nth_neighbor_interactions) != N
             throw(ArgumentError("Length of nth_neighbor_interactions must match the number of neighbors"))
+        end
+        if !isfinite(on_site_interaction) || any(!isfinite, nth_neighbor_interactions)
+            throw(ArgumentError("non-finite couplings are not supported: an Inf coupling " *
+                "makes every nested-sampling ceiling comparison degenerate (Inf >= Inf) and " *
+                "the sampler stalls silently. Model hard-core exclusion with a finite " *
+                "repulsive coupling instead — see the hard-core recipe in the " *
+                "GenericLatticeHamiltonian docstring."))
         end
         return new(on_site_interaction, SVector{N, U}(nth_neighbor_interactions))
     end

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -75,7 +75,18 @@ function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
         
         neighbors[i] = nth_neighbors
     end
-    
+
+    for k in 1:layers_of_neighbors
+        if all(isempty(nbrs[k]) for nbrs in neighbors)
+            @warn "Neighbor shell $k (cutoff radius $(cutoff_radii[k])) is empty on every " *
+                  "site; a Hamiltonian coupling for this shell silently contributes zero. " *
+                  "Check cutoff_radii against the actual neighbor distances — e.g. on a " *
+                  "triangular lattice the second-neighbor distance is √3 ≈ 1.732 lattice " *
+                  "constants, beyond the square-lattice cutoff of 1.5 — or whether the " *
+                  "supercell is too small to contain this shell."
+        end
+    end
+
     return neighbors
 end
 
@@ -194,7 +205,7 @@ Throws an `ArgumentError` if the number of components does not match `C`.
                                   basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
                                   supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 2, 1),
                                   periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
-                                  cutoff_radii::Vector{Float64}=[1.1, 1.5],
+                                  cutoff_radii::Vector{Float64}=[1.1, 1.8],
                                   components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                   adsorptions::Union{Vector{Int},Symbol}=:full)
 
@@ -362,7 +373,9 @@ function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
                                         basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
                                         supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 2, 1),
                                         periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
-                                        cutoff_radii::Vector{Float64}=[1.1, 1.5],
+                                        # The triangular second-neighbor distance is √3 ≈ 1.732, so the
+                                        # square-lattice default [1.1, 1.5] would leave shell 2 empty.
+                                        cutoff_radii::Vector{Float64}=[1.1, 1.8],
                                         components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                         adsorptions::Union{Vector{Int},Symbol}=:full,
                                     ) where C

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -385,6 +385,14 @@ reliability at each grid point is reported by the Kish effective sample size
 roughly `1/√Var(N)`. Treat grid points with small `N_eff` (≲ 100) as
 unreliable and re-run with z0 closer to the target fugacity.
 
+Athermal (hard-core) models sampled with the finite-J recipe (see the
+`GenericLatticeHamiltonian` docstring) are evaluated here at a temperature low
+enough that `β·J` exceeds the ladder depth in nats by ~40 while `β·δ ≪ 1`
+(δ = the run's `energy_perturbation`): the violating shells' `e^{-βE_j}` are
+then exact zeros, the retained shells' deviate from 1 only by `O(β·δ)`, and
+every observable is a function of `z = exp(βμ)` alone (`mean_U` reports the
+residual tie-breaking noise, ~δ).
+
 # Arguments
 - `df::DataFrame`: NS output with columns `[:iter, :emax, :num_particles]`.
 - `n_sites::Int`: Number of lattice sites M.
@@ -785,7 +793,11 @@ argument and no thermal wavelength enter (contrast the atomistic method of
 this function). The sum runs over the supplied `N_values`, which must include
 `0`; truncating `N_values` below `n_sites` truncates Ξ accordingly, which is
 safe only when `⟨N⟩` at the requested `(μ, T)` sits well below the largest
-supplied `N`.
+supplied `N`. (For an athermal hard-core model the truncation at the
+close-packing `N` is exact — every higher sector has no allowed
+configuration; see the hard-core recipe in the `GenericLatticeHamiltonian`
+docstring for the per-`N` sampling setup and the evaluation-temperature
+criterion.)
 
 ## Special sectors
 
@@ -837,13 +849,20 @@ in length or convergence.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
-A `NamedTuple` `(logXi, mean_N, var_N, mean_U)`. Each field is a
-`Matrix{Float64}` of size `(length(μ_grid), length(T_grid))` indexed
-`[i_μ, i_T]`. `logXi` is the natural log of the absolute grand partition
-function — returned in log space (unlike the atomistic method's `Xi`) because
-the binomial prior mass grows like `2^M` and `Ξ` overflows `Float64` for
-modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`, and `mean_U`
-is `⟨E⟩` (grand-canonical, in eV).
+A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values)`. The first
+four fields are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))`
+indexed `[i_μ, i_T]`. `logXi` is the natural log of the absolute grand
+partition function — returned in log space (unlike the atomistic method's
+`Xi`) because the binomial prior mass grows like `2^M` and `Ξ` overflows
+`Float64` for modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
+and `mean_U` is `⟨E⟩` (grand-canonical, in eV). `log_Z_N` is the
+`(length(N_values), length(T_grid))` matrix of log canonical
+partition-function slices `log[C(M,N) · Z_NS^{(N)}(β)]` — the per-`N`
+evidence the assembly is built from — and `N_values` echoes the particle
+counts (as `Vector{Int}`) indexing its rows. For an athermal (hard-core)
+model evaluated at a sufficiently low `T` (see the hard-core recipe in the
+`GenericLatticeHamiltonian` docstring), `log_Z_N` is `log g_N`, the log count
+of allowed `N`-particle configurations.
 """
 function gc_thermodynamic_stats_fixed_N(
     ns_outputs::AbstractVector{<:DataFrame},
@@ -925,7 +944,8 @@ function gc_thermodynamic_stats_fixed_N(
         end
     end
 
-    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
+    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
+            log_Z_N=log_Z_NS .+ log_binom, N_values=N_int)
 end
 
 

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1326,7 +1326,15 @@ truncate the prior support and bias Ξ.
   Required to be nonzero on lattices (degenerate levels stall the strict `<`
   ceiling and bias the evidence — enforced by the keyword constructor); must
   remain ≪ k_B·T at the lowest temperature targeted in post-processing, since
-  perturbed energies are recorded.
+  perturbed energies are recorded. It must also stay *above* the float
+  resolution of the largest energies on the ladder — keep
+  `energy_perturbation / eps(E_max)` above ~`K²` so the `K` walkers draw
+  distinct tie-breaking values on a degenerate plateau. The default `1e-12`
+  satisfies that only for `E_max` up to `O(1) eV`; finite-J hard-core ladders
+  reach `E_max = J·M·c/2`, so use `1e-9` there (safe through
+  `E_max ≈ 10³ eV`, i.e. a few hundred sites at `J = 1 eV`) and scale it
+  proportionally beyond — see the hard-core recipe in the
+  `GenericLatticeHamiltonian` docstring.
 - `random_seed::Int64`: Kept for parity with `GrandCanonicalNestedSamplingParameters`;
   **not currently consumed** by the NS loop — call `Random.seed!` before
   `ideal_gas_referenced_nested_sampling` for reproducible runs.

--- a/test/test-AbstractHamiltonians.jl
+++ b/test/test-AbstractHamiltonians.jl
@@ -5,6 +5,12 @@
         @testset "Constructor Tests" begin
             # Test error handling for mismatched lengths
             @test_throws ArgumentError GenericLatticeHamiltonian{3,typeof(1.0u"eV")}(1.0u"eV", [1.0, 2.0] .* u"eV")
+            # Non-finite couplings stall nested sampling silently (Inf >= Inf
+            # ceiling comparisons); hard-core models use a finite J instead
+            @test_throws ArgumentError GenericLatticeHamiltonian(0.0, [Inf, 0.0], u"eV")
+            @test_throws ArgumentError GenericLatticeHamiltonian(-Inf, [0.0], u"eV")
+            @test_throws ArgumentError GenericLatticeHamiltonian(0.0, [NaN], u"eV")
+            @test_throws ArgumentError GenericLatticeHamiltonian(0.0u"eV", [Inf * u"eV"])
         end
 
         @testset "Property Tests" begin

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -635,7 +635,9 @@
                 @test lattice.basis == [(0.0, 0.0, 0.0), (1/2, sqrt(3)/2, 0.0)]
                 @test lattice.supercell_dimensions == (4, 2, 1)
                 @test lattice.periodicity == (true, true, false)
-                @test lattice.cutoff_radii == [1.1, 1.5]
+                # Triangular default is [1.1, 1.8]: the second-neighbor
+                # distance √3 ≈ 1.732 lies beyond the square-lattice 1.5
+                @test lattice.cutoff_radii == [1.1, 1.8]
                 @test length(lattice.neighbors) == 16
                 @test length(lattice.components) == 2
                 @test length(lattice.adsorptions) == 16

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -268,10 +268,75 @@
             adjacent_sites = deepcopy(lattice)
             adjacent_sites.components[1] .= false
             adjacent_sites.components[1][1:2] .= true
-            @test interacting_energy(adjacent_sites, ham) ≈ 
+            @test interacting_energy(adjacent_sites, ham) ≈
                   2 * ham.on_site_interaction + ham.nth_neighbor_interactions[1]
-            @test interacting_energy(adjacent_sites, mlham) ≈ 
+            @test interacting_energy(adjacent_sites, mlham) ≈
                   2 * ham.on_site_interaction + ham.nth_neighbor_interactions[1]
+        end
+
+        @testset "triangular lattice energies" begin
+            using Random
+            # First triangular coverage on the energy path: six first-shell
+            # neighbors per site under PBC, and energy = J × (occupied
+            # first-shell pairs) against an independent pair counter.
+            J = 1.0
+            ham_nn = GenericLatticeHamiltonian(0.0, [J], u"eV")
+            tri = MLattice{1,TriangularLattice}(
+                lattice_constant=1.0,
+                supercell_dimensions=(3, 3, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1],
+                components=:equal,
+                adsorptions=:full)
+            M = length(tri.components[1])
+            @test M == 18
+            @test all(length(tri.neighbors[i][1]) == 6 for i in 1:M)
+            # First-shell adjacency is symmetric
+            @test all(i in tri.neighbors[j][1] for i in 1:M for j in tri.neighbors[i][1])
+
+            pair_count(occ) = sum(
+                occ[i] && occ[j] for i in 1:M for j in tri.neighbors[i][1] if j > i)
+
+            work = deepcopy(tri)
+            work.components[1] .= false
+            @test interacting_energy(work, ham_nn) ≈ 0.0u"eV"
+            work.components[1][1] = true
+            @test interacting_energy(work, ham_nn) ≈ 0.0u"eV"
+            work.components[1][first(tri.neighbors[1][1])] = true
+            @test interacting_energy(work, ham_nn) ≈ J * u"eV"
+            work.components[1] .= true
+            @test interacting_energy(work, ham_nn) ≈ J * 6 * M / 2 * u"eV"
+
+            Random.seed!(42)
+            for _ in 1:50
+                occ = rand(Bool, M)
+                work.components[1] .= occ
+                @test interacting_energy(work, ham_nn) ≈ J * pair_count(occ) * u"eV"
+            end
+
+            # The customary two-shell cutoffs [1.1, 1.5] leave the second
+            # shell EMPTY on a triangular lattice (second-neighbor distance
+            # √3 ≈ 1.732) — the constructor warns about the silent shell.
+            tri15 = @test_logs (:warn, r"empty on every") match_mode=:any MLattice{1,TriangularLattice}(
+                lattice_constant=1.0,
+                supercell_dimensions=(4, 4, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1, 1.5],
+                components=:equal,
+                adsorptions=:full)
+            @test all(isempty(tri15.neighbors[i][2])
+                      for i in 1:length(tri15.components[1]))
+            # ... while [1.1, 1.8] captures the six √3 second neighbors.
+            tri18 = MLattice{1,TriangularLattice}(
+                lattice_constant=1.0,
+                supercell_dimensions=(4, 4, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1, 1.8],
+                components=:equal,
+                adsorptions=:full)
+            M18 = length(tri18.components[1])
+            @test all(length(tri18.neighbors[i][1]) == 6 for i in 1:M18)
+            @test all(length(tri18.neighbors[i][2]) == 6 for i in 1:M18)
         end
     end
 

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -16,5 +16,7 @@
     include("test-atomistic-gcns-fixed-n.jl")
     # test lattice GC-NS fixed-N post-processing
     include("test-lattice-gcns-fixed-n.jl")
+    # test hard-core lattice models (finite-J athermal recipe)
+    include("test-hard-core-lattices.jl")
 
 end

--- a/test/test-SamplingSchemes/test-hard-core-lattices.jl
+++ b/test/test-SamplingSchemes/test-hard-core-lattices.jl
@@ -1,0 +1,311 @@
+@testset "Hard-core lattice models (finite-J athermal recipe)" begin
+    using Random
+
+    # Hard squares (square lattice, NN exclusion) and hard hexagons
+    # (triangular lattice, NN exclusion) via the finite-J recipe: a finite
+    # repulsive coupling J on a single-shell lattice makes the energy
+    # J × (number of excluded-neighbor pairs), an integer-leveled ladder whose
+    # E = 0 manifold is exactly the hard-core configuration space. Post-
+    # processing at β·J ≥ (ladder depth in nats) + ~40 turns the Boltzmann
+    # factor into an exact 0/1 indicator, so every observable is athermal —
+    # a function of the activity z = exp(βμ) alone. See the hard-core recipe
+    # in the GenericLatticeHamiltonian docstring.
+
+    kb = 8.617333262e-5  # eV/K
+    J = 1.0              # eV per excluded-neighbor pair
+    ham_hc = GenericLatticeHamiltonian(0.0, [J], u"eV")
+
+    hc_square() = MLattice{1,SquareLattice}(
+        lattice_constant=1.0,
+        basis=[(0.0, 0.0, 0.0)],
+        supercell_dimensions=(4, 4, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1],
+        components=:equal,
+        adsorptions=:full)
+
+    # (3, 3, 1) with the 2-site basis: M = 18, commensurate with the
+    # √3×√3 three-sublattice ordering (close packing N = M/3 = 6, g = 3).
+    hc_tri() = MLattice{1,TriangularLattice}(
+        lattice_constant=1.0,
+        supercell_dimensions=(3, 3, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1],
+        components=:equal,
+        adsorptions=:full)
+
+    function lattice_at(make, N::Int)
+        lat = make()
+        lat.components[1] .= false
+        lat.components[1][1:N] .= true
+        return lat
+    end
+
+    # Brute-force reference built from the neighbor lists alone (independent
+    # of EnergyEval): bitmask adjacency, count independent sets by N.
+    function neighbor_masks(lat)
+        M = length(lat.components[1])
+        masks = zeros(UInt64, M)
+        for i in 1:M
+            m = UInt64(0)
+            for j in lat.neighbors[i][1]
+                m |= UInt64(1) << (j - 1)
+            end
+            masks[i] = m
+        end
+        return masks
+    end
+
+    function independent_set_counts(masks, M)
+        g = zeros(Int, M + 1)
+        for cfg in UInt64(0):(UInt64(1) << M) - UInt64(1)
+            ok = true
+            c = cfg
+            while c != 0
+                i = trailing_zeros(c) + 1
+                if masks[i] & cfg != 0
+                    ok = false
+                    break
+                end
+                c &= c - UInt64(1)
+            end
+            ok && (g[count_ones(cfg) + 1] += 1)
+        end
+        return g
+    end
+
+    function violation_count(masks, occ)
+        v = 0
+        for i in eachindex(occ)
+            occ[i] || continue
+            for j in eachindex(occ)
+                if occ[j] && masks[i] & (UInt64(1) << (j - 1)) != 0
+                    v += 1
+                end
+            end
+        end
+        return v ÷ 2
+    end
+
+    function triangle_count(masks, M)
+        t = 0
+        for i in 1:M, j in (i + 1):M
+            masks[i] & (UInt64(1) << (j - 1)) == 0 && continue
+            common = masks[i] & masks[j] & ~((UInt64(1) << j) - UInt64(1))
+            t += count_ones(common)
+        end
+        return t
+    end
+
+    # Exact hard-core grand-canonical stats from the g_N table:
+    # Ξ(z) = Σ_N g_N z^N.
+    function exact_hc_stats(g, z)
+        Ns = [N for N in 0:length(g)-1 if g[N+1] > 0]
+        lt = [log(g[N+1]) + N * log(z) for N in Ns]
+        mx = maximum(lt)
+        w = exp.(lt .- mx)
+        sw = sum(w)
+        return (logXi=mx + log(sw),
+                mean_N=sum(w .* Ns) / sw,
+                var_N=sum(w .* Ns .^ 2) / sw - (sum(w .* Ns) / sw)^2)
+    end
+
+    sq = hc_square()
+    tr = hc_tri()
+    M_sq = length(sq.components[1])
+    M_tr = length(tr.components[1])
+    masks_sq = neighbor_masks(sq)
+    masks_tr = neighbor_masks(tr)
+    g_sq = independent_set_counts(masks_sq, M_sq)
+    g_tr = independent_set_counts(masks_tr, M_tr)
+
+    save_strategy = SaveEveryN(
+        df_filename="test_hc_df.csv",
+        wk_filename="test_hc.traj.extxyz",
+        ls_filename="test_hc.ls.extxyz",
+        n_traj=1_000_000, n_snap=1_000_000, n_info=1_000_000)
+    hc_cleanup() = foreach(f -> rm(f, force=true),
+        ("test_hc_df.csv", "test_hc.traj.extxyz", "test_hc.ls.extxyz"))
+
+    # ================================================================
+    @testset "exact enumeration references" begin
+        # Hard squares, 4×4 PBC: pins the square neighbor lists and the
+        # close-packed c(2×2) pair.
+        @test M_sq == 16
+        @test all(length(sq.neighbors[i][1]) == 4 for i in 1:M_sq)
+        @test g_sq[1:9] == [1, 16, 88, 208, 228, 128, 56, 16, 2]
+        @test all(g_sq[10:end] .== 0)
+
+        # Hard hexagons, 18-site commensurate torus: pins the triangular
+        # neighbor lists, the cell commensurability, and the three √3×√3
+        # sublattice states at close packing.
+        @test M_tr == 18
+        @test all(length(tr.neighbors[i][1]) == 6 for i in 1:M_tr)
+        @test g_tr[1:7] == [1, 18, 99, 180, 99, 18, 3]
+        @test all(g_tr[8:end] .== 0)
+
+        # Pin the adjacency graphs exactly. The square torus is bipartite
+        # (no triangles). The 18-site cell is a genuine quotient of the
+        # triangular lattice, but its x-circumference is 3, so besides the
+        # 2M = 36 face triangles it carries 6 wrap-around 3-cycles (one per
+        # a₁-row): 42 total. The exact reference is enumerated on this same
+        # graph, so the pipeline comparison is exact for this cell; it is a
+        # pipeline validation, not a thermodynamic-limit statement —
+        # production cells must use circumference ≥ 4.
+        @test triangle_count(masks_sq, M_sq) == 0
+        @test triangle_count(masks_tr, M_tr) == 42
+    end
+
+    # ================================================================
+    @testset "energy = J × violation count" begin
+        Random.seed!(7)
+        for (make, masks, M) in ((hc_square, masks_sq, M_sq),
+                                 (hc_tri, masks_tr, M_tr))
+            lat = make()
+            for _ in 1:50
+                occ = rand(Bool, M)
+                lat.components[1] .= occ
+                @test interacting_energy(lat, ham_hc) ≈
+                      J * violation_count(masks, occ) * u"eV"
+            end
+        end
+    end
+
+    # ================================================================
+    # Fixed-N route: per-N canonical NS ladders descend the violation count
+    # to the E = 0 manifold; gc_thermodynamic_stats_fixed_N assembles Ξ(z).
+    # This is the primary route for athermal models: every z is an exact
+    # polynomial evaluation in the per-N evidence (no reweighting window).
+    function fixed_N_hard_core(make, N_max; K, n_iters, mc_steps, seed)
+        Random.seed!(seed)
+        dfs = Vector{DataFrame}(undef, N_max + 1)
+        live = Vector{Vector{Float64}}(undef, N_max + 1)
+        dfs[1] = DataFrame(iter=Int[], emax=Float64[])
+        live[1] = Float64[]
+        for N in 1:N_max
+            walkers = [
+                begin
+                    lat = lattice_at(make, N)
+                    generate_random_new_lattice_sample!(lat)
+                    LatticeWalker(lat)
+                end for _ in 1:K]
+            liveset = LatticeGasWalkers(walkers, ham_hc, perturb_energy=1e-9)
+            ns_params = LatticeNestedSamplingParameters(
+                mc_steps=mc_steps,
+                energy_perturbation=1e-9,
+                allowed_fail_count=100_000)
+            df, final_ls, _ = nested_sampling(
+                liveset, ns_params, n_iters, MCRandomWalkClone(), save_strategy)
+            dfs[N + 1] = df
+            live[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
+        end
+        hc_cleanup()
+        return dfs, live
+    end
+
+    @testset "fixed-N route vs exact" begin
+        K = 60
+        # Ladder depth 900/60 = 15 nats; the athermal evaluation temperature
+        # must satisfy β·J ≥ depth + ~40: T = 150 K gives β·J ≈ 77.
+        n_iters = 900
+        T_ath = 150.0
+        zs = [0.5, 1.0, 2.0, 3.796, 11.09]  # numeric z_c of hard squares and
+                                            # Baxter's z_c = (11+5√5)/2 among them
+        μ_grid = [kb * T_ath * log(z) for z in zs] .* u"eV"
+
+        for (tag, make, M, N_max, g, seed) in (
+                ("hard squares", hc_square, M_sq, 8, g_sq, 1000),
+                ("hard hexagons", hc_tri, M_tr, 6, g_tr, 2000))
+            @testset "$tag" begin
+                dfs, live = fixed_N_hard_core(make, N_max;
+                    K=K, n_iters=n_iters, mc_steps=100, seed=seed)
+
+                # Every ladder descended into the allowed (E = 0) manifold:
+                # the athermal termination gate.
+                for N in 1:N_max
+                    @test issorted(dfs[N + 1].emax, rev=true)
+                    @test all(e -> e < J / 2, live[N + 1])
+                end
+
+                stats = gc_thermodynamic_stats_fixed_N(
+                    dfs, collect(0:N_max), M, μ_grid, [T_ath * u"K"];
+                    n_walkers=K, n_cull=1, ω0=(K + 1) / K, live_emax=live)
+
+                # Tolerances sized ≥ 3σ of the intrinsic NS shrinkage noise:
+                # the deepest sectors carry H_N = ln(C(M,N)/g_N) ≈ 8.8 nats,
+                # so σ(log Z_N) ≈ √(H_N/K) ≈ 0.38 per sector and
+                # σ(logΞ) ≈ 0.23 at the largest z after the sector mixture.
+                # atol = 0.75 ≈ 3.3σ; still discriminating (a dropped
+                # (1+z0)^M-style normalization shifts logΞ by ≫ 1).
+                for (k, z) in enumerate(zs)
+                    ex = exact_hc_stats(g, z)
+                    @test isapprox(stats.logXi[k, 1], ex.logXi, atol=0.75)
+                    @test isapprox(stats.mean_N[k, 1], ex.mean_N, atol=0.5)
+                    # Athermal: ⟨E⟩ is pure tie-breaking noise
+                    @test abs(stats.mean_U[k, 1]) < 1e-6
+                end
+
+                # Per-N evidence: at the athermal temperature log_Z_N is the
+                # log independent-set count log g_N. atol = 1.5 ≈ 3.9σ of the
+                # per-sector noise, ≪ the log C(M,N) ≥ 7.5 shift a dropped
+                # binomial factor would cause.
+                @test stats.N_values == collect(0:N_max)
+                @test size(stats.log_Z_N) == (N_max + 1, 1)
+                for N in 0:N_max
+                    @test isapprox(stats.log_Z_N[N + 1, 1], log(g[N + 1]),
+                                   atol=1.5)
+                end
+            end
+        end
+    end
+
+    # ================================================================
+    # igref route: one grand-canonical run against the z0-Bernoulli prior;
+    # the descent through the violating shells measures the allowed set's
+    # prior mass, and the (1+z0)^M normalization stays valid because the
+    # prior support is never restricted.
+    @testset "igref route vs exact (hard squares, z0 = 1)" begin
+        Random.seed!(7)
+        K = 100
+        template = hc_square()
+        template.components[1] .= false
+        walkers = [LatticeWalker(deepcopy(template), energy=0.0u"eV", iter=0)
+                   for _ in 1:K]
+        liveset = LatticeGasWalkers(walkers, ham_hc; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=1.0,
+            energy_perturbation=1e-9, allowed_fail_count=100_000)
+        mc_routine = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+        df, final_ls, _ = ideal_gas_referenced_nested_sampling(
+            liveset, params, Int64(1500), mc_routine, save_strategy)
+        hc_cleanup()
+
+        @test nrow(df) > 0
+        @test issorted(df.emax, rev=true)
+        # The ladder reached the allowed manifold and the live set sits in it
+        @test minimum(df.emax) < J / 2
+        live_E = [w.energy.val for w in final_ls.walkers]
+        live_N = [sum(w.configuration.components[1]) for w in final_ls.walkers]
+        @test all(e -> e < J / 2, live_E)
+
+        T_ath = 150.0
+        zs = [0.7, 1.0, 1.5, 2.0]
+        μs = [kb * T_ath * log(z) for z in zs]
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, M_sq, 1.0, μs, [T_ath], K;
+            ω0=(K + 1) / K, live_emax=live_E, live_numbers=live_N)
+
+        # Tolerances ≥ 3σ of the NS evidence noise (σ(logΞ) ≈ 0.25 at this
+        # depth/K), while a dropped (1+z0)^M normalization would shift logΞ
+        # by M·ln 2 ≈ 11 — still cleanly discriminating.
+        for (i, z) in enumerate(zs[1:3])  # z = 2.0 is the N_eff check below
+            ex = exact_hc_stats(g_sq, z)
+            @test isapprox(stats.logXi[i, 1], ex.logXi, atol=0.75)
+            @test isapprox(stats.mean_N[i, 1], ex.mean_N, atol=0.5)
+        end
+
+        # Kish N_eff degrades away from the run's z0 — the trust-window
+        # diagnostic every reweighted grid point must be gated on.
+        @test stats.N_eff[4, 1] < stats.N_eff[2, 1]
+    end
+end

--- a/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
@@ -109,6 +109,17 @@
             @test isapprox(stats.var_N[k, j], M * θ / (1 + zeff), rtol=1e-8)
             @test isapprox(stats.mean_U[k, j], ε * M * θ, rtol=1e-8)
         end
+
+        # Per-N evidence slices: log_Z_N = log[C(M,N) · Z_NS^{(N)}(β)], with
+        # Z_NS^{(N)} = e^{-βNε} for the flat ladders (Σω = 1 per sector).
+        @test stats.N_values == N_values
+        @test size(stats.log_Z_N) == (length(N_values), length(T_grid))
+        lb = FreeBird.AnalysisTools._log_binomial
+        for (j, T) in enumerate(T_grid), N in N_values
+            β = 1.0 / (kb * ustrip(u"K", T))
+            @test isapprox(stats.log_Z_N[N + 1, j], lb(M, N) - β * N * ε,
+                           rtol=1e-8)
+        end
     end
 
     # ================================================================


### PR DESCRIPTION
## Summary

Hard-core lattice models — hard squares (square lattice, NN exclusion) and hard hexagons (triangular lattice, NN exclusion) — are a supported, tested use pattern for the existing samplers. No new sampler and no constraint machinery: a finite repulsive coupling on a single-shell lattice gives

    E = J × (number of excluded-neighbor pairs)

an integer-leveled ladder whose E = 0 manifold is exactly the hard-core configuration space, so both the ideal-gas-referenced construction (#134) and the fixed-N construction (#135) count independent sets as-is. Post-processing at β·J ≥ (ladder depth in nats) + ~40, with β·δ ≪ 1 (δ = energy_perturbation), sets the Boltzmann factor of every violating level to exactly zero, and all observables become functions of the activity z = exp(βμ) alone.

Two alternatives were deliberately rejected. `Inf` couplings stall the samplers silently (both ceilings compare `Inf >= Inf`, the Bernoulli initializer hands back all-Inf walkers for M ≳ 30, and the run returns an empty DataFrame with only a warning — verified on an 8×8 lattice); the constructor now throws instead. And a constraint-aware sampler that never visits overlaps would invalidate the `(1+z0)^M` normalization: the descent through violating configurations is what measures the allowed set's prior mass.

## Changes

- `GenericLatticeHamiltonian` rejects non-finite couplings with an `ArgumentError` that points to the finite-J recipe, documented in the constructor docstring alongside both numerical windows (δ/eps(E_max) ≳ K² for tie-breaking; the athermal evaluation criterion).
- **Triangular default `cutoff_radii` changes from `[1.1, 1.5]` to `[1.1, 1.8]`** — the second-neighbor distance is √3 ≈ 1.732, so the old default left shell 2 empty, and any J₂ coupling contributed zero. `compute_neighbors` now warns (construction-time only) whenever a declared shell is empty on every site.
- The lattice `gc_thermodynamic_stats_fixed_N` additionally returns `log_Z_N` (= log C(M,N) + log Z_NS^(N), already computed internally) and `N_values` — a non-breaking NamedTuple extension; at an athermal temperature, `log_Z_N` is log g_N, the log count of allowed N-particle configurations.
- `.gitignore` gains `!test/**/*.jl`: the `test*.*` pattern was silently ignoring new files under `test/` subdirectories (`!test/*` re-includes direct children only).

## Validation

- New `test/test-SamplingSchemes/test-hard-core-lattices.jl` (311 lines) validates the recipe end-to-end against in-test brute-force enumeration built from neighbor lists alone: 4×4 hard squares (g_N = [1,16,88,208,228,128,56,16,2]; the two c(2×2) states at close packing) and an 18-site commensurate hard-hexagon torus (g_N = [1,18,99,180,99,18,3]; the three √3×√3 sublattice states at N = M/3). The adjacency graphs are pinned exactly (0 triangles on the bipartite square torus; 42 = 36 faces + 6 wrap-around 3-cycles on the circumference-3 quotient, documented as a same-graph pipeline validation).
- Both routes reach the exact lnΞ(z) through z = 11.09 — including hard squares' numeric z_c ≈ 3.796 and Baxter's z_c = (11+5√5)/2: the fixed-N assembly at β·J ≈ 77, with atol 0.75 ≈ 3.3σ of the √(H_N/K) shrinkage noise, mean_U at the athermal zero, and per-sector log_Z_N ≈ log g_N; the igref route at z0 = 1, with Kish N_eff degrading away from z0. Every ladder's final live set lies in the E = 0 manifold. Seeded throughout; ~20 s added CI cost.
- First triangular EnergyEval coverage: six symmetric first-shell neighbors under PBC; energy = J × pairs on 50 random configurations; shell-2 emptiness at [1.1, 1.5] (warned) vs the six √3 neighbors at [1.1, 1.8].
- Full suite passes (SamplingSchemes 967/967, all other testsets clean).

## Review note

Two user-visible behavior changes to weigh: the triangular default cutoffs (any downstream code constructing a default triangular lattice now gets a populated second shell), and the non-finite-coupling throw (nothing in-tree constructs Inf couplings; external users doing so were hitting the silent stall). The empty-shell warning deliberately has no `maxlog` — it fires per construction, keeping it testable and proportionate, since correctly configured lattices never trigger it. A first-class hard-core Hamiltonian type was considered and declined: it would either prune the prior (invalid per the normalization argument above) or re-derive exactly this finite-J ladder behind a new API.

Follow-ups, on evidence only: cavity-biased insert/delete for the igref route in the dense regime (ROADMAP); triangular geometric cluster moves as variance reduction in near-close-packed fixed-N sectors; note that complement (particle-hole) moves are invalid for hard-core models — the complement of an independent set is essentially never independent. Unrelated but adjacent: the `feature/lattice-ideal-gas-referenced-gcns` branch should not be deleted in any cleanup pass — external notebooks still pin it until a release is tagged.
