### PR TITLE
Per-dead-point observable recording for lattice NS and extended GC statistics

### DIFF
--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -25,6 +25,7 @@ export LatticeGeometry, SquareLattice, TriangularLattice, GenericLattice
 export MLattice, SLattice, GLattice
 export update_walker!
 export num_sites, occupied_site_count
+export order_parameter_c2x2
 export view_structure
 
 abstract type AbstractWalker end

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -420,6 +420,59 @@ function occupied_site_count(MLattice::MLattice{C}) where C
 end
 
 """
+    order_parameter_c2x2(lattice::MLattice{1,SquareLattice}) -> Float64
+
+Sublattice order parameter for c(2×2) checkerboard ordering on a
+single-component square lattice:
+
+    Ψ = |Σ_{occupied sites} (−1)^(i+j)| / M,
+
+where `(i, j)` are the integer lattice coordinates of each site and `M` is
+the number of sites. Equivalent to the four-sublattice
+`Ψ_c(2×2) = |N_a + N_d − N_b − N_c| / M` of Zhang, Blum & Reuter
+[PRB **75**, 235406 (2007), Eq. (8)]: sublattices (a, d) share one
+checkerboard parity and (b, c) the other. A perfect c(2×2) arrangement at
+half filling gives `1/2`; the empty and the full lattice give `0`.
+
+Ψ is not a function of `(E, N)` — degenerate energy levels contain ordered
+and disordered configurations alike — so it must be evaluated on
+configurations (e.g. per culled walker, via the `observables` keyword of the
+nested-sampling loops) rather than reconstructed from an energy ledger.
+
+Requires a single-site basis, a strictly two-dimensional supercell
+(`supercell_dimensions[3] == 1`), and even in-plane dimensions (the two
+checkerboard sublattices must tile the periodic cell evenly); violations
+throw an `ArgumentError`.
+"""
+function order_parameter_c2x2(lattice::MLattice{1,SquareLattice})
+    if length(lattice.basis) != 1
+        throw(ArgumentError("order_parameter_c2x2 requires a single-site " *
+            "basis, got $(length(lattice.basis)) basis sites"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("order_parameter_c2x2 requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    if isodd(d1) || isodd(d2)
+        throw(ArgumentError("order_parameter_c2x2 requires even in-plane " *
+            "supercell dimensions so the checkerboard sublattices tile the " *
+            "periodic cell evenly, got ($d1, $d2)"))
+    end
+    occ = lattice.components[1]
+    acc = 0
+    for s in eachindex(occ)
+        if occ[s]
+            # lattice_positions ordering: basis innermost, dimension 1 fastest
+            i0 = (s - 1) % d1
+            j0 = ((s - 1) ÷ d1) % d2
+            acc += iseven(i0 + j0) ? 1 : -1
+        end
+    end
+    return abs(acc) / (d1 * d2)
+end
+
+"""
     mutable struct LatticeWalker
 
 The `LatticeWalker` struct represents a walker on a 3D lattice.

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -404,16 +404,36 @@ residual tie-breaking noise, ~δ).
 - `ω0::Float64=1.0`: Initial phase-space volume factor.
 - `live_emax::Union{Nothing,Vector{Float64}}=nothing`: Energies of the surviving live walkers.
 - `live_numbers::Union{Nothing,Vector{Int}}=nothing`: Particle counts of the surviving live walkers.
+- `observable_cols::AbstractVector{Symbol}=Symbol[]`: Names of extra `df`
+  columns (recorded per dead point, e.g. via the `observables` keyword of
+  `ideal_gas_referenced_nested_sampling`) whose reweighted averages
+  ⟨A⟩(μ, T) are returned in `observables`. Requesting `:num_particles` or
+  `:emax` legitimately reproduces `mean_N`/`mean_U` (a self-consistency
+  check).
+- `live_observables=nothing`: Required whenever `observable_cols` is
+  non-empty and a live-set tail is supplied — a
+  `Dict{Symbol,<:AbstractVector{<:Real}}` with exactly the
+  `observable_cols` keys, holding each observable's values on the surviving
+  live walkers (one entry per `live_emax` entry, same order). Omitting the
+  tail values would silently deflate every ⟨A⟩, so this is an error rather
+  than a default.
 - `kb::Float64`: Boltzmann constant (default: eV/K).
 
 # Returns
-A `NamedTuple` of `Matrix{Float64}` of size `(length(μs), length(Ts))`,
-indexed `[i_μ, i_T]`:
+A `NamedTuple`; every field except `observables` is a `Matrix{Float64}` of
+size `(length(μs), length(Ts))`, indexed `[i_μ, i_T]`:
 - `logXi`: Natural log of the absolute grand partition function.
 - `mean_N`: Mean particle number ⟨N⟩.
 - `var_N`: Particle-number variance ⟨N²⟩ − ⟨N⟩².
 - `mean_U`: Mean configurational energy ⟨E⟩.
 - `N_eff`: Kish effective sample size of the reweighted estimate.
+- `var_U`: Energy variance ⟨E²⟩ − ⟨E⟩². The grand-canonical heat capacity
+  follows as `C = k_B β² (var_U − μ · cov_UN)`, matching the Ω-sorted
+  `gc_thermodynamic_stats` formula.
+- `cov_UN`: Energy–particle-number covariance ⟨EN⟩ − ⟨E⟩⟨N⟩.
+- `observables`: `Dict{Symbol,Matrix{Float64}}` mapping each requested
+  column to its reweighted average ⟨A⟩(μ, T); empty when no columns are
+  requested.
 """
 function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                                           n_sites::Int,
@@ -425,6 +445,8 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                                           ω0::Float64=1.0,
                                           live_emax::Union{Nothing,Vector{Float64}}=nothing,
                                           live_numbers::Union{Nothing,Vector{Int}}=nothing,
+                                          observable_cols::AbstractVector{Symbol}=Symbol[],
+                                          live_observables::Union{Nothing,AbstractDict{Symbol,<:AbstractVector{<:Real}}}=nothing,
                                           kb::Float64=8.617333262e-5)
     if z0 <= 0.0
         throw(ArgumentError("z0 must be positive"))
@@ -441,6 +463,42 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     n_dead = nrow(df)
     if n_dead == 0 && (live_emax === nothing || isempty(live_emax))
         throw(ArgumentError("df is empty and no live walkers were provided"))
+    end
+    allunique(observable_cols) || throw(ArgumentError(
+        "observable_cols must not contain duplicate entries"))
+    for col in observable_cols
+        hasproperty(df, col) || throw(ArgumentError(
+            "observable_cols: df has no column :$col"))
+        any(ismissing, df[!, col]) && throw(ArgumentError(
+            "observable_cols: df column :$col contains missing values"))
+    end
+    if live_observables !== nothing && live_emax === nothing
+        throw(ArgumentError(
+            "live_observables requires live_emax/live_numbers (the live-set tail)"))
+    end
+    if live_observables !== nothing && isempty(observable_cols)
+        throw(ArgumentError(
+            "live_observables was given but observable_cols is empty"))
+    end
+    if !isempty(observable_cols) && live_emax !== nothing
+        if live_observables === nothing
+            throw(ArgumentError(
+                "observable_cols with a live-set tail requires live_observables " *
+                "(the per-column values of the surviving live walkers); omitting " *
+                "them would silently deflate the tail's contribution to every " *
+                "observable average"))
+        end
+        if Set(keys(live_observables)) != Set(observable_cols)
+            throw(ArgumentError(
+                "live_observables keys must match observable_cols exactly"))
+        end
+        for col in observable_cols
+            if length(live_observables[col]) != length(live_emax)
+                throw(DimensionMismatch(
+                    "live_observables[:$col] must have one entry per live " *
+                    "walker (length(live_emax) = $(length(live_emax)))"))
+            end
+        end
     end
 
     # β- and μ-independent per-sample log prior-volume weights, built directly
@@ -465,6 +523,17 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
         Ns = vcat(Ns, Float64.(live_numbers))
     end
 
+    # Per-column observable values aligned with (Es, Ns): dead points first,
+    # then the live-set tail in the same order as live_emax
+    As = Dict{Symbol,Vector{Float64}}()
+    for col in observable_cols
+        A = n_dead > 0 ? Vector{Float64}(df[!, col]) : Float64[]
+        if live_emax !== nothing && !isempty(live_emax)
+            A = vcat(A, Vector{Float64}(live_observables[col]))
+        end
+        As[col] = A
+    end
+
     log_prior_mass = n_sites * log1p(z0)
     log_z0 = log(z0)
 
@@ -475,6 +544,10 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     var_N = Matrix{Float64}(undef, n_mu, n_T)
     mean_U = Matrix{Float64}(undef, n_mu, n_T)
     N_eff = Matrix{Float64}(undef, n_mu, n_T)
+    var_U = Matrix{Float64}(undef, n_mu, n_T)
+    cov_UN = Matrix{Float64}(undef, n_mu, n_T)
+    obs_out = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
     Threads.@threads for j in 1:n_T
         β = 1.0 / (kb * Ts[j])
@@ -488,12 +561,19 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
             n_avg = sum(ws .* Ns) / sum_w
             mean_N[i, j] = n_avg
             var_N[i, j] = sum(ws .* Ns .^ 2) / sum_w - n_avg^2
-            mean_U[i, j] = sum(ws .* Es) / sum_w
+            u_avg = sum(ws .* Es) / sum_w
+            mean_U[i, j] = u_avg
+            var_U[i, j] = sum(ws .* Es .^ 2) / sum_w - u_avg^2
+            cov_UN[i, j] = sum(ws .* Es .* Ns) / sum_w - u_avg * n_avg
+            for col in observable_cols
+                obs_out[col][i, j] = sum(ws .* As[col]) / sum_w
+            end
             N_eff[i, j] = sum_w^2 / sum(abs2, ws)
         end
     end
 
-    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff)
+    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff,
+            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -613,8 +613,10 @@ function _log_binomial(M::Integer, N::Integer)
 end
 
 """
-    _fixed_N_log_evidence(df, T_grid; n_walkers, n_cull, ω0, live_energies, kb)
-        -> (log_Z_NS::Vector{Float64}, mean_E::Vector{Float64})
+    _fixed_N_log_evidence(df, T_grid; n_walkers, n_cull, ω0, live_energies, kb,
+                          observable_cols=Symbol[], live_observables=nothing)
+        -> (log_Z_NS::Vector{Float64}, mean_E::Vector{Float64},
+            mean_E2::Vector{Float64}, mean_obs::Dict{Symbol,Vector{Float64}})
 
 Canonical NS evidence `log Z_NS(β) = log Σᵢ ωᵢ exp(−βEᵢ)` and canonical mean
 energy at each temperature in `T_grid`, evaluated by log-sum-exp. The discarded
@@ -625,8 +627,12 @@ low-energy samples. When `live_energies` is supplied, the residual prior mass
 evenly among the supplied energies — the live-set tail correction. An empty
 ladder records no compression, so its tail carries the sector's entire prior
 mass, exactly 1 and independent of `ω0` (matching the internally-handled
-`N = 0` sector). Internal helper shared by the `gc_thermodynamic_stats_fixed_N`
-methods.
+`N = 0` sector). `mean_E2` is the canonical ⟨E²⟩(β), and `mean_obs` carries
+the canonical average of each requested per-dead-point observable column
+(dead values from `df[!, col]`, live-tail values from `live_observables[col]`,
+aligned with `live_energies`). Internal helper shared by the
+`gc_thermodynamic_stats_fixed_N` methods; the caller validates the
+observable inputs.
 """
 function _fixed_N_log_evidence(
     df::DataFrame,
@@ -636,6 +642,8 @@ function _fixed_N_log_evidence(
     ω0::Float64,
     live_energies::Union{Nothing,AbstractVector{<:Real}},
     kb::Float64,
+    observable_cols::AbstractVector{Symbol}=Symbol[],
+    live_observables::Union{Nothing,AbstractDict{Symbol,<:AbstractVector{<:Real}}}=nothing,
 )
     Es = collect(Float64, df.emax)
     if isempty(Es) && (live_energies === nothing || isempty(live_energies))
@@ -668,8 +676,22 @@ function _fixed_N_log_evidence(
         log_ws = vcat(log_ωi, fill(log_tail, length(Es_live)))
     end
 
+    # Per-column observable values aligned with Es_all: dead points first,
+    # then the live-set tail in the same order as live_energies
+    As_all = Dict{Symbol,Vector{Float64}}()
+    for col in observable_cols
+        A = nrow(df) > 0 ? collect(Float64, df[!, col]) : Float64[]
+        if live_energies !== nothing
+            A = vcat(A, collect(Float64, live_observables[col]))
+        end
+        As_all[col] = A
+    end
+
     log_Z_NS = Vector{Float64}(undef, length(T_grid))
     mean_E = Vector{Float64}(undef, length(T_grid))
+    mean_E2 = Vector{Float64}(undef, length(T_grid))
+    mean_obs = Dict{Symbol,Vector{Float64}}(
+        col => Vector{Float64}(undef, length(T_grid)) for col in observable_cols)
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
         log_terms = log_ws .- β .* Es_all
@@ -678,8 +700,12 @@ function _fixed_N_log_evidence(
         sum_w = sum(ws)
         log_Z_NS[j] = max_log + log(sum_w)
         mean_E[j] = sum(ws .* Es_all) / sum_w
+        mean_E2[j] = sum(ws .* (Es_all .^ 2)) / sum_w
+        for col in observable_cols
+            mean_obs[col][j] = sum(ws .* As_all[col]) / sum_w
+        end
     end
-    return log_Z_NS, mean_E
+    return log_Z_NS, mean_E, mean_E2, mean_obs
 end
 
 """
@@ -926,10 +952,24 @@ in length or convergence.
   when supplied, one vector of live-walker energies (in eV) per `N` —
   normally the `n_walkers` live energies; the sector's residual prior mass is
   split evenly among the supplied entries. The entry for `N=0` is ignored.
+- `observable_cols::AbstractVector{Symbol}=Symbol[]`: names of extra ledger
+  columns (recorded per dead point in each sector's canonical run, e.g. via
+  the `observables` keyword of `nested_sampling`) whose grand-canonical
+  averages ⟨A⟩(μ, T) are returned in `observables`. Requesting observables
+  requires `live_emax` and `live_observables`.
+- `live_observables=nothing`: one `Dict{Symbol,<:AbstractVector{<:Real}}` per
+  `N` sector (aligned with `N_values`), holding each observable's values on
+  that sector's surviving live walkers (same order and length as the
+  sector's `live_emax` entry). The `N = 0` entry is **used**, unlike its
+  ignored `live_emax` counterpart: it supplies the observable value of the
+  single empty-lattice configuration (e.g. `[0.0]` for a sublattice order
+  parameter). Single-configuration sectors follow the empty-DataFrame
+  convention, with their observable value in the live entry.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
-A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values)`. The first
+A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values, var_U,
+cov_UN, observables)`. The first
 four fields are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))`
 indexed `[i_μ, i_T]`. `logXi` is the natural log of the absolute grand
 partition function — returned in log space (unlike the atomistic method's
@@ -942,7 +982,12 @@ evidence the assembly is built from — and `N_values` echoes the particle
 counts (as `Vector{Int}`) indexing its rows. For an athermal (hard-core)
 model evaluated at a sufficiently low `T` (see the hard-core recipe in the
 `GenericLatticeHamiltonian` docstring), `log_Z_N` is `log g_N`, the log count
-of allowed `N`-particle configurations.
+of allowed `N`-particle configurations. `var_U` is the grand-canonical energy
+variance ⟨E²⟩ − ⟨E⟩² and `cov_UN` the covariance ⟨EN⟩ − ⟨E⟩⟨N⟩, both
+assembled by the law of total expectation over the `N` sectors (the
+grand-canonical heat capacity follows as `C = k_B β² (var_U − μ · cov_UN)`).
+`observables` is a `Dict{Symbol,Matrix{Float64}}` mapping each requested
+column to ⟨A⟩(μ, T); empty when no columns are requested.
 """
 function gc_thermodynamic_stats_fixed_N(
     ns_outputs::AbstractVector{<:DataFrame},
@@ -954,6 +999,8 @@ function gc_thermodynamic_stats_fixed_N(
     n_cull::Int=1,
     ω0::Float64=1.0,
     live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
+    observable_cols::AbstractVector{Symbol}=Symbol[],
+    live_observables::Union{Nothing,AbstractVector{<:AbstractDict{Symbol,<:AbstractVector{<:Real}}}}=nothing,
     kb::Float64=8.617333262e-5,
 )
     if length(ns_outputs) != length(N_values)
@@ -980,8 +1027,55 @@ function gc_thermodynamic_stats_fixed_N(
     n_mu = length(μ_grid)
     n_T = length(T_grid)
 
+    allunique(observable_cols) || throw(ArgumentError(
+        "observable_cols must not contain duplicate entries"))
+    if !isempty(observable_cols)
+        if live_emax === nothing || live_observables === nothing
+            throw(ArgumentError(
+                "observable recording requires both live_emax and " *
+                "live_observables: the N = 0 and single-configuration sectors " *
+                "have no dead points, so their per-sector observable averages " *
+                "come from the live entries"))
+        end
+        if length(live_observables) != length(N_values)
+            throw(DimensionMismatch(
+                "live_observables must have one Dict per N sector " *
+                "(length(N_values) = $(length(N_values)))"))
+        end
+        for (i, d) in enumerate(live_observables)
+            Set(keys(d)) == Set(observable_cols) || throw(ArgumentError(
+                "live_observables[$i] keys must match observable_cols exactly"))
+            for col in observable_cols
+                isempty(d[col]) && throw(ArgumentError(
+                    "live_observables[$i][:$col] is empty"))
+                if N_int[i] != 0 && length(d[col]) != length(live_emax[i])
+                    throw(DimensionMismatch(
+                        "live_observables[$i][:$col] must have one entry per " *
+                        "live walker (length(live_emax[$i]) = " *
+                        "$(length(live_emax[i])))"))
+                end
+            end
+        end
+        for (i, dfi) in enumerate(ns_outputs)
+            (N_int[i] == 0 || nrow(dfi) == 0) && continue
+            for col in observable_cols
+                hasproperty(dfi, col) || throw(ArgumentError(
+                    "ns_outputs[$i] (N = $(N_int[i])) has no observable " *
+                    "column :$col"))
+                any(ismissing, dfi[!, col]) && throw(ArgumentError(
+                    "ns_outputs[$i] column :$col contains missing values"))
+            end
+        end
+    elseif live_observables !== nothing
+        throw(ArgumentError(
+            "live_observables was given but observable_cols is empty"))
+    end
+
     log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
+    mean_E2_N = Matrix{Float64}(undef, n_N, n_T)
+    obs_N = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_N, n_T) for col in observable_cols)
 
     for (i, df) in enumerate(ns_outputs)
         # The N = 0 sector is the empty lattice: a single configuration with
@@ -989,14 +1083,29 @@ function gc_thermodynamic_stats_fixed_N(
         if N_int[i] == 0
             log_Z_NS[i, :] .= 0.0
             mean_E_N[i, :] .= 0.0
+            mean_E2_N[i, :] .= 0.0
+            for col in observable_cols
+                # Unlike its ignored live_emax entry, the N = 0 sector's
+                # live_observables entry is used: it supplies the observable
+                # value of the single empty-lattice configuration directly
+                # (averaged over the given values)
+                vals = live_observables[i][col]
+                obs_N[col][i, :] .= sum(Float64, vals) / length(vals)
+            end
             continue
         end
 
         live = live_emax === nothing ? nothing : live_emax[i]
-        log_Z_NS[i, :], mean_E_N[i, :] = _fixed_N_log_evidence(
+        live_obs = isempty(observable_cols) ? nothing : live_observables[i]
+        log_Z_NS[i, :], mean_E_N[i, :], sector_E2, sector_obs = _fixed_N_log_evidence(
             df, T_grid;
             n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
-            live_energies=live, kb=kb)
+            live_energies=live, kb=kb,
+            observable_cols=observable_cols, live_observables=live_obs)
+        mean_E2_N[i, :] = sector_E2
+        for col in observable_cols
+            obs_N[col][i, :] = sector_obs[col]
+        end
     end
 
     log_binom = [_log_binomial(n_sites, N) for N in N_int]
@@ -1005,6 +1114,10 @@ function gc_thermodynamic_stats_fixed_N(
     mean_N = Matrix{Float64}(undef, n_mu, n_T)
     var_N = Matrix{Float64}(undef, n_mu, n_T)
     mean_U = Matrix{Float64}(undef, n_mu, n_T)
+    var_U = Matrix{Float64}(undef, n_mu, n_T)
+    cov_UN = Matrix{Float64}(undef, n_mu, n_T)
+    obs_out = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
@@ -1020,12 +1133,22 @@ function gc_thermodynamic_stats_fixed_N(
             mean_N[k, j] = sum(ws .* N_int) / sum_w
             mean_N2 = sum(ws .* (N_int .^ 2)) / sum_w
             var_N[k, j] = mean_N2 - mean_N[k, j]^2
-            mean_U[k, j] = sum(ws .* view(mean_E_N, :, j)) / sum_w
+            u_avg = sum(ws .* view(mean_E_N, :, j)) / sum_w
+            mean_U[k, j] = u_avg
+            # Law of total expectation over the N sectors: the grand-canonical
+            # <E^2> is the w_N-weighted canonical <E^2>_N, likewise <E N>
+            var_U[k, j] = sum(ws .* view(mean_E2_N, :, j)) / sum_w - u_avg^2
+            cov_UN[k, j] = sum(ws .* N_int .* view(mean_E_N, :, j)) / sum_w -
+                           u_avg * mean_N[k, j]
+            for col in observable_cols
+                obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
+            end
         end
     end
 
     return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
-            log_Z_N=log_Z_NS .+ log_binom, N_values=N_int)
+            log_Z_N=log_Z_NS .+ log_binom, N_values=N_int,
+            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -446,7 +446,7 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                                           live_emax::Union{Nothing,Vector{Float64}}=nothing,
                                           live_numbers::Union{Nothing,Vector{Int}}=nothing,
                                           observable_cols::AbstractVector{Symbol}=Symbol[],
-                                          live_observables::Union{Nothing,AbstractDict{Symbol,<:AbstractVector{<:Real}}}=nothing,
+                                          live_observables::Union{Nothing,AbstractDict{Symbol}}=nothing,
                                           kb::Float64=8.617333262e-5)
     if z0 <= 0.0
         throw(ArgumentError("z0 must be positive"))
@@ -466,11 +466,16 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     end
     allunique(observable_cols) || throw(ArgumentError(
         "observable_cols must not contain duplicate entries"))
-    for col in observable_cols
-        hasproperty(df, col) || throw(ArgumentError(
-            "observable_cols: df has no column :$col"))
-        any(ismissing, df[!, col]) && throw(ArgumentError(
-            "observable_cols: df column :$col contains missing values"))
+    if n_dead > 0
+        # A zero-row df contributes no dead points, so its columns are never
+        # read: live-tail-only analyses need not carry the observable columns
+        # (mirroring the fixed-N empty-sector convention)
+        for col in observable_cols
+            hasproperty(df, col) || throw(ArgumentError(
+                "observable_cols: df has no column :$col"))
+            any(ismissing, df[!, col]) && throw(ArgumentError(
+                "observable_cols: df column :$col contains missing values"))
+        end
     end
     if live_observables !== nothing && live_emax === nothing
         throw(ArgumentError(
@@ -493,7 +498,10 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                 "live_observables keys must match observable_cols exactly"))
         end
         for col in observable_cols
-            if length(live_observables[col]) != length(live_emax)
+            v = live_observables[col]
+            (v isa AbstractVector && all(x -> x isa Real, v)) || throw(ArgumentError(
+                "live_observables[:$col] must be a vector of Real values"))
+            if length(v) != length(live_emax)
                 throw(DimensionMismatch(
                     "live_observables[:$col] must have one entry per live " *
                     "walker (length(live_emax) = $(length(live_emax)))"))
@@ -534,6 +542,13 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
         As[col] = A
     end
 
+    # Second moments are formed on shifted energies (the cv() convention):
+    # the one-pass <E^2> - <E>^2 on absolute energies carries an ~eps*E^2
+    # cancellation floor that can dominate small variances at large |E|.
+    # Variances and covariances are shift-invariant, so the shift cancels.
+    E_shift = isempty(Es) ? 0.0 : minimum(Es)
+    Es_c = Es .- E_shift
+
     log_prior_mass = n_sites * log1p(z0)
     log_z0 = log(z0)
 
@@ -561,10 +576,10 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
             n_avg = sum(ws .* Ns) / sum_w
             mean_N[i, j] = n_avg
             var_N[i, j] = sum(ws .* Ns .^ 2) / sum_w - n_avg^2
-            u_avg = sum(ws .* Es) / sum_w
-            mean_U[i, j] = u_avg
-            var_U[i, j] = sum(ws .* Es .^ 2) / sum_w - u_avg^2
-            cov_UN[i, j] = sum(ws .* Es .* Ns) / sum_w - u_avg * n_avg
+            u_c = sum(ws .* Es_c) / sum_w
+            mean_U[i, j] = u_c + E_shift
+            var_U[i, j] = sum(ws .* Es_c .^ 2) / sum_w - u_c^2
+            cov_UN[i, j] = sum(ws .* Es_c .* Ns) / sum_w - u_c * n_avg
             for col in observable_cols
                 obs_out[col][i, j] = sum(ws .* As[col]) / sum_w
             end
@@ -627,7 +642,11 @@ low-energy samples. When `live_energies` is supplied, the residual prior mass
 evenly among the supplied energies — the live-set tail correction. An empty
 ladder records no compression, so its tail carries the sector's entire prior
 mass, exactly 1 and independent of `ω0` (matching the internally-handled
-`N = 0` sector). `mean_E2` is the canonical ⟨E²⟩(β), and `mean_obs` carries
+`N = 0` sector). `mean_E2` is the canonical second moment of the shifted
+energies, ⟨(E − `energy_shift`)²⟩(β) — the caller supplies one global
+`energy_shift` so sector moments combine consistently and the one-pass
+variance avoids the ~eps·E² cancellation floor (`mean_E` stays absolute) —
+and `mean_obs` carries
 the canonical average of each requested per-dead-point observable column
 (dead values from `df[!, col]`, live-tail values from `live_observables[col]`,
 aligned with `live_energies`). Internal helper shared by the
@@ -643,7 +662,8 @@ function _fixed_N_log_evidence(
     live_energies::Union{Nothing,AbstractVector{<:Real}},
     kb::Float64,
     observable_cols::AbstractVector{Symbol}=Symbol[],
-    live_observables::Union{Nothing,AbstractDict{Symbol,<:AbstractVector{<:Real}}}=nothing,
+    live_observables::Union{Nothing,AbstractDict{Symbol}}=nothing,
+    energy_shift::Float64=0.0,
 )
     Es = collect(Float64, df.emax)
     if isempty(Es) && (live_energies === nothing || isempty(live_energies))
@@ -687,6 +707,11 @@ function _fixed_N_log_evidence(
         As_all[col] = A
     end
 
+    # Second moments are formed on shifted energies (the cv() convention);
+    # the caller supplies one global shift so the sector moments stay
+    # mutually consistent in the grand-canonical assembly
+    Es_c = Es_all .- energy_shift
+
     log_Z_NS = Vector{Float64}(undef, length(T_grid))
     mean_E = Vector{Float64}(undef, length(T_grid))
     mean_E2 = Vector{Float64}(undef, length(T_grid))
@@ -700,7 +725,7 @@ function _fixed_N_log_evidence(
         sum_w = sum(ws)
         log_Z_NS[j] = max_log + log(sum_w)
         mean_E[j] = sum(ws .* Es_all) / sum_w
-        mean_E2[j] = sum(ws .* (Es_all .^ 2)) / sum_w
+        mean_E2[j] = sum(ws .* (Es_c .^ 2)) / sum_w
         for col in observable_cols
             mean_obs[col][j] = sum(ws .* As_all[col]) / sum_w
         end
@@ -1000,7 +1025,7 @@ function gc_thermodynamic_stats_fixed_N(
     ω0::Float64=1.0,
     live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
     observable_cols::AbstractVector{Symbol}=Symbol[],
-    live_observables::Union{Nothing,AbstractVector{<:AbstractDict{Symbol,<:AbstractVector{<:Real}}}}=nothing,
+    live_observables::Union{Nothing,AbstractVector{<:AbstractDict{Symbol}}}=nothing,
     kb::Float64=8.617333262e-5,
 )
     if length(ns_outputs) != length(N_values)
@@ -1046,9 +1071,12 @@ function gc_thermodynamic_stats_fixed_N(
             Set(keys(d)) == Set(observable_cols) || throw(ArgumentError(
                 "live_observables[$i] keys must match observable_cols exactly"))
             for col in observable_cols
-                isempty(d[col]) && throw(ArgumentError(
+                v = d[col]
+                (v isa AbstractVector && all(x -> x isa Real, v)) || throw(ArgumentError(
+                    "live_observables[$i][:$col] must be a vector of Real values"))
+                isempty(v) && throw(ArgumentError(
                     "live_observables[$i][:$col] is empty"))
-                if N_int[i] != 0 && length(d[col]) != length(live_emax[i])
+                if N_int[i] != 0 && length(v) != length(live_emax[i])
                     throw(DimensionMismatch(
                         "live_observables[$i][:$col] must have one entry per " *
                         "live walker (length(live_emax[$i]) = " *
@@ -1071,9 +1099,22 @@ function gc_thermodynamic_stats_fixed_N(
             "live_observables was given but observable_cols is empty"))
     end
 
+    # One global energy shift for all sector second moments (the cv()
+    # convention): variances and covariances are shift-invariant, and forming
+    # them on E - E_shift avoids the ~eps*E^2 one-pass cancellation floor.
+    # The N = 0 sector pins E = 0 into the spectrum, hence the min with 0.
+    E_shift = 0.0
+    for (i, dfi) in enumerate(ns_outputs)
+        N_int[i] == 0 && continue
+        nrow(dfi) > 0 && (E_shift = min(E_shift, minimum(dfi.emax)))
+        if live_emax !== nothing && !isempty(live_emax[i])
+            E_shift = min(E_shift, minimum(live_emax[i]))
+        end
+    end
+
     log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
-    mean_E2_N = Matrix{Float64}(undef, n_N, n_T)
+    mean_E2_N = Matrix{Float64}(undef, n_N, n_T)   # shifted: <(E - E_shift)^2>
     obs_N = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_N, n_T) for col in observable_cols)
 
@@ -1083,7 +1124,7 @@ function gc_thermodynamic_stats_fixed_N(
         if N_int[i] == 0
             log_Z_NS[i, :] .= 0.0
             mean_E_N[i, :] .= 0.0
-            mean_E2_N[i, :] .= 0.0
+            mean_E2_N[i, :] .= E_shift^2   # <(0 - E_shift)^2>
             for col in observable_cols
                 # Unlike its ignored live_emax entry, the N = 0 sector's
                 # live_observables entry is used: it supplies the observable
@@ -1101,7 +1142,8 @@ function gc_thermodynamic_stats_fixed_N(
             df, T_grid;
             n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
             live_energies=live, kb=kb,
-            observable_cols=observable_cols, live_observables=live_obs)
+            observable_cols=observable_cols, live_observables=live_obs,
+            energy_shift=E_shift)
         mean_E2_N[i, :] = sector_E2
         for col in observable_cols
             obs_N[col][i, :] = sector_obs[col]
@@ -1135,11 +1177,13 @@ function gc_thermodynamic_stats_fixed_N(
             var_N[k, j] = mean_N2 - mean_N[k, j]^2
             u_avg = sum(ws .* view(mean_E_N, :, j)) / sum_w
             mean_U[k, j] = u_avg
-            # Law of total expectation over the N sectors: the grand-canonical
-            # <E^2> is the w_N-weighted canonical <E^2>_N, likewise <E N>
-            var_U[k, j] = sum(ws .* view(mean_E2_N, :, j)) / sum_w - u_avg^2
-            cov_UN[k, j] = sum(ws .* N_int .* view(mean_E_N, :, j)) / sum_w -
-                           u_avg * mean_N[k, j]
+            # Law of total expectation over the N sectors, formed on shifted
+            # energies (mean_E2_N holds <(E - E_shift)^2>_N; variances and
+            # covariances are shift-invariant)
+            u_c = u_avg - E_shift
+            var_U[k, j] = sum(ws .* view(mean_E2_N, :, j)) / sum_w - u_c^2
+            cov_UN[k, j] = sum(ws .* N_int .* (view(mean_E_N, :, j) .- E_shift)) / sum_w -
+                           u_c * mean_N[k, j]
             for col in observable_cols
                 obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
             end

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1089,9 +1089,11 @@ Perform a nested sampling loop for a given number of steps.
   `name`, exactly paired with that row's `iter`-keyed prior-volume weight.
   Names must not collide with the built-in ledger columns
   (`$(join(String.(_RESERVED_LEDGER_COLUMNS), ", "))`); callbacks must be
-  pure functions of the configuration returning a `Real`. Supported for
-  single-cull MC routines — a pairing guard raises an error otherwise.
-  The default `nothing` leaves the ledger schema unchanged.
+  pure functions of the configuration returning a `Real`. Parallel and
+  multi-cull MC routines (`MCRoutineParallel` subtypes) are rejected up
+  front with an `ArgumentError`; a bit-exact pairing guard additionally
+  raises an error if a step ever culls a different walker than the one the
+  row records. The default `nothing` leaves the ledger schema unchanged.
 
 # Returns
 - `df`: A DataFrame containing the iteration number and maximum energy for each step,
@@ -1116,6 +1118,10 @@ function nested_sampling(liveset::AbstractLiveSet,
     end
     df = DataFrame(iter=Int[], emax=Float64[])
     if observables !== nothing
+        mc_routine isa MCRoutineParallel && throw(ArgumentError(
+            "observables: parallel/multi-cull MC routines are not supported " *
+            "— each accepted iteration culls multiple walkers but records a " *
+            "single ledger row, so per-dead-point pairing is undefined"))
         _validate_observables(observables, liveset)
         for (name, _) in observables
             df[!, name] = Float64[]

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -429,6 +429,48 @@ function update_iter!(liveset::AbstractLiveSet)
     end
 end
 
+const _RESERVED_LEDGER_COLUMNS = (:iter, :emax, :omega, :energy, :num_particles)
+
+"""
+    _validate_observables(observables, liveset::AbstractLiveSet)
+
+Validate an `observables` specification — a vector of `name::Symbol =>
+callback` pairs — for per-dead-point recording in a nested-sampling loop.
+
+Throws `ArgumentError` on an empty list, duplicate names, a name colliding
+with a reserved ledger column, or a callback whose probe evaluation on
+`liveset.walkers[1].configuration` does not return a `Real`; warns when the
+probe value is non-finite (a non-finite observable contributes NaN/Inf to
+every weighted average downstream). Callbacks must be pure functions of the
+configuration: each is evaluated once here as a probe and once per accepted
+iteration on the culled walker.
+"""
+function _validate_observables(observables::AbstractVector{<:Pair{Symbol,<:Any}},
+                               liveset::AbstractLiveSet)
+    isempty(observables) && throw(ArgumentError(
+        "observables: empty list; pass `nothing` to disable observable recording"))
+    names = first.(observables)
+    allunique(names) || throw(ArgumentError(
+        "observables: duplicate names in $(names)"))
+    for name in names
+        if name in _RESERVED_LEDGER_COLUMNS
+            throw(ArgumentError(
+                "observables: name :$name collides with a reserved ledger " *
+                "column; reserved names are $(_RESERVED_LEDGER_COLUMNS)"))
+        end
+    end
+    for (name, f) in observables
+        probe = f(liveset.walkers[1].configuration)
+        probe isa Real || throw(ArgumentError(
+            "observables: callback :$name returned a $(typeof(probe)); " *
+            "callbacks must return a Real"))
+        if !isfinite(Float64(probe))
+            @warn "observables: probe evaluation of :$name returned a non-finite value ($probe)"
+        end
+    end
+    return nothing
+end
+
 """
     estimate_temperature(n_walker::Int, n_cull::Int, ediff::Float64)
 Estimate the temperature for the nested sampling algorithm from dlog(ω)/dE.
@@ -1041,17 +1083,28 @@ Perform a nested sampling loop for a given number of steps.
 - `ns_params::NestedSamplingParameters`: The parameters for nested sampling.
 - `n_steps::Int64`: The number of steps to perform.
 - `mc_routine::MCRoutine`: The Monte Carlo routine to use.
+- `observables`: Optional vector of `name::Symbol => callback` pairs. Each
+  callback is evaluated on the culled walker's `configuration` at every
+  accepted iteration and recorded as an extra `Float64` ledger column named
+  `name`, exactly paired with that row's `iter`-keyed prior-volume weight.
+  Names must not collide with the built-in ledger columns
+  (`$(join(String.(_RESERVED_LEDGER_COLUMNS), ", "))`); callbacks must be
+  pure functions of the configuration returning a `Real`. Supported for
+  single-cull MC routines — a pairing guard raises an error otherwise.
+  The default `nothing` leaves the ledger schema unchanged.
 
 # Returns
-- `df`: A DataFrame containing the iteration number and maximum energy for each step.
+- `df`: A DataFrame containing the iteration number and maximum energy for each step,
+  plus one column per requested observable.
 - `liveset`: The updated set of walkers.
 - `ns_params`: The updated nested sampling parameters.
 """
-function nested_sampling(liveset::AbstractLiveSet, 
-                                ns_params::NestedSamplingParameters, 
-                                n_steps::Int64, 
+function nested_sampling(liveset::AbstractLiveSet,
+                                ns_params::NestedSamplingParameters,
+                                n_steps::Int64,
                                 mc_routine::MCRoutine,
-                                save_strategy::DataSavingStrategy)
+                                save_strategy::DataSavingStrategy;
+                                observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
     # Initialize cluster_p and reset counters from MCMixedMoves if applicable
     if mc_routine isa MCMixedMoves && mc_routine.clusters_freq > 0
         ns_params.cluster_p = mc_routine.initial_cluster_p
@@ -1062,9 +1115,25 @@ function nested_sampling(liveset::AbstractLiveSet,
         empty!(ns_params.cluster_adjust_iterations)
     end
     df = DataFrame(iter=Int[], emax=Float64[])
+    if observables !== nothing
+        _validate_observables(observables, liveset)
+        for (name, _) in observables
+            df[!, name] = Float64[]
+        end
+    end
+    culled = nothing
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
+        if observables !== nothing
+            # Pre-sort with the step's own comparator and hold the walker the
+            # step will cull: the step re-sorts (stable sort, so the identity
+            # permutation here) and culls walkers[1] on accept. `popfirst!`
+            # removes but never mutates the culled walker, so evaluating the
+            # callbacks on it after the step is exact.
+            sort_by_energy!(liveset)
+            culled = liveset.walkers[1]
+        end
         iter, emax, liveset, ns_params = nested_sampling_step!(liveset, ns_params, mc_routine; ns_iteration=i)
         @debug "n_step $i, iter: $iter, emax: $emax"
         if ns_params.fail_count >= ns_params.allowed_fail_count
@@ -1073,7 +1142,17 @@ function nested_sampling(liveset::AbstractLiveSet,
             ns_params.step_size = ns_params.initial_step_size
         end
         if !(iter isa typeof(missing))
-            push!(df, (iter, emax.val))
+            if observables === nothing
+                push!(df, (iter, emax.val))
+            else
+                emax == culled.energy || error(
+                    "NS observable recording: dead-point/observable pairing " *
+                    "lost (step culled a walker with energy $emax, but the " *
+                    "pre-sorted worst walker had $(culled.energy)); this MC " *
+                    "routine is not supported with `observables`")
+                push!(df, (iter, emax.val,
+                           (Float64(f(culled.configuration)) for (_, f) in observables)...))
+            end
         end
         print_message(i, iter, emax, ns_params.step_size, print_info, liveset)
         write_df_every_n(df, i, save_strategy)
@@ -1232,9 +1311,13 @@ highest-Ω walker, record (Ω, E, N), replace with a decorrelated clone.
 - `n_steps::Int64`: Number of NS iterations.
 - `mc_routine::MCGrandCanonicalMoves`: The GC move routine.
 - `save_strategy::DataSavingStrategy`: Strategy for periodic output.
+- `observables`: Optional vector of `name::Symbol => callback` pairs
+  recording per-dead-point observables as extra ledger columns; see
+  [`nested_sampling`](@ref).
 
 # Returns
-- `df::DataFrame`: Columns `[:iter, :omega, :energy, :num_particles]`.
+- `df::DataFrame`: Columns `[:iter, :omega, :energy, :num_particles]`,
+  plus one column per requested observable.
 - `liveset::LatticeGasWalkers`: The final liveset (surviving walkers).
 - `gc_params::GrandCanonicalNestedSamplingParameters`: Updated parameters.
 """
@@ -1242,7 +1325,8 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
                                          gc_params::GrandCanonicalNestedSamplingParameters,
                                          n_steps::Int64,
                                          mc_routine::MCGrandCanonicalMoves,
-                                         save_strategy::DataSavingStrategy)
+                                         save_strategy::DataSavingStrategy;
+                                         observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
     # Initialize walkers with random microstates
     _init_gc_walkers!(liveset, gc_params)
 
@@ -1257,10 +1341,26 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
     end
 
     df = DataFrame(iter=Int[], omega=Float64[], energy=Float64[], num_particles=Int[])
+    if observables !== nothing
+        _validate_observables(observables, liveset)
+        for (name, _) in observables
+            df[!, name] = Float64[]
+        end
+    end
+    culled = nothing
 
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
+
+        if observables !== nothing
+            # Pre-sort with the step's own comparator (Ω = E − μN, descending)
+            # and hold the walker the step will cull; see `nested_sampling`.
+            sort!(liveset.walkers,
+                  by = w -> _grand_potential(w, gc_params.chemical_potential),
+                  rev=true)
+            culled = liveset.walkers[1]
+        end
 
         iter, omega, energy, n_par, liveset, gc_params = nested_sampling_step!(
             liveset, gc_params, mc_routine; ns_iteration=i)
@@ -1273,7 +1373,17 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
         end
 
         if !(iter isa typeof(missing))
-            push!(df, (iter, omega.val, energy.val, n_par))
+            if observables === nothing
+                push!(df, (iter, omega.val, energy.val, n_par))
+            else
+                omega == _grand_potential(culled, gc_params.chemical_potential) || error(
+                    "GC-NS observable recording: dead-point/observable " *
+                    "pairing lost (step culled a walker with Ω = $omega, but " *
+                    "the pre-sorted worst walker had Ω = " *
+                    "$(_grand_potential(culled, gc_params.chemical_potential)))")
+                push!(df, (iter, omega.val, energy.val, n_par,
+                           (Float64(f(culled.configuration)) for (_, f) in observables)...))
+            end
         end
 
         if print_info && !(iter isa typeof(missing))
@@ -1533,9 +1643,15 @@ extract them from the returned liveset.
 - `n_steps::Int64`: Number of NS iterations.
 - `mc_routine::MCGrandCanonicalMoves`: The GC move routine (reused from the Ω-sorted construction).
 - `save_strategy::DataSavingStrategy`: Strategy for periodic output.
+- `observables`: Optional vector of `name::Symbol => callback` pairs
+  recording per-dead-point observables (e.g. `order_parameter_c2x2`) as
+  extra ledger columns; see [`nested_sampling`](@ref). The recorded columns
+  feed the `observable_cols` machinery of
+  `gc_thermodynamic_stats_ideal_ref`.
 
 # Returns
-- `df::DataFrame`: Columns `[:iter, :emax, :num_particles]`.
+- `df::DataFrame`: Columns `[:iter, :emax, :num_particles]`,
+  plus one column per requested observable.
 - `liveset::LatticeGasWalkers`: The final liveset (surviving walkers).
 - `params::IdealGasReferencedGCNSParameters`: Updated parameters.
 """
@@ -1543,7 +1659,8 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
                                               params::IdealGasReferencedGCNSParameters,
                                               n_steps::Int64,
                                               mc_routine::MCGrandCanonicalMoves,
-                                              save_strategy::DataSavingStrategy)
+                                              save_strategy::DataSavingStrategy;
+                                              observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
     # Initialize walkers as i.i.d. draws from the Bernoulli(z0/(1+z0)) prior
     _init_ideal_gas_ref_walkers!(liveset, params)
 
@@ -1558,10 +1675,24 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
     end
 
     df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
+    if observables !== nothing
+        _validate_observables(observables, liveset)
+        for (name, _) in observables
+            df[!, name] = Float64[]
+        end
+    end
+    culled = nothing
 
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
+
+        if observables !== nothing
+            # Pre-sort with the step's own comparator (energy, descending)
+            # and hold the walker the step will cull; see `nested_sampling`.
+            sort_by_energy!(liveset)
+            culled = liveset.walkers[1]
+        end
 
         iter, emax, n_par, liveset, params = nested_sampling_step!(
             liveset, params, mc_routine; ns_iteration=i)
@@ -1574,7 +1705,16 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
         end
 
         if !(iter isa typeof(missing))
-            push!(df, (iter, emax.val, n_par))
+            if observables === nothing
+                push!(df, (iter, emax.val, n_par))
+            else
+                emax == culled.energy || error(
+                    "IG-ref GC-NS observable recording: dead-point/observable " *
+                    "pairing lost (step culled a walker with energy $emax, " *
+                    "but the pre-sorted worst walker had $(culled.energy))")
+                push!(df, (iter, emax.val, n_par,
+                           (Float64(f(culled.configuration)) for (_, f) in observables)...))
+            end
         end
 
         if print_info && !(iter isa typeof(missing))

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -18,5 +18,7 @@
     include("test-lattice-gcns-fixed-n.jl")
     # test hard-core lattice models (finite-J athermal recipe)
     include("test-hard-core-lattices.jl")
+    # test per-dead-point observable recording and its post-processing
+    include("test-ns-observables.jl")
 
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -352,4 +352,163 @@
             [df0, df1, df2], N_values, M, μ_grid, T_grid;
             n_walkers=K, live_emax=live_E, live_observables=live_psi)
     end
+
+    # ================================================================
+    @testset "end-to-end: exact reference and route consistency (4x4, NN repulsion)" begin
+        # Statistical NS checks: seed the global RNG (the random_seed field on
+        # the NS parameters is not consumed). The igref tolerances were sized
+        # at or above 3 sigma of three-seed scatter at this configuration
+        # (max observed: |dlnXi| 0.23, |dN| 0.17, |dU| 0.0011, |dvar_U| 1e-4,
+        # |dcov_UN| 0.0024, |dpsi| 0.014, all N_eff >= 248); the fixed-N
+        # tolerances follow the existing exact-enumeration testset pattern.
+        # The prior must sit near the target ensemble: with repulsive
+        # couplings, z0 = 1 centers the Bernoulli prior at N = M/2 and the
+        # mu grid at ln z0 = 0, and the ladder-depth formula below is the
+        # full-compression depth M ln(1 + 1/z0).
+        Random.seed!(4400)
+        kb = 8.617333262e-5
+
+        M = 16
+        J = 0.1                      # eV, repulsive nearest-neighbor coupling
+        ham = GenericLatticeHamiltonian(0.0, [J, 0.0], u"eV")
+        lattice_at(N) = begin
+            lat = obs_square_lattice(4, 4)
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            lat
+        end
+        psi_from_occ(occ) = abs(sum(occ[s] ?
+            (iseven(((s - 1) % 4) + ((s - 1) ÷ 4)) ? 1 : -1) : 0
+            for s in eachindex(occ))) / length(occ)
+
+        # Exact per-configuration (E, N, psi) from fixed-N enumeration of all
+        # 2^16 configurations
+        exact_E = Dict{Int,Vector{Float64}}()
+        exact_psi = Dict{Int,Vector{Float64}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(lattice_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            exact_psi[N] = [psi_from_occ(cfg[1]) for cfg in df_exact.config]
+            @test length(exact_E[N]) == binomial(M, N)
+        end
+
+        function exact_stats(μ_val, T_val)
+            β = 1.0 / (kb * T_val)
+            lt = Float64[]; Ns = Float64[]; Es = Float64[]; Ps = Float64[]
+            for N in 0:M, i in eachindex(exact_E[N])
+                push!(lt, N * β * μ_val - β * exact_E[N][i])
+                push!(Ns, N); push!(Es, exact_E[N][i]); push!(Ps, exact_psi[N][i])
+            end
+            w = exp.(lt .- maximum(lt)); sw = sum(w)
+            u = sum(w .* Es) / sw; n = sum(w .* Ns) / sw
+            (logXi=maximum(lt) + log(sw), mean_N=n,
+             var_N=sum(w .* Ns .^ 2) / sw - n^2, mean_U=u,
+             var_U=sum(w .* Es .^ 2) / sw - u^2,
+             cov_UN=sum(w .* Es .* Ns) / sw - u * n,
+             psi=sum(w .* Ps) / sw)
+        end
+
+        μs = [-0.010, 0.000, 0.010]
+        Ts = [300.0, 450.0]
+
+        # ---- igref route with psi recording ----
+        z0 = 1.0
+        K_ig = 150
+        n_ig = ceil(Int, 1.15 * K_ig * M * log1p(1 / z0)) + 2 * K_ig
+        walkers = [LatticeWalker(deepcopy(lattice_at(0)), energy=0.0u"eV", iter=0)
+                   for _ in 1:K_ig]
+        ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        df_ig, final_ig, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(n_ig), MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3),
+            obs_save; observables=[:psi => order_parameter_c2x2])
+        obs_cleanup()
+        live_E_ig = [w.energy.val for w in final_ig.walkers]
+        live_N_ig = [sum(w.configuration.components[1]) for w in final_ig.walkers]
+        live_psi_ig = [order_parameter_c2x2(w.configuration) for w in final_ig.walkers]
+
+        st_ig = gc_thermodynamic_stats_ideal_ref(df_ig, M, z0, μs, Ts, K_ig;
+            ω0=(K_ig + 1) / K_ig, live_emax=live_E_ig, live_numbers=live_N_ig,
+            observable_cols=[:psi], live_observables=Dict(:psi => live_psi_ig))
+
+        n_gated = 0
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            st_ig.N_eff[i, j] >= 200 || continue
+            n_gated += 1
+            ex = exact_stats(μ, T)
+            @test isapprox(st_ig.logXi[i, j], ex.logXi, atol=0.7)
+            @test isapprox(st_ig.mean_N[i, j], ex.mean_N, atol=0.5)
+            @test isapprox(st_ig.mean_U[i, j], ex.mean_U, atol=0.01)
+            @test isapprox(st_ig.var_U[i, j], ex.var_U, rtol=0.4, atol=0.001)
+            @test isapprox(st_ig.cov_UN[i, j], ex.cov_UN, rtol=0.4, atol=0.01)
+            @test isapprox(st_ig.observables[:psi][i, j], ex.psi, atol=0.05)
+        end
+        # The grid was chosen inside the z0 window, so most points must pass
+        # the Kish gate
+        @test n_gated >= 4
+
+        # ---- fixed-N route with psi recording ----
+        K_fn = 100
+        n_fn = 1200
+        dfs = Vector{DataFrame}(undef, M + 1)
+        live_E_fn = Vector{Vector{Float64}}(undef, M + 1)
+        live_psi_fn = Vector{Dict{Symbol,Vector{Float64}}}(undef, M + 1)
+
+        dfs[1] = DataFrame(iter=Int[], emax=Float64[])
+        live_E_fn[1] = Float64[]
+        live_psi_fn[1] = Dict(:psi => [0.0])          # psi of the empty lattice
+
+        for N in 1:(M - 1)
+            walkers = [
+                begin
+                    lat = lattice_at(N)
+                    generate_random_new_lattice_sample!(lat)
+                    LatticeWalker(lat)
+                end for _ in 1:K_fn]
+            liveset = LatticeGasWalkers(walkers, ham, perturb_energy=1e-9)
+            ns_params = LatticeNestedSamplingParameters(
+                mc_steps=60, energy_perturbation=1e-9,
+                allowed_fail_count=100_000)
+            df, final_ls, _ = nested_sampling(
+                liveset, ns_params, n_fn, MCRandomWalkClone(), obs_save;
+                observables=[:psi => order_parameter_c2x2])
+            dfs[N + 1] = df
+            live_E_fn[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
+            live_psi_fn[N + 1] = Dict(
+                :psi => [order_parameter_c2x2(w.configuration) for w in final_ls.walkers])
+        end
+        obs_cleanup()
+
+        # N = M: single configuration; empty ladder + live tail with K copies
+        dfs[M + 1] = DataFrame(iter=Int[], emax=Float64[])
+        live_E_fn[M + 1] = fill(only(exact_E[M]), K_fn)
+        live_psi_fn[M + 1] = Dict(:psi => fill(0.0, K_fn))   # full lattice: psi = 0
+
+        st_fn = gc_thermodynamic_stats_fixed_N(dfs, collect(0:M), M,
+            μs .* u"eV", Ts .* u"K";
+            n_walkers=K_fn, n_cull=1, ω0=(K_fn + 1) / K_fn,
+            live_emax=live_E_fn,
+            observable_cols=[:psi], live_observables=live_psi_fn)
+
+        for (j, T) in enumerate(Ts), (k, μ) in enumerate(μs)
+            ex = exact_stats(μ, T)
+            @test isapprox(st_fn.logXi[k, j], ex.logXi, atol=0.3)
+            @test isapprox(st_fn.mean_N[k, j], ex.mean_N, rtol=0.05, atol=0.3)
+            @test isapprox(st_fn.mean_U[k, j], ex.mean_U, rtol=0.05, atol=0.03)
+            @test isapprox(st_fn.var_U[k, j], ex.var_U, rtol=0.3, atol=0.015)
+            @test isapprox(st_fn.cov_UN[k, j], ex.cov_UN, rtol=0.3, atol=0.08)
+            @test isapprox(st_fn.observables[:psi][k, j], ex.psi, atol=0.04)
+        end
+
+        # ---- route consistency where the igref window is healthy ----
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            st_ig.N_eff[i, j] >= 200 || continue
+            @test isapprox(st_ig.observables[:psi][i, j],
+                           st_fn.observables[:psi][i, j], atol=0.07)
+            @test isapprox(st_ig.var_U[i, j], st_fn.var_U[i, j],
+                           rtol=0.5, atol=0.005)
+        end
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -65,4 +65,118 @@
             adsorptions=:full)
         @test_throws ArgumentError order_parameter_c2x2(lat2b)
     end
+
+    # ================================================================
+    obs_ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+    obs_save = SaveEveryN("t_obs.csv", "t_obs.traj", "t_obs.ls",
+                          1000000, 1000000, 1000000)
+    obs_cleanup() = rm.(["t_obs.csv", "t_obs.traj", "t_obs.ls"], force=true)
+    count_N(cfg) = Float64(sum(cfg.components[1]))
+
+    @testset "observable hook: validation" begin
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:8]
+        ls = LatticeGasWalkers(walkers, obs_ham)
+        params = LatticeNestedSamplingParameters(mc_steps=10, energy_perturbation=1e-9)
+
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(2),
+            MCRandomWalkClone(), obs_save;
+            observables=[:a => order_parameter_c2x2, :a => order_parameter_c2x2])
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(2),
+            MCRandomWalkClone(), obs_save;
+            observables=[:emax => order_parameter_c2x2])
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(2),
+            MCRandomWalkClone(), obs_save;
+            observables=Pair{Symbol,Function}[])
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(2),
+            MCRandomWalkClone(), obs_save;
+            observables=[:bad => (cfg -> "not a number")])
+        # Non-finite probe values warn but do not throw
+        @test_logs (:warn, r"non-finite") min_level=Base.CoreLogging.Warn match_mode=:any nested_sampling(
+            ls, params, Int64(2), MCRandomWalkClone(), obs_save;
+            observables=[:nanobs => (cfg -> NaN)])
+        obs_cleanup()
+    end
+
+    # ================================================================
+    @testset "observable hook: exact dead-point pairing (igref route)" begin
+        Random.seed!(42)
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:30]
+        ls = LatticeGasWalkers(walkers, obs_ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(mc_steps=30, reference_fugacity=1.0)
+        mc = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+
+        df, final_ls, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(400), mc, obs_save;
+            observables=[:n_check => count_N, :psi => order_parameter_c2x2])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "num_particles", "n_check", "psi"]
+        @test eltype(df.n_check) == Float64
+        @test eltype(df.psi) == Float64
+        # The load-bearing check: the observable column, evaluated on the
+        # captured culled walker, reproduces the independently recorded
+        # num_particles column row by row over a full run
+        @test df.n_check == Float64.(df.num_particles)
+        @test all(0.0 .<= df.psi .<= 0.5)
+
+        # Schema is unchanged when observables are not requested
+        Random.seed!(42)
+        walkers2 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:30]
+        ls2 = LatticeGasWalkers(walkers2, obs_ham; assign_energy=false)
+        params2 = IdealGasReferencedGCNSParameters(mc_steps=30, reference_fugacity=1.0)
+        df2, _, _ = ideal_gas_referenced_nested_sampling(
+            ls2, params2, Int64(50), mc, obs_save)
+        obs_cleanup()
+        @test names(df2) == ["iter", "emax", "num_particles"]
+    end
+
+    # ================================================================
+    @testset "observable hook: exact dead-point pairing (omega-sorted route)" begin
+        Random.seed!(11)
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:20]
+        ls = LatticeGasWalkers(walkers, obs_ham; assign_energy=false)
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=30, chemical_potential=-0.02)
+        mc = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+
+        df, _, _ = grand_canonical_nested_sampling(
+            ls, gc_params, Int64(200), mc, obs_save;
+            observables=[:n_check => count_N])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "omega", "energy", "num_particles", "n_check"]
+        @test df.n_check == Float64.(df.num_particles)
+    end
+
+    # ================================================================
+    @testset "observable hook: exact dead-point pairing (canonical route)" begin
+        Random.seed!(7)
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:20]
+        # Fixed-N ladder at N = 5: place 5 particles per walker
+        for w in walkers
+            occ = vcat(fill(true, 5), fill(false, 11))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls = LatticeGasWalkers(walkers, obs_ham; perturb_energy=1e-9)
+        params = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+
+        df, _, _ = nested_sampling(ls, params, Int64(200),
+            MCRandomWalkClone(), obs_save;
+            observables=[:e_check => (cfg -> interacting_energy(cfg, obs_ham).val),
+                         :psi => order_parameter_c2x2])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "e_check", "psi"]
+        # N is conserved on the canonical route, so pair the recomputed
+        # (unperturbed) energy against the recorded emax instead; they differ
+        # only by the tie-breaking perturbation
+        @test all(isapprox.(df.e_check, df.emax; atol=1e-8))
+        @test all(0.0 .<= df.psi .<= 0.5)
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -99,6 +99,44 @@
     end
 
     # ================================================================
+    # The pairing-guard test needs a step method that violates the cull
+    # invariant; structs and method extensions must live at module top level
+    @eval begin
+        struct BrokenObsRoutine <: MCRoutine end
+        function FreeBird.SamplingSchemes.nested_sampling_step!(
+                liveset::LatticeGasWalkers,
+                ns_params::NestedSamplingParameters,
+                mc_routine::BrokenObsRoutine;
+                ns_iteration::Int=0)
+            # Claims an accepted iteration whose emax does not belong to the
+            # pre-sorted worst walker
+            return 1, liveset.walkers[1].energy + 1.0u"eV", liveset, ns_params
+        end
+    end
+
+    @testset "observable hook: parallel rejection and pairing guard" begin
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                   for _ in 1:6]
+        ls = LatticeGasWalkers(walkers, obs_ham)
+        params = LatticeNestedSamplingParameters(mc_steps=5,
+            energy_perturbation=1e-9)
+
+        # Parallel/multi-cull routines cull several walkers per recorded row,
+        # so they are rejected up front rather than corrupting the ledger
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(1),
+            MCRandomWalkMaxEParallel(), obs_save;
+            observables=[:psi => order_parameter_c2x2])
+
+        # A step that reports a different walker than the pre-sorted worst
+        # trips the bit-exact pairing guard
+        @test_throws ErrorException nested_sampling(ls, params, Int64(1),
+            BrokenObsRoutine(), obs_save;
+            observables=[:psi => order_parameter_c2x2])
+        obs_cleanup()
+    end
+
+    # ================================================================
     @testset "observable hook: exact dead-point pairing (igref route)" begin
         Random.seed!(42)
         lat = obs_square_lattice(4, 4)
@@ -218,13 +256,28 @@
 
         # Self-consistency: averaging the ledger's own columns reproduces
         # mean_N and mean_U
+        # Mixed value types (Vector{Int} + Vector{Float64} typejoin to
+        # Dict{Symbol,Vector}) pin the loosened Dict annotation: this is
+        # exactly the documented self-consistency call
         stats2 = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K;
             ω0=ω0, live_emax=live_E, live_numbers=live_N,
             observable_cols=[:num_particles, :emax],
-            live_observables=Dict(:num_particles => Float64.(live_N),
-                                  :emax => live_E))
+            live_observables=Dict(:num_particles => live_N, :emax => live_E))
         @test stats2.observables[:num_particles] ≈ stats2.mean_N rtol = 1e-12
         @test stats2.observables[:emax] ≈ stats2.mean_U rtol = 1e-12
+
+        # Live-tail-only analysis: a zero-row ledger need not carry the
+        # observable columns (mirrors the fixed-N empty-sector convention)
+        df_empty = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
+        st_tail = gc_thermodynamic_stats_ideal_ref(df_empty, M, z0, μs, Ts, K;
+            ω0=ω0, live_emax=live_E, live_numbers=live_N,
+            observable_cols=[:a], live_observables=Dict(:a => live_a))
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            β = 1 / (kb * T)
+            w = exp.(β * μ .* Float64.(live_N) .- β .* live_E)
+            @test st_tail.observables[:a][i, j] ≈
+                  sum(w .* live_a) / sum(w) rtol = 1e-12
+        end
 
         # Backward compatibility: pre-existing fields keep their order, new
         # fields are appended, positional destructuring still works
@@ -312,6 +365,34 @@
             # The N = 0 sector contributes psi = 0 with weight wN[1]
             @test stats.observables[:psi][k, j] ≈
                   (wN[2] * p1 + wN[3] * p2) / sw rtol = 1e-10
+        end
+
+        # The N = 0 live_observables entry is USED (its live_emax counterpart
+        # is ignored): with a nonzero Int-typed sentinel — which also pins the
+        # loosened heterogeneous-Dict annotation — the empty sector's
+        # contribution wN[1] * 10 must appear in <b>, and it dominates at the
+        # strongly negative mu grid point
+        df1b = DataFrame(iter=[1, 2], emax=[0.3, 0.1], psi=[0.2, 0.4],
+                         b=[1.0, 3.0])
+        live_b = [Dict{Symbol,Vector}(:psi => [0.0], :b => [10]),
+                  Dict{Symbol,Vector}(:psi => [0.6, 0.8], :b => [5.0, 7.0]),
+                  Dict{Symbol,Vector}(:psi => [0.5, 0.5, 0.5],
+                                      :b => [2.0, 2.0, 2.0])]
+        stats_b = gc_thermodynamic_stats_fixed_N(
+            [df0, df1b, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0, live_emax=live_E,
+            observable_cols=[:psi, :b], live_observables=live_b)
+        @test stats_b.observables[:psi] ≈ stats.observables[:psi] rtol = 1e-12
+        for (j, T) in enumerate([300.0, 600.0]), (k, μ) in enumerate([-0.05, 0.02])
+            β = 1 / (kb * T)
+            b1v = w1 .* exp.(-β .* E1)
+            z1 = sum(b1v)
+            bb1 = sum(b1v .* vcat(df1b.b, live_b[2][:b])) / z1
+            z2 = exp(-β * 0.02)
+            wN = binom .* [1.0, z1, z2] .* exp.(β * μ .* [0.0, 1.0, 2.0])
+            sw = sum(wN)
+            @test stats_b.observables[:b][k, j] ≈
+                  (wN[1] * 10.0 + wN[2] * bb1 + wN[3] * 2.0) / sw rtol = 1e-10
         end
 
         # Backward compatibility: field order preserved, new fields appended

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -257,4 +257,99 @@
             df, M, z0, μs, Ts, K;
             live_observables=Dict(:a => live_a))
     end
+
+    # ================================================================
+    @testset "fixed-N stats: var_U, cov_UN, and observable averages" begin
+        kb = 8.617333262e-5
+        M = 4
+        K = 3
+        ω0 = (K + 1) / K
+        N_values = [0, 1, 2]
+        T_grid = [300.0, 600.0] .* u"K"
+        μ_grid = [-0.05, 0.02] .* u"eV"
+
+        df0 = DataFrame(iter=Int[], emax=Float64[])
+        df1 = DataFrame(iter=[1, 2], emax=[0.3, 0.1], psi=[0.2, 0.4])
+        df2 = DataFrame(iter=Int[], emax=Float64[])   # single-config convention
+        live_E = [Float64[], [0.05, 0.01], [0.02, 0.02, 0.02]]
+        live_psi = [Dict(:psi => [0.0]),
+                    Dict(:psi => [0.6, 0.8]),
+                    Dict(:psi => [0.5, 0.5, 0.5])]
+
+        stats = gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0, live_emax=live_E,
+            observable_cols=[:psi], live_observables=live_psi)
+
+        # Independent linear-space reference. Sector 1: two dead points plus
+        # a two-entry tail (n_iters = 2). Sector 2: empty ladder, tail mass
+        # exactly 1 split over three copies of the sector energy.
+        w1 = vcat(ω0 * (1 / (K + 1)) .* (K / (K + 1)) .^ df1.iter,
+                  fill(ω0 * (K / (K + 1))^2 / 2, 2))
+        E1 = vcat(df1.emax, live_E[2])
+        a1 = vcat(df1.psi, live_psi[2][:psi])
+        binom = [1.0, 4.0, 6.0]                       # C(4, N)
+        for (j, T) in enumerate([300.0, 600.0]), (k, μ) in enumerate([-0.05, 0.02])
+            β = 1 / (kb * T)
+            b1 = w1 .* exp.(-β .* E1)
+            z1 = sum(b1)
+            e1 = sum(b1 .* E1) / z1
+            e1sq = sum(b1 .* E1 .^ 2) / z1
+            p1 = sum(b1 .* a1) / z1
+            z2 = exp(-β * 0.02)
+            e2, e2sq, p2 = 0.02, 0.02^2, 0.5
+            wN = binom .* [1.0, z1, z2] .* exp.(β * μ .* [0.0, 1.0, 2.0])
+            sw = sum(wN)
+            U = (wN[2] * e1 + wN[3] * e2) / sw
+            Nbar = (wN[2] * 1 + wN[3] * 2) / sw
+            @test stats.logXi[k, j] ≈ log(sw) rtol = 1e-10
+            @test stats.mean_N[k, j] ≈ Nbar rtol = 1e-10
+            @test stats.mean_U[k, j] ≈ U rtol = 1e-10
+            @test stats.var_U[k, j] ≈
+                  (wN[2] * e1sq + wN[3] * e2sq) / sw - U^2 rtol = 1e-8
+            @test stats.cov_UN[k, j] ≈
+                  (wN[2] * 1 * e1 + wN[3] * 2 * e2) / sw - U * Nbar rtol = 1e-8
+            # The N = 0 sector contributes psi = 0 with weight wN[1]
+            @test stats.observables[:psi][k, j] ≈
+                  (wN[2] * p1 + wN[3] * p2) / sw rtol = 1e-10
+        end
+
+        # Backward compatibility: field order preserved, new fields appended
+        stats_nc = gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0, live_emax=live_E)
+        @test keys(stats_nc) == (:logXi, :mean_N, :var_N, :mean_U,
+                                 :log_Z_N, :N_values, :var_U, :cov_UN,
+                                 :observables)
+        @test isempty(stats_nc.observables)
+        @test stats_nc.logXi ≈ stats.logXi rtol = 1e-14
+
+        # Validation traps
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi])
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, observable_cols=[:psi], live_observables=live_psi)
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi],
+            live_observables=live_psi[1:2])
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi],
+            live_observables=[Dict(:other => [0.0]), live_psi[2], live_psi[3]])
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi],
+            live_observables=[live_psi[1], Dict(:psi => [0.6]), live_psi[3]])
+        df1_nocol = DataFrame(iter=[1, 2], emax=[0.3, 0.1])
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1_nocol, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi],
+            live_observables=live_psi)
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, live_observables=live_psi)
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -179,4 +179,82 @@
         @test all(isapprox.(df.e_check, df.emax; atol=1e-8))
         @test all(0.0 .<= df.psi .<= 0.5)
     end
+
+    # ================================================================
+    @testset "igref stats: var_U, cov_UN, and observable averages" begin
+        kb = 8.617333262e-5
+        df = DataFrame(iter=[1, 2, 3], emax=[0.5, 0.3, 0.1],
+                       num_particles=[2, 1, 0], a=[1.0, 2.0, 4.0])
+        live_E = [0.05, 0.02]
+        live_N = [1, 2]
+        live_a = [8.0, 16.0]
+        K, z0, M = 4, 1.0, 16
+        ω0 = (K + 1) / K
+        μs = [-0.02, 0.03]
+        Ts = [300.0, 600.0]
+
+        stats = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K;
+            ω0=ω0, live_emax=live_E, live_numbers=live_N,
+            observable_cols=[:a], live_observables=Dict(:a => live_a))
+
+        # Independent linear-space reference for the closed-form weighted sums
+        w0 = ω0 * (1 / (K + 1)) .* (K / (K + 1)) .^ df.iter
+        wt = fill((K / (K + 1))^3 / K, 2)      # tail carries no ω0 factor
+        w_all = vcat(w0, wt)
+        E_all = vcat(df.emax, live_E)
+        N_all = vcat(Float64.(df.num_particles), Float64.(live_N))
+        a_all = vcat(df.a, live_a)
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            β = 1 / (kb * T)
+            w = w_all .* exp.(β * μ .* N_all .- β .* E_all)   # z0 = 1
+            sw = sum(w)
+            u = sum(w .* E_all) / sw
+            n = sum(w .* N_all) / sw
+            @test stats.mean_U[i, j] ≈ u rtol = 1e-12
+            @test stats.var_U[i, j] ≈ sum(w .* E_all .^ 2) / sw - u^2 rtol = 1e-10
+            @test stats.cov_UN[i, j] ≈ sum(w .* E_all .* N_all) / sw - u * n rtol = 1e-10
+            @test stats.observables[:a][i, j] ≈ sum(w .* a_all) / sw rtol = 1e-12
+        end
+
+        # Self-consistency: averaging the ledger's own columns reproduces
+        # mean_N and mean_U
+        stats2 = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K;
+            ω0=ω0, live_emax=live_E, live_numbers=live_N,
+            observable_cols=[:num_particles, :emax],
+            live_observables=Dict(:num_particles => Float64.(live_N),
+                                  :emax => live_E))
+        @test stats2.observables[:num_particles] ≈ stats2.mean_N rtol = 1e-12
+        @test stats2.observables[:emax] ≈ stats2.mean_U rtol = 1e-12
+
+        # Backward compatibility: pre-existing fields keep their order, new
+        # fields are appended, positional destructuring still works
+        stats3 = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K)
+        @test isempty(stats3.observables)
+        @test keys(stats3) == (:logXi, :mean_N, :var_N, :mean_U, :N_eff,
+                               :var_U, :cov_UN, :observables)
+        lX, mN, vN, mU, Ne = stats3
+        @test lX == stats3.logXi && Ne == stats3.N_eff
+
+        # Validation traps
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:nope])
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:a, :a],
+            live_emax=live_E, live_numbers=live_N,
+            live_observables=Dict(:a => live_a))
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:a],
+            live_emax=live_E, live_numbers=live_N)
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:a],
+            live_emax=live_E, live_numbers=live_N,
+            live_observables=Dict(:b => live_a))
+        @test_throws DimensionMismatch gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:a],
+            live_emax=live_E, live_numbers=live_N,
+            live_observables=Dict(:a => [1.0]))
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K;
+            live_observables=Dict(:a => live_a))
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -1,0 +1,68 @@
+@testset "NS observables" begin
+    using Random
+
+    # Shared single-component square-lattice builder
+    function obs_square_lattice(d1, d2)
+        MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(d1, d2, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:d1*d2]],
+            adsorptions=:full)
+    end
+
+    # ================================================================
+    @testset "order_parameter_c2x2" begin
+        lat = obs_square_lattice(4, 4)
+
+        # Empty and full lattices carry no c(2x2) order
+        @test order_parameter_c2x2(lat) == 0.0
+        lat.components[1] .= true
+        @test order_parameter_c2x2(lat) == 0.0
+
+        # Single particle: |±1| / M
+        lat.components[1] .= false
+        lat.components[1][1] = true
+        @test order_parameter_c2x2(lat) == 1 / 16
+
+        # Perfect checkerboards (both sublattices) at half filling: 1/2.
+        # Site ordering: dimension 1 fastest, so i0 = (s-1) % d1, j0 = (s-1) ÷ d1.
+        checker = [iseven(((s - 1) % 4) + ((s - 1) ÷ 4)) for s in 1:16]
+        lat.components[1] .= checker
+        @test order_parameter_c2x2(lat) == 0.5
+        lat.components[1] .= .!checker
+        @test order_parameter_c2x2(lat) == 0.5
+
+        # A column stripe alternates parity along the column and cancels
+        lat.components[1] .= [(s - 1) % 4 == 0 for s in 1:16]
+        @test order_parameter_c2x2(lat) == 0.0
+
+        # Odd in-plane dimensions: the sublattices do not tile evenly
+        @test_throws ArgumentError order_parameter_c2x2(obs_square_lattice(3, 4))
+        @test_throws ArgumentError order_parameter_c2x2(obs_square_lattice(4, 3))
+
+        # Three-dimensional supercell
+        lat3d = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 2),
+            periodicity=(true, true, true),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:32]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_c2x2(lat3d)
+
+        # Multi-site basis
+        lat2b = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[0.8],
+            components=[[false for _ in 1:32]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_c2x2(lat2b)
+    end
+end


### PR DESCRIPTION
Closes #137. Supersedes the trajectory-stream route of #140 for configuration-resolved observables.

## Why

Configuration-resolved observables such as the c(2x2) sublattice order parameter are not functions of (E, N): degenerate energy levels contain ordered and disordered configurations alike, so they cannot be reconstructed from the existing ledgers, which record only (iter, emax/omega, num_particles). This PR records such observables per dead point, exactly paired with each row's iter-keyed prior-volume weight, and extends the grand-canonical post-processing to average them.

## What

- All three NS loop functions (canonical, omega-sorted GC, ideal-gas-referenced GC) gain an opt-in `observables` keyword: `name => callback` pairs evaluated on the culled walker's configuration at every accepted iteration and recorded as extra `Float64` ledger columns. The loop pre-sorts with the step's own comparator and holds the walker the step will cull; a bit-exact guard errors on any pairing violation, and parallel/multi-cull routines are rejected up front.
- New exported `order_parameter_c2x2(::MLattice{1,SquareLattice})`, the checkerboard order parameter of Zhang, Blum & Reuter [PRB 75, 235406 (2007), Eq. (8)].
- `gc_thermodynamic_stats_ideal_ref` and the lattice `gc_thermodynamic_stats_fixed_N` additionally return `var_U`, `cov_UN` (the ingredients of the GC heat capacity and the Var(U)-peak transition locator), and reweighted averages `<A>(mu, T)` for any recorded observable column via `observable_cols`/`live_observables`. Second moments are formed on shifted energies (the `cv()` convention). The fixed-N assembly uses the law of total expectation over the N sectors, with documented conventions for the N = 0 and single-configuration sectors.

## Compatibility

Fully opt-in: without `observables`, every ledger schema is unchanged; new NamedTuple fields are appended after the existing ones, so positional destructuring and by-name access are unaffected. The atomistic fixed-N method is untouched.

## Validation

- Exact unit tests for the order parameter; row-by-row pairing regressions on all three routes (the observable column reproduces the independently recorded `num_particles`/`emax` columns over full runs containing failed steps); the pairing guard's error path is exercised directly.
- Deterministic weighted-sum algebra tests against closed-form references (rtol 1e-10 to 1e-12), including the live-tail and empty-sector conventions.
- End-to-end validation against exact enumeration of a 4x4 lattice gas with nearest-neighbor repulsion (all 2^16 configurations): lnXi, <N>, <U>, Var(U), Cov(U,N), and <Psi> on both the igref route (Kish-gated) and the fixed-N route, plus a route-consistency check; statistical tolerances sized at or above 3 sigma of three-seed scatter.
- An adversarial review pass produced seven hardening fixes, folded into the final commit.
- Full test suite passes; the new file adds 200 tests. The six commits are individually reviewable, and each intermediate state was test-verified.
