### PR TITLE
Multi-body (cluster) lattice Hamiltonian with motif enumeration

### DIFF
--- a/src/AbstractHamiltonians/AbstractHamiltonians.jl
+++ b/src/AbstractHamiltonians/AbstractHamiltonians.jl
@@ -12,6 +12,7 @@ using StaticArrays
 export AbstractHamiltonian
 export ClassicalHamiltonian
 export GenericLatticeHamiltonian, MLatticeHamiltonian
+export ClusterInteraction, ClusterLatticeHamiltonian
 
 abstract type AbstractHamiltonian end
 
@@ -175,6 +176,141 @@ function Base.show(io::IO, hamiltonian::MLatticeHamiltonian{C,N,U}) where {C,N,U
        for j in 1:C
            println(io, "    Hamiltonians[$i, $j]: ", hamiltonian.Hamiltonians[i,j])
        end
+    end
+end
+
+"""
+    struct ClusterInteraction{K,U}
+
+A single multi-body (cluster) interaction figure on a lattice: one coupling
+plus the explicit list of the figure's embeddings, each an ordered `K`-tuple
+of site indices. The coupling is the energy contributed per fully occupied
+embedding. Each unordered site set appears exactly once, in canonical
+(strictly increasing) form, so double counting of symmetric motifs is
+structurally impossible. Embedding lists are typically produced by
+`enumerate_motif_embeddings` under the torus (minimum-image) convention,
+matching how the pair shells count neighbors.
+
+Only orders `K ≥ 3` are represented: on-site and pair terms belong in the
+wrapped `GenericLatticeHamiltonian` of a [`ClusterLatticeHamiltonian`](@ref).
+
+Note: "cluster" here names an interaction figure of a cluster expansion,
+not the geometric cluster Monte Carlo moves elsewhere in FreeBird.
+
+# Constructor
+```julia
+ClusterInteraction(coupling, embeddings::Vector{NTuple{K,Int}})
+```
+Throws `ArgumentError` on `K < 3`, a non-finite coupling, an embedding that
+is not strictly increasing or contains a non-positive index, or a duplicate
+embedding; warns on an empty embedding list (which contributes exactly
+zero energy).
+"""
+struct ClusterInteraction{K,U}
+    coupling::U
+    embeddings::Vector{NTuple{K,Int}}
+
+    function ClusterInteraction{K,U}(coupling::U, embeddings::Vector{NTuple{K,Int}}) where {K,U}
+        if K < 3
+            throw(ArgumentError(
+                "ClusterInteraction is for 3-body and higher motifs (got K = $K); " *
+                "on-site and pair terms belong in the wrapped GenericLatticeHamiltonian"))
+        end
+        if !isfinite(coupling)
+            throw(ArgumentError(
+                "non-finite cluster couplings are not supported; model hard " *
+                "constraints with finite couplings (see the hard-core recipe " *
+                "in the GenericLatticeHamiltonian docstring)"))
+        end
+        isempty(embeddings) &&
+            @warn "ClusterInteraction with an empty embedding list contributes exactly zero energy"
+        seen = Set{NTuple{K,Int}}()
+        for e in embeddings
+            if e[1] < 1
+                throw(ArgumentError("embedding $e contains a non-positive site index"))
+            end
+            for k in 1:K-1
+                if e[k] >= e[k+1]
+                    throw(ArgumentError(
+                        "embedding $e is not in canonical (strictly increasing) " *
+                        "order; each unordered site set must appear exactly once"))
+                end
+            end
+            if e in seen
+                throw(ArgumentError("duplicate embedding $e would double-count its energy"))
+            end
+            push!(seen, e)
+        end
+        return new(coupling, embeddings)
+    end
+end
+
+function ClusterInteraction(coupling::U, embeddings::Vector{NTuple{K,Int}}) where {K,U}
+    return ClusterInteraction{K,U}(coupling, embeddings)
+end
+
+function Base.show(io::IO, c::ClusterInteraction{K,U}) where {K,U}
+    print(io, "ClusterInteraction{$K}: coupling = ", c.coupling,
+          ", ", length(c.embeddings), " embeddings")
+end
+
+"""
+    struct ClusterLatticeHamiltonian{N,U} <: ClassicalHamiltonian
+
+A lattice Hamiltonian with on-site, pair-shell, and multi-body (cluster)
+terms: a `GenericLatticeHamiltonian{N,U}` carrying the on-site energy and
+the `N` pair-shell couplings, plus a vector of [`ClusterInteraction`](@ref)
+figures of arbitrary orders `K ≥ 3`. The total energy is the pair part
+plus, for every figure, the coupling times the number of its fully
+occupied embeddings.
+
+Sign and unit conventions follow `GenericLatticeHamiltonian`: positive
+couplings are repulsive. Published binding-energy parameter sets (e.g. the
+O-Pd(100) lattice-gas Hamiltonian of Zhang, Blum & Reuter, PRB 75, 235406
+(2007), whose optimum expansion carries four pair shells, four trios, and
+one quattro) map onto FreeBird by negating every parameter.
+
+Evaluated by `interacting_energy(lattice, h)` for single-component
+(`SLattice`) configurations, and therefore usable in every sampler that
+calls it generically.
+
+# Constructor
+```julia
+ClusterLatticeHamiltonian(pair_ham::GenericLatticeHamiltonian{N,U}, clusters)
+```
+`clusters` is a vector of `ClusterInteraction`s whose coupling type matches
+`U`; heterogeneous orders `K` are allowed.
+"""
+struct ClusterLatticeHamiltonian{N,U} <: ClassicalHamiltonian
+    pair_ham::GenericLatticeHamiltonian{N,U}
+    clusters::Vector{ClusterInteraction{K,U} where K}
+
+    function ClusterLatticeHamiltonian(pair_ham::GenericLatticeHamiltonian{N,U},
+                                       clusters::AbstractVector) where {N,U}
+        converted = Vector{ClusterInteraction{K,U} where K}()
+        for (i, c) in enumerate(clusters)
+            if !(c isa ClusterInteraction)
+                throw(ArgumentError(
+                    "clusters[$i] is a $(typeof(c)); expected a ClusterInteraction"))
+            end
+            if !(typeof(c.coupling) == U)
+                throw(ArgumentError(
+                    "clusters[$i] has coupling type $(typeof(c.coupling)), which " *
+                    "does not match the pair Hamiltonian's $U; construct every " *
+                    "coupling with the same units and value type"))
+            end
+            push!(converted, c)
+        end
+        return new{N,U}(pair_ham, converted)
+    end
+end
+
+function Base.show(io::IO, h::ClusterLatticeHamiltonian{N,U}) where {N,U}
+    println(io, "ClusterLatticeHamiltonian{$N,$U}:")
+    println(io, "    pair part: ", h.pair_ham)
+    println(io, "    clusters:")
+    for c in h.clusters
+        println(io, "        ", c)
     end
 end
 

--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -29,11 +29,16 @@ _n_coupled_shells(h) = nothing
 """
     _check_cluster_sites(hamiltonian, cfg)
 
-One-time check at liveset construction: a `ClusterLatticeHamiltonian`
-whose embeddings reference site indices beyond the lattice was built for a
-different lattice; failing here with a descriptive `ArgumentError` beats a
-`BoundsError` from deep inside the energy kernel. A no-op for every other
-Hamiltonian type.
+One-time check at run setup (the `LatticeGasWalkers` constructor and the
+raw-lattice `wang_landau`/`nvt_monte_carlo` entry points): a
+`ClusterLatticeHamiltonian` whose embeddings reference site indices beyond
+the lattice was built for a different lattice; failing here with a
+descriptive `ArgumentError` beats a `BoundsError` from deep inside the
+energy kernel. A no-op for every other Hamiltonian type. The converse
+mismatch — a Hamiltonian enumerated on a *smaller* lattice, whose indices
+all exist but whose embeddings have wrong geometry — is undetectable from
+indices alone and remains the caller's responsibility: always enumerate on
+the lattice being sampled.
 """
 _check_cluster_sites(hamiltonian, cfg) = nothing
 function _check_cluster_sites(h::ClusterLatticeHamiltonian, cfg::AbstractLattice)

--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -23,7 +23,33 @@ end
 
 _n_coupled_shells(h::GenericLatticeHamiltonian{N,U}) where {N,U} = N
 _n_coupled_shells(h::MLatticeHamiltonian{C,N,U}) where {C,N,U} = N
+_n_coupled_shells(h::ClusterLatticeHamiltonian{N,U}) where {N,U} = N
 _n_coupled_shells(h) = nothing
+
+"""
+    _check_cluster_sites(hamiltonian, cfg)
+
+One-time check at liveset construction: a `ClusterLatticeHamiltonian`
+whose embeddings reference site indices beyond the lattice was built for a
+different lattice; failing here with a descriptive `ArgumentError` beats a
+`BoundsError` from deep inside the energy kernel. A no-op for every other
+Hamiltonian type.
+"""
+_check_cluster_sites(hamiltonian, cfg) = nothing
+function _check_cluster_sites(h::ClusterLatticeHamiltonian, cfg::AbstractLattice)
+    M = num_sites(cfg)
+    for (i, c) in enumerate(h.clusters)
+        for e in c.embeddings
+            if e[end] > M   # canonical form: the last index is the maximum
+                throw(ArgumentError(
+                    "clusters[$i] embedding $e references site $(e[end]) but " *
+                    "the lattice has only $M sites; the Hamiltonian was " *
+                    "built for a different lattice"))
+            end
+        end
+    end
+    return nothing
+end
 
 """
     _warn_uncoupled_shells(cfg_or_walkers, hamiltonian)
@@ -76,6 +102,7 @@ struct  LatticeGasWalkers <: LatticeWalkers
     hamiltonian::ClassicalHamiltonian
     function LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::ClassicalHamiltonian; assign_energy=true, perturb_energy::Float64=0.0) where C
         _warn_uncoupled_shells(walkers, hamiltonian)
+        isempty(walkers) || _check_cluster_sites(hamiltonian, walkers[1].configuration)
         if assign_energy
             [assign_energy!(walker, hamiltonian; perturb_energy=perturb_energy) for walker in walkers]
         end

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -26,6 +26,7 @@ export MLattice, SLattice, GLattice
 export update_walker!
 export num_sites, occupied_site_count
 export order_parameter_c2x2
+export enumerate_motif_embeddings, motif_distances
 export view_structure
 
 abstract type AbstractWalker end

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -534,6 +534,15 @@ Diagnostics:
 Note: for a pair signature (`K = 2`) this reproduces the sites of a
 neighbor shell as unordered pairs — useful as a counting diagnostic; pair
 couplings themselves belong in `GenericLatticeHamiltonian`.
+
+**Homometry caveat**: for `K ≥ 4`, non-congruent figures can share a
+distance multiset (homometric figures), and this method then enumerates
+the embeddings of every such figure together — it warns about this. Pass
+the coordinate template instead (the `coords` method) to enumerate only
+embeddings whose full distance *matrix* matches the template under some
+site permutation, which excludes homometric aliases while preserving the
+torus counting convention. For `K ≤ 3` the multiset determines the figure
+and the two methods agree.
 """
 function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector{<:Real};
                                     tol::Float64=1e-6,
@@ -545,7 +554,79 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
             "distances must be the full pairwise multiset of a K-site motif " *
             "— 1 (K = 2), 3 (K = 3), 6 (K = 4), or 10 (K = 5) entries — got $npairs"))
     end
-    sig = sort(collect(Float64, distances))
+    if K >= 4
+        @warn "a distance multiset does not determine a figure for K ≥ 4 " *
+              "(homometric figures share multisets); embeddings of every " *
+              "figure with this multiset are enumerated together. Pass the " *
+              "coordinate template to enumerate_motif_embeddings to select " *
+              "the congruent embeddings only."
+    end
+    return _enumerate_motif_core(lattice, collect(Float64, distances), K,
+                                 nothing, tol, expected_count)
+end
+
+"""
+    enumerate_motif_embeddings(lattice::MLattice, coords::AbstractVector{<:Tuple};
+                               tol=1e-6, expected_count=nothing)
+
+Template method: declare the motif by its site coordinates (as accepted by
+[`motif_distances`](@ref)) and enumerate only the embeddings whose full
+minimum-image distance matrix matches the template's under some site
+permutation. This is the recommended method for `K ≥ 4`, where a distance
+multiset alone does not determine the figure (homometric figures).
+"""
+function enumerate_motif_embeddings(lattice::MLattice, coords::AbstractVector{<:Tuple};
+                                    tol::Float64=1e-6,
+                                    expected_count::Union{Int,Nothing}=nothing)
+    K = length(coords)
+    2 <= K <= 5 || throw(ArgumentError(
+        "the motif template must have 2 to 5 sites, got $K"))
+    to3(t) = (Float64(t[1]), Float64(t[2]), length(t) >= 3 ? Float64(t[3]) : 0.0)
+    pts = [to3(t) for t in coords]
+    T = zeros(K, K)
+    for a in 1:K, b in 1:K
+        T[a, b] = sqrt((pts[a][1] - pts[b][1])^2 +
+                       (pts[a][2] - pts[b][2])^2 +
+                       (pts[a][3] - pts[b][3])^2)
+    end
+    sig = sort([T[a, b] for a in 1:K for b in (a+1):K])
+    return _enumerate_motif_core(lattice, sig, K, T, tol, expected_count)
+end
+
+# Does some permutation of `sites` match the template distance matrix `T`
+# entrywise within tol? Backtracking assignment with early pruning; K ≤ 5,
+# so at most 120 permutations are ever considered.
+function _matches_template(sites::Vector{Int}, dist, T::Matrix{Float64}, tol::Float64)
+    K = length(sites)
+    perm = zeros(Int, K)
+    used = falses(K)
+    function assign(a)
+        a > K && return true
+        for b in 1:K
+            used[b] && continue
+            ok = true
+            for a2 in 1:(a-1)
+                if abs(dist(sites[perm[a2]], sites[b]) - T[a2, a]) > tol
+                    ok = false
+                    break
+                end
+            end
+            ok || continue
+            used[b] = true
+            perm[a] = b
+            assign(a + 1) && return true
+            used[b] = false
+        end
+        return false
+    end
+    return assign(1)
+end
+
+function _enumerate_motif_core(lattice::MLattice, distances::Vector{Float64}, K::Int,
+                               template::Union{Nothing,Matrix{Float64}},
+                               tol::Float64, expected_count::Union{Int,Nothing})
+    npairs = length(distances)
+    sig = sort(distances)
     all(>(0.0), sig) || throw(ArgumentError("motif distances must be positive"))
     tol > 0 || throw(ArgumentError("tol must be positive"))
 
@@ -556,19 +637,25 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
     pos = lattice.positions
     per = lattice.periodicity
 
-    # Wrap-around guard: a periodic circumference not exceeding K·d_max
-    # admits winding embeddings; counts then follow the torus convention
+    # Wrap-around guard: the shortest periodic translation (over small
+    # integer combinations of the periodic supercell vectors, which covers
+    # reasonably reduced cells; extreme shear beyond ±1 combinations is not
+    # detected) must exceed K·d_max, else winding embeddings are admitted
+    # and counts follow the torus convention
     d_max = sig[end]
-    for k in 1:3
-        per[k] || continue
-        C = norm(scv[:, k])
-        if C <= K * d_max + tol
-            @warn "periodic circumference $(round(C, digits=4)) along axis $k " *
-                  "does not exceed K·d_max = $(K * d_max); the cell is not a " *
-                  "faithful quotient and embeddings follow the torus " *
-                  "(minimum-image) convention"
-            break
-        end
+    C_min = Inf
+    for n1 in -1:1, n2 in -1:1, n3 in -1:1
+        (n1 == 0 && n2 == 0 && n3 == 0) && continue
+        (!per[1] && n1 != 0) && continue
+        (!per[2] && n2 != 0) && continue
+        (!per[3] && n3 != 0) && continue
+        C_min = min(C_min, norm(n1 * scv[:, 1] + n2 * scv[:, 2] + n3 * scv[:, 3]))
+    end
+    if isfinite(C_min) && C_min <= K * d_max + tol
+        @warn "shortest periodic translation $(round(C_min, digits=4)) does " *
+              "not exceed K·d_max = $(K * d_max); the cell is not a faithful " *
+              "quotient and embeddings follow the torus (minimum-image) " *
+              "convention"
     end
 
     uniq = Float64[]
@@ -581,11 +668,14 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
 
     # Per-site candidates at any signature distance, restricted to j > i:
     # anchored strictly increasing enumeration makes each unordered set
-    # appear exactly once, with the anchor as its minimum index
+    # appear exactly once, with the anchor as its minimum index. Pruning
+    # measures 2·tol from the merged uniq representatives so it stays a
+    # relaxation of the elementwise acceptance below (a representative can
+    # sit up to tol away from the signature entry it absorbed).
     cand = [Int[] for _ in 1:M]
     for i in 1:M, j in (i+1):M
         d = dist(i, j)
-        if any(u -> abs(u - d) <= tol, uniq)
+        if any(u -> abs(u - d) <= 2 * tol, uniq)
             push!(cand[i], j)
         end
     end
@@ -600,7 +690,9 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
             end
             sort!(ds)
             if all(abs(ds[t] - sig[t]) <= tol for t in 1:npairs)
-                push!(embeddings, NTuple{K,Int}(partial))
+                if template === nothing || _matches_template(partial, dist, template, tol)
+                    push!(embeddings, NTuple{K,Int}(partial))
+                end
             end
             return nothing
         end
@@ -609,7 +701,7 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
             ok = true
             for s in partial
                 dj = dist(s, j)
-                if !any(u -> abs(u - dj) <= tol, uniq)
+                if !any(u -> abs(u - dj) <= 2 * tol, uniq)
                     ok = false
                     break
                 end

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -17,15 +17,38 @@ Compute the nearest and next-nearest neighbors for each atom in a 3D lattice.
 
 """
 
-function compute_neighbors(supercell_lattice_vectors::Matrix{Float64}, 
-                           positions::Matrix{Float64}, 
-                           periodicity::Tuple{Bool, Bool, Bool}, 
+"""
+    _minimum_image_distance(supercell_lattice_vectors, reciprocal_lattice_vectors,
+                            periodicity, pos_i, pos_j)
+
+Minimum-image distance between two Cartesian positions under the given
+supercell and periodicity — the single distance kernel shared by
+`compute_neighbors` and `enumerate_motif_embeddings`, so pair shells and
+cluster embeddings follow the identical torus convention.
+"""
+@inline function _minimum_image_distance(supercell_lattice_vectors::AbstractMatrix{Float64},
+                                         reciprocal_lattice_vectors::AbstractMatrix{Float64},
+                                         periodicity::Tuple{Bool,Bool,Bool},
+                                         pos_i, pos_j)
+    dr = [pos_j[1] - pos_i[1], pos_j[2] - pos_i[2], pos_j[3] - pos_i[3]]
+    fractional_dr = reciprocal_lattice_vectors * dr
+    for k in 1:3
+        if periodicity[k]
+            fractional_dr[k] -= round(fractional_dr[k])
+        end
+    end
+    return norm(supercell_lattice_vectors * fractional_dr)
+end
+
+function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
+                           positions::Matrix{Float64},
+                           periodicity::Tuple{Bool, Bool, Bool},
                            cutoff_radii::Vector{Float64}
                            )
-                           
+
     neighbors = Vector{Vector{Vector{Int}}}(undef, size(positions, 1))
     num_atoms = size(positions, 1)
-    
+
     # Compute reciprocal lattice vectors for minimum image convention
     a1 = supercell_lattice_vectors[:, 1]
     a2 = supercell_lattice_vectors[:, 2]
@@ -39,40 +62,22 @@ function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
         for _ in 1:layers_of_neighbors
             push!(nth_neighbors, Int[])
         end
-        pos_i = positions[i, :]
-        
+
         for j in 1:num_atoms
             if i != j
-                pos_j = positions[j, :]
-                dx = pos_j[1] - pos_i[1]
-                dy = pos_j[2] - pos_i[2]
-                dz = pos_j[3] - pos_i[3]
+                distance = _minimum_image_distance(
+                    supercell_lattice_vectors, reciprocal_lattice_vectors,
+                    periodicity, view(positions, i, :), view(positions, j, :))
 
-                # Apply minimum image convention using reciprocal lattice vectors
-                dr = [dx, dy, dz]
-                fractional_dr = reciprocal_lattice_vectors * dr
-                
-                for k in 1:3
-                    if periodicity[k]
-                        fractional_dr[k] -= round(fractional_dr[k])
+                for k in 1:layers_of_neighbors
+                    if distance <= cutoff_radii[k]
+                        push!(nth_neighbors[k], j)
+                        break
                     end
                 end
-                
-                dr = supercell_lattice_vectors * fractional_dr
-
-                distance = norm(dr)
-
-                for i in 1:layers_of_neighbors
-                    if distance <= cutoff_radii[i]
-                        push!(nth_neighbors[i], j)
-                        break
-                    end 
-                end
-
-
             end
         end
-        
+
         neighbors[i] = nth_neighbors
     end
 
@@ -470,6 +475,178 @@ function order_parameter_c2x2(lattice::MLattice{1,SquareLattice})
         end
     end
     return abs(acc) / (d1 * d2)
+end
+
+"""
+    motif_distances(coords::AbstractVector{<:Tuple}) -> Vector{Float64}
+
+Sorted multiset of the pairwise Euclidean distances of a coordinate
+template, for transcribing a cluster-interaction figure straight from a
+paper's geometry (e.g. the trio `[(0, 0), (1, 0), (0, 1)]` gives
+`[1, 1, √2]`). Two-component tuples are treated as in-plane coordinates
+with `z = 0`. The result is the `distances` argument of
+[`enumerate_motif_embeddings`](@ref).
+"""
+function motif_distances(coords::AbstractVector{<:Tuple})
+    n = length(coords)
+    n >= 2 || throw(ArgumentError("a motif needs at least two sites"))
+    to3(t) = (Float64(t[1]), Float64(t[2]), length(t) >= 3 ? Float64(t[3]) : 0.0)
+    pts = [to3(t) for t in coords]
+    ds = Float64[]
+    for a in 1:n, b in (a+1):n
+        push!(ds, sqrt((pts[a][1] - pts[b][1])^2 +
+                       (pts[a][2] - pts[b][2])^2 +
+                       (pts[a][3] - pts[b][3])^2))
+    end
+    return sort(ds)
+end
+
+"""
+    enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector{<:Real};
+                               tol::Float64=1e-6,
+                               expected_count::Union{Int,Nothing}=nothing)
+        -> Vector{NTuple{K,Int}}
+
+Enumerate every embedding of a cluster motif on a periodic lattice. The
+motif is declared by the sorted multiset of its pairwise minimum-image
+distances (`K` is inferred from the multiset length: 1 → pair, 3 → trio,
+6 → quattro, 10 → quinto); [`motif_distances`](@ref) builds the multiset
+from a coordinate template. Distances are compared with absolute tolerance
+`tol`, using the same minimum-image kernel as `compute_neighbors`, so
+embeddings follow the identical torus convention as the pair shells: one
+entry per unordered site set whose distances match, in canonical strictly
+increasing order — the form [`ClusterInteraction`](@ref) requires.
+
+Diagnostics:
+- The total embedding count and the count per site are logged (`@info`).
+- A warning is emitted when the per-site embedding membership is not
+  uniform: on a site-transitive lattice, nonuniformity indicates distance
+  aliasing or an unsuitable `tol`.
+- A warning is emitted when any periodic circumference does not exceed
+  `K · maximum(distances)`: such a cell is not a faithful quotient, and
+  winding (wrap-around) embeddings are counted under the torus convention
+  (e.g. the 18-site triangular cell carries 42 nearest-neighbor-triangle
+  embeddings: 36 faces plus 6 winding three-cycles).
+- When `expected_count` is given (e.g. a hand-derived per-cell
+  multiplicity), a mismatch throws an `ArgumentError` — the recommended
+  guard against silent transcription errors.
+
+Note: for a pair signature (`K = 2`) this reproduces the sites of a
+neighbor shell as unordered pairs — useful as a counting diagnostic; pair
+couplings themselves belong in `GenericLatticeHamiltonian`.
+"""
+function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector{<:Real};
+                                    tol::Float64=1e-6,
+                                    expected_count::Union{Int,Nothing}=nothing)
+    npairs = length(distances)
+    K = round(Int, (1 + sqrt(1 + 8.0 * npairs)) / 2)
+    if K * (K - 1) ÷ 2 != npairs || !(2 <= K <= 5)
+        throw(ArgumentError(
+            "distances must be the full pairwise multiset of a K-site motif " *
+            "— 1 (K = 2), 3 (K = 3), 6 (K = 4), or 10 (K = 5) entries — got $npairs"))
+    end
+    sig = sort(collect(Float64, distances))
+    all(>(0.0), sig) || throw(ArgumentError("motif distances must be positive"))
+    tol > 0 || throw(ArgumentError("tol must be positive"))
+
+    M = num_sites(lattice)
+    dims = lattice.supercell_dimensions
+    scv = lattice.lattice_vectors * Diagonal([dims[1], dims[2], dims[3]])
+    rec = inv(scv)
+    pos = lattice.positions
+    per = lattice.periodicity
+
+    # Wrap-around guard: a periodic circumference not exceeding K·d_max
+    # admits winding embeddings; counts then follow the torus convention
+    d_max = sig[end]
+    for k in 1:3
+        per[k] || continue
+        C = norm(scv[:, k])
+        if C <= K * d_max + tol
+            @warn "periodic circumference $(round(C, digits=4)) along axis $k " *
+                  "does not exceed K·d_max = $(K * d_max); the cell is not a " *
+                  "faithful quotient and embeddings follow the torus " *
+                  "(minimum-image) convention"
+            break
+        end
+    end
+
+    uniq = Float64[]
+    for d in sig
+        any(u -> abs(u - d) <= tol, uniq) || push!(uniq, d)
+    end
+
+    dist(i, j) = _minimum_image_distance(scv, rec, per,
+                                         view(pos, i, :), view(pos, j, :))
+
+    # Per-site candidates at any signature distance, restricted to j > i:
+    # anchored strictly increasing enumeration makes each unordered set
+    # appear exactly once, with the anchor as its minimum index
+    cand = [Int[] for _ in 1:M]
+    for i in 1:M, j in (i+1):M
+        d = dist(i, j)
+        if any(u -> abs(u - d) <= tol, uniq)
+            push!(cand[i], j)
+        end
+    end
+
+    embeddings = Vector{NTuple{K,Int}}()
+    partial = Int[]
+    function extend!()
+        if length(partial) == K
+            ds = Float64[]
+            for a in 1:K, b in (a+1):K
+                push!(ds, dist(partial[a], partial[b]))
+            end
+            sort!(ds)
+            if all(abs(ds[t] - sig[t]) <= tol for t in 1:npairs)
+                push!(embeddings, NTuple{K,Int}(partial))
+            end
+            return nothing
+        end
+        for j in cand[partial[1]]
+            j > partial[end] || continue
+            ok = true
+            for s in partial
+                dj = dist(s, j)
+                if !any(u -> abs(u - dj) <= tol, uniq)
+                    ok = false
+                    break
+                end
+            end
+            ok || continue
+            push!(partial, j)
+            extend!()
+            pop!(partial)
+        end
+        return nothing
+    end
+    for i in 1:M
+        empty!(partial)
+        push!(partial, i)
+        extend!()
+    end
+
+    counts = zeros(Int, M)
+    for e in embeddings, s in e
+        counts[s] += 1
+    end
+    total = length(embeddings)
+    @info "enumerate_motif_embeddings: $total embeddings of a $K-site motif " *
+          "($(round(total / M, digits=4)) per site)"
+    if !isempty(embeddings) && !all(==(counts[1]), counts)
+        @warn "per-site embedding membership is not uniform " *
+              "(min $(minimum(counts)), max $(maximum(counts))); on a " *
+              "site-transitive lattice this indicates distance aliasing or " *
+              "an unsuitable tol"
+    end
+    if expected_count !== nothing && total != expected_count
+        throw(ArgumentError(
+            "enumerated $total embeddings but expected_count = " *
+            "$expected_count; check the motif signature, tol, and the cell " *
+            "size (wrap-around)"))
+    end
+    return embeddings
 end
 
 """

--- a/src/EnergyEval/lattice_energies.jl
+++ b/src/EnergyEval/lattice_energies.jl
@@ -116,6 +116,49 @@ function interacting_energy(lattice::SLattice, h::MLatticeHamiltonian{C,N,U}) wh
 end
 
 """
+    cluster_energy(occupations::Vector{Bool}, c::ClusterInteraction{K,U})
+
+Energy contribution of one cluster figure: the coupling times the number of
+its embeddings whose `K` sites are all occupied. The per-figure function
+barrier keeps the inner loop type-stable across the heterogeneous cluster
+orders of a `ClusterLatticeHamiltonian`. Bounds checks stay on: an
+embedding referencing a site beyond the occupation vector must raise a
+`BoundsError` rather than read memory (the liveset constructor validates
+this once up front).
+"""
+function cluster_energy(occupations::Vector{Bool}, c::ClusterInteraction{K,U}) where {K,U}
+    n = 0
+    for emb in c.embeddings
+        occupied = true
+        for s in emb
+            if !occupations[s]
+                occupied = false
+                break
+            end
+        end
+        n += occupied ? 1 : 0
+    end
+    return n * c.coupling
+end
+
+"""
+    interacting_energy(lattice::SLattice, h::ClusterLatticeHamiltonian{N,U})
+
+Total energy under a multi-body lattice Hamiltonian: the wrapped pair
+part (on-site + `N` pair shells, evaluated exactly as for a bare
+`GenericLatticeHamiltonian`) plus every cluster figure's contribution.
+Single-component (`SLattice`) configurations only.
+"""
+function interacting_energy(lattice::SLattice, h::ClusterLatticeHamiltonian{N,U}) where {N,U}
+    e = interacting_energy(lattice, h.pair_ham)
+    occ = lattice.components[1]
+    for c in h.clusters
+        e += cluster_energy(occ, c)
+    end
+    return e
+end
+
+"""
     interacting_energy(lattice::MLattice{C,G}, h::MLatticeHamiltonian{C,N,U})
 
 Compute the interaction energy of a multi-component lattice configuration using the Hamiltonian parameters.

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -80,8 +80,9 @@ function nvt_monte_carlo(
     # Set the random seed
     Random.seed!(random_seed)
 
-    # No liveset is built on this path, so run the shell-coverage check here
+    # No liveset is built on this path, so run the setup checks here
     AbstractLiveSets._warn_uncoupled_shells(lattice, h)
+    AbstractLiveSets._check_cluster_sites(h, lattice)
 
     energies = Vector{Float64}(undef, num_steps)
     configurations = Vector{typeof(lattice)}(undef, num_steps)

--- a/src/SamplingSchemes/wang_landau.jl
+++ b/src/SamplingSchemes/wang_landau.jl
@@ -112,8 +112,9 @@ function wang_landau(
     # Set the random seed
     Random.seed!(wl_params.random_seed)
 
-    # No liveset is built on this path, so run the shell-coverage check here
+    # No liveset is built on this path, so run the setup checks here
     AbstractLiveSets._warn_uncoupled_shells(lattice, h)
+    AbstractLiveSets._check_cluster_sites(h, lattice)
 
     energy_bins_count = length(wl_params.energy_bins)
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,8 @@ include("test-AnalysisTools.jl")
 
 include("test-EnergyEval.jl")
 
+include("test-EnergyEval-clusters.jl")
+
 include("test-MonteCarloMoves.jl")
 
 include("test-SamplingSchemes/test-SamplingSchemes.jl")

--- a/test/test-AbstractHamiltonians.jl
+++ b/test/test-AbstractHamiltonians.jl
@@ -126,4 +126,48 @@
         end
 
     end
+
+    @testset "ClusterInteraction and ClusterLatticeHamiltonian tests" begin
+        trio = ClusterInteraction(0.168u"eV", [(1, 2, 3), (2, 3, 4)])
+        @test trio.coupling == 0.168u"eV"
+        @test length(trio.embeddings) == 2
+        @test trio isa ClusterInteraction{3,typeof(1.0u"eV")}
+
+        quattro = ClusterInteraction(-0.120u"eV", [(1, 2, 5, 6)])
+        @test quattro isa ClusterInteraction{4,typeof(1.0u"eV")}
+
+        # Pair and on-site terms belong in the wrapped pair Hamiltonian
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV", [(1, 2)])
+        # Non-finite couplings
+        @test_throws ArgumentError ClusterInteraction(Inf * u"eV", [(1, 2, 3)])
+        # Canonical form: strictly increasing, positive, no duplicates
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV", [(2, 1, 3)])
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV", [(1, 1, 2)])
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV", [(0, 1, 2)])
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV",
+            [(1, 2, 3), (1, 2, 3)])
+        # Empty embedding lists contribute exactly zero and warn
+        @test_logs (:warn, r"exactly zero") match_mode = :any ClusterInteraction(
+            0.1u"eV", NTuple{3,Int}[])
+
+        pair = GenericLatticeHamiltonian(-1.249, [0.292, 0.090, -0.050, -0.010], u"eV")
+        h = ClusterLatticeHamiltonian(pair, [trio, quattro])
+        @test h isa ClusterLatticeHamiltonian{4,typeof(1.0u"eV")}
+        @test h.pair_ham === pair
+        @test length(h.clusters) == 2
+
+        # Coupling value type must match the pair Hamiltonian
+        trio_mev = ClusterInteraction(168.0u"meV", [(1, 2, 3)])
+        @test_throws ArgumentError ClusterLatticeHamiltonian(pair, [trio_mev])
+        # Non-ClusterInteraction elements are rejected
+        @test_throws ArgumentError ClusterLatticeHamiltonian(pair, [1.0])
+
+        # Show methods
+        buf = IOBuffer()
+        show(buf, h)
+        output = String(take!(buf))
+        @test contains(output, "ClusterLatticeHamiltonian")
+        @test contains(output, "ClusterInteraction{3}")
+        @test contains(output, "2 embeddings")
+    end
 end

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -46,10 +46,14 @@
         @test length(enumerate_motif_embeddings(sq8, [1.0, 1.0, 2.0];
                                                 expected_count=128)) == 128
 
-        # Unit-square quattro: one per plaquette
+        # Unit-square quattro via the template method: one per plaquette
         @test length(enumerate_motif_embeddings(sq8,
-            motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]);
-            expected_count=64)) == 64
+            [(0, 0), (1, 0), (0, 1), (1, 1)]; expected_count=64)) == 64
+        # The multiset method warns for K ≥ 4 (homometric figures share
+        # multisets); the unit square has no alias, so the counts agree
+        q_ms = @test_logs (:warn, r"[Hh]omometric") match_mode = :any enumerate_motif_embeddings(
+            sq8, motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]))
+        @test length(q_ms) == 64
 
         # Pair signature (K = 2) reproduces the nearest-neighbor shell as
         # unordered pairs: 2M on the square lattice
@@ -94,6 +98,40 @@
     end
 
     # ================================================================
+    @testset "homometric figures and tolerance semantics" begin
+        # A homometric pair: non-congruent quattros sharing one distance
+        # multiset. The template method separates the two families (each has
+        # a mirror stabilizer of order 2, hence 4M embeddings); the multiset
+        # method warns and enumerates both together.
+        sq10 = cluster_square(10)
+        A = [(0, 0), (1, 0), (0, 1), (2, 2)]
+        B = [(0, 0), (1, 0), (2, 1), (2, 2)]
+        @test motif_distances(A) ≈ motif_distances(B)
+        eA = enumerate_motif_embeddings(sq10, A; expected_count=400)
+        eB = enumerate_motif_embeddings(sq10, B; expected_count=400)
+        @test isempty(intersect(Set(eA), Set(eB)))
+        both = @test_logs (:warn, r"[Hh]omometric") match_mode = :any enumerate_motif_embeddings(
+            sq10, motif_distances(A))
+        @test length(both) == 800
+        @test Set(both) == union(Set(eA), Set(eB))
+
+        # Candidate pruning is a relaxation of acceptance: a distance within
+        # tol of a signature entry that was merged into a nearby uniq
+        # representative must still be found (regression: pruning at tol
+        # from the representative silently dropped it)
+        gen = MLattice{1,GenericLattice}(
+            [5.0 0.0 0.0; 0.0 5.0 0.0; 0.0 0.0 1.0],
+            [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.1, 0.0, 0.0)],
+            (1, 1, 1),
+            (false, false, false),
+            [2.2],
+            [[false, false, false]],
+            [true, true, true])
+        found = enumerate_motif_embeddings(gen, [1.0, 1.05, 2.1]; tol=0.06)
+        @test length(found) == 1   # sides (1.0, 1.1, 2.1) accepted elementwise
+    end
+
+    # ================================================================
     @testset "cluster energy evaluation" begin
         Random.seed!(139)
         L = 6
@@ -102,7 +140,7 @@
         t1_embs = enumerate_motif_embeddings(sq6,
             motif_distances([(0, 0), (1, 0), (0, 1)]); expected_count=4M)
         q_embs = enumerate_motif_embeddings(sq6,
-            motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]); expected_count=M)
+            [(0, 0), (1, 0), (0, 1), (1, 1)]; expected_count=M)
         V0, J1, J2 = -0.1, 0.05, 0.02
         Jt, Jq = 0.168, -0.120
         pair = GenericLatticeHamiltonian(V0, [J1, J2], u"eV")
@@ -190,20 +228,40 @@
             dy = min(mod(ja - jb, 4), mod(jb - ja, 4))
             return dx^2 + dy^2
         end
-        brute3 = Float64[]
+        brute3 = Dict{NTuple{3,Int},Float64}()
         for a in 1:16, b in (a+1):16, c in (b+1):16
             r2s = sort([d24(a, b), d24(a, c), d24(b, c)])
-            push!(brute3, 0.05 * count(==(1), r2s) +
-                          (r2s == [1, 1, 2] ? 0.168 : 0.0))
+            brute3[(a, b, c)] = 0.05 * count(==(1), r2s) +
+                                (r2s == [1, 1, 2] ? 0.168 : 0.0)
         end
-        lib3 = sort([ustrip(u"eV", e) for e in df_exact.energy])
-        @test length(lib3) == 560
-        @test maximum(abs.(lib3 .- sort(brute3))) < 1e-10
+        @test nrow(df_exact) == 560
+        # Configuration-resolved: each enumerated configuration's energy
+        # against the brute force keyed by its occupied sites (a multiset
+        # comparison could not detect energies permuted among configurations)
+        for row in eachrow(df_exact)
+            occ_sites = NTuple{3,Int}(findall(row.config[1]))
+            @test abs(ustrip(u"eV", row.energy) - brute3[occ_sites]) < 1e-10
+        end
 
         # A Hamiltonian built for a larger lattice fails fast at liveset
-        # construction instead of raising a BoundsError mid-run
+        # construction instead of raising a BoundsError mid-run — and at the
+        # raw-lattice sampler entry points, which never build a liveset
         w4 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
         @test_throws ArgumentError LatticeGasWalkers(w4, h)
+        wl_params = WangLandauParameters(energy_min=-8.0, energy_max=8.0,
+                                         num_energy_bins=30, num_steps=10,
+                                         max_iter=2, random_seed=7)
+        @test_throws ArgumentError wang_landau(deepcopy(lat4), h, wl_params)
+        @test_throws ArgumentError nvt_monte_carlo(MCNewSample(), deepcopy(lat4),
+                                                   h, 300.0, 5, 7)
+
+        # The converse mismatch — a Hamiltonian enumerated on a smaller
+        # lattice, all of whose indices exist on the bigger one — is
+        # undetectable from indices alone: construction succeeds and the
+        # embeddings are geometric nonsense. Documented caller
+        # responsibility: always enumerate on the lattice being sampled.
+        w6 = [LatticeWalker(deepcopy(sq6), energy=0.0u"eV", iter=0)]
+        @test LatticeGasWalkers(w6, h4) isa LatticeGasWalkers
     end
 
     # ================================================================
@@ -229,8 +287,7 @@
         function zhang_hamiltonian(L)
             lat = cluster_square(L; cutoffs=[1.1, 1.5, 2.1, 2.3])
             clusters = [ClusterInteraction(zhang_J[k] * u"eV",
-                            enumerate_motif_embeddings(lat,
-                                motif_distances(zhang_motifs[k]);
+                            enumerate_motif_embeddings(lat, zhang_motifs[k];
                                 expected_count=zhang_per_site[k] * L * L))
                         for k in keys(zhang_motifs)]
             ham = ClusterLatticeHamiltonian(
@@ -261,6 +318,13 @@
         set_phase!((i, j) -> iseven(i + j))
         @test interacting_energy(sq12, zhang).val ≈
               72 * (-1.249 + 2 * 0.090 + 2 * (-0.050) + 2 * 0.051) atol = 1e-10
+        # p(2×1) stripes (every other column), 72 adatoms: pins J1 and the
+        # linear t1 separately from t2 (per adatom: 1 vertical first-shell
+        # pair, 2 third-shell pairs, 2 fourth-shell pairs, 1 vertical t1
+        # trio; no √2 pairs, so t2, t3, t6, and q2 are all inactive)
+        set_phase!((i, j) -> i % 2 == 0)
+        @test interacting_energy(sq12, zhang).val ≈
+              72 * (-1.249 + 0.292 + 2 * (-0.050) + 2 * (-0.010) + 0.168) atol = 1e-10
         # (1×1), 144 adatoms: every figure at its per-site multiplicity
         sq12.components[1] .= true
         @test interacting_energy(sq12, zhang).val ≈

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -205,4 +205,105 @@
         w4 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
         @test_throws ArgumentError LatticeGasWalkers(w4, h)
     end
+
+    # ================================================================
+    @testset "Zhang O-Pd(100) m = 9 expansion: counts, adlayers, sampling" begin
+        # Figure geometry transcribed from Zhang, Blum & Reuter, PRB 75,
+        # 235406 (2007), Fig. 1 (arXiv:cond-mat/0701549). In the paper's own
+        # labeling, V^t_1 is the LINEAR (1, 1, 2) trio and V^t_2 the
+        # (1, 1, √2) right triangle; t3 is the scalene (1, √2, √5), t6 the
+        # diagonal linear (√2, √2, 2√2), and q2 the "hut"
+        # (0,0)-(1,0)-(2,0)+(1,1). FreeBird couplings are the negated GGA
+        # values of their Table III (positive = repulsive).
+        zhang_motifs = (
+            t1=[(0, 0), (1, 0), (2, 0)],
+            t2=[(0, 0), (1, 0), (0, 1)],
+            t3=[(0, 1), (1, 0), (2, 0)],
+            t6=[(0, 0), (1, 1), (2, 2)],
+            q2=[(0, 0), (1, 0), (2, 0), (1, 1)])
+        zhang_J = (t1=0.168, t2=-0.060, t3=0.048, t6=0.051, q2=-0.120)
+        # Embeddings per site under standard full-orbit counting: 8 divided
+        # by the order of the motif's point-group stabilizer
+        zhang_per_site = (t1=2, t2=4, t3=8, t6=2, q2=4)
+
+        function zhang_hamiltonian(L)
+            lat = cluster_square(L; cutoffs=[1.1, 1.5, 2.1, 2.3])
+            clusters = [ClusterInteraction(zhang_J[k] * u"eV",
+                            enumerate_motif_embeddings(lat,
+                                motif_distances(zhang_motifs[k]);
+                                expected_count=zhang_per_site[k] * L * L))
+                        for k in keys(zhang_motifs)]
+            ham = ClusterLatticeHamiltonian(
+                GenericLatticeHamiltonian(-1.249, [0.292, 0.090, -0.050, -0.010], u"eV"),
+                clusters)
+            return lat, ham
+        end
+
+        L12 = 12
+        M12 = L12 * L12
+        sq12, zhang = zhang_hamiltonian(L12)
+
+        # Ordered adlayers: closed forms from hand-derived per-adatom motif
+        # multiplicities (pins transcription, sign convention, and counting
+        # simultaneously)
+        set_phase!(pred) = (sq12.components[1] .=
+            [pred((s - 1) % L12, (s - 1) ÷ L12) for s in 1:M12])
+
+        # (3×3), 16 adatoms, no neighbor within √5: on-site only
+        set_phase!((i, j) -> i % 3 == 0 && j % 3 == 0)
+        @test interacting_energy(sq12, zhang).val ≈ 16 * (-1.249) atol = 1e-10
+        # p(2×2), 36 adatoms: 2 third-shell pairs per adatom, no multi-body
+        set_phase!((i, j) -> i % 2 == 0 && j % 2 == 0)
+        @test interacting_energy(sq12, zhang).val ≈
+              36 * (-1.249 + 2 * (-0.050)) atol = 1e-10
+        # c(2×2), 72 adatoms: 2 second- and 2 third-shell pairs plus 2
+        # diagonal-linear t6 trios per adatom
+        set_phase!((i, j) -> iseven(i + j))
+        @test interacting_energy(sq12, zhang).val ≈
+              72 * (-1.249 + 2 * 0.090 + 2 * (-0.050) + 2 * 0.051) atol = 1e-10
+        # (1×1), 144 adatoms: every figure at its per-site multiplicity
+        sq12.components[1] .= true
+        @test interacting_energy(sq12, zhang).val ≈
+              144 * (-1.249 +
+                     2 * 0.292 + 2 * 0.090 + 2 * (-0.050) + 4 * (-0.010) +
+                     2 * 0.168 + 4 * (-0.060) + 8 * 0.048 + 2 * 0.051 +
+                     4 * (-0.120)) atol = 1e-10
+
+        # The Θ ≤ 1/2 closed forms also match the paper's Table I DFT
+        # binding energies to ≤ 2 meV per adatom under this counting
+        # convention. The dense phases ((2×2)-3O, (1×1)) follow a different
+        # multiplicity convention in the paper and are deliberately not
+        # asserted against Table I.
+        for (pred, n_ad, Eb_table) in (
+                ((i, j) -> i % 3 == 0 && j % 3 == 0, 16, 1.249),
+                ((i, j) -> i % 2 == 0 && j % 2 == 0, 36, 1.348),
+                ((i, j) -> iseven(i + j), 72, 1.069))
+            set_phase!(pred)
+            @test isapprox(-interacting_energy(sq12, zhang).val / n_ad, Eb_table;
+                           atol=0.003)
+        end
+
+        # The full Zhang Hamiltonian runs in GC-NS unmodified: seeded igref
+        # run on 6×6, live-set energies match direct recomputation
+        Random.seed!(1390)
+        sq6z, z6 = zhang_hamiltonian(6)
+        walkers = [LatticeWalker(deepcopy(sq6z), energy=0.0u"eV", iter=0)
+                   for _ in 1:20]
+        ls = LatticeGasWalkers(walkers, z6; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=20, reference_fugacity=1.0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        save = SaveEveryN("t_zh.csv", "t_zh.traj", "t_zh.ls",
+                          1000000, 1000000, 1000000)
+        df, fls, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(150),
+            MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3), save)
+        rm.(["t_zh.csv", "t_zh.traj", "t_zh.ls"], force=true)
+        @test nrow(df) > 0
+        for w in fls.walkers
+            @test isapprox(w.energy.val,
+                           interacting_energy(w.configuration, z6).val;
+                           atol=1e-8)
+        end
+    end
 end

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -1,0 +1,95 @@
+@testset "Cluster lattice Hamiltonian tests" begin
+    using Random
+
+    cluster_square(L; cutoffs=[1.1, 1.5]) = MLattice{1,SquareLattice}(
+        lattice_constant=1.0,
+        basis=[(0.0, 0.0, 0.0)],
+        supercell_dimensions=(L, L, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=cutoffs,
+        components=[[false for _ in 1:L*L]],
+        adsorptions=:full)
+
+    cluster_triangular(nx, ny) = MLattice{1,TriangularLattice}(
+        lattice_constant=1.0,
+        supercell_dimensions=(nx, ny, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1],
+        components=:equal,
+        adsorptions=:full)
+
+    # ================================================================
+    @testset "motif_distances" begin
+        @test motif_distances([(0, 0), (1, 0), (0, 1)]) ≈ [1.0, 1.0, sqrt(2)]
+        @test motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]) ≈
+              [1.0, 1.0, 1.0, 1.0, sqrt(2), sqrt(2)]
+        @test motif_distances([(0.0, 0.0, 0.0), (0.0, 0.0, 2.0)]) ≈ [2.0]
+        @test_throws ArgumentError motif_distances([(0, 0)])
+    end
+
+    # ================================================================
+    @testset "embedding counts on faithful cells" begin
+        sq8 = cluster_square(8)
+
+        # Right isoceles trio (1, 1, √2): four per plaquette
+        t1 = enumerate_motif_embeddings(sq8, motif_distances([(0, 0), (1, 0), (0, 1)]);
+                                        expected_count=256)
+        @test length(t1) == 256
+        counts = zeros(Int, 64)
+        for e in t1, s in e
+            counts[s] += 1
+        end
+        @test all(==(12), counts)   # per-site membership is uniform
+        @test all(e -> e[1] < e[2] < e[3], t1)   # canonical form
+
+        # Linear trio (1, 1, 2): two orientations per site pair
+        @test length(enumerate_motif_embeddings(sq8, [1.0, 1.0, 2.0];
+                                                expected_count=128)) == 128
+
+        # Unit-square quattro: one per plaquette
+        @test length(enumerate_motif_embeddings(sq8,
+            motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]);
+            expected_count=64)) == 64
+
+        # Pair signature (K = 2) reproduces the nearest-neighbor shell as
+        # unordered pairs: 2M on the square lattice
+        @test length(enumerate_motif_embeddings(sq8, [1.0];
+                                                expected_count=128)) == 128
+
+        # Triangular lattice, faithful cell: faces and linear trios
+        tri44 = cluster_triangular(4, 4)   # M = 32
+        @test length(enumerate_motif_embeddings(tri44, [1.0, 1.0, 1.0];
+                                                expected_count=64)) == 64
+        # (1, 1, 2) has K·d_max = 6 > C_x = 4: the wrap warning fires, and
+        # the torus-convention count still equals 3M (ring-of-four subsets
+        # coincide with the consecutive triples)
+        tri_lin = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            tri44, [1.0, 1.0, 2.0])
+        @test length(tri_lin) == 96
+
+        # expected_count mismatches throw
+        @test_throws ArgumentError enumerate_motif_embeddings(
+            sq8, [1.0, 1.0, sqrt(2)]; expected_count=999)
+        # Signature-length and value validation
+        @test_throws ArgumentError enumerate_motif_embeddings(sq8, [1.0, 1.0])
+        @test_throws ArgumentError enumerate_motif_embeddings(sq8, [1.0, 1.0, -2.0])
+        @test_throws ArgumentError enumerate_motif_embeddings(sq8, [1.0, 1.0, 2.0]; tol=0.0)
+    end
+
+    # ================================================================
+    @testset "wrap-around pathology (torus convention)" begin
+        # The 18-site triangular cell: 36 faces plus 6 winding three-cycles,
+        # the Study V5 diagnostic number, with the wrap warning
+        tri33 = cluster_triangular(3, 3)   # M = 18
+        t = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            tri33, [1.0, 1.0, 1.0])
+        @test length(t) == 42
+
+        # Square 4×4 with the linear trio: distance 2 = C/2 ties; the count
+        # equals every 3-subset of each 4-ring, which coincides with 2M here
+        sq4 = cluster_square(4)
+        t4 = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            sq4, [1.0, 1.0, 2.0])
+        @test length(t4) == 32
+    end
+end

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -92,4 +92,117 @@
             sq4, [1.0, 1.0, 2.0])
         @test length(t4) == 32
     end
+
+    # ================================================================
+    @testset "cluster energy evaluation" begin
+        Random.seed!(139)
+        L = 6
+        M = L * L
+        sq6 = cluster_square(L)
+        t1_embs = enumerate_motif_embeddings(sq6,
+            motif_distances([(0, 0), (1, 0), (0, 1)]); expected_count=4M)
+        q_embs = enumerate_motif_embeddings(sq6,
+            motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]); expected_count=M)
+        V0, J1, J2 = -0.1, 0.05, 0.02
+        Jt, Jq = 0.168, -0.120
+        pair = GenericLatticeHamiltonian(V0, [J1, J2], u"eV")
+        h = ClusterLatticeHamiltonian(pair,
+            [ClusterInteraction(Jt * u"eV", t1_embs),
+             ClusterInteraction(Jq * u"eV", q_embs)])
+
+        # Empty lattice, single site, and full lattice (closed forms: every
+        # site has 4 first- and 4 second-shell neighbors, 4M trio and M
+        # quattro embeddings are all occupied)
+        sq6.components[1] .= false
+        @test interacting_energy(sq6, h) == 0.0u"eV"
+        sq6.components[1][1] = true
+        @test interacting_energy(sq6, h) ≈ V0 * u"eV" atol = 1e-14 * u"eV"
+        sq6.components[1] .= true
+        E_full = M * (V0 + 2J1 + 2J2) + 4M * Jt + M * Jq
+        @test interacting_energy(sq6, h) ≈ E_full * u"eV" atol = 1e-10 * u"eV"
+
+        # 50 random configurations against an independent brute force that
+        # classifies pairs, trios, and quattros by integer squared
+        # minimum-image distances; no code shared with the enumerator
+        coord(s) = ((s - 1) % L, (s - 1) ÷ L)
+        function d2(a, b)
+            (ia, ja) = coord(a)
+            (ib, jb) = coord(b)
+            dx = min(mod(ia - ib, L), mod(ib - ia, L))
+            dy = min(mod(ja - jb, L), mod(jb - ja, L))
+            return dx^2 + dy^2
+        end
+        function brute_E(occ)
+            s = findall(occ)
+            n = length(s)
+            E = V0 * n
+            for x in 1:n, y in (x+1):n
+                r2 = d2(s[x], s[y])
+                r2 == 1 && (E += J1)
+                r2 == 2 && (E += J2)
+            end
+            for x in 1:n, y in (x+1):n, z in (y+1):n
+                r2s = sort([d2(s[x], s[y]), d2(s[x], s[z]), d2(s[y], s[z])])
+                r2s == [1, 1, 2] && (E += Jt)
+            end
+            for w in 1:n, x in (w+1):n, y in (x+1):n, z in (y+1):n
+                q = (s[w], s[x], s[y], s[z])
+                r2s = sort([d2(q[a], q[b]) for a in 1:4 for b in (a+1):4])
+                r2s == [1, 1, 1, 1, 2, 2] && (E += Jq)
+            end
+            return E
+        end
+        for _ in 1:50
+            occ = rand(M) .< 0.5
+            sq6.components[1] .= occ
+            @test interacting_energy(sq6, h).val ≈ brute_E(occ) atol = 1e-10
+        end
+
+        # Translation and point-group images leave the energy unchanged
+        occ0 = rand(M) .< 0.5
+        translate(occ) = [occ[((i0 + 1) % L) + j0 * L + 1]
+                          for j0 in 0:L-1 for i0 in 0:L-1]
+        rotate(occ) = [occ[j0 + ((L - i0) % L) * L + 1]
+                       for j0 in 0:L-1 for i0 in 0:L-1]
+        sq6.components[1] .= occ0
+        E0 = interacting_energy(sq6, h).val
+        sq6.components[1] .= translate(occ0)
+        @test interacting_energy(sq6, h).val ≈ E0 atol = 1e-12
+        sq6.components[1] .= rotate(occ0)
+        @test interacting_energy(sq6, h).val ≈ E0 atol = 1e-12
+
+        # Fixed-N exact enumeration with a trio term: full N = 3 spectrum on
+        # 4×4 against a hand-rolled triple loop
+        lat4 = cluster_square(4)
+        t1_4 = enumerate_motif_embeddings(lat4,
+            motif_distances([(0, 0), (1, 0), (0, 1)]); expected_count=64)
+        h4 = ClusterLatticeHamiltonian(
+            GenericLatticeHamiltonian(0.0, [0.05, 0.0], u"eV"),
+            [ClusterInteraction(0.168u"eV", t1_4)])
+        lat4.components[1] .= false
+        lat4.components[1][1:3] .= true
+        df_exact, _ = exact_enumeration(lat4, h4)
+        coord4(s) = ((s - 1) % 4, (s - 1) ÷ 4)
+        function d24(a, b)
+            (ia, ja) = coord4(a)
+            (ib, jb) = coord4(b)
+            dx = min(mod(ia - ib, 4), mod(ib - ia, 4))
+            dy = min(mod(ja - jb, 4), mod(jb - ja, 4))
+            return dx^2 + dy^2
+        end
+        brute3 = Float64[]
+        for a in 1:16, b in (a+1):16, c in (b+1):16
+            r2s = sort([d24(a, b), d24(a, c), d24(b, c)])
+            push!(brute3, 0.05 * count(==(1), r2s) +
+                          (r2s == [1, 1, 2] ? 0.168 : 0.0))
+        end
+        lib3 = sort([ustrip(u"eV", e) for e in df_exact.energy])
+        @test length(lib3) == 560
+        @test maximum(abs.(lib3 .- sort(brute3))) < 1e-10
+
+        # A Hamiltonian built for a larger lattice fails fast at liveset
+        # construction instead of raising a BoundsError mid-run
+        w4 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+        @test_throws ArgumentError LatticeGasWalkers(w4, h)
+    end
 end


### PR DESCRIPTION
Closes #139.

## Why

Lattice Hamiltonians supported only on-site and pair-shell terms, while published lattice-gas Hamiltonians for real adsorbate systems routinely carry multi-body figures: the optimum m = 9 expansion for O-Pd(100) of Zhang, Blum & Reuter (PRB 75, 235406 (2007)) has four pair shells, four trios, and one quattro, and the O/Pt(111) cluster expansions of Schmidt et al. (J. Chem. Theory Comput. 8, 264 (2012)) and Wu et al. (J. Catal. 286, 88 (2012)) use pairs to the eighth neighbor plus two triplet motifs on a triangular lattice.

## What

- `ClusterInteraction{K,U}`: one coupling (energy per fully occupied embedding) plus explicit embeddings in canonical strictly increasing form, so each unordered site set appears exactly once. `ClusterLatticeHamiltonian{N,U}` wraps an unchanged `GenericLatticeHamiltonian` pair part and adds figures of arbitrary orders K ≥ 3.
- `enumerate_motif_embeddings`: declares a motif by its pairwise minimum-image distance multiset or, recommended for K ≥ 4, by a coordinate template whose full distance matrix is matched under site permutation (distance multisets do not determine a figure for K ≥ 4, and the multiset method warns about such homometric figures). Uses the same minimum-image kernel as `compute_neighbors` (now factored into a shared helper), so embeddings and pair shells follow the identical torus convention. Diagnostics: per-site-uniformity warning, an `expected_count` assertion against hand-derived multiplicities, and a faithful-quotient warning based on the shortest periodic translation.
- `cluster_energy` and `interacting_energy(::SLattice, ::ClusterLatticeHamiltonian)`: the new Hamiltonian works in every sampler that evaluates lattice energies generically, with zero sampler changes. Mismatched Hamiltonians fail fast at liveset construction and at the raw-lattice `wang_landau`/`nvt_monte_carlo` entry points.

Note: the paper's own Fig. 1 labeling has V<sup>t</sup><sub>1</sub> as the linear (1, 1, 2) trio and V<sup>t</sup><sub>2</sub> as the (1, 1, √2) right triangle, correcting the guess in #139's text.

## Compatibility

Purely additive. The `compute_neighbors` refactor is behavior-identical; the full pre-existing suite passes unchanged.

## Validation

- Exact embedding counts with per-site-uniformity assertions on faithful cells, plus the pathological cells: the 18-site triangular cell's 42 nearest-neighbor triangles (36 faces + 6 winding three-cycles) and the 4×4 four-ring coincidence.
- A constructed homometric quattro pair: the template method separates the two 400-embedding families; the multiset method returns exactly their union with a warning.
- Energy exactness: closed-form empty/single/full-lattice energies; 50 random configurations and the complete fixed-N spectrum (configuration-resolved, 560 configurations) against independent integer-arithmetic brute forces sharing no code with the enumerator; translation and point-group invariance.
- Zhang m = 9 end to end: figure geometries transcribed from Fig. 1, multiplicities 2/4/8/2/4 pinned by `expected_count`, closed-form adlayer energies for (3×3), p(2×2), c(2×2), p(2×1) stripes, and (1×1) from hand-derived per-adatom multiplicities; the phases at coverages Θ ≤ 1/2 additionally reproduce the paper's Table I to ≤ 2 meV per adatom (the dense phases follow a different multiplicity convention in the paper and are deliberately not asserted). A seeded ideal-gas-referenced GC-NS run with the full Hamiltonian matches direct energy recomputation.
- An adversarial review pass produced eight findings (homometric aliasing, tolerance semantics, sheared-cell wrap guard, sampler entry points, four test strengthenings), all folded in. Full test suite passes.
