### PR TITLE
Geometric cluster moves on the triangular lattice

### DIFF
--- a/src/MonteCarloMoves/cluster_moves.jl
+++ b/src/MonteCarloMoves/cluster_moves.jl
@@ -47,7 +47,8 @@ function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64)
     seed = rand(1:n_sites)
 
     # Build cluster via BFS with fixed growth probability
-    cluster = _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, Lz, p)
+    reflect = s -> _reflect_site(s, pivot_gx, pivot_gy, Lx, Ly, Lz)
+    cluster = _build_geometric_cluster(lattice, seed, reflect, p)
 
     # Swap occupation states for each (site, reflected_site) pair
     for (a, b) in cluster
@@ -103,16 +104,17 @@ is preserved (no reflection in the non-periodic z direction).
 end
 
 """
-    _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, Lz, p) -> Vector{Tuple{Int,Int}}
+    _build_geometric_cluster(lattice, seed, reflect, p) -> Vector{Tuple{Int,Int}}
 
-Grow a geometric cluster from `seed` using BFS with fixed growth probability `p`.
+Grow a geometric cluster from `seed` using BFS with fixed growth probability `p`,
+pairing each visited site with its image under the `reflect` closure (a
+self-inverse site-index map supplied by the geometry-specific caller).
 Returns a vector of (site, reflected_site) pairs.
 """
-function _build_geometric_cluster(lattice::MLattice{C,SquareLattice},
+function _build_geometric_cluster(lattice::MLattice,
                                   seed::Int,
-                                  pivot_gx::Int, pivot_gy::Int,
-                                  Lx::Int, Ly::Int, Lz::Int,
-                                  p::Float64) where C
+                                  reflect::F,
+                                  p::Float64) where {F}
     visited = Set{Int}()
     stack = Int[seed]
     cluster = Tuple{Int,Int}[]
@@ -123,7 +125,7 @@ function _build_geometric_cluster(lattice::MLattice{C,SquareLattice},
         s in visited && continue
 
         push!(visited, s)
-        r = _reflect_site(s, pivot_gx, pivot_gy, Lx, Ly, Lz)
+        r = reflect(s)
         push!(visited, r)
         push!(cluster, (s, r))
 
@@ -136,4 +138,124 @@ function _build_geometric_cluster(lattice::MLattice{C,SquareLattice},
     end
 
     return cluster
+end
+
+# --- Triangular lattice (two-site centered-rectangular basis) ---
+
+"""
+    _tri_site_to_halfgrid(site::Int, nx::Int) -> Tuple{Int,Int}
+
+Half-grid coordinates (hx, hy) = (2·ci + b, 2·cj + b) of a site on the
+two-site-basis triangular lattice, in units of a/2 and √3·a/2, where
+b = basis index and (ci, cj) the 0-indexed cell. Under the standard site
+ordering (basis innermost, dimension 1 next), the site set is exactly
+{(hx, hy) : hx ≡ hy (mod 2)} on the (2·nx, 2·ny) torus — the
+centered-rectangular condition.
+"""
+@inline function _tri_site_to_halfgrid(site::Int, nx::Int)
+    s = site - 1
+    b = s % 2
+    cell = s ÷ 2
+    ci = cell % nx
+    cj = cell ÷ nx
+    return (2 * ci + b, 2 * cj + b)
+end
+
+"""
+    _tri_halfgrid_to_site(hx::Int, hy::Int, nx::Int) -> Int
+
+Inverse of [`_tri_site_to_halfgrid`](@ref) for in-range half-grid
+coordinates with hx ≡ hy (mod 2).
+"""
+@inline function _tri_halfgrid_to_site(hx::Int, hy::Int, nx::Int)
+    b = hx & 1
+    ci = (hx - b) >> 1
+    cj = (hy - b) >> 1
+    return b + 2 * (ci + nx * cj) + 1
+end
+
+"""
+    _tri_reflect_site(site::Int, hpx::Int, hpy::Int, nx::Int, ny::Int) -> Int
+
+Point inversion of `site` through the pivot whose doubled half-grid
+position is (hpx, hpy) = h(s₁) + h(s₂) for two pivot sites s₁, s₂, with
+periodic wrapping: σ(h) = (hpx, hpy) − h mod (2·nx, 2·ny). Both pivot
+sites satisfy hx ≡ hy (mod 2), so hpx ≡ hpy (mod 2) and σ preserves the
+parity difference — the reflected point is always a site. Site pivots
+(s₁ = s₂, hpx even) preserve each site's basis index; midpoint pivots
+with hpx odd exchange the two basis sublattices. σ is an involution:
+σ(σ(h)) = h.
+"""
+@inline function _tri_reflect_site(site::Int, hpx::Int, hpy::Int, nx::Int, ny::Int)
+    hx, hy = _tri_site_to_halfgrid(site, nx)
+    rx = mod(hpx - hx, 2 * nx)
+    ry = mod(hpy - hy, 2 * ny)
+    return _tri_halfgrid_to_site(rx, ry, nx)
+end
+
+"""
+    geometric_cluster_swap!(lattice::MLattice{C,TriangularLattice}, p::Float64) where C
+
+Geometric cluster move on the two-site-basis triangular lattice by point
+inversion through a random centrosymmetry center.
+
+The pivot is the midpoint of two random sites drawn with replacement,
+which covers exactly the two families of inversion centers of the
+triangular lattice (sites and half-lattice midpoints) and can never
+produce an invalid pivot: plaquette centers, whose doubled position is
+not a lattice vector, are unreachable by construction. The reflection
+runs in integer half-grid coordinates ((hx, hy) = (2·ci + b, 2·cj + b) on
+the (2·nx, 2·ny) torus), so no floating-point rounding or lookup table is
+involved. Cluster growth and the pair swap are shared with the square
+method via [`_build_geometric_cluster`](@ref).
+
+Detailed balance holds exactly as in the square case: the reflection is
+an involution on site indices, cluster growth is
+configuration-independent, and the swap is symmetric, so the proposal
+needs no Metropolis correction and nested sampling keeps its bare
+energy-ceiling accept test (Heringa & Blöte, Phys. Rev. E 57, 4976
+(1998)).
+
+Requires the two-site basis and a strictly two-dimensional supercell
+(`supercell_dimensions[3] == 1`); violations throw an `ArgumentError`.
+"""
+function geometric_cluster_swap!(lattice::MLattice{C,TriangularLattice}, p::Float64) where C
+    if length(lattice.basis) != 2
+        throw(ArgumentError("geometric_cluster_swap! on a triangular lattice " *
+            "requires the two-site centered-rectangular basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
+    nx, ny, nz = lattice.supercell_dimensions
+    if nz != 1
+        throw(ArgumentError("geometric_cluster_swap! on a triangular lattice " *
+            "requires a two-dimensional supercell " *
+            "(supercell_dimensions[3] == 1), got $nz layers"))
+    end
+    n_sites = num_sites(lattice)
+
+    # Pivot: midpoint of two random sites (with replacement); keep its
+    # doubled half-grid position so all arithmetic stays integer
+    h1 = _tri_site_to_halfgrid(rand(1:n_sites), nx)
+    h2 = _tri_site_to_halfgrid(rand(1:n_sites), nx)
+    hpx = h1[1] + h2[1]
+    hpy = h1[2] + h2[2]
+
+    # Choose random seed site (1-indexed)
+    seed = rand(1:n_sites)
+
+    # Build cluster via BFS with fixed growth probability
+    reflect = s -> _tri_reflect_site(s, hpx, hpy, nx, ny)
+    cluster = _build_geometric_cluster(lattice, seed, reflect, p)
+
+    # Swap occupation states for each (site, reflected_site) pair
+    for (a, b) in cluster
+        if a != b
+            for comp in 1:C
+                lattice.components[comp][a], lattice.components[comp][b] =
+                    lattice.components[comp][b], lattice.components[comp][a]
+            end
+        end
+    end
+
+    return lattice
 end

--- a/test/test-SamplingSchemes/test-hard-core-lattices.jl
+++ b/test/test-SamplingSchemes/test-hard-core-lattices.jl
@@ -176,7 +176,8 @@
     # to the E = 0 manifold; gc_thermodynamic_stats_fixed_N assembles Ξ(z).
     # This is the primary route for athermal models: every z is an exact
     # polynomial evaluation in the per-N evidence (no reweighting window).
-    function fixed_N_hard_core(make, N_max; K, n_iters, mc_steps, seed)
+    function fixed_N_hard_core(make, N_max; K, n_iters, mc_steps, seed,
+                               routine=MCRandomWalkClone())
         Random.seed!(seed)
         dfs = Vector{DataFrame}(undef, N_max + 1)
         live = Vector{Vector{Float64}}(undef, N_max + 1)
@@ -195,7 +196,7 @@
                 energy_perturbation=1e-9,
                 allowed_fail_count=100_000)
             df, final_ls, _ = nested_sampling(
-                liveset, ns_params, n_iters, MCRandomWalkClone(), save_strategy)
+                liveset, ns_params, n_iters, routine, save_strategy)
             dfs[N + 1] = df
             live[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
         end
@@ -257,6 +258,54 @@
                 end
             end
         end
+    end
+
+    # ================================================================
+    # Cluster-move A/B: the triangular geometric cluster move is variance
+    # reduction only, so mixed-move ladders must reproduce the same exact
+    # per-N evidence as the local-move reference above. Unbiasedness is the
+    # assertion; a hard variance comparison over a few seeds would be
+    # F-statistics noise and is deliberately not asserted.
+    @testset "fixed-N route with cluster moves (hard hexagons)" begin
+        K = 60
+        n_iters = 900
+        T_ath = 150.0
+        routine = MCMixedMoves(walks_freq=1, clusters_freq=1)
+        dfs, live = fixed_N_hard_core(hc_tri, 6;
+            K=K, n_iters=n_iters, mc_steps=100, seed=4000, routine=routine)
+
+        # Every mixed-move ladder still descends into the E = 0 manifold
+        for N in 1:6
+            @test issorted(dfs[N + 1].emax, rev=true)
+            @test all(e -> e < J / 2, live[N + 1])
+        end
+
+        stats = gc_thermodynamic_stats_fixed_N(
+            dfs, collect(0:6), M_tr, [0.0] .* u"eV", [T_ath * u"K"];
+            n_walkers=K, n_cull=1, ω0=(K + 1) / K, live_emax=live)
+
+        # Same per-sector tolerance as the local-move reference (≥ 3σ)
+        for N in 0:6
+            @test isapprox(stats.log_Z_N[N + 1, 1], log(g_tr[N + 1]), atol=1.5)
+        end
+
+        # Wiring: the mixed step exercised cluster moves, tuned cluster_p
+        # adaptively, and conserved N through the full NS machinery
+        Random.seed!(4001)
+        walkers = [
+            begin
+                lat = lattice_at(hc_tri, 4)
+                generate_random_new_lattice_sample!(lat)
+                LatticeWalker(lat)
+            end for _ in 1:20]
+        liveset = LatticeGasWalkers(walkers, ham_hc, perturb_energy=1e-9)
+        ns_params = LatticeNestedSamplingParameters(
+            mc_steps=40, energy_perturbation=1e-9, allowed_fail_count=100_000)
+        _, ls_out, params_out = nested_sampling(
+            liveset, ns_params, 200, routine, save_strategy)
+        hc_cleanup()
+        @test !isempty(params_out.cluster_p_history)
+        @test all(sum(w.configuration.components[1]) == 4 for w in ls_out.walkers)
     end
 
     # ================================================================

--- a/test/test-lattice-random-walks.jl
+++ b/test/test-lattice-random-walks.jl
@@ -228,5 +228,178 @@
             @test changed
         end
 
+        # ---- triangular lattice (two-site centered-rectangular basis) ----
+
+        @testset "triangular reflection: half-grid round-trip" begin
+            for (nx, ny) in ((3, 3), (6, 4))
+                M = 2 * nx * ny
+                for s in 1:M
+                    hx, hy = MonteCarloMoves._tri_site_to_halfgrid(s, nx)
+                    # The centered-rectangular condition: hx ≡ hy (mod 2)
+                    @test (hx & 1) == (hy & 1)
+                    @test 0 <= hx < 2 * nx
+                    @test 0 <= hy < 2 * ny
+                    @test MonteCarloMoves._tri_halfgrid_to_site(hx, hy, nx) == s
+                end
+            end
+        end
+
+        @testset "triangular reflection: involution and bijection" begin
+            using Random
+            Random.seed!(5)
+            for (nx, ny) in ((3, 3), (6, 4))
+                M = 2 * nx * ny
+                for _ in 1:25
+                    h1 = MonteCarloMoves._tri_site_to_halfgrid(rand(1:M), nx)
+                    h2 = MonteCarloMoves._tri_site_to_halfgrid(rand(1:M), nx)
+                    hpx, hpy = h1[1] + h2[1], h1[2] + h2[2]
+                    σ = [MonteCarloMoves._tri_reflect_site(s, hpx, hpy, nx, ny)
+                         for s in 1:M]
+                    @test sort(σ) == collect(1:M)          # bijection on sites
+                    @test all(σ[σ[s]] == s for s in 1:M)   # involution
+                end
+            end
+        end
+
+        @testset "triangular reflection is a lattice symmetry" begin
+            # Geometric check against the stored positions, independent of
+            # the half-grid index arithmetic: 2·pivot − r(s) − r(σ(s)) must
+            # be a supercell lattice vector (periods Ax = nx·a, Ay = ny·√3·a)
+            using Random
+            Random.seed!(6)
+            for (nx, ny) in ((3, 3), (6, 4))
+                lat = MLattice{1,TriangularLattice}(
+                    supercell_dimensions=(nx, ny, 1),
+                    cutoff_radii=[1.1],
+                    components=[[1]],
+                    adsorptions=:full)
+                M = 2 * nx * ny
+                Ax = nx * 1.0
+                Ay = ny * sqrt(3)
+                for _ in 1:10
+                    s1 = rand(1:M)
+                    s2 = rand(1:M)
+                    h1 = MonteCarloMoves._tri_site_to_halfgrid(s1, nx)
+                    h2 = MonteCarloMoves._tri_site_to_halfgrid(s2, nx)
+                    px = (lat.positions[s1, 1] + lat.positions[s2, 1]) / 2
+                    py = (lat.positions[s1, 2] + lat.positions[s2, 2]) / 2
+                    for s in 1:M
+                        r = MonteCarloMoves._tri_reflect_site(
+                            s, h1[1] + h2[1], h1[2] + h2[2], nx, ny)
+                        fx = (2 * px - lat.positions[s, 1] - lat.positions[r, 1]) / Ax
+                        fy = (2 * py - lat.positions[s, 2] - lat.positions[r, 2]) / Ay
+                        @test isapprox(fx, round(fx), atol=1e-9)
+                        @test isapprox(fy, round(fy), atol=1e-9)
+                    end
+                end
+            end
+        end
+
+        @testset "triangular basis-sublattice rule" begin
+            nx, ny = 3, 3
+            M = 2 * nx * ny
+            basis_of(s) = (s - 1) % 2
+            # Site pivots (s1 == s2, parity sum even): basis index preserved
+            for s1 in (1, 4, 18)
+                h = MonteCarloMoves._tri_site_to_halfgrid(s1, nx)
+                for s in 1:M
+                    r = MonteCarloMoves._tri_reflect_site(s, 2 * h[1], 2 * h[2], nx, ny)
+                    @test basis_of(r) == basis_of(s)
+                end
+            end
+            # Midpoint pivot with odd parity sum: basis 0 and basis 1 exchange
+            h1 = MonteCarloMoves._tri_site_to_halfgrid(1, nx)   # basis 0
+            h2 = MonteCarloMoves._tri_site_to_halfgrid(2, nx)   # basis 1
+            @test isodd(h1[1] + h2[1])
+            for s in 1:M
+                r = MonteCarloMoves._tri_reflect_site(
+                    s, h1[1] + h2[1], h1[2] + h2[2], nx, ny)
+                @test basis_of(r) == 1 - basis_of(s)
+            end
+        end
+
+        @testset "particle count preserved (triangular, C=1)" begin
+            sl = SLattice{TriangularLattice}(
+                supercell_dimensions=(6, 4, 1),
+                cutoff_radii=[1.1],
+                components=[[1, 2, 5, 10, 17, 24, 33, 40]],
+                adsorptions=:full)
+            original_count = occupied_site_count(sl)
+            for _ in 1:50
+                geometric_cluster_swap!(sl, 0.3)
+                @test occupied_site_count(sl) == original_count
+            end
+        end
+
+        @testset "particle count preserved (triangular, C=2)" begin
+            ml = MLattice{2,TriangularLattice}(
+                supercell_dimensions=(3, 3, 1),
+                cutoff_radii=[1.1],
+                components=[[1, 3, 5, 7], [2, 4, 6, 8]],
+                adsorptions=:full)
+            original_counts = occupied_site_count(ml)
+            for _ in 1:50
+                geometric_cluster_swap!(ml, 0.4)
+                @test occupied_site_count(ml) == original_counts
+            end
+        end
+
+        @testset "self-inverse for fixed cluster (triangular)" begin
+            using Random
+            sl = SLattice{TriangularLattice}(
+                supercell_dimensions=(6, 4, 1),
+                cutoff_radii=[1.1],
+                components=[[1, 5, 10, 20, 30, 40]],
+                adsorptions=:full)
+            original_components = deepcopy(sl.components)
+
+            seed = 42
+            Random.seed!(seed)
+            geometric_cluster_swap!(sl, 0.3)
+            Random.seed!(seed)
+            geometric_cluster_swap!(sl, 0.3)
+
+            @test sl.components == original_components
+        end
+
+        @testset "cluster move can change configuration (triangular)" begin
+            sl = SLattice{TriangularLattice}(
+                supercell_dimensions=(6, 4, 1),
+                cutoff_radii=[1.1],
+                components=[[1, 2, 3, 4, 5, 6]],
+                adsorptions=:full)
+            original_components = deepcopy(sl.components)
+            changed = false
+            for _ in 1:100
+                test_sl = deepcopy(sl)
+                geometric_cluster_swap!(test_sl, 0.5)
+                if test_sl.components != original_components
+                    changed = true
+                    break
+                end
+            end
+            @test changed
+        end
+
+        @testset "triangular guards" begin
+            # One-site basis: the half-grid index arithmetic does not apply
+            lat1b = MLattice{1,TriangularLattice}(
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(3, 3, 1),
+                cutoff_radii=[1.1],
+                components=[[1]],
+                adsorptions=:full)
+            @test_throws ArgumentError geometric_cluster_swap!(lat1b, 0.3)
+
+            # Three-dimensional supercell: not supported on triangular
+            lat3d = MLattice{1,TriangularLattice}(
+                supercell_dimensions=(3, 3, 2),
+                periodicity=(true, true, true),
+                cutoff_radii=[1.1],
+                components=[[1]],
+                adsorptions=:full)
+            @test_throws ArgumentError geometric_cluster_swap!(lat3d, 0.3)
+        end
+
     end
 end


### PR DESCRIPTION
Implements #146.

## What

- `geometric_cluster_swap!(::MLattice{C,TriangularLattice}, p)`: geometric cluster moves on the two-site centered-rectangular triangular representation, by point inversion in integer half-grid coordinates ((hx, hy) = (2·ci + b, 2·cj + b) on the (2·nx, 2·ny) torus; the site set is exactly {hx ≡ hy (mod 2)}). The pivot is the midpoint of two random sites drawn with replacement, stored as the doubled position h(s₁) + h(s₂), so every step is integer arithmetic: no floating-point rounding and no lookup table. Because the two basis sites are two cosets of one triangular Bravais lattice, the midpoint of any two sites is automatically an inversion center of the full lattice; plaquette centers, whose doubled position is not a lattice vector, are unreachable by construction. Site pivots preserve each site's basis index; midpoint pivots with odd parity sum exchange the two basis sublattices.
- `_build_geometric_cluster` is generalized to take a reflection closure; the square method passes its existing `_reflect_site` unchanged with an identical rand() draw order, so the pre-existing re-seeded self-inverse square tests pass unmodified.
- Detailed balance is inherited from the square case: the reflection is an involution on site indices (a modular-arithmetic identity, valid for every pivot), cluster growth is configuration-independent, and the pair swap is symmetric, so nested sampling keeps its bare energy-ceiling accept test (Heringa–Blöte, Phys. Rev. E 57, 4976 (1998)).
- Guards, both `ArgumentError`: a non-two-site basis (the half-grid arithmetic would index out of range) and `supercell_dimensions[3] ≠ 1`.
- `clusters_freq > 0` in `MCMixedMoves` and `MCGrandCanonicalMoves` is now usable on triangular lattices with no sampler changes.

## Tests

- Half-grid round trip, the parity condition, and involution + bijection of the reflection over random pivots on `(3, 3)` and `(6, 4)` cells.
- A geometric check independent of the index arithmetic: 2·pivot − r(s) − r(σ(s)) is a supercell lattice vector for every site, verified against the stored positions.
- The basis-sublattice rule: site pivots preserve the basis index, odd-parity-sum midpoint pivots exchange the two basis sublattices.
- Particle-count preservation (C = 1 and C = 2), re-seeded self-inverse, a configuration-change check, and both guard paths.
- Fixed-N A/B on the 18-site hard-hexagon cell: mixed-move ladders (`walks_freq=1, clusters_freq=1`) reproduce the exact per-N independent-set counts within the same ≥3σ tolerance as the local-move reference, every ladder still descends into the E = 0 manifold, the adaptive cluster_p machinery runs (`cluster_p_history` nonempty; the tuning window closes deterministically at iteration 50), and N is conserved through the full NS machinery. Unbiasedness is the assertion; a hard variance comparison over a few seeds would be F-statistics noise and is deliberately not asserted. Observed over three scatter seeds, as information only: the cluster arm's per-sector evidence scatter was smaller than the local-move reference's in the deepest sectors (N = 6: rms 0.36 vs 0.61 nats; N = 5: 0.20 vs 0.35), consistent with variance reduction at the √3×√3 basins.

An adversarial review pass re-derived the half-grid map from the position generator, proved the involution for every integer pivot, traced the adaptive-tuning window arithmetic, and produced no findings. Full test suite passes (SamplingSchemes 1290, Monte Carlo Moves 3807, FreeBirdIO 51).
