### PR TITLE
Warn on wrapped periodic-image bonds and add opt-in image multiplicity

### DIFF
--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -214,9 +214,10 @@ MLattice{C,G}(
     basis::Vector{Tuple{Float64, Float64, Float64}},
     supercell_dimensions::Tuple{Int64, Int64, Int64},
     periodicity::Tuple{Bool, Bool, Bool},
-    components::Vector{Vector{Bool}},
-    adsorptions::Vector{Bool},
     cutoff_radii::Vector{Float64},
+    components::Vector{Vector{Bool}},
+    adsorptions::Vector{Bool};
+    image_multiplicity::Bool=false,
 ) where {C,G}
 ```
 The `C` parameter is the number of components in the system, and the `G` parameter defines the geometry of the lattice.
@@ -239,7 +240,8 @@ MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
     periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
     cutoff_radii::Vector{Float64}=[1.1, 1.5],
     components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
-    adsorptions::Union{Vector{Int},Symbol}=:full)
+    adsorptions::Union{Vector{Int},Symbol}=:full,
+    image_multiplicity::Bool=false)
 ```
 
 You may notice that the code above returns a `SLattice` type.

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -1,23 +1,4 @@
 """
-compute_neighbors(supercell_lattice_vectors::Matrix{Float64}, 
-                  positions::Matrix{Float64}, 
-                  cutoff_radii::Vector{Float64}, 
-                  periodicity::Tuple{Bool, Bool, Bool})
-
-Compute the nearest and next-nearest neighbors for each atom in a 3D lattice.
-
-# Arguments
-- `supercell_lattice_vectors::Matrix{Float64}`: The lattice vectors of the supercell.
-- `positions::Matrix{Float64}`: The positions of the atoms in the supercell.
-- `periodicity::Tuple{Bool, Bool, Bool}`: A Boolean tuple of length three indicating periodicity in each dimension (true for periodic, false for non-periodic).
-- `cutoff_radii::Vector{Float64}`: The cutoff radii for the *index*-th nearest neighbors.
-
-# Returns
-- `neighbors::Vector{Tuple{Vector{Int}, Vector{Int}}}`: A vector of tuples containing the indices of the first and second nearest neighbors for each atom.
-
-"""
-
-"""
     _minimum_image_distance(supercell_lattice_vectors, reciprocal_lattice_vectors,
                             periodicity, pos_i, pos_j)
 
@@ -40,11 +21,59 @@ cluster embeddings follow the identical torus convention.
     return norm(supercell_lattice_vectors * fractional_dr)
 end
 
+"""
+    compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
+                      positions::Matrix{Float64},
+                      periodicity::Tuple{Bool, Bool, Bool},
+                      cutoff_radii::Vector{Float64};
+                      image_multiplicity::Bool=false)
+
+Compute the neighbor shells of every site in a supercell. Each in-cutoff
+distance is assigned to the first shell whose cutoff admits it (a nested
+`<=` cutoff ladder), so `cutoff_radii` must be non-empty, finite, strictly
+positive, and strictly increasing; anything else throws an
+`ArgumentError`.
+
+# Arguments
+- `supercell_lattice_vectors::Matrix{Float64}`: The lattice vectors of the supercell, one cell vector per column.
+- `positions::Matrix{Float64}`: The Cartesian positions of the sites, one site per row.
+- `periodicity::Tuple{Bool, Bool, Bool}`: A Boolean tuple of length three indicating periodicity in each dimension (true for periodic, false for non-periodic).
+- `cutoff_radii::Vector{Float64}`: The cutoff radii for the *index*-th nearest neighbors, strictly increasing.
+- `image_multiplicity::Bool=false`: The neighbor-counting convention, see below.
+
+# Returns
+- `neighbors::Vector{Vector{Vector{Int}}}`: For each site, one vector of neighbor indices per shell.
+
+# Conventions
+
+With `image_multiplicity=false` (the default), each site pair is counted
+once, in the shell of its minimum-image distance. On a cell whose periodic
+circumference does not exceed twice a shell cutoff, pairs connected
+through more than one periodic image are still counted once — the affected
+shells sit below their bulk-tiled coordination — and one warning listing
+every such shell and its collapsed-image count is emitted per call.
+Detection is exact (the periodic images are enumerated), so faithful cells
+never warn.
+
+With `image_multiplicity=true`, a neighbor index is pushed once per
+in-cutoff periodic image, including a site's own images (self-entries,
+`j == i`, which arise when a periodic circumference is within the cutoff):
+the cluster-expansion small-cell convention, under which the periodic
+cell's energy equals the bulk energy per cell of the tiled configuration.
+"""
 function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
                            positions::Matrix{Float64},
                            periodicity::Tuple{Bool, Bool, Bool},
-                           cutoff_radii::Vector{Float64}
+                           cutoff_radii::Vector{Float64};
+                           image_multiplicity::Bool=false,
                            )
+
+    if isempty(cutoff_radii) || any(r -> !(isfinite(r) && r > 0.0), cutoff_radii) ||
+       !all(cutoff_radii[k] < cutoff_radii[k+1] for k in 1:length(cutoff_radii)-1)
+        throw(ArgumentError(
+            "cutoff_radii must be finite, positive, and strictly increasing " *
+            "(shells are assigned by a nested cutoff ladder), got $cutoff_radii"))
+    end
 
     neighbors = Vector{Vector{Vector{Int}}}(undef, size(positions, 1))
     num_atoms = size(positions, 1)
@@ -56,6 +85,45 @@ function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
     reciprocal_lattice_vectors = inv([a1 a2 a3])
 
     layers_of_neighbors = length(cutoff_radii)
+    r_max = last(cutoff_radii)
+
+    # First shell whose cutoff admits the distance (the nested `<=` ladder);
+    # 0 when the distance is beyond the outermost cutoff.
+    function shell_of(distance::Float64)
+        for k in 1:layers_of_neighbors
+            if distance <= cutoff_radii[k]
+                return k
+            end
+        end
+        return 0
+    end
+
+    # Periodic-image offsets that can reach into the outermost cutoff:
+    # n_k in -N_k:N_k with N_k = floor(r_max·‖row k of inv(scv)‖ + 1/2) + 1.
+    # The inverse-cell row norm is the reciprocal of the perpendicular cell
+    # height, so this range provably contains every in-cutoff image on
+    # skewed cells too. Non-periodic directions contribute only n_k = 0.
+    offset_ranges = map(1:3) do k
+        if periodicity[k]
+            N = floor(Int, r_max * norm(view(reciprocal_lattice_vectors, k, :)) + 0.5) + 1
+            -N:N
+        else
+            0:0
+        end
+    end
+    # Precomputed Cartesian offsets; the Bool marks the zero offset (the
+    # central image, which is the kept image for j != i and the null term
+    # for j == i).
+    offsets = Tuple{Float64,Float64,Float64,Bool}[]
+    for n1 in offset_ranges[1], n2 in offset_ranges[2], n3 in offset_ranges[3]
+        push!(offsets, (n1 * a1[1] + n2 * a2[1] + n3 * a3[1],
+                        n1 * a1[2] + n2 * a2[2] + n3 * a3[2],
+                        n1 * a1[3] + n2 * a2[3] + n3 * a3[3],
+                        n1 == 0 && n2 == 0 && n3 == 0))
+    end
+
+    # Discarded in-cutoff images per shell (default mode only)
+    collapsed = zeros(Int, layers_of_neighbors)
 
     for i in 1:num_atoms
         nth_neighbors = Vector{Int}[]
@@ -64,21 +132,67 @@ function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
         end
 
         for j in 1:num_atoms
-            if i != j
-                distance = _minimum_image_distance(
-                    supercell_lattice_vectors, reciprocal_lattice_vectors,
-                    periodicity, view(positions, i, :), view(positions, j, :))
+            # Central image: the same rounding reduction as
+            # _minimum_image_distance, so `dmin` below is bit-identical to
+            # the per-pair minimum-image distance used before this rewrite —
+            # neighbor-list order feeds seeded RNG streams, so the default
+            # path must reproduce the previous lists element-for-element.
+            dr = [positions[j, 1] - positions[i, 1],
+                  positions[j, 2] - positions[i, 2],
+                  positions[j, 3] - positions[i, 3]]
+            fractional_dr = reciprocal_lattice_vectors * dr
+            for k in 1:3
+                if periodicity[k]
+                    fractional_dr[k] -= round(fractional_dr[k])
+                end
+            end
+            dr_c = supercell_lattice_vectors * fractional_dr
 
-                for k in 1:layers_of_neighbors
-                    if distance <= cutoff_radii[k]
-                        push!(nth_neighbors[k], j)
-                        break
-                    end
+            if image_multiplicity
+                # Push j once per in-cutoff periodic image (self-images
+                # included); only the single zero-displacement self term is
+                # skipped — it is not a bond.
+                for (ox, oy, oz, central) in offsets
+                    (j == i && central) && continue
+                    d = sqrt((dr_c[1] + ox)^2 + (dr_c[2] + oy)^2 + (dr_c[3] + oz)^2)
+                    k = shell_of(d)
+                    k != 0 && push!(nth_neighbors[k], j)
+                end
+            else
+                # Minimum-image convention: for j != i push j once, into the
+                # shell of the central (minimum-image) distance, exactly as
+                # before; tally every other in-cutoff image — the collapsed
+                # images of j != i pairs and all in-cutoff self-images — per
+                # that image's own shell.
+                if j != i
+                    kept_shell = shell_of(norm(dr_c))
+                    kept_shell != 0 && push!(nth_neighbors[kept_shell], j)
+                end
+                for (ox, oy, oz, central) in offsets
+                    central && continue
+                    d = sqrt((dr_c[1] + ox)^2 + (dr_c[2] + oy)^2 + (dr_c[3] + oz)^2)
+                    k = shell_of(d)
+                    k != 0 && (collapsed[k] += 1)
                 end
             end
         end
 
         neighbors[i] = nth_neighbors
+    end
+
+    if any(>(0), collapsed)
+        wrapped = ["$k (cutoff $(cutoff_radii[k])): $(collapsed[k]) collapsed image bond(s)"
+                   for k in 1:layers_of_neighbors if collapsed[k] > 0]
+        @warn "neighbor shell(s) [" * join(wrapped, ", ") * "] wrap the " *
+              "periodic cell: some pairs (or a site and its own periodic " *
+              "image) are connected through more than one image within the " *
+              "cutoff but are counted once under the minimum-image " *
+              "convention, so per-site coordination, and any energy " *
+              "coupling these shells, is below the bulk-tiled value. " *
+              "Enlarge the supercell so every periodic circumference " *
+              "exceeds twice the shell cutoff, or construct the lattice " *
+              "with `image_multiplicity=true` to count every image (the " *
+              "cluster-expansion small-cell convention)."
     end
 
     for k in 1:layers_of_neighbors
@@ -182,9 +296,10 @@ A mutable struct representing a lattice with the following fields:
         basis::Vector{Tuple{Float64, Float64, Float64}},
         supercell_dimensions::Tuple{Int64, Int64, Int64},
         periodicity::Tuple{Bool, Bool, Bool},
-        components::Vector{Vector{Bool}},
-        adsorptions::Vector{Bool},
         cutoff_radii::Vector{Float64},
+        components::Vector{Vector{Bool}},
+        adsorptions::Vector{Bool};
+        image_multiplicity::Bool=false,
     ) where {C,G}
 
 Creates an `MLattice` instance with the specified parameters. The constructor performs the following steps:
@@ -192,7 +307,7 @@ Creates an `MLattice` instance with the specified parameters. The constructor pe
 1. Validates that the number of components matches the expected value `C`.
 2. Computes the positions of the lattice points using `lattice_positions`.
 3. Computes the supercell lattice vectors.
-4. Computes the neighbors of each lattice point using `compute_neighbors`.
+4. Computes the neighbors of each lattice point using `compute_neighbors`, passing the `image_multiplicity` keyword through.
 
 Throws an `ArgumentError` if the number of components does not match `C`.
 
@@ -204,7 +319,8 @@ Throws an `ArgumentError` if the number of components does not match `C`.
                                periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
                                cutoff_radii::Vector{Float64}=[1.1, 1.5],
                                components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
-                               adsorptions::Union{Vector{Int},Symbol}=:full)
+                               adsorptions::Union{Vector{Int},Symbol}=:full,
+                               image_multiplicity::Bool=false)
 
     MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
                                   basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
@@ -212,11 +328,25 @@ Throws an `ArgumentError` if the number of components does not match `C`.
                                   periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
                                   cutoff_radii::Vector{Float64}=[1.1, 1.8],
                                   components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
-                                  adsorptions::Union{Vector{Int},Symbol}=:full)
+                                  adsorptions::Union{Vector{Int},Symbol}=:full,
+                                  image_multiplicity::Bool=false)
 
 Constructs a square/triangular lattice with the specified parameters. The `components` and `adsorptions` arguments can be a vector of integers specifying
-the indices of the occupied sites, or a symbol. If `components` is `:equal`, the lattice is divided into `C` equal components when possible, or 
+the indices of the occupied sites, or a symbol. If `components` is `:equal`, the lattice is divided into `C` equal components when possible, or
 nearest to equal components otherwise. If `adsorptions` is `:full`, all sites are classified as adsorption sites.
+
+The `image_multiplicity` keyword selects the neighbor-counting convention of
+[`compute_neighbors`](@ref): under the default minimum-image convention each
+site pair is counted once and a warning reports any shells that wrap the
+periodic cell; with `image_multiplicity=true` every in-cutoff periodic image
+is counted, self-image entries included (the cluster-expansion small-cell
+convention, under which the cell's energy equals the bulk energy per cell of
+the tiled configuration). The duplicated entries compose correctly
+downstream: the energy kernels add `coupling/2` per ordered-pair entry, so a
+doubled bond reaches the full bond energy and a self-image entry passes the
+occupation test exactly when the site is occupied; geometric-cluster growth
+reads only the first shell, and growth across a duplicated bond remains a
+configuration-independent symmetric proposal.
 
 ## Returns
 - `MLattice{C,G}`: A square/triangular lattice object with `C` components.
@@ -240,7 +370,8 @@ mutable struct MLattice{C,G} <: AbstractLattice
         periodicity::Tuple{Bool, Bool, Bool},
         cutoff_radii::Vector{Float64},
         components::Vector{Vector{Bool}},
-        adsorptions::Vector{Bool},
+        adsorptions::Vector{Bool};
+        image_multiplicity::Bool=false,
     ) where {C,G}
 
         num_components = length(components)
@@ -252,7 +383,8 @@ mutable struct MLattice{C,G} <: AbstractLattice
         positions = lattice_positions(lattice_vectors, basis, supercell_dimensions)
 
         supercell_lattice_vectors = lattice_vectors * Diagonal([supercell_dimensions[1], supercell_dimensions[2], supercell_dimensions[3]])
-        neighbors = compute_neighbors(supercell_lattice_vectors, positions, periodicity, cutoff_radii)
+        neighbors = compute_neighbors(supercell_lattice_vectors, positions, periodicity, cutoff_radii;
+                                      image_multiplicity=image_multiplicity)
         
         return new{C,G}(lattice_vectors, positions, basis, supercell_dimensions, periodicity, cutoff_radii, components, neighbors, adsorptions)
     end
@@ -366,12 +498,14 @@ function MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
                                     cutoff_radii::Vector{Float64}=[1.1, 1.5],
                                     components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                     adsorptions::Union{Vector{Int},Symbol}=:full,
+                                    image_multiplicity::Bool=false,
                                 ) where C
 
     lattice_vectors = [lattice_constant 0.0 0.0; 0.0 lattice_constant 0.0; 0.0 0.0 1.0]
     lattice_comp, lattice_adsorptions = mlattice_setup(C, basis, supercell_dimensions, components, adsorptions)
 
-    return MLattice{C,SquareLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions)
+    return MLattice{C,SquareLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions;
+                                     image_multiplicity=image_multiplicity)
 end
 
 function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
@@ -383,13 +517,15 @@ function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
                                         cutoff_radii::Vector{Float64}=[1.1, 1.8],
                                         components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                         adsorptions::Union{Vector{Int},Symbol}=:full,
+                                        image_multiplicity::Bool=false,
                                     ) where C
 
     lattice_vectors = [lattice_constant 0.0 0.0; 0.0 sqrt(3)*lattice_constant 0.0; 0.0 0.0 1.0]
     lattice_comp, lattice_adsorptions = mlattice_setup(C, basis, supercell_dimensions, components, adsorptions)
 
-    return MLattice{C,TriangularLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions)
-    
+    return MLattice{C,TriangularLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions;
+                                         image_multiplicity=image_multiplicity)
+
 end
 
 

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -277,7 +277,13 @@
                 periodicity = (true, true, true)
                 cutoff_radii = [1.1, 1.5, 1.8]
 
-                neighbors = AbstractWalkers.compute_neighbors(lattice_vectors, positions, periodicity, cutoff_radii)
+                # Every cutoff exceeds half the cell edge on this one-cell
+                # torus, so pairs are connected through several images: the
+                # pinned per-site counts below are the documented
+                # minimum-image convention, and the collapsed-image warning
+                # fires
+                neighbors = @test_logs (:warn, r"wrap the periodic cell") match_mode=:any AbstractWalkers.compute_neighbors(
+                    lattice_vectors, positions, periodicity, cutoff_radii)
                 
                 for i in 1:5
                     if i == 1
@@ -294,6 +300,103 @@
                         @test length(neighbors[i][3]) == 0
                     end
                 end
+            end
+        end
+
+
+        @testset "image multiplicity and cutoff_radii validation" begin
+
+            # Full-occupancy single-component square builder
+            sq_lattice(dims, per, cutoffs; kwargs...) = MLattice{1,SquareLattice}(;
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=dims,
+                periodicity=per,
+                cutoff_radii=cutoffs,
+                components=[[true for _ in 1:prod(dims)]],
+                adsorptions=:full,
+                kwargs...)
+
+            @testset "wrapped 4x4 three-shell coordination pins" begin
+                # The third shell (distance 2 = L/2) wraps: the +2 and -2
+                # images of the same site collapse to one entry under the
+                # minimum-image convention ...
+                lat_def = @test_logs (:warn, r"wrap the periodic cell") match_mode=:any sq_lattice(
+                    (4, 4, 1), (true, true, false), [1.1, 1.5, 2.1])
+                @test all(length.(lat_def.neighbors[i]) == [4, 4, 2] for i in 1:16)
+                # ... while multiplicity restores the bulk-tiled coordination,
+                # with no warning
+                lat_mult = @test_logs min_level=Base.CoreLogging.Warn sq_lattice(
+                    (4, 4, 1), (true, true, false), [1.1, 1.5, 2.1], image_multiplicity=true)
+                @test all(length.(lat_mult.neighbors[i]) == [4, 4, 4] for i in 1:16)
+                # Element-pinned lists for the corner site: entries ascending
+                # in j, multiplicity entries grouped by j
+                @test lat_def.neighbors[1] == [[2, 4, 5, 13], [6, 8, 14, 16], [3, 9]]
+                @test lat_mult.neighbors[1] == [[2, 4, 5, 13], [6, 8, 14, 16], [3, 3, 9, 9]]
+            end
+
+            @testset "L = 2r degeneracy and warning content: triangular (4, 2, 1)" begin
+                # The a2 circumference 2√3 equals exactly twice the
+                # second-neighbor distance √3, so the degenerate image
+                # distances are bit-identical — no tolerance involved — and
+                # the warning names the wrapped shell with its exact
+                # collapsed-image count
+                warnpat = r"neighbor shell\(s\) \[2 \(cutoff 1\.8\): 16 collapsed image bond\(s\)\] wrap the periodic cell"
+                lat_def = @test_logs (:warn, warnpat) match_mode=:any MLattice{1,TriangularLattice}()
+                M = length(lat_def.components[1])
+                @test M == 16
+                @test all(length(lat_def.neighbors[i][1]) == 6 for i in 1:M)
+                @test all(length(lat_def.neighbors[i][2]) == 5 for i in 1:M)
+
+                lat_mult = @test_logs min_level=Base.CoreLogging.Warn MLattice{1,TriangularLattice}(
+                    image_multiplicity=true)
+                @test all(length(lat_mult.neighbors[i][1]) == 6 for i in 1:M)
+                @test all(length(lat_mult.neighbors[i][2]) == 6 for i in 1:M)
+                # Exactly one second-shell neighbor per site — the a2-wrapped
+                # one — is doubled
+                @test all(length(unique(lat_mult.neighbors[i][2])) == 5 for i in 1:M)
+                # The faithful first shell agrees between the conventions
+                @test all(lat_mult.neighbors[i][1] == lat_def.neighbors[i][1] for i in 1:M)
+            end
+
+            @testset "1D chains, periodicity (true, false, false)" begin
+                # (4,1,1): the second shell (distance 2 = L/2) wraps
+                ch_def = @test_logs (:warn, r"wrap the periodic cell") match_mode=:any sq_lattice(
+                    (4, 1, 1), (true, false, false), [1.1, 2.1])
+                @test [n[1] for n in ch_def.neighbors] == [[2, 4], [1, 3], [2, 4], [1, 3]]
+                @test [n[2] for n in ch_def.neighbors] == [[3], [4], [1], [2]]
+                ch_mult = @test_logs min_level=Base.CoreLogging.Warn sq_lattice(
+                    (4, 1, 1), (true, false, false), [1.1, 2.1], image_multiplicity=true)
+                @test [n[1] for n in ch_mult.neighbors] == [[2, 4], [1, 3], [2, 4], [1, 3]]
+                @test [n[2] for n in ch_mult.neighbors] == [[3, 3], [4, 4], [1, 1], [2, 2]]
+
+                # (2,1,1): first-shell multiplicity 2 through the ±1 images of
+                # the other site, plus two second-shell self-image entries
+                # (j == i) through the ±2 self-images
+                ch2_def = @test_logs (:warn, r"wrap the periodic cell") match_mode=:any sq_lattice(
+                    (2, 1, 1), (true, false, false), [1.1, 2.1])
+                @test ch2_def.neighbors == [[[2], Int[]], [[1], Int[]]]
+                ch2_mult = @test_logs min_level=Base.CoreLogging.Warn sq_lattice(
+                    (2, 1, 1), (true, false, false), [1.1, 2.1], image_multiplicity=true)
+                @test ch2_mult.neighbors == [[[2, 2], [1, 1]], [[1, 1], [2, 2]]]
+            end
+
+            @testset "ArgumentError on invalid cutoff_radii ladders" begin
+                lv = [4.0 0.0 0.0; 0.0 4.0 0.0; 0.0 0.0 1.0]
+                pos = [0.0 0.0 0.0; 1.0 0.0 0.0]
+                per = (true, true, false)
+                for bad in ([1.5, 1.1], [1.1, 1.1], [-1.0], Float64[], [Inf], [1.1, Inf], [NaN])
+                    @test_throws ArgumentError AbstractWalkers.compute_neighbors(lv, pos, per, bad)
+                end
+                err = try
+                    AbstractWalkers.compute_neighbors(lv, pos, per, [1.5, 1.1])
+                catch e
+                    e
+                end
+                @test occursin("nested cutoff ladder", err.msg)
+                # ... and the validation is reached through the constructors
+                @test_throws ArgumentError MLattice{1,SquareLattice}(cutoff_radii=[1.5, 1.1])
+                @test_throws ArgumentError MLattice{1,TriangularLattice}(cutoff_radii=Float64[])
             end
         end
 

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -416,7 +416,7 @@
     @testset "multi-shell pair couplings (shell-count validation, sign-mixed sets)" begin
         using Random
 
-        function shell_lattice(L, cutoffs)
+        function shell_lattice(L, cutoffs; image_multiplicity::Bool=false)
             MLattice{1,SquareLattice}(
                 lattice_constant=1.0,
                 basis=[(0.0, 0.0, 0.0)],
@@ -424,7 +424,8 @@
                 periodicity=(true, true, false),
                 cutoff_radii=cutoffs,
                 components=[[false for _ in 1:L*L]],
-                adsorptions=:full)
+                adsorptions=:full,
+                image_multiplicity=image_multiplicity)
         end
 
         # Square-lattice shells at distances 1, √2, 2, √5, 2√2, 3, √10, √13, 4
@@ -571,6 +572,105 @@
             @test nrow(df) > 0
             # Live-set energies match direct recomputation up to the
             # tie-breaking perturbation
+            for w in final_ls.walkers
+                @test isapprox(w.energy.val,
+                               interacting_energy(w.configuration, ham).val;
+                               atol=1e-8)
+            end
+        end
+
+        # ------------------------------------------------------------
+        @testset "image multiplicity: faithful cells unchanged" begin
+            # On cells faithful for every shell (circumference > 2 x outermost
+            # cutoff) the two conventions must agree element-for-element, and
+            # neither construction may warn
+            for (L, cutoffs) in ((4, [1.1, 1.5]), (8, cut4), (16, cut9))
+                lat_def = @test_logs min_level = Base.CoreLogging.Warn shell_lattice(L, cutoffs)
+                lat_mult = @test_logs min_level = Base.CoreLogging.Warn shell_lattice(
+                    L, cutoffs; image_multiplicity=true)
+                @test lat_mult.neighbors == lat_def.neighbors
+            end
+        end
+
+        # ------------------------------------------------------------
+        @testset "image multiplicity: closed-form energies on wrapped cells" begin
+            # 4x4 with a unit third-shell coupling: the third shell (distance
+            # 2 = L/2) is halved under the minimum-image convention (16 eV),
+            # while multiplicity recovers the bulk-tiled 32 eV
+            ham3 = GenericLatticeHamiltonian(0.0, [0.0, 0.0, 1.0], u"eV")
+            sq_def = @test_logs (:warn, r"wrap the periodic cell") match_mode = :any shell_lattice(
+                4, [1.1, 1.5, 2.1])
+            sq_def.components[1] .= true
+            @test all(length.(sq_def.neighbors[i]) == [4, 4, 2] for i in 1:16)
+            @test interacting_energy(sq_def, ham3).val ≈ 16.0 atol = 1e-10
+            sq_mult = @test_logs min_level = Base.CoreLogging.Warn shell_lattice(
+                4, [1.1, 1.5, 2.1]; image_multiplicity=true)
+            sq_mult.components[1] .= true
+            @test all(length.(sq_mult.neighbors[i]) == [4, 4, 4] for i in 1:16)
+            @test interacting_energy(sq_mult, ham3).val ≈ 32.0 atol = 1e-10
+
+            # Shipped triangular (4, 2, 1) cell with a unit second-shell
+            # coupling: the 5-bond vs 6-bond per-site closed forms
+            ham2 = GenericLatticeHamiltonian(0.0, [0.0, 1.0], u"eV")
+            tri_def = @test_logs (:warn, r"wrap the periodic cell") match_mode = :any MLattice{1,TriangularLattice}()
+            tri_def.components[1] .= true
+            @test interacting_energy(tri_def, ham2).val ≈ 40.0 atol = 1e-10
+            tri_mult = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,TriangularLattice}(
+                image_multiplicity=true)
+            tri_mult.components[1] .= true
+            @test interacting_energy(tri_mult, ham2).val ≈ 48.0 atol = 1e-10
+
+            # Bulk-tiled chain closed forms, periodicity (true, false, false)
+            chain(d1, cutoffs; kwargs...) = MLattice{1,SquareLattice}(;
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(d1, 1, 1),
+                periodicity=(true, false, false),
+                cutoff_radii=cutoffs,
+                components=[[true for _ in 1:d1]],
+                adsorptions=:full,
+                kwargs...)
+
+            # (4,1,1) with a unit second-shell coupling: one wrapped
+            # second-shell bond per site by default, two when tiled
+            hamc = GenericLatticeHamiltonian(0.0, [0.0, 1.0], u"eV")
+            c4_def = @test_logs (:warn, r"wrap the periodic cell") match_mode = :any chain(4, [1.1, 2.1])
+            @test interacting_energy(c4_def, hamc).val ≈ 2.0 atol = 1e-10
+            c4_mult = chain(4, [1.1, 2.1]; image_multiplicity=true)
+            @test interacting_energy(c4_mult, hamc).val ≈ 4.0 atol = 1e-10
+
+            # (2,1,1) with J1 = J2 = 1: multiplicity counts the doubled
+            # nearest-neighbor bond (2 eV, shell 1) plus the self-image bonds
+            # (2 eV, shell 2) — the bulk-tiled chain value; the minimum-image
+            # convention sees a single bond in total
+            hamcc = GenericLatticeHamiltonian(0.0, [1.0, 1.0], u"eV")
+            c2_def = @test_logs (:warn, r"wrap the periodic cell") match_mode = :any chain(2, [1.1, 2.1])
+            @test interacting_energy(c2_def, hamcc).val ≈ 1.0 atol = 1e-10
+            c2_mult = chain(2, [1.1, 2.1]; image_multiplicity=true)
+            @test interacting_energy(c2_mult, hamcc).val ≈ 4.0 atol = 1e-10
+        end
+
+        # ------------------------------------------------------------
+        @testset "multiplicity lattice through GC-NS end-to-end" begin
+            Random.seed!(2081)
+            ham = GenericLatticeHamiltonian(-0.05, [0.292, 0.090, -0.050], u"eV")
+            lat = shell_lattice(4, [1.1, 1.5, 2.1]; image_multiplicity=true)
+            walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                       for _ in 1:20]
+            ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+            params = IdealGasReferencedGCNSParameters(
+                mc_steps=20, reference_fugacity=1.0, energy_perturbation=1e-9)
+            save = SaveEveryN("t_mult.csv", "t_mult.traj", "t_mult.ls",
+                              1000000, 1000000, 1000000)
+            df, final_ls, _ = ideal_gas_referenced_nested_sampling(
+                ls, params, Int64(100),
+                MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3), save)
+            rm.(["t_mult.csv", "t_mult.traj", "t_mult.ls"], force=true)
+
+            @test nrow(df) > 0
+            # Live-set energies stay consistent with direct recomputation on
+            # the duplicated neighbor lists, up to the tie-breaking
+            # perturbation
             for w in final_ls.walkers
                 @test isapprox(w.energy.val,
                                interacting_energy(w.configuration, ham).val;


### PR DESCRIPTION
Implements #150.

## What

- `compute_neighbors` gains an `image_multiplicity::Bool=false` keyword, threaded through the `MLattice` inner constructor and both outer constructors. The default path reproduces the previous minimum-image behavior element-for-element, in the same list order (neighbor-list order feeds seeded RNG streams downstream), using the same central-image reduction as `_minimum_image_distance`, which is itself untouched.
- With `image_multiplicity=true`, each in-cutoff periodic image contributes its own neighbor entry, self-images included (on a cell whose circumference is within the cutoff, a site is a neighbor of its own image). Duplicated entries compose correctly downstream: the energy kernels add coupling/2 per ordered-pair entry, so a doubled bond lands at the full bond energy and the cell's energy equals the bulk energy per cell of the tiled configuration (the cluster-expansion small-cell convention).
- Under the default convention, every discarded in-cutoff image is tallied per shell and one warning per construction reports the wrapped shells with their collapsed-image counts. Detection is exact (actual collapsed images, no circumference heuristic), so faithful cells stay silent. The pre-existing empty-shell warning is unchanged and still runs after.
- Image enumeration ranges: n<sub>k</sub> ∈ −N<sub>k</sub>:N<sub>k</sub> with N<sub>k</sub> = floor(r<sub>max</sub>·‖row k of inv(scv)‖ + 1/2) + 1 per periodic direction; the inverse-cell row norm is the reciprocal of the perpendicular cell height, so the range provably contains every in-cutoff image on skewed cells too.
- `cutoff_radii` is validated up front: non-empty, finite, strictly positive, strictly increasing, else `ArgumentError`. Finiteness is one hardening beyond the filed issue: an infinite cutoff would overflow the image-enumeration bound, where the pre-change code silently accepted `[Inf]`.
- Docstrings: `compute_neighbors` gains a real attached docstring (replacing a stale orphan block that had the wrong argument order and return type); the `MLattice` docstring documents the keyword and its downstream composition, its inner-constructor signature's pre-existing wrong argument order is corrected, and `docs/src/tutorials.md` is brought into line with both signatures.

## Tests

- Coordination pins on the 4×4 three-shell cell: [4, 4, 2] default vs [4, 4, 4] multiplicity, with element-pinned corner-site lists.
- Closed-form full-occupancy energies on deliberately wrapped cells: 16 vs 32 eV (4×4, third shell), 40 vs 48 eV (the shipped triangular default `(4, 2, 1)`, second shell), 2 vs 4 eV (chain `(4, 1, 1)`), 1 vs 4 eV (chain `(2, 1, 1)`, including the two shell-2 self-image entries per site).
- L = 2r exact degeneracy on the shipped triangular default cell, with the warning content pinned (shell 2, cutoff 1.8, 16 collapsed image bonds).
- Faithful-cell no-change: on the 4×4 two-shell, 8×8 four-shell, and 16×16 nine-shell cells, multiplicity lists equal default lists element-for-element and both constructions are warning-free.
- `ArgumentError` paths: `[1.5, 1.1]`, `[1.1, 1.1]`, `[-1.0]`, `Float64[]`, `[Inf]`, `[1.1, Inf]`, `[NaN]`, via `compute_neighbors` directly and through both outer constructors, with the message pinned.
- End-to-end: a seeded ideal-gas-referenced GC-NS run on a multiplicity 4×4 three-shell lattice completes, with live-set energies matching `interacting_energy` recomputation.
- Collateral: the fully periodic 2×2×2 fixture keeps its pinned minimum-image counts, wrapped in `@test_logs`; no existing expected value changed anywhere.

An adversarial review pass reimplemented the pre-change loop and confirmed default-path list equality in order on faithful and wrapped cells, proved the offset-range bound from the fractional reduction, and verified the closed-form energies, warning counts, and keyword threading, with no must-fix findings; the finiteness validation above resolves its one hardening suggestion. Full test suite passes (AbstractWalkers 319, Energy Evaluation 262, Cluster lattice Hamiltonian 678, SamplingSchemes 1290, Monte Carlo Moves 3807, FreeBirdIO 51).
