### PR TITLE
Add order_parameter_sqrt3: a (√3×√3)R30° three-sublattice order parameter for the triangular lattice

### DIFF
--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -26,6 +26,7 @@ export MLattice, SLattice, GLattice
 export update_walker!
 export num_sites, occupied_site_count
 export order_parameter_c2x2
+export order_parameter_sqrt3
 export enumerate_motif_embeddings, motif_distances
 export view_structure
 

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -478,6 +478,89 @@ function order_parameter_c2x2(lattice::MLattice{1,SquareLattice})
 end
 
 """
+    order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice}) -> Float64
+
+Three-sublattice order parameter for (√3×√3)R30° ordering on a
+single-component triangular lattice:
+
+    Ψ = |Σ_{occupied sites} ω^{c(s)}| / M,   ω = e^{2πi/3},
+
+where `c(s) ∈ {0,1,2}` is the site's sublattice label under the standard
+tripartition of the triangular lattice and `M` is the number of sites. This
+is the modulus of the complex three-state Potts order parameter: the Z₃
+phase distinguishing the three degenerate ordered states is divided out, so
+all three give the same value. A perfect √3×√3 arrangement at coverage 1/3
+gives `1/3`; the empty and the full lattice give `0` (1 + ω + ω² = 0).
+
+Ψ is not a function of `(E, N)`: degenerate energy levels contain ordered
+and disordered configurations alike, so it must be evaluated on
+configurations (e.g. per culled walker, via the `observables` keyword of
+the nested-sampling loops). Higher moments for Binder-cumulant analysis are
+composed caller-side, with no library change:
+
+    observables = [:psi  => order_parameter_sqrt3,
+                   :psi2 => cfg -> order_parameter_sqrt3(cfg)^2,
+                   :psi4 => cfg -> order_parameter_sqrt3(cfg)^4]
+
+after which ⟨Ψ⟩, ⟨Ψ²⟩, ⟨Ψ⁴⟩ come from `observable_cols=[:psi, :psi2, :psi4]`
+in the grand-canonical stats functions.
+
+Requires the standard two-site centered-rectangular triangular basis
+`[(0, 0, 0), (a/2, √3·a/2, 0)]` consistent with the lattice vectors, a
+strictly two-dimensional supercell (`supercell_dimensions[3] == 1`), and
+`supercell_dimensions[1]` divisible by 3 (the tripartition closes on the
+periodic cell iff the a₁ circumference is a multiple of 3; the a₂ dimension
+is unconstrained); violations throw an `ArgumentError`. Note the shipped
+default `supercell_dimensions = (4, 2, 1)` is *not* commensurate.
+"""
+function order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice})
+    if length(lattice.basis) != 2
+        throw(ArgumentError("order_parameter_sqrt3 requires the two-site " *
+            "centered-rectangular triangular basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
+    ax, ay = lattice.lattice_vectors[1, 1], lattice.lattice_vectors[2, 2]
+    b1, b2 = lattice.basis
+    if !(isapprox(b1[1], 0.0, atol=1e-9) && isapprox(b1[2], 0.0, atol=1e-9) &&
+         isapprox(b2[1], ax / 2, atol=1e-9) && isapprox(b2[2], ay / 2, atol=1e-9))
+        throw(ArgumentError("order_parameter_sqrt3 requires the standard " *
+            "triangular basis [(0, 0, 0), (a/2, √3·a/2, 0)] consistent with " *
+            "the lattice vectors, got $(lattice.basis)"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("order_parameter_sqrt3 requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    if d1 % 3 != 0
+        throw(ArgumentError("order_parameter_sqrt3 requires " *
+            "supercell_dimensions[1] divisible by 3 so the three √3×√3 " *
+            "sublattices close on the periodic cell, got $d1"))
+    end
+    occ = lattice.components[1]
+    # Sublattice occupations n[c+1], c ∈ {0,1,2}. lattice_positions ordering:
+    # basis innermost, dimension 1 next. In triangular integer coordinates
+    # (m, n) with r = m·t₁ + n·t₂, a valid tripartition is c = (m − n) mod 3;
+    # the basis-0 site of cell column ci sits at (ci − cj, 2cj), giving
+    # c = ci mod 3, and the basis-1 site adds one t₂ step, giving
+    # c = (ci + 2) mod 3. Wrapping the a₁ circumference shifts c by d1 mod 3,
+    # hence the commensurability guard above.
+    n = zeros(Int, 3)
+    for s in eachindex(occ)
+        occ[s] || continue
+        b = (s - 1) % 2
+        ci = ((s - 1) ÷ 2) % d1
+        c = b == 0 ? ci % 3 : (ci + 2) % 3
+        n[c+1] += 1
+    end
+    M = 2 * d1 * d2
+    # |n₀ + n₁·ω + n₂·ω²|² = n₀² + n₁² + n₂² − n₀n₁ − n₁n₂ − n₂n₀, exact in
+    # integers; one final square root, no complex arithmetic.
+    s2 = n[1]^2 + n[2]^2 + n[3]^2 - n[1] * n[2] - n[2] * n[3] - n[3] * n[1]
+    return sqrt(Float64(s2)) / M
+end
+
+"""
     motif_distances(coords::AbstractVector{<:Tuple}) -> Vector{Float64}
 
 Sorted multiset of the pairwise Euclidean distances of a coordinate

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -73,6 +73,173 @@
     obs_cleanup() = rm.(["t_obs.csv", "t_obs.traj", "t_obs.ls"], force=true)
     count_N(cfg) = Float64(sum(cfg.components[1]))
 
+    # ================================================================
+    @testset "order_parameter_sqrt3" begin
+        # Shared single-component triangular-lattice builder (NN shell only)
+        function obs_tri_lattice(d1, d2)
+            MLattice{1,TriangularLattice}(
+                lattice_constant=1.0,
+                supercell_dimensions=(d1, d2, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1],
+                components=[[false for _ in 1:2*d1*d2]],
+                adsorptions=:full)
+        end
+
+        # Independent geometric decoder: recover the triangular integer
+        # coordinates (m, n) by inverting [t1 t2] on the stored positions and
+        # color with c = (m - n) mod 3, so the labels are derived from the
+        # geometry rather than from the index arithmetic under test
+        function sqrt3_labels(lat)
+            a = lat.lattice_vectors[1, 1]
+            map(1:size(lat.positions, 1)) do s
+                x, y = lat.positions[s, 1], lat.positions[s, 2]
+                n = round(Int, 2 * y / (sqrt(3) * a))
+                m = round(Int, x / a - n / 2)
+                mod(m - n, 3)
+            end
+        end
+
+        for (d1, d2) in [(3, 3), (6, 2)]
+            lat = obs_tri_lattice(d1, d2)
+            M = 2 * d1 * d2
+            labels = sqrt3_labels(lat)
+            # The hardcoded decoder inside order_parameter_sqrt3, recomputed
+            # here, must match the geometric labels site by site
+            hard = [begin
+                        b = (s - 1) % 2
+                        ci = ((s - 1) ÷ 2) % d1
+                        b == 0 ? ci % 3 : (ci + 2) % 3
+                    end for s in 1:M]
+            @test labels == hard
+            # Each sublattice holds exactly M/3 sites
+            @test [count(==(c), labels) for c in 0:2] == fill(M ÷ 3, 3)
+            # A proper 3-coloring: no first-shell neighbor pair shares a
+            # label (this also pins the neighbor lists)
+            @test all(labels[nb] != labels[s]
+                      for s in 1:M for nb in lat.neighbors[s][1])
+        end
+
+        # Exact values on the 18-site commensurate cell
+        lat = obs_tri_lattice(3, 3)
+        labels = sqrt3_labels(lat)
+
+        # Empty and full lattices carry no sqrt3 order (1 + ω + ω² = 0)
+        @test order_parameter_sqrt3(lat) == 0.0
+        lat.components[1] .= true
+        @test order_parameter_sqrt3(lat) == 0.0
+
+        # Each pure sublattice state, built from the geometric labels: 1/3
+        for c in 0:2
+            lat.components[1] .= (labels .== c)
+            @test order_parameter_sqrt3(lat) == 1 / 3
+        end
+
+        # Single particle: 1/M
+        lat.components[1] .= false
+        lat.components[1][1] = true
+        @test order_parameter_sqrt3(lat) == 1 / 18
+
+        # Mixed state with sublattice counts (2, 1, 0): |2 + ω| / 18 = √3/18
+        lat.components[1] .= false
+        a_sites = findall(==(0), labels)
+        b_sites = findall(==(1), labels)
+        lat.components[1][a_sites[1]] = true
+        lat.components[1][a_sites[2]] = true
+        lat.components[1][b_sites[1]] = true
+        @test order_parameter_sqrt3(lat) ≈ sqrt(3) / 18 rtol = 1e-12
+
+        # The shipped default (4, 2, 1) cell is incommensurate: d1 % 3 != 0
+        @test_throws ArgumentError order_parameter_sqrt3(obs_tri_lattice(4, 2))
+
+        # Three-dimensional supercell
+        lat3d = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(3, 3, 2),
+            periodicity=(true, true, true),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:36]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_sqrt3(lat3d)
+
+        # One-site basis
+        lat1b = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(3, 3, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:9]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_sqrt3(lat1b)
+
+        # A distorted basis breaks the tripartition arithmetic
+        latdb = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.3, 0.3, 0.0)],
+            supercell_dimensions=(3, 3, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:18]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_sqrt3(latdb)
+
+        # lattice_constant != 1 scales lattice_vectors but not the default
+        # basis, so the geometry is no longer triangular; the basis-values
+        # guard rejects it
+        latlc = MLattice{1,TriangularLattice}(
+            lattice_constant=2.0,
+            supercell_dimensions=(3, 3, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.2],
+            components=[[false for _ in 1:18]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_sqrt3(latlc)
+
+        # A short seeded canonical NS run records psi and its square through
+        # the moment-callback pattern from the docstring
+        Random.seed!(21)
+        tri_ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        walkers = [LatticeWalker(deepcopy(obs_tri_lattice(3, 3)),
+                                 energy=0.0u"eV", iter=0) for _ in 1:20]
+        # Fixed-N ladder at N = 6: place 6 particles per walker
+        for w in walkers
+            occ = vcat(fill(true, 6), fill(false, 12))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls = LatticeGasWalkers(walkers, tri_ham; perturb_energy=1e-9)
+        params = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+
+        df, _, _ = nested_sampling(ls, params, Int64(200),
+            MCRandomWalkClone(), obs_save;
+            observables=[:psi => order_parameter_sqrt3,
+                         :psi2 => (cfg -> order_parameter_sqrt3(cfg)^2)])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "psi", "psi2"]
+        @test all(0.0 .<= df.psi .<= 1 / 3)
+        @test all(isapprox.(df.psi2, df.psi .^ 2; rtol=1e-12))
+
+        # Schema is unchanged when observables are not requested
+        Random.seed!(21)
+        walkers2 = [LatticeWalker(deepcopy(obs_tri_lattice(3, 3)),
+                                  energy=0.0u"eV", iter=0) for _ in 1:20]
+        for w in walkers2
+            occ = vcat(fill(true, 6), fill(false, 12))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls2 = LatticeGasWalkers(walkers2, tri_ham; perturb_energy=1e-9)
+        params2 = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+        df2, _, _ = nested_sampling(ls2, params2, Int64(50),
+            MCRandomWalkClone(), obs_save)
+        obs_cleanup()
+        @test names(df2) == ["iter", "emax"]
+    end
+
     @testset "observable hook: validation" begin
         lat = obs_square_lattice(4, 4)
         walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:8]


### PR DESCRIPTION
Implements #144.

## What

- `order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice}) -> Float64`, a sibling of `order_parameter_c2x2`: the modulus of the complex three-state Potts order parameter Ψ = |Σ<sub>occ</sub> ω<sup>c(s)</sup>|/M for (√3×√3)R30° ordering, evaluated through an exact integer identity with one final square root (no complex arithmetic). Unnormalized, mirroring the c(2×2) convention: a perfect √3×√3 arrangement at coverage 1/3 gives 1/3; the empty and the full lattice give 0.
- The sublattice decoder is hardcoded from the centered-rectangular two-site representation (basis-0 label ci mod 3, basis-1 label (ci + 2) mod 3), with the derivation in a source comment. The modulus is invariant under the Z₃ phase, so the three degenerate ordered states give the same value.
- Guards, all `ArgumentError`: a non-two-site basis; basis values inconsistent with the lattice vectors (this also rejects `lattice_constant ≠ 1` with the unscaled default basis, which is not a triangular geometry); `supercell_dimensions[3] ≠ 1`; and `supercell_dimensions[1]` not divisible by 3 (the tripartition closes on the torus iff the a<sub>1</sub> circumference is a multiple of 3; the shipped default `(4, 2, 1)` cell is incommensurate and throws).
- The docstring shows the moment-callback pattern (`psi`/`psi2`/`psi4` as separate observables) for Binder-cumulant analysis through the existing grand-canonical stats functions, with no stats-layer change.

## Tests

- An independent geometric decoder (inverting [t<sub>1</sub> t<sub>2</sub>] on the stored positions) reproduces the hardcoded labels site by site on `(3, 3, 1)` and `(6, 2, 1)`; each sublattice holds exactly M/3 sites; no first-shell neighbor pair shares a label (a proper 3-coloring, which also pins the neighbor lists).
- Exact values on the 18-site commensurate cell: the empty and the full lattice give exactly 0, each of the three pure sublattice states gives exactly 1/3, a single particle gives exactly 1/18, and a (2, 1, 0) mixed state gives √3/18.
- Every guard path, including the default incommensurate `(4, 2, 1)` cell and the `lattice_constant = 2.0` quirk.
- A short seeded canonical nested-sampling run records `psi` and `psi2` per culled walker: 0 ≤ Ψ ≤ 1/3 throughout, `psi2` equals `psi` squared row by row, and the ledger schema is unchanged when observables are not requested.

An adversarial review pass independently re-derived the decoder (including the torus-closure argument: the a<sub>2</sub> dimension is unconstrained) and the modulus identity, and produced no findings. Full test suite passes (SamplingSchemes 1189, Monte Carlo Moves 1946, FreeBirdIO 51).
