### PR TITLE
Fix the hard-coded out-of-plane lattice spacing and expose interlayer_spacing

### DIFF
--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -235,6 +235,7 @@ The `components=[[1,2,3,4]]` argument specifies that the system has a single com
 and the first four sites are occupied.
 ```julia
 MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
+    interlayer_spacing::Union{Nothing,Float64}=nothing,
     basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0)],
     supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 4, 1),
     periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),

--- a/scripts/tutorials.jl
+++ b/scripts/tutorials.jl
@@ -131,9 +131,10 @@ MLattice{C,G}(
     basis::Vector{Tuple{Float64, Float64, Float64}},
     supercell_dimensions::Tuple{Int64, Int64, Int64},
     periodicity::Tuple{Bool, Bool, Bool},
-    components::Vector{Vector{Bool}},
-    adsorptions::Vector{Bool},
     cutoff_radii::Vector{Float64},
+    components::Vector{Vector{Bool}},
+    adsorptions::Vector{Bool};
+    image_multiplicity::Bool=false,
 ) where {C,G}
 ```
 =====================#
@@ -150,12 +151,14 @@ The `components=[[1,2,3,4]]` argument specifies that the system has a single com
 and the first four sites are occupied.
 ```julia
 MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
+    interlayer_spacing::Union{Nothing,Float64}=nothing,
     basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0)],
     supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 4, 1),
     periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
     cutoff_radii::Vector{Float64}=[1.1, 1.5],
     components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
-    adsorptions::Union{Vector{Int},Symbol}=:full)
+    adsorptions::Union{Vector{Int},Symbol}=:full,
+    image_multiplicity::Bool=false)
 ```
 ==#
 

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -314,6 +314,7 @@ Throws an `ArgumentError` if the number of components does not match `C`.
 # Outer Constructors
 
     MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
+                               interlayer_spacing::Union{Nothing,Float64}=nothing,
                                basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0)],
                                supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 4, 1),
                                periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
@@ -323,6 +324,7 @@ Throws an `ArgumentError` if the number of components does not match `C`.
                                image_multiplicity::Bool=false)
 
     MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
+                                  interlayer_spacing::Union{Nothing,Float64}=nothing,
                                   basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
                                   supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 2, 1),
                                   periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
@@ -347,6 +349,29 @@ doubled bond reaches the full bond energy and a self-image entry passes the
 occupation test exactly when the site is occupied; geometric-cluster growth
 reads only the first shell, and growth across a duplicated bond remains a
 configuration-independent symmetric proposal.
+
+The `interlayer_spacing` keyword sets the out-of-plane (third-axis) lattice
+spacing. The default `nothing` means isotropic spacing: the third lattice
+vector is `[0, 0, lattice_constant]`. Note this is a behavior change on one
+previously broken path: 3D cells built with `lattice_constant ≠ 1` used to
+mix scales (the out-of-plane spacing was fixed at 1.0, so a "nearest-neighbor"
+cutoff could select only interlayer bonds without warning); such cells now
+default to isotropic spacing. Pass `interlayer_spacing = 1.0` to reproduce
+the old geometry. An explicit value `c` gives a tetragonal cell whose
+square-lattice distance ladder is a, c, √2·a, √(a² + c²), 2a, …, so a
+suitable cutoff ladder separates in-plane from interlayer nearest neighbors
+into distinct shells: with a = 1.0, c = 1.25 and `cutoff_radii = [1.1, 1.35]`,
+shell 1 is in-plane only and shell 2 interlayer only (the next distance
+√2 ≈ 1.414 is excluded), so a `GenericLatticeHamiltonian` with couplings
+`[J∥, J⊥]` expresses direction-resolved nearest-neighbor interactions with no
+other library changes. Avoid degenerate spacings that alias the two bond
+classes into one shell (c = √2·a puts interlayer bonds at the in-plane
+second-neighbor distance, c = 2a at the third); the strictly-increasing
+cutoff-ladder validation and the empty-shell warning of
+[`compute_neighbors`](@ref) are the runtime backstops. The keyword composes
+with `image_multiplicity`; the third axis is non-periodic by default, so
+slabs gain no z-wrap images. Must be finite and strictly positive when given;
+violations throw an `ArgumentError`.
 
 ## Returns
 - `MLattice{C,G}`: A square/triangular lattice object with `C` components.
@@ -491,7 +516,26 @@ function mlattice_setup(C::Int,
     return lattice_comp, lattice_adsorptions
 end
 
+"""
+    _out_of_plane_spacing(lattice_constant, interlayer_spacing)
+
+Resolve the third-axis lattice spacing for the keyword constructors:
+`nothing` means isotropic spacing (the in-plane `lattice_constant`); an
+explicit value must be finite and strictly positive, the cutoff-ladder
+idiom of `compute_neighbors`, and violations throw an `ArgumentError`.
+"""
+function _out_of_plane_spacing(lattice_constant::Float64, interlayer_spacing::Union{Nothing,Float64})
+    interlayer_spacing === nothing && return lattice_constant
+    if !(isfinite(interlayer_spacing) && interlayer_spacing > 0.0)
+        throw(ArgumentError(
+            "interlayer_spacing must be finite and strictly positive, " *
+            "got $interlayer_spacing"))
+    end
+    return interlayer_spacing
+end
+
 function MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
+                                    interlayer_spacing::Union{Nothing,Float64}=nothing,
                                     basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0)],
                                     supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 4, 1),
                                     periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
@@ -501,7 +545,8 @@ function MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
                                     image_multiplicity::Bool=false,
                                 ) where C
 
-    lattice_vectors = [lattice_constant 0.0 0.0; 0.0 lattice_constant 0.0; 0.0 0.0 1.0]
+    c = _out_of_plane_spacing(lattice_constant, interlayer_spacing)
+    lattice_vectors = [lattice_constant 0.0 0.0; 0.0 lattice_constant 0.0; 0.0 0.0 c]
     lattice_comp, lattice_adsorptions = mlattice_setup(C, basis, supercell_dimensions, components, adsorptions)
 
     return MLattice{C,SquareLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions;
@@ -509,6 +554,7 @@ function MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
 end
 
 function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
+                                        interlayer_spacing::Union{Nothing,Float64}=nothing,
                                         basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
                                         supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 2, 1),
                                         periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
@@ -520,7 +566,8 @@ function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
                                         image_multiplicity::Bool=false,
                                     ) where C
 
-    lattice_vectors = [lattice_constant 0.0 0.0; 0.0 sqrt(3)*lattice_constant 0.0; 0.0 0.0 1.0]
+    c = _out_of_plane_spacing(lattice_constant, interlayer_spacing)
+    lattice_vectors = [lattice_constant 0.0 0.0; 0.0 sqrt(3)*lattice_constant 0.0; 0.0 0.0 c]
     lattice_comp, lattice_adsorptions = mlattice_setup(C, basis, supercell_dimensions, components, adsorptions)
 
     return MLattice{C,TriangularLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions;

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -719,7 +719,10 @@
                     adsorptions=custom_adsorptions
                 )
                 
-                @test lattice.lattice_vectors ≈ [2.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 1.0]
+                # Isotropic default: the stored third diagonal now follows
+                # lattice_constant (at d3 = 1 the z axis never enters
+                # positions, so the geometry is unchanged)
+                @test lattice.lattice_vectors ≈ [2.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 2.0]
                 @test lattice.basis == custom_basis
                 @test lattice.supercell_dimensions == custom_dims
                 @test lattice.periodicity == custom_periodicity
@@ -762,13 +765,104 @@
                     adsorptions=custom_adsorptions
                 )
             
-                @test lattice.lattice_vectors ≈ [2.0 0.0 0.0; 0.0 2.0*sqrt(3) 0.0; 0.0 0.0 1.0]
+                # Isotropic default: see the square-constructor twin above
+                @test lattice.lattice_vectors ≈ [2.0 0.0 0.0; 0.0 2.0*sqrt(3) 0.0; 0.0 0.0 2.0]
                 @test lattice.basis == custom_basis
                 @test lattice.supercell_dimensions == custom_dims
                 @test lattice.periodicity == custom_periodicity
                 @test length(lattice.neighbors) == 4
                 @test length(lattice.components) == 2
                 @test count(lattice.adsorptions) == 2
+            end
+
+            @testset "Interlayer spacing" begin
+                # Isotropic fix: with lattice_constant = 2.0 the out-of-plane
+                # spacing now follows it, so the nearest-neighbor shell mixes
+                # in-plane and interlayer bonds at the same distance 2.0
+                # (previously the interlayer bonds sat at 1.0, silently)
+                iso = MLattice{1,SquareLattice}(
+                    lattice_constant=2.0,
+                    supercell_dimensions=(3, 3, 2),
+                    cutoff_radii=[2.2],
+                    components=[[false for _ in 1:18]]
+                )
+                @test iso.lattice_vectors[3, 3] == 2.0
+                # lattice_positions ordering: dimension 3 outermost, so the
+                # second layer is the second block of 9 sites
+                @test iso.positions[:, 3] == vcat(zeros(9), fill(2.0, 9))
+                # 4 in-plane + 1 axial on the two-layer slab (z non-periodic)
+                @test all(length(iso.neighbors[s][1]) == 5 for s in 1:18)
+                @test all((s + 9) in iso.neighbors[s][1] for s in 1:9)
+
+                # Old-geometry reproduction: interlayer_spacing = 1.0 restores
+                # the pre-change mixed-scale positions exactly
+                old = MLattice{1,SquareLattice}(
+                    lattice_constant=2.0,
+                    interlayer_spacing=1.0,
+                    supercell_dimensions=(3, 3, 2),
+                    cutoff_radii=[2.2],
+                    components=[[false for _ in 1:18]]
+                )
+                @test old.lattice_vectors[3, 3] == 1.0
+                @test old.positions[:, 3] == vcat(zeros(9), ones(9))
+
+                # Tetragonal shell separation: a = 1.0, c = 1.25 with the
+                # ladder [1.1, 1.35] puts in-plane bonds alone in shell 1 and
+                # interlayer bonds alone in shell 2 (next distance sqrt(2) ≈
+                # 1.414 excluded); construction is silent (in-plane
+                # circumference 3 > 2*1.1, no collapsed images; no empty shell)
+                tet = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,SquareLattice}(
+                    lattice_constant=1.0,
+                    interlayer_spacing=1.25,
+                    supercell_dimensions=(3, 3, 2),
+                    cutoff_radii=[1.1, 1.35],
+                    components=[[false for _ in 1:18]]
+                )
+                @test all(length(tet.neighbors[s][1]) == 4 for s in 1:18)
+                @test all(length(tet.neighbors[s][2]) == 1 for s in 1:18)
+                @test all(tet.neighbors[s][2] == [s + 9] for s in 1:9)
+                # Three layers: the middle layer has axial neighbors both ways
+                tet3 = MLattice{1,SquareLattice}(
+                    lattice_constant=1.0,
+                    interlayer_spacing=1.25,
+                    supercell_dimensions=(3, 3, 3),
+                    cutoff_radii=[1.1, 1.35],
+                    components=[[false for _ in 1:27]]
+                )
+                @test all(length(tet3.neighbors[s][2]) == 1 for s in 1:9)
+                @test all(length(tet3.neighbors[s][2]) == 2 for s in 10:18)
+                @test all(length(tet3.neighbors[s][2]) == 1 for s in 19:27)
+
+                # Default-path no-change: an explicit spacing equal to
+                # lattice_constant reproduces the default element for element
+                expl = MLattice{1,SquareLattice}(
+                    lattice_constant=2.0,
+                    interlayer_spacing=2.0,
+                    supercell_dimensions=(3, 3, 2),
+                    cutoff_radii=[2.2],
+                    components=[[false for _ in 1:18]]
+                )
+                @test expl.positions == iso.positions
+                @test expl.neighbors == iso.neighbors
+
+                # Guard paths: finite and strictly positive
+                @test_throws ArgumentError MLattice{1,SquareLattice}(
+                    interlayer_spacing=0.0, components=[[false for _ in 1:16]])
+                @test_throws ArgumentError MLattice{1,SquareLattice}(
+                    interlayer_spacing=-1.0, components=[[false for _ in 1:16]])
+                @test_throws ArgumentError MLattice{1,SquareLattice}(
+                    interlayer_spacing=Inf, components=[[false for _ in 1:16]])
+                @test_throws ArgumentError MLattice{1,TriangularLattice}(
+                    interlayer_spacing=0.0, components=[[false for _ in 1:16]])
+
+                # Triangular acceptance: keyword lands in the third vector
+                tri = MLattice{1,TriangularLattice}(
+                    supercell_dimensions=(4, 2, 2),
+                    interlayer_spacing=1.25,
+                    cutoff_radii=[1.1, 1.3],
+                    components=[[false for _ in 1:32]]
+                )
+                @test tri.lattice_vectors ≈ [1.0 0.0 0.0; 0.0 sqrt(3) 0.0; 0.0 0.0 1.25]
             end
 
             @testset "Error handling" begin


### PR DESCRIPTION
Implements #157.

## What

- Both `MLattice` keyword constructors previously pinned the third lattice vector to `[0, 0, 1.0]` while the in-plane vectors scale with `lattice_constant`, so any three-dimensional cell with `lattice_constant ≠ 1.0` silently mixed scales (a "nearest-neighbor" cutoff could select only interlayer bonds, with no warning). The default is now isotropic: the third lattice vector is `[0, 0, lattice_constant]`. Positions and neighbor lists are bit-identical for every construction with `lattice_constant = 1.0` or `supercell_dimensions[3] == 1`, which covers the entire shipped suite and documentation; the behavior changes only on the silently broken mixed-scale path. Release note: 3D cells built with `lattice_constant ≠ 1` previously mixed scales (the out-of-plane spacing was fixed at 1.0); such cells now default to isotropic spacing, and passing `interlayer_spacing = 1.0` reproduces the old geometry.
- New keyword `interlayer_spacing::Union{Nothing,Float64}=nothing` on both constructors, resolved through a shared internal `_out_of_plane_spacing` helper: `nothing` means isotropic; an explicit value `c` gives a tetragonal cell and must be finite and strictly positive (`ArgumentError` otherwise, the cutoff-ladder validation idiom). With c ≠ a the square-lattice distance ladder a, c, √2·a, √(a² + c²), 2a, … separates in-plane from interlayer nearest neighbors into distinct shells, so a `GenericLatticeHamiltonian` with couplings `[J<sub>∥</sub>, J<sub>⊥</sub>]` expresses direction-resolved nearest-neighbor interactions with zero changes to `compute_neighbors`, the Hamiltonian types, or the energy kernels; anisotropic in-plane versus out-of-plane couplings are standard in lattice models of adsorbed multilayers and thin films.
- The `MLattice` struct docstring documents the keyword on both constructor signatures and carries the tetragonal recipe: the worked example a = 1.0, c = 1.25, `cutoff_radii = [1.1, 1.35]` (shell 1 in-plane only, shell 2 interlayer only, √2 ≈ 1.414 excluded), a warning against degenerate spacings that alias the two bond classes (c = √2·a, c = 2a), backed at runtime by the existing strictly-increasing-ladder validation and empty-shell warning, and the note that the keyword composes with `image_multiplicity` (the third axis is non-periodic by default, so slabs gain no z-wrap images).
- The reproduced constructor signatures in `docs/src/tutorials.md` and its Literate source `scripts/tutorials.jl` gain the keyword; the `scripts/tutorials.jl` copy also gains the previously missing `image_multiplicity` line, closing a pre-existing drift between the two blocks.

## Tests

- New `"Interlayer spacing"` testset in `test/test-AbstractWalkers.jl`: the isotropic-fix pin (a = 2.0 on a (3, 3, 2) slab: third diagonal 2.0, layer-2 positions at z = 2.0, per-site nearest-neighbor count exactly 5 with the axial partner identity s + 9); old-geometry reproduction (`interlayer_spacing = 1.0` restores the pre-change z stacking exactly); tetragonal shell separation (a = 1.0, c = 1.25, `[1.1, 1.35]`: per-site shell counts exactly 4 and 1, axial partners pinned, construction silent under `@test_logs min_level = Warn`, and the three-layer per-site shell-2 profile [1, 2, 1]); default-path invariance (explicit `interlayer_spacing == lattice_constant` reproduces the default construction's positions and neighbors element for element); guards (0.0, −1.0, Inf on both geometries) and triangular acceptance (`lattice_vectors ≈ [1 0 0; 0 √3 0; 0 0 1.25]`).
- The only two shipped assertions pinning the old hard-coded third row, the a = 2.0 `lattice_vectors` matrix literals in the square and triangular constructor testsets (both at d₃ = 1, where the z axis never enters positions), are updated to the isotropic matrix; every behavioral assertion in the suite is untouched, and the full suite runs green on the unchanged path.

An adversarial check verified the new assertions bind: rebuilding the tetragonal fixture with the old geometry (c = 1.0) yields shell counts (5, 0) where the tests demand (4, 1), the position pins distinguish the two stackings exactly, and NaN is rejected by the guard; an independent review pass over the diff checked the helper's validation composition, swept the repository for other reproductions of the constructor signatures or the hard-coded third row, and confirmed no other test or documentation example sits on the changed path, with no findings; its one aside is applied here: `scripts/tutorials.jl` carried a second stale signature copy (the inner constructor's positional-argument order, disagreeing with the source and with `docs/src/tutorials.md`), now synced as well. Full test suite passes (SamplingSchemes 5812, AbstractWalkers 339, AbstractHamiltonians 80, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 3807, FreeBirdIO 51).
