### PR TITLE
Stripe and Bragg-peak order parameters for the square lattice

### DIFF
--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -27,6 +27,8 @@ export update_walker!
 export num_sites, occupied_site_count
 export order_parameter_c2x2
 export order_parameter_sqrt3
+export bragg_amplitude
+export order_parameter_stripe
 export enumerate_motif_embeddings, motif_distances
 export view_structure
 

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -561,6 +561,144 @@ function order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice})
 end
 
 """
+    bragg_amplitude(lattice::MLattice{1,SquareLattice}, m::Int, n::Int) -> Float64
+
+Normalized Bragg-peak amplitude of the occupation pattern on a
+single-component square lattice:
+
+    |ρ(k)| = |Σ_{occupied sites} e^{ik·r}| / M,   k = 2π·(m/d₁, n/d₂),
+
+in units of the inverse lattice constant, where `(d₁, d₂)` are the in-plane
+supercell dimensions and `M = d₁·d₂` is the number of sites. This is the
+LEED-intensity convention of Zhang, Blum & Reuter
+[PRB **75**, 235406 (2007)]; [`order_parameter_c2x2`](@ref) is the
+k = (π, π) member of the family, and
+`bragg_amplitude(lat, d1 ÷ 2, d2 ÷ 2) == order_parameter_c2x2(lat)` on
+even-dimension cells. Integer indices on the supercell reciprocal grid make
+every representable k commensurate by construction; indices wrap modulo the
+dimensions, so negative and out-of-range values are valid:
+`bragg_amplitude(lat, m, n) == bragg_amplitude(lat, m + d1, n)`. The empty
+and the full lattice give `0` for any `(m, n)` not both `≡ 0` modulo the
+dimensions; a single particle gives `1/M`.
+
+Like the named order parameters, |ρ(k)| is not a function of `(E, N)` and
+must be evaluated on configurations (e.g. per culled walker, via the
+`observables` keyword of the nested-sampling loops); see
+[`order_parameter_stripe`](@ref) for the composed-observable recipes.
+
+Requires a single-site basis and a strictly two-dimensional supercell
+(`supercell_dimensions[3] == 1`); violations throw an `ArgumentError`.
+"""
+function bragg_amplitude(lattice::MLattice{1,SquareLattice}, m::Int, n::Int)
+    if length(lattice.basis) != 1
+        throw(ArgumentError("bragg_amplitude requires a single-site " *
+            "basis, got $(length(lattice.basis)) basis sites"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("bragg_amplitude requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    # Phase tables over mod-reduced cispi arguments: half-turn phases are
+    # exactly ±1.0 and quarter-turn phases exactly ±1.0/±1.0im, so the c2x2
+    # identity and the period-4 values hold to full precision
+    col = [cispi(2 * mod(m * x, d1) / d1) for x in 0:d1-1]
+    row = [cispi(2 * mod(n * y, d2) / d2) for y in 0:d2-1]
+    occ = lattice.components[1]
+    z = 0.0 + 0.0im
+    for s in eachindex(occ)
+        if occ[s]
+            # lattice_positions ordering: basis innermost, dimension 1 fastest
+            i0 = (s - 1) % d1
+            j0 = ((s - 1) ÷ d1) % d2
+            z += col[i0+1] * row[j0+1]
+        end
+    end
+    return abs(z) / (d1 * d2)
+end
+
+"""
+    order_parameter_stripe(lattice::MLattice{1,SquareLattice}; period::Int = 2) -> Float64
+
+Orientation-degenerate axial stripe order parameter on a single-component
+square lattice: the quadrature sum of the two axial Bragg amplitudes at
+wavevector 2π/P, with P = `period` in lattice constants,
+
+    Ψ = √(|ρ(2π/P, 0)|² + |ρ(0, 2π/P)|²),
+
+i.e. `sqrt(bragg_amplitude(lat, d1 ÷ period, 0)^2 +
+bragg_amplitude(lat, 0, d2 ÷ period)^2)` with the normalized amplitudes of
+[`bragg_amplitude`](@ref). A perfect single-orientation period-P stripe
+with the half-period filled attains `1/(P·sin(π/P))`: each of the `d₂` rows
+contributes `d₁/P` copies of the geometric phasor sum
+`Σ_{x=0}^{P/2−1} e^{2πix/P}`, of modulus `1/sin(π/P)`, and dividing by
+`M = d₁·d₂` leaves `1/(P·sin(π/P))`. That gives `1/2` at P = 2 (matching
+the c(2×2) = 1/2 convention at half filling) and `√2/4` at P = 4; the
+perpendicular component vanishes on a perfect stripe, so the quadrature
+maximum equals the single-orientation value. `period = 2` detects the (2×1)
+row and column stripes — the superantiferromagnetic phase of the square
+lattice with nearest- and next-nearest-neighbor couplings [Binder & Landau,
+PRB **21**, 1941 (1980)] — `period = 4` the axial period-4 phases that
+appear with third-neighbor couplings [Landau & Binder, PRB **31**, 5946
+(1985)], and `period = 2h` the width-h stripes of dipolar-frustrated
+ferromagnets [MacIsaac, Whitehead, Robinson & De'Bell, PRB **51**, 16033
+(1995)]. The perfect checkerboard and the empty and the full lattice
+give `0`.
+
+Ψ is not a function of `(E, N)` — degenerate energy levels contain ordered
+and disordered configurations alike — so it must be evaluated on
+configurations (e.g. per culled walker, via the `observables` keyword of
+the nested-sampling loops). Higher moments for Binder-cumulant analysis are
+composed caller-side, with no library change:
+
+    observables = [:stripe  => order_parameter_stripe,
+                   :stripe2 => cfg -> order_parameter_stripe(cfg)^2,
+                   :stripe4 => cfg -> order_parameter_stripe(cfg)^4]
+
+Diagonal period-4 order is composed the same way, from the k = (π/2, ±π/2)
+quadrature
+
+    cfg -> sqrt(bragg_amplitude(cfg, d1 ÷ 4, d2 ÷ 4)^2 +
+                bragg_amplitude(cfg, d1 ÷ 4, -(d2 ÷ 4))^2)
+
+which equals `√2/4` on every member of the k = (π/2, ±π/2) ground manifold
+of the nearest-neighbor-attraction plus isotropic third-neighbor-repulsion
+model — p(2×2) blocks and diagonal period-4 stripes alike — while
+`order_parameter_stripe(period=4)` is exactly `0` there; the two
+observables separate the axial and diagonal period-4 phases.
+
+Requires a single-site basis, a strictly two-dimensional supercell
+(`supercell_dimensions[3] == 1`), `period >= 2`, and `period` dividing both
+in-plane dimensions (both orientations are evaluated, and an incommensurate
+orientation leaks a spurious amplitude); violations throw an
+`ArgumentError`.
+"""
+function order_parameter_stripe(lattice::MLattice{1,SquareLattice}; period::Int=2)
+    if length(lattice.basis) != 1
+        throw(ArgumentError("order_parameter_stripe requires a single-site " *
+            "basis, got $(length(lattice.basis)) basis sites"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("order_parameter_stripe requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    if period < 2
+        throw(ArgumentError("order_parameter_stripe requires period >= 2, " *
+            "got $period"))
+    end
+    if d1 % period != 0 || d2 % period != 0
+        bad = d1 % period != 0 ? d1 : d2
+        throw(ArgumentError("order_parameter_stripe requires the period to " *
+            "divide both in-plane supercell dimensions, since both stripe " *
+            "orientations are evaluated and an incommensurate orientation " *
+            "leaks a spurious amplitude; period $period does not divide $bad"))
+    end
+    return sqrt(bragg_amplitude(lattice, d1 ÷ period, 0)^2 +
+                bragg_amplitude(lattice, 0, d2 ÷ period)^2)
+end
+
+"""
     motif_distances(coords::AbstractVector{<:Tuple}) -> Vector{Float64}
 
 Sorted multiset of the pairwise Euclidean distances of a coordinate

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -240,6 +240,149 @@
         @test names(df2) == ["iter", "emax"]
     end
 
+    # ================================================================
+    @testset "bragg_amplitude and order_parameter_stripe" begin
+        lat = obs_square_lattice(4, 4)
+        # Occupation from a predicate on the integer coordinates; site
+        # ordering: dimension 1 fastest, so x = (s-1) % d1, y = (s-1) ÷ d1
+        function fill_xy!(l, pred)
+            d1, d2 = l.supercell_dimensions[1], l.supercell_dimensions[2]
+            l.components[1] .= [pred((s - 1) % d1, ((s - 1) ÷ d1) % d2)
+                                for s in 1:d1*d2]
+            l
+        end
+
+        # k = (π, π) is order_parameter_c2x2: the two code paths agree on
+        # random occupations, and indices wrap modulo the dimensions
+        Random.seed!(1234)
+        for _ in 1:20
+            lat.components[1] .= rand(Bool, 16)
+            @test bragg_amplitude(lat, 2, 2) == order_parameter_c2x2(lat)
+            @test bragg_amplitude(lat, 1, 3) == bragg_amplitude(lat, 5, 3)
+            @test bragg_amplitude(lat, 1, 3) == bragg_amplitude(lat, -3, 3)
+        end
+
+        # Perfect (2x1) stripes, both orientations, both phases: 1/2, with
+        # order_parameter_c2x2 blind to all four (the :49 anti-case, from
+        # the other side); the perfect checkerboard is the converse
+        for pred in [(x, y) -> x % 2 == 0, (x, y) -> x % 2 == 1,
+                     (x, y) -> y % 2 == 0, (x, y) -> y % 2 == 1]
+            fill_xy!(lat, pred)
+            @test order_parameter_stripe(lat) ≈ 1 / 2 atol = 1e-12
+            @test order_parameter_c2x2(lat) == 0.0
+        end
+        fill_xy!(lat, (x, y) -> iseven(x + y))
+        @test order_parameter_stripe(lat) == 0.0
+
+        # Period-4 axial double stripes, both orientations, all four phases,
+        # on 4x4 and 8x8: sqrt(2)/4 at the stripe harmonic, exactly 0 at the
+        # period-2 harmonic (wrong-harmonic blindness)
+        for (d1, d2) in [(4, 4), (8, 8)]
+            latp = obs_square_lattice(d1, d2)
+            for p in 0:3, pred in [(x, y) -> mod(x - p, 4) < 2,
+                                   (x, y) -> mod(y - p, 4) < 2]
+                fill_xy!(latp, pred)
+                @test order_parameter_stripe(latp, period=4) ≈ sqrt(2) / 4 atol = 1e-12
+                @test order_parameter_stripe(latp, period=2) == 0.0
+            end
+        end
+
+        # Block and diagonal period-4 states: the axial stripe order
+        # parameter is exactly 0 while the documented diagonal quadrature
+        # resolves the k = (π/2, ±π/2) manifold at sqrt(2)/4
+        diag_quad(cfg) = sqrt(bragg_amplitude(cfg, 1, 1)^2 +
+                              bragg_amplitude(cfg, 1, -1)^2)
+        fill_xy!(lat, (x, y) -> x ÷ 2 == y ÷ 2)
+        @test order_parameter_stripe(lat, period=4) == 0.0
+        @test bragg_amplitude(lat, 1, 1) ≈ 1 / 4 atol = 1e-12
+        @test bragg_amplitude(lat, 1, -1) ≈ 1 / 4 atol = 1e-12
+        @test diag_quad(lat) ≈ sqrt(2) / 4 atol = 1e-12
+        fill_xy!(lat, (x, y) -> mod(x + y, 4) < 2)
+        @test order_parameter_stripe(lat, period=4) == 0.0
+        @test bragg_amplitude(lat, 1, 1) ≈ sqrt(2) / 4 atol = 1e-12
+        @test bragg_amplitude(lat, 1, -1) == 0.0
+        @test diag_quad(lat) ≈ sqrt(2) / 4 atol = 1e-12
+
+        # Empty and full lattices scatter nothing off the (0, 0) rod
+        lat.components[1] .= false
+        @test bragg_amplitude(lat, 1, 0) == 0.0
+        @test order_parameter_stripe(lat) == 0.0
+        lat.components[1] .= true
+        for (m, n) in [(1, 0), (0, 1), (2, 2), (3, 1)]
+            @test bragg_amplitude(lat, m, n) == 0.0
+        end
+        @test order_parameter_stripe(lat) == 0.0
+        @test order_parameter_stripe(lat, period=4) == 0.0
+
+        # Single particle: 1/M at any k, sqrt(2)/M in quadrature
+        lat.components[1] .= false
+        lat.components[1][1] = true
+        @test bragg_amplitude(lat, 1, 0) == 1 / 16
+        @test bragg_amplitude(lat, 2, 3) == 1 / 16
+        @test order_parameter_stripe(lat) ≈ sqrt(2) / 16 atol = 1e-12
+
+        # Two-site basis
+        lat2b = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[0.8],
+            components=[[false for _ in 1:32]],
+            adsorptions=:full)
+        @test_throws ArgumentError bragg_amplitude(lat2b, 1, 0)
+        @test_throws ArgumentError order_parameter_stripe(lat2b)
+
+        # Three-dimensional supercell
+        lat3d = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 2),
+            periodicity=(true, true, true),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:32]],
+            adsorptions=:full)
+        @test_throws ArgumentError bragg_amplitude(lat3d, 1, 0)
+        @test_throws ArgumentError order_parameter_stripe(lat3d)
+
+        # Incommensurate and degenerate periods
+        @test_throws ArgumentError order_parameter_stripe(
+            obs_square_lattice(4, 4), period=3)
+        @test_throws ArgumentError order_parameter_stripe(
+            obs_square_lattice(6, 4), period=4)
+        @test_throws ArgumentError order_parameter_stripe(
+            obs_square_lattice(4, 4), period=1)
+        @test_throws ArgumentError order_parameter_stripe(
+            obs_square_lattice(4, 4), period=0)
+
+        # A short seeded canonical NS run records the stripe Binder moments
+        # through the moment-callback pattern from the docstring
+        Random.seed!(23)
+        walkers = [LatticeWalker(deepcopy(obs_square_lattice(4, 4)),
+                                 energy=0.0u"eV", iter=0) for _ in 1:20]
+        # Fixed-N ladder at N = 6: place 6 particles per walker
+        for w in walkers
+            occ = vcat(fill(true, 6), fill(false, 10))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls = LatticeGasWalkers(walkers, obs_ham; perturb_energy=1e-9)
+        params = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+
+        df, _, _ = nested_sampling(ls, params, Int64(200),
+            MCRandomWalkClone(), obs_save;
+            observables=[:stripe => order_parameter_stripe,
+                         :stripe2 => (cfg -> order_parameter_stripe(cfg)^2),
+                         :stripe4 => (cfg -> order_parameter_stripe(cfg)^4)])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "stripe", "stripe2", "stripe4"]
+        @test all(0.0 .<= df.stripe .<= 1 / 2)
+        @test all(isapprox.(df.stripe2, df.stripe .^ 2; rtol=1e-12))
+        @test all(isapprox.(df.stripe4, df.stripe .^ 4; rtol=1e-12))
+    end
+
     @testset "observable hook: validation" begin
         lat = obs_square_lattice(4, 4)
         walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:8]


### PR DESCRIPTION
Implements #151.

## What

- `bragg_amplitude(lattice::MLattice{1,SquareLattice}, m::Int, n::Int)`: the diffraction amplitude |ρ(k)| = |Σ<sub>occupied</sub> e<sup>ik·r</sup>| / M at k = 2π(m/d₁, n/d₂) on the supercell reciprocal grid, so every representable k is commensurate by construction; integer indices wrap, so negative and out-of-range values are valid. One complex multiply-accumulate per occupied site over mod-reduced `cispi` phase tables, making half-turn phases exactly ±1 and quarter-turn phases exactly ±1/±i: the identity `bragg_amplitude(lat, d1÷2, d2÷2) == order_parameter_c2x2(lat)` holds exactly, and period-4 values hit √2/4 to full precision. O(M) per call with O(d₁+d₂) allocation.
- `order_parameter_stripe(lattice; period=2)`: the orientation-degenerate axial stripe order parameter, the quadrature sum over k = (2π/P, 0) and (0, 2π/P). A perfect single-orientation period-P stripe with the half-period filled attains 1/(P·sin(π/P)), the geometric phasor sum: 1/2 at P = 2 (matching the c(2×2) = 1/2 convention at half filling) and √2/4 at P = 4; P = 2h detects width-h stripes. Guards, all `ArgumentError`: single-site basis, two-dimensional supercell, period ≥ 2, and period dividing both in-plane dimensions (both orientations are evaluated; an incommensurate orientation leaks a spurious amplitude).
- Docstrings carry the Binder moment-callback recipe (`:stripe`/`:stripe2`/`:stripe4` through the `observables` hook) and the diagonal period-4 quadrature recipe for the k = (π/2, ±π/2) ground manifold (p(2×2) blocks and diagonal period-4 stripes) of the nearest-neighbor-attraction plus isotropic third-neighbor-repulsion model, on which the axial P = 4 order parameter is exactly 0 while the diagonal composite is √2/4 for every member. References: Zhang, Blum and Reuter, Phys. Rev. B 75, 235406 (2007); Binder and Landau, Phys. Rev. B 21, 1941 (1980); Landau and Binder, Phys. Rev. B 31, 5946 (1985); MacIsaac, Whitehead, Robinson and De'Bell, Phys. Rev. B 51, 16033 (1995).

## Tests

- Exact identity with `order_parameter_c2x2` on seeded random occupations (exact `==`, tying the two code paths), plus the index-wrapping identities at m ± d₁.
- Perfect (2×1) stripes, both orientations and both phases: stripe order parameter 1/2 with `order_parameter_c2x2` = 0 on the same states; the perfect checkerboard gives stripe order parameter exactly 0.
- Period-4 axial double stripes on 4×4 and 8×8, both orientations, all four phases: √2/4 at P = 4 and exactly 0 at P = 2 (wrong-harmonic blindness).
- Block and diagonal period-4 states: axial P = 4 order parameter 0 while the diagonal quadrature gives √2/4 across the degenerate manifold.
- Edge values (empty, full, single particle), every guard path, and a seeded canonical nested-sampling run recording `:stripe`/`:stripe2`/`:stripe4` through the observables hook with row-by-row moment consistency and every value in [0, 1/2].

An adversarial review pass cross-checked the index arithmetic against a position-based reimplementation on non-square cells, confirmed the exact-equality and wrapping identities, and verified the documented maxima by exhaustive enumeration of all 65,536 4×4 configurations (1/2 at P = 2 and √2/4 at P = 4 are attained and never exceeded), with no must-fix findings; its one suggestion, pinning the c(2×2) identity as exact `==` rather than a 10<sup>−12</sup> tolerance, is applied. Full test suite passes (SamplingSchemes 1422, AbstractWalkers 283, Energy Evaluation 216, Cluster lattice Hamiltonian 678, Monte Carlo Moves 3807, FreeBirdIO 51).
