### PR TITLE
Validate Hamiltonian shell counts against the lattice neighbor shells

### DIFF
--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -21,6 +21,43 @@ function assign_energy!(walker::LatticeWalker{C}, hamiltonian::ClassicalHamilton
     return walker
 end
 
+_n_coupled_shells(h::GenericLatticeHamiltonian{N,U}) where {N,U} = N
+_n_coupled_shells(h::MLatticeHamiltonian{C,N,U}) where {C,N,U} = N
+_n_coupled_shells(h) = nothing
+
+"""
+    _warn_uncoupled_shells(cfg_or_walkers, hamiltonian)
+
+One-time check at run setup: warn when the lattice carries more neighbor
+shells (`cutoff_radii`) than the Hamiltonian couples, since the outer
+shells then contribute exactly zero energy — silently, if unnoticed. The
+converse mismatch (more coupled shells than the lattice provides) throws
+an `ArgumentError` at energy evaluation instead. Complements the
+empty-shell warning emitted by `compute_neighbors` at lattice
+construction. Called from the `LatticeGasWalkers` constructor and from the
+lattice entry points of `wang_landau` and `nvt_monte_carlo`, which take a
+raw lattice and never build a liveset.
+"""
+function _warn_uncoupled_shells(cfg::AbstractLattice, hamiltonian)
+    cfg isa MLattice || return nothing
+    n_coupled = _n_coupled_shells(hamiltonian)
+    n_coupled === nothing && return nothing
+    n_shells = length(cfg.cutoff_radii)
+    if n_coupled < n_shells
+        @warn "the lattice carries $n_shells neighbor shells (cutoff_radii) " *
+              "but the Hamiltonian couples only the first $n_coupled; the " *
+              "outer $(n_shells - n_coupled) shell(s) contribute zero " *
+              "energy. Drop the unused cutoff_radii or extend " *
+              "nth_neighbor_interactions if this is unintended."
+    end
+    return nothing
+end
+
+function _warn_uncoupled_shells(walkers::Vector{<:LatticeWalker}, hamiltonian)
+    isempty(walkers) && return nothing
+    return _warn_uncoupled_shells(walkers[1].configuration, hamiltonian)
+end
+
 """
     struct LatticeGasWalkers <: LatticeWalkers
 
@@ -38,6 +75,7 @@ struct  LatticeGasWalkers <: LatticeWalkers
     walkers::Vector{LatticeWalker{C}} where C
     hamiltonian::ClassicalHamiltonian
     function LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::ClassicalHamiltonian; assign_energy=true, perturb_energy::Float64=0.0) where C
+        _warn_uncoupled_shells(walkers, hamiltonian)
         if assign_energy
             [assign_energy!(walker, hamiltonian; perturb_energy=perturb_energy) for walker in walkers]
         end

--- a/src/EnergyEval/lattice_energies.jl
+++ b/src/EnergyEval/lattice_energies.jl
@@ -1,4 +1,22 @@
 """
+    _check_shell_counts(lattice_neighbors, n_coupled::Int)
+
+Throw an `ArgumentError` when a Hamiltonian couples more neighbor shells
+than the lattice's neighbor list provides. Called from the energy kernels,
+so it is a single integer comparison in the common case.
+"""
+@inline function _check_shell_counts(lattice_neighbors::Vector{Vector{Vector{Int64}}}, n_coupled::Int)
+    n_shells = isempty(lattice_neighbors) ? 0 : length(lattice_neighbors[1])
+    if n_coupled > n_shells
+        throw(ArgumentError(
+            "the Hamiltonian couples $n_coupled neighbor shells but the " *
+            "lattice provides only $n_shells (= length(cutoff_radii)); " *
+            "extend cutoff_radii so every coupled shell exists"))
+    end
+    return nothing
+end
+
+"""
     lattice_interaction_energy(lattice_occupations::Vector{Bool}, lattice_neighbors::Vector{Vector{Vector{Int64}}}, h::GenericLatticeHamiltonian{N,U})
 
 Compute the interaction energy of a lattice configuration using the Hamiltonian parameters.
@@ -11,8 +29,15 @@ Compute the interaction energy of a lattice configuration using the Hamiltonian 
 # Returns
 - `e_interaction::U`: The interaction energy of the lattice configuration.
 
+Throws an `ArgumentError` when the Hamiltonian couples more neighbor shells
+than the lattice's neighbor list provides (`N > length(cutoff_radii)`),
+which would otherwise surface as a raw `BoundsError` from the innermost
+loop. The converse mismatch (fewer coupled shells than the lattice carries)
+is legal — the outer shells are simply not coupled — and is flagged once,
+with a warning, at `LatticeGasWalkers` construction.
 """
 function lattice_interaction_energy(lattice_occupations::Vector{Bool}, lattice_neighbors::Vector{Vector{Vector{Int64}}}, h::GenericLatticeHamiltonian{N,U}) where {N,U}
+    _check_shell_counts(lattice_neighbors, N)
     e_interaction::U = 0.0*unit(h.on_site_interaction)
     for index in eachindex(lattice_occupations)
         if lattice_occupations[index]
@@ -42,8 +67,11 @@ Compute the interaction energy between two lattice configurations using the Hami
 # Returns
 - `e_interaction::U`: The interaction energy between the two lattice configurations.
 
+Throws an `ArgumentError` on the same shell-count mismatch as
+[`lattice_interaction_energy`](@ref).
 """
 function inter_component_energy(lattice1::Vector{Bool}, lattice2::Vector{Bool}, lattice_neighbors::Vector{Vector{Vector{Int64}}}, h::GenericLatticeHamiltonian{N,U}) where {N,U}
+    _check_shell_counts(lattice_neighbors, N)
     e_interaction::U = 0.0*unit(h.on_site_interaction)
     for index in eachindex(lattice1)
         if lattice1[index]

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -79,7 +79,10 @@ function nvt_monte_carlo(
 )
     # Set the random seed
     Random.seed!(random_seed)
-    
+
+    # No liveset is built on this path, so run the shell-coverage check here
+    AbstractLiveSets._warn_uncoupled_shells(lattice, h)
+
     energies = Vector{Float64}(undef, num_steps)
     configurations = Vector{typeof(lattice)}(undef, num_steps)
     # df = DataFrame(energy=Float64[], config=Vector{Vector{Bool}}[])

--- a/src/SamplingSchemes/wang_landau.jl
+++ b/src/SamplingSchemes/wang_landau.jl
@@ -111,7 +111,10 @@ function wang_landau(
 )
     # Set the random seed
     Random.seed!(wl_params.random_seed)
-    
+
+    # No liveset is built on this path, so run the shell-coverage check here
+    AbstractLiveSets._warn_uncoupled_shells(lattice, h)
+
     energy_bins_count = length(wl_params.energy_bins)
     
     # Set g(E) = 1 and H(E) = 0

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -411,6 +411,172 @@
             @test length(list_num_par) == 1
             @test length(new_sys) == 1
         end
-    end    
+    end
+
+    @testset "multi-shell pair couplings (shell-count validation, sign-mixed sets)" begin
+        using Random
+
+        function shell_lattice(L, cutoffs)
+            MLattice{1,SquareLattice}(
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(L, L, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=cutoffs,
+                components=[[false for _ in 1:L*L]],
+                adsorptions=:full)
+        end
+
+        # Square-lattice shells at distances 1, √2, 2, √5, 2√2, 3, √10, √13, 4
+        cut4 = [1.1, 1.5, 2.1, 2.3]
+        cut9 = [1.1, 1.5, 2.1, 2.3, 2.9, 3.1, 3.2, 3.7, 4.1]
+
+        # ------------------------------------------------------------
+        @testset "Zhang pair part: closed-form adlayer energies (8x8, 4 shells)" begin
+            # Pair part of the Zhang, Blum & Reuter O-Pd(100) lattice-gas
+            # Hamiltonian [PRB 75, 235406 (2007)], FreeBird sign convention
+            # (positive = repulsive); four shells with mixed signs
+            V0 = -1.249
+            J = [0.292, 0.090, -0.050, -0.010]
+            ham = GenericLatticeHamiltonian(V0, J, u"eV")
+            lat = shell_lattice(8, cut4)
+
+            # c(2x2) checkerboard at half coverage: each occupied site sees 4
+            # occupied 2nd-shell (√2) and 4 occupied 3rd-shell (distance 2)
+            # neighbors; shells 1 and 4 connect opposite sublattices and
+            # contribute exactly zero
+            lat.components[1] .= [iseven(((s - 1) % 8) + ((s - 1) ÷ 8)) for s in 1:64]
+            @test interacting_energy(lat, ham).val ≈
+                  32 * (V0 + 2 * J[2] + 2 * J[3]) atol = 1e-10
+
+            # p(2x2) at quarter coverage: only the 3rd shell (distance 2)
+            # connects occupied sites
+            lat.components[1] .= [((s - 1) % 8) % 2 == 0 && ((s - 1) ÷ 8) % 2 == 0
+                                  for s in 1:64]
+            @test interacting_energy(lat, ham).val ≈
+                  16 * (V0 + 2 * J[3]) atol = 1e-10
+        end
+
+        # ------------------------------------------------------------
+        @testset "Kappus-shape nine-shell set vs independent brute force (16x16)" begin
+            # Kappus [Surf. Sci. 691, 121444 (2020)] elastic O-Pd(100) pair
+            # set: nine shells, mixed signs. The 16x16 cell is faithful for
+            # every shell (circumference 16 > 2 x 4).
+            Random.seed!(138)
+            J9 = [0.228, 0.066, -0.043, -0.015, 0.020, 0.007, -0.006, -0.009, 0.008]
+            ham9 = GenericLatticeHamiltonian(0.0, J9, u"eV")
+            L = 16
+            lat = shell_lattice(L, cut9)
+
+            # Independent reference: integer minimum-image squared distances
+            # classify the shells exactly; shares no code with
+            # compute_neighbors. (r² = 17, i.e. √17 ≈ 4.12, falls outside the
+            # 4.1 cutoff, matching the library's shell assignment.)
+            shell_of_r2 = Dict(1 => 1, 2 => 2, 4 => 3, 5 => 4, 8 => 5,
+                               9 => 6, 10 => 7, 13 => 8, 16 => 9)
+            function brute_force_E(occ)
+                E = 0.0
+                for a in 1:L*L, b in (a+1):L*L
+                    (occ[a] && occ[b]) || continue
+                    ia, ja = (a - 1) % L, (a - 1) ÷ L
+                    ib, jb = (b - 1) % L, (b - 1) ÷ L
+                    dx = min(mod(ia - ib, L), mod(ib - ia, L))
+                    dy = min(mod(ja - jb, L), mod(jb - ja, L))
+                    sh = get(shell_of_r2, dx^2 + dy^2, 0)
+                    sh == 0 || (E += J9[sh])
+                end
+                return E
+            end
+
+            # atol sized for summation-order headroom (~2000 terms, |E| up
+            # to ~28 eV: observed discrepancy ~4e-13); adjacent shell
+            # couplings differ by >= 1e-3, so 1e-9 loses no bug-catching power
+            for _ in 1:50
+                occ = rand(L * L) .< 0.4
+                lat.components[1] .= occ
+                @test interacting_energy(lat, ham9).val ≈ brute_force_E(occ) atol = 1e-9
+            end
+        end
+
+        # ------------------------------------------------------------
+        @testset "shell-count mismatch behavior" begin
+            lat4 = shell_lattice(4, cut4)
+            lat4.components[1][1:2] .= true
+
+            # More coupled shells than the lattice provides: ArgumentError,
+            # not a raw BoundsError — on every energy path and at liveset
+            # construction (where energies are assigned)
+            ham5 = GenericLatticeHamiltonian(0.0, [0.1, 0.1, 0.1, 0.1, 0.1], u"eV")
+            @test_throws ArgumentError interacting_energy(lat4, ham5)
+            @test_throws ArgumentError FreeBird.EnergyEval.lattice_interaction_energy(
+                lat4.components[1], lat4.neighbors, ham5)
+            @test_throws ArgumentError FreeBird.EnergyEval.inter_component_energy(
+                lat4.components[1], lat4.components[1], lat4.neighbors, ham5)
+            walkers5 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+            @test_throws ArgumentError LatticeGasWalkers(walkers5, ham5)
+
+            # Fewer coupled shells than the lattice carries: legal (outer
+            # shells simply uncoupled), but warned once at liveset construction
+            ham2 = GenericLatticeHamiltonian(0.0, [0.1, 0.05], u"eV")
+            E2 = interacting_energy(lat4, ham2)
+            @test unit(E2) == u"eV"
+            walkers2 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+            @test_logs (:warn, r"couples only the first 2") match_mode = :any LatticeGasWalkers(
+                walkers2, ham2)
+
+            # Matching counts: silent
+            ham4 = GenericLatticeHamiltonian(0.0, [0.1, 0.05, 0.02, 0.01], u"eV")
+            walkers4 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+            @test_logs min_level = Base.CoreLogging.Warn LatticeGasWalkers(walkers4, ham4)
+
+            # Both guards fire through the MLatticeHamiltonian dispatch too
+            # (its shell count is the shared type parameter N, not C)
+            mham2 = MLatticeHamiltonian(2,
+                [GenericLatticeHamiltonian(0.0, [0.1, 0.05], u"eV") for _ in 1:3])
+            lat1 = shell_lattice(4, [1.1])
+            lat1.components[1][1:2] .= true
+            @test_throws ArgumentError interacting_energy(lat1, mham2)
+            walkers_m = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+            @test_logs (:warn, r"couples only the first 2") match_mode = :any LatticeGasWalkers(
+                walkers_m, mham2)
+
+            # The warn also reaches the raw-lattice sampler entry points,
+            # which never construct a liveset
+            wl_params = WangLandauParameters(energy_min=-0.5, energy_max=3.0,
+                                             num_energy_bins=30, num_steps=10,
+                                             max_iter=2, random_seed=7)
+            @test_logs (:warn, r"couples only the first 2") match_mode = :any wang_landau(
+                deepcopy(lat4), ham2, wl_params)
+            @test_logs (:warn, r"couples only the first 2") match_mode = :any nvt_monte_carlo(
+                MCNewSample(), deepcopy(lat4), ham2, 300.0, 5, 7)
+        end
+
+        # ------------------------------------------------------------
+        @testset "sign-mixed multi-shell GC-NS smoke run" begin
+            Random.seed!(1380)
+            ham = GenericLatticeHamiltonian(-0.05, [0.292, 0.090, -0.050, -0.010], u"eV")
+            lat = shell_lattice(8, cut4)
+            walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                       for _ in 1:20]
+            ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+            params = IdealGasReferencedGCNSParameters(
+                mc_steps=20, reference_fugacity=1.0, energy_perturbation=1e-9)
+            save = SaveEveryN("t_shell.csv", "t_shell.traj", "t_shell.ls",
+                              1000000, 1000000, 1000000)
+            df, final_ls, _ = ideal_gas_referenced_nested_sampling(
+                ls, params, Int64(100),
+                MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3), save)
+            rm.(["t_shell.csv", "t_shell.traj", "t_shell.ls"], force=true)
+
+            @test nrow(df) > 0
+            # Live-set energies match direct recomputation up to the
+            # tie-breaking perturbation
+            for w in final_ls.walkers
+                @test isapprox(w.energy.val,
+                               interacting_energy(w.configuration, ham).val;
+                               atol=1e-8)
+            end
+        end
+    end
 
 end


### PR DESCRIPTION
Closes #138.

## Why

The pair path silently mishandles both shell-count mismatches. A Hamiltonian coupling more neighbor shells than the lattice provides raises a raw `BoundsError` from the innermost energy loop; a lattice carrying more `cutoff_radii` shells than the Hamiltonian couples runs the whole simulation with the outer shells contributing exactly zero, with no indication. Only up to three shells and single-sign couplings had test coverage, while published parameter sets such as the nine-shell, sign-mixed Kappus O-Pd(100) pair set (Surf. Sci. 691, 121444 (2020)) exercise both untested regimes.

## What

- A shared `_check_shell_counts` guard at the top of both lattice energy kernels (`lattice_interaction_energy`, `inter_component_energy`): more coupled shells than the lattice provides now raises an `ArgumentError` naming both counts. Fewer coupled shells stays legal.
- A one-time `_warn_uncoupled_shells` check for the converse case (outer shells silently contributing zero), emitted at `LatticeGasWalkers` construction and at the raw-lattice `wang_landau` and `nvt_monte_carlo` entry points, which never build a liveset. It complements the existing empty-shell warning in `compute_neighbors` and dispatches over both `GenericLatticeHamiltonian` and `MLatticeHamiltonian` (whose shell count is the shared type parameter `N`), skipping non-lattice Hamiltonians.

## Compatibility

No behavior change for matched shell counts. Calls that previously crashed with a `BoundsError` now raise a descriptive `ArgumentError`; calls that previously ran with silently uncoupled shells now emit one warning at setup. Nothing in the existing suite triggers either path.

## Validation

- Closed-form adlayer energies for the four-shell, sign-mixed pair part of the Zhang, Blum & Reuter O-Pd(100) lattice-gas Hamiltonian (PRB 75, 235406 (2007)): c(2×2) at half coverage and p(2×2) at quarter coverage on an 8×8 torus, asserted against hand-derived shell counts.
- The nine-shell Kappus set on 16×16 (faithful for every shell) against an independent brute-force pair sum classifying shells by integer minimum-image squared distances, over 50 seeded random configurations; the tolerance carries ≈1000× floating-point headroom without losing bug-catching power (adjacent shell couplings differ by ≥ 10<sup>−3</sup> eV).
- The full mismatch matrix (throw, warn, silence) through both Hamiltonian types, all three energy call paths, liveset construction, and both raw-lattice sampler entry points; and a short seeded sign-mixed GC-NS run whose live-set energies match direct recomputation.
- An adversarial review pass produced three findings (sampler entry points missing the warn, tolerance headroom, untested `MLatticeHamiltonian` branches), all folded in. Full test suite passes.
