### PR TITLE
Site-resolved on-site fields and layer-resolved coverage observables for lattice slabs

### DIFF
--- a/src/AbstractHamiltonians/AbstractHamiltonians.jl
+++ b/src/AbstractHamiltonians/AbstractHamiltonians.jl
@@ -13,6 +13,7 @@ export AbstractHamiltonian
 export ClassicalHamiltonian
 export GenericLatticeHamiltonian, MLatticeHamiltonian
 export ClusterInteraction, ClusterLatticeHamiltonian
+export SiteFieldLatticeHamiltonian
 
 abstract type AbstractHamiltonian end
 
@@ -109,7 +110,7 @@ end
 function Base.show(io::IO, hamiltonian::GenericLatticeHamiltonian{N,U}) where {N,U}
     println(io, "GenericLatticeHamiltonian{$N,$U}:")
     println(io, "    on_site_interaction:      ", hamiltonian.on_site_interaction)
-    println(io, "    nth_neighbor_interactions: ", [hamiltonian.nth_neighbor_interactions[i].val for i in 1:N], " ", unit(U))
+    println(io, "    nth_neighbor_interactions: ", [ustrip(hamiltonian.nth_neighbor_interactions[i]) for i in 1:N], " ", unit(U))
 end
     
     """
@@ -312,6 +313,154 @@ function Base.show(io::IO, h::ClusterLatticeHamiltonian{N,U}) where {N,U}
     for c in h.clusters
         println(io, "        ", c)
     end
+end
+
+"""
+    _coupling_type(hamiltonian)
+
+Internal trait returning the concrete coupling type `U` of a lattice
+Hamiltonian (the exact `typeof` shared by its on-site, pair, and cluster
+couplings), or `nothing` for Hamiltonian types that do not declare one. The
+[`SiteFieldLatticeHamiltonian`](@ref) constructor uses it to require that
+every field entry's type equals the base's coupling type (same units and
+value type; no promotion), mirroring the per-cluster coupling check of
+[`ClusterLatticeHamiltonian`](@ref). New `ClassicalHamiltonian` types opt
+in by adding a method.
+"""
+_coupling_type(hamiltonian) = nothing
+_coupling_type(::GenericLatticeHamiltonian{N,U}) where {N,U} = U
+_coupling_type(::MLatticeHamiltonian{C,N,U}) where {C,N,U} = U
+_coupling_type(::ClusterLatticeHamiltonian{N,U}) where {N,U} = U
+
+"""
+    struct SiteFieldLatticeHamiltonian{H,U} <: ClassicalHamiltonian
+
+A wrapper Hamiltonian adding a site-resolved on-site energy (a "field") to
+a lattice Hamiltonian: the total energy is the wrapped base Hamiltonian's
+energy plus `Σ field[i]` over every occupied site `i`. One number per site
+breaks the site equivalence the base Hamiltonians assume, which is what
+layered adsorption physics needs: a substrate potential decaying with
+height, canonically a contact term plus an inverse-cube tail in the
+multilayer lattice-gas models of de Oliveira and Griffiths
+[Surf. Sci. 71, 687 (1978)] and Pandit, Schick and Wortis
+[Phys. Rev. B 26, 5112 (1982)], is expressed as a per-layer profile
+broadcast over sites with `layer_field`.
+
+# Fields
+- `base::H`: the wrapped Hamiltonian (`GenericLatticeHamiltonian`,
+  `MLatticeHamiltonian`, or `ClusterLatticeHamiltonian`).
+- `field::Vector{U}`: one on-site energy per site, added once per occupied
+  site; `U` equals the base's coupling type exactly.
+
+# Additive contract
+
+The field adds on top of the base's own on-site term: a base with
+`on_site_interaction = ε` still contributes `ε × (number of occupied
+adsorption sites)` through `lattice.adsorptions`. The two on-site channels
+compose additively, so supplying a full per-site field while the base
+carries a nonzero on-site energy double-counts every occupied adsorption
+site. When a full field is supplied, zero the base's on-site energy and
+put the entire on-site physics in the field.
+
+The wrapper subsumes the adsorption mechanism exactly: for a lattice with
+adsorption mask `A = lattice.adsorptions`,
+
+    GenericLatticeHamiltonian(ε, J)   # ε once per occupied adsorption site
+    ≡ SiteFieldLatticeHamiltonian(GenericLatticeHamiltonian(zero(ε), J), ε .* A)
+
+since the masked field `ε .* A` carries `ε` on each adsorption site and an
+exact zero elsewhere.
+
+## Layer-profile recipe
+
+    lat = SLattice{SquareLattice}(supercell_dimensions=(4, 4, 3),
+                                  periodicity=(true, true, false),
+                                  cutoff_radii=[1.1])
+    field = layer_field(lat, [-0.27, -0.03375, -0.01] .* u"eV")  # inverse-cube tail
+    h = SiteFieldLatticeHamiltonian(GenericLatticeHamiltonian(0.0, [-0.01], u"eV"), field)
+
+# Constructors
+```julia
+SiteFieldLatticeHamiltonian(base::ClassicalHamiltonian, field::Vector)
+SiteFieldLatticeHamiltonian(base::ClassicalHamiltonian, field::Vector{Float64}, energy_units::Unitful.Units)
+```
+
+The three-argument form attaches `energy_units` to a plain `Float64`
+vector, like the units convenience constructor of
+[`GenericLatticeHamiltonian`](@ref). The field vector is copied.
+
+Throws an `ArgumentError` when the base is itself a
+`SiteFieldLatticeHamiltonian` (compose site fields by adding the vectors,
+not by nesting wrappers), when the field is empty, when the base's
+coupling type cannot be determined, when any entry's type differs from the
+base's coupling type (exact `typeof` equality: same units and value type,
+no promotion), or when any entry is non-finite (an `Inf` makes every
+nested-sampling ceiling comparison degenerate and the sampler stalls
+silently; see the hard-core recipe in the
+[`GenericLatticeHamiltonian`](@ref) docstring).
+
+The field length is *not* checked here (no lattice is in scope at
+construction) but once per run at setup, in the `LatticeGasWalkers`
+constructor and the raw-lattice `wang_landau`/`nvt_monte_carlo` entry
+points, where a length differing from the lattice's site count throws.
+"""
+struct SiteFieldLatticeHamiltonian{H<:ClassicalHamiltonian,U} <: ClassicalHamiltonian
+    base::H
+    field::Vector{U}
+
+    function SiteFieldLatticeHamiltonian(base::ClassicalHamiltonian, field::AbstractVector)
+        if base isa SiteFieldLatticeHamiltonian
+            throw(ArgumentError(
+                "nesting SiteFieldLatticeHamiltonian wrappers is not supported; " *
+                "compose site fields by adding the vectors: " *
+                "SiteFieldLatticeHamiltonian(base.base, base.field .+ field)"))
+        end
+        if isempty(field)
+            throw(ArgumentError(
+                "field is empty; supply one on-site energy per lattice site " *
+                "(build a layer profile with layer_field)"))
+        end
+        U = _coupling_type(base)
+        if U === nothing
+            throw(ArgumentError(
+                "cannot determine the coupling type of a $(typeof(base)); " *
+                "SiteFieldLatticeHamiltonian supports GenericLatticeHamiltonian, " *
+                "MLatticeHamiltonian and ClusterLatticeHamiltonian bases, or any " *
+                "Hamiltonian type that defines AbstractHamiltonians._coupling_type"))
+        end
+        for (i, v) in enumerate(field)
+            if !(typeof(v) == U)
+                throw(ArgumentError(
+                    "field[$i] has type $(typeof(v)), which does not match the " *
+                    "base Hamiltonian's coupling type $U; construct every field " *
+                    "entry with the same units and value type as the base couplings"))
+            end
+            if !isfinite(v)
+                throw(ArgumentError(
+                    "field[$i] is not finite; non-finite on-site energies are not " *
+                    "supported: an Inf makes every nested-sampling ceiling " *
+                    "comparison degenerate (Inf >= Inf) and the sampler stalls " *
+                    "silently. Model site exclusion with a finite repulsive value " *
+                    "instead; see the hard-core recipe in the " *
+                    "GenericLatticeHamiltonian docstring."))
+            end
+        end
+        return new{typeof(base),U}(base, collect(U, field))
+    end
+end
+
+function SiteFieldLatticeHamiltonian(base::ClassicalHamiltonian, field::Vector{Float64}, energy_units::Unitful.Units)
+    return SiteFieldLatticeHamiltonian(base, field .* energy_units)
+end
+
+_coupling_type(::SiteFieldLatticeHamiltonian{H,U}) where {H,U} = U
+
+function Base.show(io::IO, h::SiteFieldLatticeHamiltonian{H,U}) where {H,U}
+    println(io, "SiteFieldLatticeHamiltonian{$H,$U}:")
+    lo, hi = extrema(h.field)
+    println(io, "    field: ", length(h.field), " sites, extrema [",
+            ustrip(lo), ", ", ustrip(hi), "] ", unit(U))
+    println(io, "    base: ", h.base)
 end
 
 end # module Hamiltonians

--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -24,6 +24,7 @@ end
 _n_coupled_shells(h::GenericLatticeHamiltonian{N,U}) where {N,U} = N
 _n_coupled_shells(h::MLatticeHamiltonian{C,N,U}) where {C,N,U} = N
 _n_coupled_shells(h::ClusterLatticeHamiltonian{N,U}) where {N,U} = N
+_n_coupled_shells(h::SiteFieldLatticeHamiltonian) = _n_coupled_shells(h.base)
 _n_coupled_shells(h) = nothing
 
 """
@@ -34,7 +35,8 @@ raw-lattice `wang_landau`/`nvt_monte_carlo` entry points): a
 `ClusterLatticeHamiltonian` whose embeddings reference site indices beyond
 the lattice was built for a different lattice; failing here with a
 descriptive `ArgumentError` beats a `BoundsError` from deep inside the
-energy kernel. A no-op for every other Hamiltonian type. The converse
+energy kernel. A `SiteFieldLatticeHamiltonian` delegates the check to its
+wrapped base; a no-op for every other Hamiltonian type. The converse
 mismatch — a Hamiltonian enumerated on a *smaller* lattice, whose indices
 all exist but whose embeddings have wrong geometry — is undetectable from
 indices alone and remains the caller's responsibility: always enumerate on
@@ -52,6 +54,33 @@ function _check_cluster_sites(h::ClusterLatticeHamiltonian, cfg::AbstractLattice
                     "built for a different lattice"))
             end
         end
+    end
+    return nothing
+end
+_check_cluster_sites(h::SiteFieldLatticeHamiltonian, cfg::AbstractLattice) =
+    _check_cluster_sites(h.base, cfg)
+
+"""
+    _check_field_length(hamiltonian, cfg)
+
+One-time check at run setup (the `LatticeGasWalkers` constructor and the
+raw-lattice `wang_landau`/`nvt_monte_carlo` entry points): a
+`SiteFieldLatticeHamiltonian` whose field length differs from the number
+of lattice sites was built for a different lattice; failing here with a
+descriptive `ArgumentError` beats a `DimensionMismatch` from inside the
+energy kernel. A no-op for every other Hamiltonian type. A field of the
+*right* length built for a different lattice of the same size is
+undetectable from the length alone and remains the caller's
+responsibility: always build the field (e.g. with `layer_field`) on the
+lattice being sampled.
+"""
+_check_field_length(hamiltonian, cfg) = nothing
+function _check_field_length(h::SiteFieldLatticeHamiltonian, cfg::AbstractLattice)
+    M = num_sites(cfg)
+    if length(h.field) != M
+        throw(ArgumentError(
+            "the site field has $(length(h.field)) entries but the lattice " *
+            "has $M sites; the Hamiltonian was built for a different lattice"))
     end
     return nothing
 end
@@ -108,6 +137,7 @@ struct  LatticeGasWalkers <: LatticeWalkers
     function LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::ClassicalHamiltonian; assign_energy=true, perturb_energy::Float64=0.0) where C
         _warn_uncoupled_shells(walkers, hamiltonian)
         isempty(walkers) || _check_cluster_sites(hamiltonian, walkers[1].configuration)
+        isempty(walkers) || _check_field_length(hamiltonian, walkers[1].configuration)
         if assign_energy
             [assign_energy!(walker, hamiltonian; perturb_energy=perturb_energy) for walker in walkers]
         end

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -29,6 +29,7 @@ export order_parameter_c2x2
 export order_parameter_sqrt3
 export bragg_amplitude
 export order_parameter_stripe
+export site_layers, layer_coverage, occupancy_profile, layer_field
 export enumerate_motif_embeddings, motif_distances
 export view_structure
 

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -835,6 +835,146 @@ function order_parameter_stripe(lattice::MLattice{1,SquareLattice}; period::Int=
 end
 
 """
+    _check_planar_basis(caller::Symbol, lattice::MLattice)
+
+Shared guard for the layer helpers: throw an `ArgumentError`, naming the
+public entry point `caller`, unless all basis z-components are equal.
+Layers along dimension 3 are geometrically well defined only for a planar
+basis.
+"""
+function _check_planar_basis(caller::Symbol, lattice::MLattice)
+    zs = [b[3] for b in lattice.basis]
+    if any(z -> z != zs[1], zs)
+        throw(ArgumentError("$caller requires a planar basis (all basis " *
+            "z-components equal) so layers along dimension 3 are " *
+            "geometrically well defined, got basis z-components $zs"))
+    end
+    return nothing
+end
+
+"""
+    site_layers(lattice::MLattice) -> Vector{Int}
+
+Layer index of every site along the third supercell dimension: site `s`
+belongs to layer `(s − 1) ÷ B + 1` with `B = length(basis) · d₁ · d₂`,
+exact because `lattice_positions` orders sites with dimension 3 outermost
+(basis innermost, dimension 1 fastest), making each layer one contiguous
+block of `B` sites. The result has `num_sites(lattice)` entries with
+values in `1:d₃`.
+
+Requires a planar basis (all basis z-components equal), so that "layer" is
+geometrically unambiguous; violations throw an `ArgumentError`.
+"""
+function site_layers(lattice::MLattice)
+    _check_planar_basis(:site_layers, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    B = length(lattice.basis) * d1 * d2
+    # lattice_positions ordering: dimension 3 outermost, so layers are
+    # contiguous blocks of B sites
+    return [(s - 1) ÷ B + 1 for s in 1:(B * d3)]
+end
+
+"""
+    layer_coverage(lattice::MLattice{1,G}, layer::Int) -> Float64
+
+Occupied fraction of one layer of a single-component lattice: the number
+of occupied sites in layer `layer`'s contiguous block of
+`B = length(basis) · d₁ · d₂` sites (see [`site_layers`](@ref)), divided
+by `B`. This is the layer-resolved complement of the in-plane order
+parameters for three-dimensional supercells; the per-layer coverages
+θ_k are the order parameters of lattice-gas layering transitions. It
+returns a scalar `Real`, so `cfg -> layer_coverage(cfg, k)`
+is directly usable as an `observables` callback in the nested-sampling
+loops: like the shipped order parameters, θ is not a function of `(E, N)`
+and must be evaluated per configuration rather than reconstructed from an
+energy ledger. At `d₃ == 1` it degenerates to the total coverage `N/M`,
+which is legal and intentional, so no two-dimensionality guard applies.
+
+Requires a planar basis (all basis z-components equal) and
+`1 ≤ layer ≤ d₃`; violations throw an `ArgumentError`.
+"""
+function layer_coverage(lattice::MLattice{1,G}, layer::Int) where G
+    _check_planar_basis(:layer_coverage, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    if !(1 <= layer <= d3)
+        throw(ArgumentError("layer_coverage requires 1 <= layer <= $d3 " *
+            "(= supercell_dimensions[3]), got $layer"))
+    end
+    B = length(lattice.basis) * d1 * d2
+    occ = lattice.components[1]
+    n = 0
+    for s in ((layer - 1) * B + 1):(layer * B)
+        n += occ[s] ? 1 : 0
+    end
+    return n / B
+end
+
+"""
+    occupancy_profile(lattice::MLattice{1,G}) -> Vector{Float64}
+
+Vector of layer coverages, `[layer_coverage(lattice, k) for k in 1:d₃]`,
+computed in one pass. Every layer holds `B = length(basis) · d₁ · d₂`
+sites, so `mean(occupancy_profile(lat)) == N/M` exactly (`N` occupied
+sites, `M` total sites).
+
+The return value is a `Vector`, not a scalar, so `occupancy_profile` is
+*not* directly usable as an `observables` callback (callbacks must return
+a `Real`); record per-layer coverages by composing scalar callbacks
+caller-side, with no library change:
+
+    observables = [Symbol(:theta, k) => (cfg -> layer_coverage(cfg, k)) for k in 1:d₃]
+
+after which ⟨θ₁⟩ … ⟨θ_d₃⟩ come from `observable_cols=[:theta1, :theta2, …]`
+in the grand-canonical stats functions.
+
+Requires a planar basis (all basis z-components equal); violations throw
+an `ArgumentError`.
+"""
+function occupancy_profile(lattice::MLattice{1,G}) where G
+    _check_planar_basis(:occupancy_profile, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    B = length(lattice.basis) * d1 * d2
+    occ = lattice.components[1]
+    counts = zeros(Int, d3)
+    for s in eachindex(occ)
+        if occ[s]
+            counts[(s - 1) ÷ B + 1] += 1
+        end
+    end
+    return counts ./ B
+end
+
+"""
+    layer_field(lattice::MLattice, per_layer::AbstractVector) -> Vector
+
+Broadcast a per-layer value over every site of its layer: the result has
+`num_sites(lattice)` entries, with `per_layer[k]` at every site of layer
+`k` (see [`site_layers`](@ref)). The element type of `per_layer` is
+preserved, so a `Unitful` profile feeds a `SiteFieldLatticeHamiltonian`
+directly:
+
+    field = layer_field(lat, [-0.27, -0.03375, -0.01] .* u"eV")
+    h = SiteFieldLatticeHamiltonian(GenericLatticeHamiltonian(0.0, [-0.01], u"eV"), field)
+
+A height profile is physically meaningful only when dimension 3 is
+non-periodic (`periodicity[3] == false`); this is not checked.
+
+Requires a planar basis (all basis z-components equal) and
+`length(per_layer) == d₃` (= `supercell_dimensions[3]`); violations throw
+an `ArgumentError`.
+"""
+function layer_field(lattice::MLattice, per_layer::AbstractVector)
+    _check_planar_basis(:layer_field, lattice)
+    d3 = lattice.supercell_dimensions[3]
+    if length(per_layer) != d3
+        throw(ArgumentError("layer_field requires one value per layer " *
+            "(length(per_layer) == supercell_dimensions[3] == $d3), got " *
+            "$(length(per_layer)) values"))
+    end
+    return per_layer[site_layers(lattice)]
+end
+
+"""
     motif_distances(coords::AbstractVector{<:Tuple}) -> Vector{Float64}
 
 Sorted multiset of the pairwise Euclidean distances of a coordinate

--- a/src/EnergyEval/lattice_energies.jl
+++ b/src/EnergyEval/lattice_energies.jl
@@ -159,6 +159,42 @@ function interacting_energy(lattice::SLattice, h::ClusterLatticeHamiltonian{N,U}
 end
 
 """
+    site_field_energy(occupations::Vector{Bool}, field::Vector{U})
+
+Energy contribution of a per-site field: the sum of `field[i]` over every
+occupied site `i`. Iteration runs over `eachindex(occupations, field)`, so
+a field whose length differs from the occupation vector (a Hamiltonian
+built for a different lattice) raises a `DimensionMismatch` rather than
+silently summing a truncated or padded range; the liveset constructor and
+the raw-lattice sampler entry points validate the length once up front,
+with a descriptive error.
+"""
+function site_field_energy(occupations::Vector{Bool}, field::Vector{U}) where U
+    e::U = zero(U)
+    for i in eachindex(occupations, field)
+        if occupations[i]
+            e += field[i]
+        end
+    end
+    return e
+end
+
+"""
+    interacting_energy(lattice::SLattice, h::SiteFieldLatticeHamiltonian{H,U})
+
+Total energy under a site-field wrapper: the wrapped base Hamiltonian's
+energy, evaluated exactly as if the base were passed directly (including
+its `on_site_interaction × occupied-adsorption-sites` term), plus the
+occupation-masked field sum of [`site_field_energy`](@ref).
+Single-component (`SLattice`) configurations only.
+"""
+function interacting_energy(lattice::SLattice, h::SiteFieldLatticeHamiltonian{H,U}) where {H,U}
+    e_base::U = interacting_energy(lattice, h.base)
+    e_field::U = site_field_energy(lattice.components[1], h.field)
+    return e_base + e_field
+end
+
+"""
     interacting_energy(lattice::MLattice{C,G}, h::MLatticeHamiltonian{C,N,U})
 
 Compute the interaction energy of a multi-component lattice configuration using the Hamiltonian parameters.

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -83,6 +83,7 @@ function nvt_monte_carlo(
     # No liveset is built on this path, so run the setup checks here
     AbstractLiveSets._warn_uncoupled_shells(lattice, h)
     AbstractLiveSets._check_cluster_sites(h, lattice)
+    AbstractLiveSets._check_field_length(h, lattice)
 
     energies = Vector{Float64}(undef, num_steps)
     configurations = Vector{typeof(lattice)}(undef, num_steps)

--- a/src/SamplingSchemes/wang_landau.jl
+++ b/src/SamplingSchemes/wang_landau.jl
@@ -115,6 +115,7 @@ function wang_landau(
     # No liveset is built on this path, so run the setup checks here
     AbstractLiveSets._warn_uncoupled_shells(lattice, h)
     AbstractLiveSets._check_cluster_sites(h, lattice)
+    AbstractLiveSets._check_field_length(h, lattice)
 
     energy_bins_count = length(wl_params.energy_bins)
     

--- a/test/test-AbstractHamiltonians.jl
+++ b/test/test-AbstractHamiltonians.jl
@@ -170,4 +170,76 @@
         @test contains(output, "ClusterInteraction{3}")
         @test contains(output, "2 embeddings")
     end
+
+    @testset "SiteFieldLatticeHamiltonian tests" begin
+        base = GenericLatticeHamiltonian(0.0, [0.0], u"eV")
+        h = SiteFieldLatticeHamiltonian(base, [-0.27, -0.03375, -0.01], u"eV")
+        @test h isa SiteFieldLatticeHamiltonian{typeof(base),typeof(1.0u"eV")}
+        @test h.base === base
+        @test h.field == [-0.27, -0.03375, -0.01] .* u"eV"
+        @test length(h.field) == 3
+
+        # The convenience (Float64 + units) and direct (unitful vector)
+        # constructors agree
+        h2 = SiteFieldLatticeHamiltonian(base, [-0.27, -0.03375, -0.01] .* u"eV")
+        @test h2.field == h.field
+
+        # The field is copied, not aliased
+        raw = [-0.1, -0.2] .* u"eV"
+        h_copy = SiteFieldLatticeHamiltonian(base, raw)
+        raw[1] = 0.0u"eV"
+        @test h_copy.field[1] == -0.1u"eV"
+
+        # The field-type rule is "match the base's coupling type", not
+        # "must be eV": an all-meV pairing is legal
+        base_mev = GenericLatticeHamiltonian(-40.0, [-10.0], u"meV")
+        h_mev = SiteFieldLatticeHamiltonian(base_mev, [-1.0, -2.0], u"meV")
+        @test h_mev.field == [-1.0, -2.0] .* u"meV"
+
+        # A cluster Hamiltonian is a legal base (any non-nested
+        # ClassicalHamiltonian with a declared coupling type)
+        pair = GenericLatticeHamiltonian(-1.249, [0.292, 0.090], u"eV")
+        cl = ClusterLatticeHamiltonian(pair, [ClusterInteraction(0.168u"eV", [(1, 2, 3)])])
+        hcl = SiteFieldLatticeHamiltonian(cl, [-0.1, -0.1, -0.1], u"eV")
+        @test hcl.base === cl
+
+        # An MLatticeHamiltonian is a legal base too: the coupling-type
+        # trait reads its shared U parameter
+        mlh = MLatticeHamiltonian(1, [GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")])
+        hml = SiteFieldLatticeHamiltonian(mlh, [-0.1], u"eV")
+        @test hml.base === mlh
+        @test hml isa SiteFieldLatticeHamiltonian{typeof(mlh),typeof(1.0u"eV")}
+
+        # A unitless base is constructible, and the wrapper (including the
+        # delegated base print) shows without error
+        h_unitless = SiteFieldLatticeHamiltonian(
+            GenericLatticeHamiltonian(-0.04, [-0.01]), [0.1, 0.2])
+        buf_u = IOBuffer()
+        show(buf_u, h_unitless)
+        @test contains(String(take!(buf_u)), "field: 2 sites")
+
+        # Empty fields have no meaning: which sites would they cover?
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, Float64[], u"eV")
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, typeof(1.0u"eV")[])
+        # Non-finite entries stall nested sampling silently (Inf >= Inf
+        # ceiling comparisons), the coupling-guard rationale
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [0.1, Inf], u"eV")
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [NaN], u"eV")
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [0.1u"eV", Inf * u"eV"])
+        # Field element type must equal the base coupling type exactly,
+        # mirroring the cluster coupling-type check
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [0.1, 0.2])
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [100.0, 200.0] .* u"meV")
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base_mev, [-1.0], u"eV")
+        # Nesting is rejected: compose site fields by adding the vectors
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(h, [-0.1, -0.2, -0.3], u"eV")
+
+        # Show method
+        buf = IOBuffer()
+        show(buf, h)
+        output = String(take!(buf))
+        @test contains(output, "SiteFieldLatticeHamiltonian")
+        @test contains(output, "field: 3 sites")
+        @test contains(output, "base: ")
+    end
 end

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -679,4 +679,159 @@
         end
     end
 
+    @testset "site-field lattice Hamiltonian (exactness, subsumption, setup checks)" begin
+        using Random
+
+        function sf_lattice(L; cutoffs=[1.1, 1.5], ads=:full)
+            MLattice{1,SquareLattice}(
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(L, L, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=cutoffs,
+                components=[[false for _ in 1:L*L]],
+                adsorptions=ads)
+        end
+
+        # ------------------------------------------------------------
+        @testset "field-only exactness on hand configurations" begin
+            # Base contributes exactly zero (zero on-site, zero coupling),
+            # so the energy is the masked field sum and nothing else.
+            # Distinct per-site values catch any index permutation.
+            lat = sf_lattice(4; cutoffs=[1.1])
+            base0 = GenericLatticeHamiltonian(0.0, [0.0], u"eV")
+            h = SiteFieldLatticeHamiltonian(base0, collect(1:16) .* 1e-3, u"eV")
+
+            lat.components[1] .= false
+            @test isapprox(interacting_energy(lat, h), 0.0u"eV"; atol=1e-12u"eV")
+            lat.components[1][1] = true
+            @test isapprox(interacting_energy(lat, h), 0.001u"eV"; atol=1e-12u"eV")
+            lat.components[1][7] = true                       # sites {1, 7}
+            @test isapprox(interacting_energy(lat, h), 0.008u"eV"; atol=1e-12u"eV")
+            lat.components[1] .= false
+            lat.components[1][[2, 5, 16]] .= true
+            @test isapprox(interacting_energy(lat, h), 0.023u"eV"; atol=1e-12u"eV")
+            lat.components[1] .= true
+            @test isapprox(interacting_energy(lat, h), 0.136u"eV"; atol=1e-12u"eV")
+        end
+
+        # ------------------------------------------------------------
+        @testset "subsumption identity both ways (20 random 4x4 occupations)" begin
+            # "Both ways": (i) forward, the masked scalar on-site of a bare
+            # GenericLatticeHamiltonian re-expressed as field = eps .* mask
+            # gives identical energies; (ii) reverse, the wrapper with the
+            # bare Hamiltonian as base and an all-zero field is the identity
+            # on its base. Plus the additive contract: base on-site x mask
+            # and a nonuniform field coexist and add.
+            mask = Bool[1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0]  # fixed, 8 sites
+            lat_m = sf_lattice(4; ads=findall(mask))
+            ε = -0.04
+            J = [-0.01, -0.0025]
+            bare = GenericLatticeHamiltonian(ε, J, u"eV")
+            wrapF = SiteFieldLatticeHamiltonian(
+                GenericLatticeHamiltonian(0.0, J, u"eV"), ε .* mask, u"eV")
+            wrap0 = SiteFieldLatticeHamiltonian(bare, zeros(16), u"eV")
+            g = collect(1:16) .* 1e-3
+            wrapB = SiteFieldLatticeHamiltonian(bare, g, u"eV")
+
+            Random.seed!(202)
+            for _ in 1:20
+                occ = rand(Bool, 16)
+                lat_m.components[1] .= occ
+                E_bare = interacting_energy(lat_m, bare)
+                # forward direction of the identity
+                @test isapprox(interacting_energy(lat_m, wrapF), E_bare;
+                               atol=1e-12u"eV")
+                # reverse direction: zero-field wrapper == base
+                @test isapprox(interacting_energy(lat_m, wrap0), E_bare;
+                               atol=1e-12u"eV")
+                # additive contract with the base's on-site x adsorptions term
+                @test isapprox(interacting_energy(lat_m, wrapB),
+                               E_bare + sum(g[occ]) * u"eV"; atol=1e-12u"eV")
+            end
+        end
+
+        # ------------------------------------------------------------
+        @testset "setup-check matrix: field length and delegation" begin
+            lat = sf_lattice(4)   # 16 sites, 2 neighbor shells
+            base2 = GenericLatticeHamiltonian(0.0, [0.1, 0.05], u"eV")
+            h_short = SiteFieldLatticeHamiltonian(base2, fill(-0.01, 15), u"eV")
+            h_long = SiteFieldLatticeHamiltonian(base2, fill(-0.01, 17), u"eV")
+            h_ok = SiteFieldLatticeHamiltonian(base2, fill(-0.01, 16), u"eV")
+
+            # Built-for-a-different-lattice register: ArgumentError at every
+            # setup entry point, mirroring the shell-count matrix above
+            w1 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_throws ArgumentError LatticeGasWalkers(w1, h_short)
+            w2 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_throws ArgumentError LatticeGasWalkers(w2, h_long)
+            wl_params = WangLandauParameters(energy_min=-0.5, energy_max=3.0,
+                                             num_energy_bins=30, num_steps=10,
+                                             max_iter=2, random_seed=7)
+            @test_throws ArgumentError wang_landau(deepcopy(lat), h_short, wl_params)
+            @test_throws ArgumentError nvt_monte_carlo(
+                MCNewSample(), deepcopy(lat), h_short, 300.0, 5, 7)
+
+            # Matching length: silent
+            w3 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_logs min_level = Base.CoreLogging.Warn LatticeGasWalkers(w3, h_ok)
+
+            # A stale field reaching the raw energy path must crash, not
+            # sum a truncated or padded range: eachindex(occupations, field)
+            # raises DimensionMismatch in BOTH directions
+            lat16 = deepcopy(lat)
+            lat16.components[1][16] = true
+            @test_throws DimensionMismatch interacting_energy(lat16, h_short)
+            @test_throws DimensionMismatch interacting_energy(lat16, h_long)
+
+            # The uncoupled-shell warning threads through the wrapper
+            # (_n_coupled_shells delegates to base): 1-shell base, 2-shell lattice
+            h_1shell = SiteFieldLatticeHamiltonian(
+                GenericLatticeHamiltonian(0.0, [0.1], u"eV"), fill(-0.01, 16), u"eV")
+            w4 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_logs (:warn, r"couples only the first 1") match_mode = :any LatticeGasWalkers(
+                w4, h_1shell)
+            # ... and reaches the raw-lattice sampler entry points too
+            @test_logs (:warn, r"couples only the first 1") match_mode = :any wang_landau(
+                deepcopy(lat), h_1shell, wl_params)
+            @test_logs (:warn, r"couples only the first 1") match_mode = :any nvt_monte_carlo(
+                MCNewSample(), deepcopy(lat), h_1shell, 300.0, 5, 7)
+
+            # The cluster-embedding check threads through the wrapper
+            # (_check_cluster_sites delegates to base): stale embeddings
+            # throw at liveset construction
+            pair = GenericLatticeHamiltonian(0.0, [0.1, 0.05], u"eV")
+            stale = ClusterLatticeHamiltonian(
+                pair, [ClusterInteraction(0.2u"eV", [(1, 2, 17)])])
+            h_stale = SiteFieldLatticeHamiltonian(stale, fill(-0.01, 16), u"eV")
+            w5 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_throws ArgumentError LatticeGasWalkers(w5, h_stale)
+
+            # A valid wrapped cluster composes additively: pair shells +
+            # trio coupling + field sum, hand closed form. Sites {1, 2, 5}:
+            # (1,2) and (1,5) are first-shell pairs, (2,5) is the sqrt(2)
+            # shell, and the trio (1,2,5) is fully occupied.
+            good = ClusterLatticeHamiltonian(
+                pair, [ClusterInteraction(0.2u"eV", [(1, 2, 5)])])
+            h_good = SiteFieldLatticeHamiltonian(good, collect(1:16) .* 1e-3, u"eV")
+            lat3 = deepcopy(lat)
+            lat3.components[1][[1, 2, 5]] .= true
+            @test isapprox(interacting_energy(lat3, h_good),
+                           (2 * 0.1 + 0.05 + 0.2 + 0.008) * u"eV"; atol=1e-10u"eV")
+
+            # An MLatticeHamiltonian{1} base evaluates through the same
+            # delegation: wrapper energy == bare energy + field sum
+            mlh = MLatticeHamiltonian(1,
+                [GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")])
+            g_m = collect(1:16) .* 1e-3
+            wrapM = SiteFieldLatticeHamiltonian(mlh, g_m, u"eV")
+            lat_m2 = deepcopy(lat)
+            lat_m2.components[1][[1, 2, 5, 11]] .= true
+            @test isapprox(interacting_energy(lat_m2, wrapM),
+                           interacting_energy(lat_m2, mlh) +
+                           sum(g_m[lat_m2.components[1]]) * u"eV";
+                           atol=1e-12u"eV")
+        end
+    end
+
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -24,6 +24,26 @@
             adsorptions=:full)
     end
 
+    # Shared single-component square slab builder, d3 layers of d1 x d2
+    # sites. At d1 = d2 = 2 the first shell wraps the periodic cell (each
+    # in-plane pair is connected through both images), which the default
+    # minimum-image lists warn about at construction; build with
+    # image_multiplicity=true so construction stays silent. The doubled
+    # in-plane bonds are energetically irrelevant everywhere the builder
+    # is used (J = 0 throughout, and the layer helpers never read
+    # neighbor lists).
+    function obs_slab_lattice(d1, d2, d3)
+        MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(d1, d2, d3),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:d1*d2*d3]],
+            adsorptions=:full,
+            image_multiplicity=true)
+    end
+
     # ================================================================
     @testset "order_parameter_c2x2" begin
         lat = obs_square_lattice(4, 4)
@@ -1421,5 +1441,250 @@
         # N_eff >= 330 across the calibration seeds (floor 200); one point
         # of slack retained, per the square end-to-end precedent
         @test n_gated >= 2
+    end
+
+    # ================================================================
+    @testset "layer helpers: site_layers, layer_coverage, occupancy_profile, layer_field" begin
+        slab = obs_slab_lattice(2, 2, 3)
+
+        # lattice_positions ordering: basis innermost, dimension 1 fastest,
+        # dimension 3 outermost, so layers are contiguous blocks
+        @test site_layers(slab) == [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+
+        # Hand coverages: layer 1 full, one site of layer 2, layer 3 empty
+        slab.components[1] .= false
+        slab.components[1][1:4] .= true
+        slab.components[1][6] = true
+        @test layer_coverage(slab, 1) == 1.0
+        @test layer_coverage(slab, 2) == 0.25
+        @test layer_coverage(slab, 3) == 0.0
+        @test occupancy_profile(slab) == [1.0, 0.25, 0.0]
+
+        # mean(occupancy_profile) == N/M holds exactly in Float64: each
+        # n_k/4 is a dyadic rational, their sum is exact, and the single
+        # rounding of /3 equals the single rounding of N/12
+        Random.seed!(29)
+        for _ in 1:20
+            occ = rand(Bool, 12)
+            slab.components[1] .= occ
+            @test mean(occupancy_profile(slab)) == sum(occ) / 12
+        end
+
+        # Two-site planar basis: n_basis enters the layer block size (8/layer)
+        slab2b = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.0)],
+            supercell_dimensions=(2, 2, 2),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full,
+            image_multiplicity=true)   # d1 = d2 = 2 wraps shell 1; see obs_slab_lattice
+        @test site_layers(slab2b) == vcat(fill(1, 8), fill(2, 8))
+        slab2b.components[1] .= false
+        slab2b.components[1][1:3] .= true
+        @test layer_coverage(slab2b, 1) == 3 / 8
+        @test occupancy_profile(slab2b) == [3 / 8, 0.0]
+
+        # d3 = 1 degenerates to the total coverage (documented, allowed)
+        flat = obs_square_lattice(4, 4)
+        flat.components[1] .= false
+        flat.components[1][1:5] .= true
+        @test site_layers(flat) == fill(1, 16)
+        @test layer_coverage(flat, 1) == 5 / 16
+        @test occupancy_profile(flat) == [5 / 16]
+
+        # layer_field broadcast pins; element type preserved
+        vals = [-0.27, -0.03375, -0.01]
+        @test layer_field(obs_slab_lattice(2, 2, 3), vals) ==
+              vcat(fill(-0.27, 4), fill(-0.03375, 4), fill(-0.01, 4))
+        fu = layer_field(obs_slab_lattice(2, 2, 3), vals .* u"eV")
+        @test eltype(fu) == typeof(1.0u"eV")
+        @test fu == vcat(fill(-0.27, 4), fill(-0.03375, 4), fill(-0.01, 4)) .* u"eV"
+        @test layer_field(flat, [0.5]) == fill(0.5, 16)
+        # ... and the unitful profile feeds SiteFieldLatticeHamiltonian
+        # directly, as the docstring recipe promises
+        @test SiteFieldLatticeHamiltonian(
+            GenericLatticeHamiltonian(0.0, [0.0], u"eV"), fu) isa
+              SiteFieldLatticeHamiltonian
+
+        # Layer bounds: 1 <= layer <= d3
+        @test_throws ArgumentError layer_coverage(obs_slab_lattice(2, 2, 3), 0)
+        @test_throws ArgumentError layer_coverage(obs_slab_lattice(2, 2, 3), 4)
+        @test_throws ArgumentError layer_coverage(flat, 2)
+        # layer_field length must equal d3
+        @test_throws ArgumentError layer_field(obs_slab_lattice(2, 2, 3), [-0.27, -0.01])
+        @test_throws ArgumentError layer_field(flat, [0.5, 0.5])
+        # Non-planar basis: the z-block layer index is ill-defined, so all
+        # four helpers refuse
+        tilted = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.5)],
+            supercell_dimensions=(2, 2, 2),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full,
+            image_multiplicity=true)
+        @test_throws ArgumentError site_layers(tilted)
+        @test_throws ArgumentError layer_coverage(tilted, 1)
+        @test_throws ArgumentError occupancy_profile(tilted)
+        @test_throws ArgumentError layer_field(tilted, [0.0, 0.0])
+    end
+
+    # ================================================================
+    @testset "end-to-end: inhomogeneous Langmuir slab (2,2,3), site field, igref + theta ledger" begin
+        # J = 0 with the inverse-cube layer profile eps_k = B/k^3,
+        # B = -0.27 eV (the layer_field docstring example): the grand
+        # ensemble factorizes exactly, Xi = prod_k (1 + x_k)^4 with
+        # x_k = e^{beta(mu - eps_k)}, and theta_k = x_k/(1 + x_k), an
+        # independent closed form sharing no code with the field energy
+        # path. First end-to-end trip of a three-dimensional supercell
+        # through enumeration, sampling, and the stats layer.
+        # Statistical NS checks: seed the global RNG (the random_seed field
+        # on the NS parameters is not consumed); the seed is planted after
+        # the enumeration block, which consumes RNG. Tolerances sized at or
+        # above 3x the maximum three-seed deviation at this configuration
+        # (seeds 4701/4702/4703; max observed over the 18 gated points:
+        # |dlnXi| 0.324, |dN| 0.136, |dU| 0.0034, |dtheta| 0.019, every
+        # grid point gated in every seed at N_eff >= 549), sanity-checked
+        # against sigma(lnXi) ~ sqrt(D/K) ~ 0.30 at the full-compression
+        # depth D = 12 log1p(1/0.5) = 13.2 nats.
+        kb = 8.617333262e-5
+
+        M = 12
+        eps_layer = [-0.27, -0.03375, -0.01]     # eV, B/k^3 with B = -0.27
+        slab_at(N) = begin
+            lat = obs_slab_lattice(2, 2, 3)
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            lat
+        end
+        base = GenericLatticeHamiltonian(0.0, [0.0], u"eV")   # J = 0
+        field = layer_field(obs_slab_lattice(2, 2, 3), eps_layer .* u"eV")
+        ham = SiteFieldLatticeHamiltonian(base, field)
+
+        # Independent per-site profile from hardcoded index arithmetic,
+        # sharing no code with site_layers/layer_field
+        site_eps = [eps_layer[(s - 1) ÷ 4 + 1] for s in 1:M]
+        @test field == site_eps .* u"eV"   # welds the two oracles at the entrance
+
+        # Exact per-configuration (E, N, n_k) from fixed-N enumeration of
+        # all 2^12 = 4096 configurations; every energy must be the masked
+        # field sum to 1e-12 eV, the exactness bound applied exhaustively
+        exact_E = Dict{Int,Vector{Float64}}()
+        exact_nk = Dict{Int,Vector{Vector{Int}}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(slab_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            occs = [Vector{Bool}(cfg[1]) for cfg in df_exact.config]
+            @test length(exact_E[N]) == binomial(M, N)
+            for (e, occ) in zip(exact_E[N], occs)
+                @test isapprox(e, sum(site_eps[occ]; init=0.0); atol=1e-12)
+            end
+            exact_nk[N] = [[sum(occ[4k-3:4k]) for k in 1:3] for occ in occs]
+        end
+
+        # Closed forms from the layer factorization
+        langmuir(μ_val, T_val) = begin
+            β = 1 / (kb * T_val)
+            x = exp.(β .* (μ_val .- eps_layer))
+            θ = x ./ (1 .+ x)
+            (logXi=4 * sum(log1p, x), θ=θ,
+             mean_N=4 * sum(θ), mean_U=4 * sum(eps_layer .* θ))
+        end
+
+        # Grand sums from the enumeration, assembled in the log domain
+        function enum_stats(μ_val, T_val)
+            β = 1 / (kb * T_val)
+            lt = Float64[]; Ns = Float64[]; Es = Float64[]
+            th = [Float64[] for _ in 1:3]
+            for N in 0:M, i in eachindex(exact_E[N])
+                push!(lt, N * β * μ_val - β * exact_E[N][i])
+                push!(Ns, N); push!(Es, exact_E[N][i])
+                for k in 1:3
+                    push!(th[k], exact_nk[N][i][k] / 4)
+                end
+            end
+            w = exp.(lt .- maximum(lt)); sw = sum(w)
+            (logXi=maximum(lt) + log(sw),
+             mean_N=sum(w .* Ns) / sw, mean_U=sum(w .* Es) / sw,
+             θ=[sum(w .* th[k]) / sw for k in 1:3])
+        end
+
+        # mu grid inside the igref trust window of z0 = 0.5 at 300 K; the
+        # layers discriminate strongly across it (theta1 ~ 1, theta2 and
+        # theta3 partially filled)
+        μs = [-0.03, -0.015, 0.0]
+        Ts = [300.0, 600.0]
+
+        # Deterministic weld: enumeration == closed form at every grid
+        # point (pure summation, house deterministic tolerance; the
+        # extensive mean_N and mean_U carry a factor-M headroom)
+        for T in Ts, μ in μs
+            ex = langmuir(μ, T); en = enum_stats(μ, T)
+            @test isapprox(en.logXi, ex.logXi; atol=1e-10)
+            @test isapprox(en.mean_N, ex.mean_N; atol=1e-9)
+            @test isapprox(en.mean_U, ex.mean_U; atol=1e-9)
+            @test all(isapprox.(en.θ, ex.θ; atol=1e-10))
+        end
+
+        # ---- igref route recording theta1..theta3 (the sampler-hook
+        # check rides this same run: identical fixture and ledger) ----
+        Random.seed!(4701)
+        z0 = 0.5                     # ln z0 = -0.69 centers the mu grid at 300 K
+        K_ig = 150
+        n_ig = ceil(Int, 1.15 * K_ig * M * log1p(1 / z0)) + 2 * K_ig
+        walkers = [LatticeWalker(deepcopy(slab_at(0)), energy=0.0u"eV", iter=0)
+                   for _ in 1:K_ig]
+        ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        df_ig, final_ig, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(n_ig), MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3),
+            obs_save;
+            observables=[Symbol(:theta, k) => (cfg -> layer_coverage(cfg, k))
+                         for k in 1:3])
+        obs_cleanup()
+
+        # Ledger integrity: columns, range, and the quarter-integer
+        # lattice of 4-site-layer coverages
+        @test names(df_ig) == ["iter", "emax", "num_particles",
+                               "theta1", "theta2", "theta3"]
+        for col in (df_ig.theta1, df_ig.theta2, df_ig.theta3)
+            @test all(0.0 .<= col .<= 1.0)
+            @test all(isinteger.(4 .* col))
+        end
+
+        live_E = [w.energy.val for w in final_ig.walkers]
+        live_N = [sum(w.configuration.components[1]) for w in final_ig.walkers]
+        live_th = Dict(Symbol(:theta, k) =>
+                       [layer_coverage(w.configuration, k) for w in final_ig.walkers]
+                       for k in 1:3)
+        st = gc_thermodynamic_stats_ideal_ref(df_ig, M, z0, μs, Ts, K_ig;
+            ω0=(K_ig + 1) / K_ig, live_emax=live_E, live_numbers=live_N,
+            observable_cols=[:theta1, :theta2, :theta3], live_observables=live_th)
+
+        # var_U and cov_UN are exercised by the existing end-to-end
+        # testsets; the new code under test here is the field energy and
+        # the theta observables, so those are what the gate asserts
+        n_gated = 0
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            st.N_eff[i, j] >= 200 || continue
+            n_gated += 1
+            ex = langmuir(μ, T)
+            @test isapprox(st.logXi[i, j], ex.logXi, atol=1.0)
+            @test isapprox(st.mean_N[i, j], ex.mean_N, atol=0.5)
+            @test isapprox(st.mean_U[i, j], ex.mean_U, atol=0.011)
+            for k in 1:3
+                @test isapprox(st.observables[Symbol(:theta, k)][i, j],
+                               ex.θ[k], atol=0.06)
+            end
+        end
+        # ln z0 centered on the 300 K grid: all six points gated at
+        # N_eff >= 549 across the calibration seeds (floor 200); one
+        # point of slack retained, per the end-to-end precedents
+        @test n_gated >= 5
     end
 end


### PR DESCRIPTION
Implements #156.

## What

- `SiteFieldLatticeHamiltonian(base, field)`: a wrapper `ClassicalHamiltonian` carrying a site-resolved on-site energy, with total energy = base energy + Σ field[i] over occupied sites i, expressing the layer-dependent binding profiles of multilayer adsorption models (de Oliveira and Griffiths, Surf. Sci. 71, 687 (1978); Pandit, Schick and Wortis, Phys. Rev. B 26, 5112 (1982)). The base's own on-site × adsorptions channel is preserved and documented as additive; the docstring records the exact subsumption identity `GenericLatticeHamiltonian(ε, J)` with adsorption mask A ≡ `SiteFieldLatticeHamiltonian(GenericLatticeHamiltonian(zero(ε), J), ε .* A)`, spelled with `zero(ε)` since an `Int` zero does not construct against `Float64` couplings, and recommends zeroing the base on-site when a full field is supplied. Guards, all `ArgumentError`: nested wrapper bases (compose by adding the vectors), empty fields, non-finite entries (the established Inf rationale), and any field element whose type differs from the base's coupling type, resolved through a small internal `_coupling_type` trait (`GenericLatticeHamiltonian`, `MLatticeHamiltonian`, `ClusterLatticeHamiltonian`, or any type that adds a method) with exact `typeof` equality, mirroring the cluster coupling check. Every lattice sampler call site takes `h::ClassicalHamiltonian` generically, so no sampler changes.
- Energy path: `interacting_energy(::SLattice, ::SiteFieldLatticeHamiltonian)` delegates the base energy and adds a `site_field_energy` kernel; the kernel iterates `eachindex(occupations, field)`, so a stale Hamiltonian against a different-sized lattice raises `DimensionMismatch` in either direction rather than silently summing a truncated or padded range (plain bounds checks would leave the field-longer case silent).
- One-time setup check `_check_field_length` beside `_check_cluster_sites` in the `LatticeGasWalkers` constructor and the raw-lattice `wang_landau`/`nvt_monte_carlo` entry points, in the built-for-a-different-lattice register; `_n_coupled_shells` and `_check_cluster_sites` delegate to the wrapped base, so the uncoupled-shell warning and the embedding check thread through the wrapper.
- Layer helpers in `AbstractWalkers`: `site_layers` (layer index (s − 1) ÷ B + 1 with B = n<sub>basis</sub>·d₁·d₂, exact because `lattice_positions` orders dimension 3 outermost), `layer_coverage` (scalar and therefore observables-hook compatible; at d₃ = 1 it degenerates to the total coverage, documented), `occupancy_profile` (one-pass coverage vector, documented as not hook-compatible together with the composed per-layer closure recipe), and `layer_field` (per-layer values broadcast to a per-site vector with element type preserved, so a Unitful profile feeds the wrapper directly). All four require a planar basis (equal basis z-components) and throw `ArgumentError` otherwise; being the three-dimensional complement of the in-plane order parameters, they deliberately omit the two-dimensionality guard that family carries.

## Tests

- Constructor guards pinned per class: empty field (both constructor forms), Inf and NaN entries, unit and value-type mismatches in both directions (Float64 vs eV, meV vs eV, eV vs meV), nested wrappers, legal meV/cluster/`MLatticeHamiltonian`/unitless bases, field copy semantics, and the show method.
- Field-only exactness on hand configurations with distinct per-site values (catches any index permutation), atol 10<sup>−12</sup> eV; the subsumption identity in both directions plus the additive contract, on 20 seeded random 4×4 occupations.
- Setup-check matrix mirroring the shell-count matrix: `ArgumentError` at `LatticeGasWalkers`, `wang_landau`, and `nvt_monte_carlo` for wrong-length fields, silence at matching length, `DimensionMismatch` from the kernel in both mismatch directions, the uncoupled-shell warning and the stale-embedding check threading through the wrapper at every entry point, a wrapped-cluster hand closed form, and an `MLatticeHamiltonian{1}`-base energy-parity check.
- Layer-helper pins on a (2, 2, 3) slab: the contiguous-block `site_layers` vector, hand coverages, `mean(occupancy_profile) == N/M` as exact Float64 equality on seeded random occupations (provably exact: dyadic n<sub>k</sub>/4 with a single rounding on each side), a two-site planar basis, the d₃ = 1 degenerate case, element-type preservation into the wrapper, and every guard path including a non-planar basis refused by all four helpers.
- Inhomogeneous Langmuir slab end to end on (2, 2, 3), J = 0 with the inverse-cube profile ε<sub>k</sub> = −0.27/k³ eV built through `layer_field`: an exhaustive weld of all 4096 enumerated configuration energies against an independently hardcoded per-site profile at 10<sup>−12</sup> eV, per-sector binomial count pins, and the enumeration grand sums against the closed form Ξ = Π<sub>k</sub> (1 + e<sup>β(μ−ε_k)</sup>)⁴ at every μ × T grid point to 10<sup>−10</sup>.
- Ideal-gas-referenced route (K = 150, z₀ = 0.5, the file's ladder-depth convention) recording the per-layer coverages as composed closures: ledger schema, 0 ≤ θ ≤ 1 with the quarter-integer pin, and lnΞ, ⟨N⟩, ⟨U⟩, ⟨θ₁⟩, ⟨θ₂⟩, ⟨θ₃⟩ against the closed form at every Kish-gated grid point. All six μ × T points gate at N<sub>eff</sub> ≥ 549 in every calibration seed (floor 200, one point of slack retained); tolerances shipped at ≥ 3× the three-seed maxima (lnΞ 1.0, ⟨N⟩ 0.5, ⟨U⟩ 0.011, θ 0.06), sanity-checked against σ(lnΞ) ≈ √(D/K) ≈ 0.30 at the full-compression depth D = 13.2 nats. First end-to-end trip of a three-dimensional supercell through enumeration, sampling, and the stats layer.

An adversarial review pass independently re-derived the Langmuir closed form and the layer-index arithmetic, verified by mutation that the test oracles bind (a sign-flipped closed form disagrees by 44 nats; a broken layer decode fails the per-configuration weld on 756 of 924 N = 6 configurations), ran the observables file twice in one session to exclude RNG and ordering coupling between testsets, and confirmed every remaining claim by live reproduction, with no must-fix findings; its two suggestions are applied here: the pre-existing `.val` in the `GenericLatticeHamiltonian` show method, which crashed the display of any unitless Hamiltonian and became reachable through the wrapper's delegated base print, is replaced with `ustrip`, and the documented `MLatticeHamiltonian` base gains a construction pin and the energy-parity test. Full test suite passes (SamplingSchemes 5812, AbstractWalkers 319, AbstractHamiltonians 80, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 3807, FreeBirdIO 51). One pre-existing stochastic testset outside this PR (GC-NS with cluster moves: validation against exact enumeration, `test-grand_canonical_ns.jl:523`, which does not seed the RNG and carries a marginal ⟨N⟩ tolerance) failed once in three full-suite runs during verification and passed 5 of 5 standalone repetitions; it is untouched by this diff and may occasionally redden a CI job.
