### PR TITLE
Contact- and cavity-biased insertion channels for the grand-canonical lattice walk

### DIFF
--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -27,6 +27,7 @@ export MC_cluster_walk!
 export geometric_cluster_swap!
 export random_microstate!
 export lattice_insert_particle!, lattice_delete_particle!
+export lattice_biased_sites
 export MC_grand_canonical_walk!
 
 export free_component_index, free_par_index

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -745,13 +745,71 @@ function lattice_delete_particle!(lattice::SLattice)
 end
 
 """
+    lattice_biased_sites(lattice::SLattice; predicate::Symbol=:contact, shells::Int=1)
+
+Return the indices of empty sites selected by an occupancy predicate over
+neighbor shells `1:shells`:
+
+- `:contact`: empty sites with at least one occupied neighbor.
+- `:cavity`: empty sites with no occupied neighbor.
+
+For fixed `shells` the two predicates partition the empty sites:
+`length(contact set) + length(cavity set) == M - N`. Neighbor lists carrying
+periodic-image multiplicity (the same neighbor listed more than once) work
+as-is: any occupied appearance marks contact.
+
+Useful as a nested-sampling observable, e.g.
+`:n_cavity => cfg -> length(lattice_biased_sites(cfg; predicate=:cavity))`.
+
+Throws `ArgumentError` for an unknown predicate, `shells < 1`, or `shells`
+exceeding the lattice's neighbor-shell count.
+"""
+function lattice_biased_sites(lattice::SLattice; predicate::Symbol=:contact, shells::Int=1)
+    if predicate !== :contact && predicate !== :cavity
+        throw(ArgumentError("unknown predicate :$predicate; expected :contact or :cavity"))
+    end
+    if shells < 1
+        throw(ArgumentError("shells must be >= 1, got $shells"))
+    end
+    neighbors = lattice.neighbors
+    n_shells = isempty(neighbors) ? 0 : length(neighbors[1])
+    if shells > n_shells
+        throw(ArgumentError(
+            "the biased-site predicate spans $shells neighbor shells but the " *
+            "lattice provides only $n_shells (= length(cutoff_radii)); " *
+            "extend cutoff_radii so every counted shell exists"))
+    end
+    occ = lattice.components[1]
+    sites = Int[]
+    for site in eachindex(occ)
+        occ[site] && continue
+        has_occupied_neighbor = false
+        for shell in 1:shells
+            for nb in neighbors[site][shell]
+                if occ[nb]
+                    has_occupied_neighbor = true
+                    break
+                end
+            end
+            has_occupied_neighbor && break
+        end
+        if predicate === :contact ? has_occupied_neighbor : !has_occupied_neighbor
+            push!(sites, site)
+        end
+    end
+    return sites
+end
+
+"""
     MC_grand_canonical_walk!(n_steps::Int, lattice::LatticeWalker{1},
                              h::ClassicalHamiltonian, omega_max::Float64,
                              mu::Float64;
                              p_move::Float64=0.5, p_insert::Float64=0.25,
                              energy_perturb::Float64=0.0, n_max::Int=typemax(Int),
                              clusters_freq::Int=0, swaps_freq::Int=1,
-                             cluster_p::Float64=0.3, z0::Float64=1.0)
+                             cluster_p::Float64=0.3, z0::Float64=1.0,
+                             p_bias::Float64=0.0, bias_predicate::Symbol=:contact,
+                             bias_shells::Int=1)
 
 Perform grand-canonical MCMC on a single-component lattice, mixing fixed-N
 moves (local swaps and/or geometric cluster moves) with single-site insertion
@@ -791,6 +849,19 @@ Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 - `cluster_p::Float64=0.3`: Current cluster growth probability.
 - `z0::Float64=1.0`: Reference fugacity of the prior preserved by insert/delete
   (1.0 = uniform prior over microstates).
+- `p_bias::Float64=0.0`: Probability that an insertion draws its site uniformly
+  from `lattice_biased_sites(x; predicate=bias_predicate, shells=bias_shells)`
+  instead of from all empty sites. The acceptance then uses the composite
+  proposal density evaluated for the actually chosen site, and the deletion
+  acceptance uses the reverse composite density evaluated on the post-deletion
+  configuration (every set quantity on the lower-N member of the pair; the
+  delete ratio's particle count `n` is the pre-delete count), so the
+  `z0`-weighted prior stays invariant. An empty biased set makes the biased
+  sub-channel a null proposal (counted as attempted, nothing changes); a zero
+  reverse density (`p_bias = 1` with the vacated site outside the biased set)
+  is an immediate reject. `0.0` reproduces the legacy sampler bit-for-bit.
+- `bias_predicate::Symbol=:contact`: Biased-set predicate, `:contact` or `:cavity`.
+- `bias_shells::Int=1`: Neighbor shells scanned by the predicate.
 
 # Returns
 - `accept_this_walker::Bool`: Whether at least one move was accepted.
@@ -798,6 +869,11 @@ Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 - `lattice::LatticeWalker{1}`: The updated walker.
 - `cluster_accepted_count::Int`: Number of accepted cluster moves (for adaptive tuning).
 - `cluster_total_count::Int`: Number of attempted cluster moves (for adaptive tuning).
+- `move_stats::NamedTuple`: Per-move-type attempt/accept counters for the walk:
+  `swap_*`, `cluster_*` (duplicating the two preceding elements),
+  `insert_uniform_*`, `insert_biased_*`, `delete_*`. Attempts are counted at
+  proposal: ceiling rejections included, guard skips excluded, and an
+  empty-biased-set null proposal counts as an attempted biased insert.
 """
 function MC_grand_canonical_walk!(n_steps::Int,
                                   lattice::LatticeWalker{1},
@@ -811,12 +887,34 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   clusters_freq::Int=0,
                                   swaps_freq::Int=1,
                                   cluster_p::Float64=0.3,
-                                  z0::Float64=1.0)
+                                  z0::Float64=1.0,
+                                  p_bias::Float64=0.0,
+                                  bias_predicate::Symbol=:contact,
+                                  bias_shells::Int=1)
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
     if z0 <= 0.0
         throw(ArgumentError("z0 must be positive"))
+    end
+    if !(0.0 <= p_bias <= 1.0)
+        throw(ArgumentError("p_bias must satisfy 0 <= p_bias <= 1"))
+    end
+    if bias_predicate !== :contact && bias_predicate !== :cavity
+        throw(ArgumentError("unknown bias_predicate :$bias_predicate; expected :contact or :cavity"))
+    end
+    if bias_shells < 1
+        throw(ArgumentError("bias_shells must be >= 1, got $bias_shells"))
+    end
+    if p_bias > 0.0
+        nbrs = lattice.configuration.neighbors
+        n_lattice_shells = isempty(nbrs) ? 0 : length(nbrs[1])
+        if bias_shells > n_lattice_shells
+            throw(ArgumentError(
+                "the biased insertion channel spans $bias_shells neighbor shells but the " *
+                "lattice provides only $n_lattice_shells (= length(cutoff_radii)); " *
+                "extend cutoff_radii so every counted shell exists"))
+        end
     end
 
     n_accept = 0
@@ -832,6 +930,21 @@ function MC_grand_canonical_walk!(n_steps::Int,
 
     cluster_accepted_count = 0
     cluster_total_count = 0
+    swap_attempted = 0
+    swap_accepted = 0
+    insert_uniform_attempted = 0
+    insert_uniform_accepted = 0
+    insert_biased_attempted = 0
+    insert_biased_accepted = 0
+    delete_attempted = 0
+    delete_accepted = 0
+
+    # Reused inside the loop only when p_bias > 0 (the default path never
+    # computes biased sets)
+    biased_set = Int[]
+    insert_site = 0
+    insert_from_biased = false
+    deleted_site = 0
 
     for _ in 1:n_steps
         r = rand()
@@ -849,26 +962,68 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 # Local swap
                 lattice_random_walk!(proposed_lattice)
                 move_type = :move
+                swap_attempted += 1
             end
         elseif r < p_move + p_insert
             # Insertion
             if n >= n_cap || p_insert <= 0.0
-                continue
+                continue                # guard skip: not counted as an attempt
             end
-            success, proposed_lattice = lattice_insert_particle!(proposed_lattice)
-            if !success
-                continue
+            if p_bias > 0.0
+                # Composite channel. S(x) is computed ONCE per attempt and
+                # reused for both the biased draw and the composite proposal
+                # density in the acceptance below.
+                biased_set = lattice_biased_sites(proposed_lattice;
+                                                  predicate=bias_predicate,
+                                                  shells=bias_shells)
+                if rand() < p_bias
+                    insert_biased_attempted += 1
+                    if isempty(biased_set)
+                        continue        # null proposal: counted, no further draws
+                    end
+                    insert_site = rand(biased_set)
+                    insert_from_biased = true
+                else
+                    # Uniform sub-channel: the same single rand(::Vector) draw
+                    # as lattice_insert_particle!, inlined to capture the site
+                    # for the composite density (keep in lockstep with it)
+                    insert_uniform_attempted += 1
+                    empty_sites = findall(.!proposed_lattice.components[1])
+                    insert_site = rand(empty_sites)
+                    insert_from_biased = false
+                end
+                proposed_lattice.components[1][insert_site] = true
+            else
+                # p_bias == 0: legacy path, bit-identical RNG stream (no
+                # channel draw; lattice_insert_particle! draws exactly once)
+                success, proposed_lattice = lattice_insert_particle!(proposed_lattice)
+                if !success
+                    continue
+                end
+                insert_uniform_attempted += 1
+                insert_from_biased = false
             end
             move_type = :insert
         else
-            # Deletion
+            # Deletion: site selection is uniform over occupied sites in both
+            # paths; only the acceptance differs
             if n == 0 || p_delete <= 0.0
-                continue
+                continue                # guard skip: not counted as an attempt
             end
-            success, proposed_lattice = lattice_delete_particle!(proposed_lattice)
-            if !success
-                continue
+            if p_bias > 0.0
+                # Inlined uniform deletion (the same single rand(::Vector)
+                # draw as lattice_delete_particle!) to capture the vacated
+                # site for the reverse composite density (keep in lockstep)
+                occupied_sites = findall(proposed_lattice.components[1])
+                deleted_site = rand(occupied_sites)
+                proposed_lattice.components[1][deleted_site] = false
+            else
+                success, proposed_lattice = lattice_delete_particle!(proposed_lattice)
+                if !success
+                    continue
+                end
             end
+            delete_attempted += 1
             move_type = :delete
         end
 
@@ -886,14 +1041,45 @@ function MC_grand_canonical_walk!(n_steps::Int,
         # Cluster and local swap moves are symmetric — no correction needed
         accept = true
         if move_type == :insert
-            ratio = z0 * (p_delete / p_insert) * (n_sites - n) / (n + 1)
+            if p_bias > 0.0
+                # Composite forward density for the ACTUAL chosen site
+                q_fwd = p_insert * ((insert_site in biased_set ?
+                                         p_bias / length(biased_set) : 0.0) +
+                                    (1.0 - p_bias) / (n_sites - n))
+                ratio = z0 * p_delete / ((n + 1) * q_fwd)
+            else
+                # Legacy expression kept literally: bit-identical arithmetic
+                ratio = z0 * (p_delete / p_insert) * (n_sites - n) / (n + 1)
+            end
             if ratio < 1.0 && rand() >= ratio
                 accept = false
             end
         elseif move_type == :delete
-            ratio = (p_insert / p_delete) * n / (z0 * (n_sites - n + 1))
-            if ratio < 1.0 && rand() >= ratio
-                accept = false
+            if p_bias > 0.0
+                # Reverse composite density on the POST-deletion configuration
+                rev_set = lattice_biased_sites(proposed_lattice;
+                                               predicate=bias_predicate,
+                                               shells=bias_shells)
+                q_rev = p_insert * ((deleted_site in rev_set ?
+                                         p_bias / length(rev_set) : 0.0) +
+                                    (1.0 - p_bias) / (n_sites - n + 1))
+                if q_rev == 0.0
+                    # Only reachable at p_bias == 1 with the vacated site
+                    # outside S(x'): reject with no MH rand draw
+                    accept = false
+                else
+                    # n is the pre-delete particle count (docstring convention)
+                    ratio = n * q_rev / (z0 * p_delete)
+                    if ratio < 1.0 && rand() >= ratio
+                        accept = false
+                    end
+                end
+            else
+                # Legacy expression kept literally: bit-identical arithmetic
+                ratio = (p_insert / p_delete) * n / (z0 * (n_sites - n + 1))
+                if ratio < 1.0 && rand() >= ratio
+                    accept = false
+                end
             end
         end
 
@@ -904,10 +1090,27 @@ function MC_grand_canonical_walk!(n_steps::Int,
             accept_this_walker = true
             if move_type == :cluster
                 cluster_accepted_count += 1
+            elseif move_type == :move
+                swap_accepted += 1
+            elseif move_type == :insert
+                if insert_from_biased
+                    insert_biased_accepted += 1
+                else
+                    insert_uniform_accepted += 1
+                end
+            else # :delete
+                delete_accepted += 1
             end
         end
     end
 
     return accept_this_walker, n_accept / max(n_steps, 1), lattice,
-           cluster_accepted_count, cluster_total_count
+           cluster_accepted_count, cluster_total_count,
+           (swap_attempted=swap_attempted, swap_accepted=swap_accepted,
+            cluster_attempted=cluster_total_count, cluster_accepted=cluster_accepted_count,
+            insert_uniform_attempted=insert_uniform_attempted,
+            insert_uniform_accepted=insert_uniform_accepted,
+            insert_biased_attempted=insert_biased_attempted,
+            insert_biased_accepted=insert_biased_accepted,
+            delete_attempted=delete_attempted, delete_accepted=delete_accepted)
 end

--- a/src/SamplingSchemes/helpers.jl
+++ b/src/SamplingSchemes/helpers.jl
@@ -84,3 +84,19 @@ function _accumulate_cluster_stats!(params::SamplingParameters, mc_routine,
     end
     return params
 end
+
+"""
+    _accumulate_move_stats!(params::SamplingParameters, stats::NamedTuple)
+
+Merge one decorrelation walk's per-move-type attempt/accept counters into
+`params.move_stats` as run totals. Unlike the window-reset cluster counters
+handled by `_accumulate_cluster_stats!`, these are never reset during a run
+(the drivers clear them once at run start). Shared by the grand-canonical
+`nested_sampling_step!` methods.
+"""
+function _accumulate_move_stats!(params::SamplingParameters, stats::NamedTuple)
+    for (key, count) in pairs(stats)
+        params.move_stats[key] = get(params.move_stats, key, 0) + count
+    end
+    return params
+end

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -277,11 +277,23 @@ particle insertion and deletion.
 - `cluster_adjust_interval::Int`: Number of NS iterations between cluster p adjustments (default 50).
 - `cluster_p_floor::Float64`: Lower bound for adaptive cluster p (default 0.01).
 - `cluster_p_ceiling::Float64`: Upper bound for adaptive cluster p (default 1.0).
+- `p_bias::Float64`: Probability an insertion draws from the biased site set
+  (default 0.0 = legacy uniform insertions).
+- `bias_predicate::Symbol`: Biased-set predicate, `:contact` or `:cavity`
+  (default `:contact`).
+- `bias_shells::Int`: Neighbor shells scanned by the predicate (default 1).
 
 When `clusters_freq == 0` (the default), the fixed-N branch uses only local swaps
 (`lattice_random_walk!`), preserving backward compatibility with existing scripts.
 When `clusters_freq > 0`, the fixed-N branch mixes geometric cluster moves with
 local swaps according to the `clusters_freq:swaps_freq` ratio.
+
+With `p_bias > 0` insertions mix a sub-channel restricted to
+`lattice_biased_sites(x; predicate=bias_predicate, shells=bias_shells)` into
+the uniform proposal; the walk's composite Metropolis-Hastings correction
+keeps the sampled prior unchanged. `p_bias = 1.0` constructs but warns: the
+pure biased channel freezes N whenever the biased set is empty, so the
+uniform sub-channel is what repairs ergodicity.
 """
 struct MCGrandCanonicalMoves <: MCRoutine
     p_move::Float64
@@ -293,6 +305,9 @@ struct MCGrandCanonicalMoves <: MCRoutine
     cluster_adjust_interval::Int
     cluster_p_floor::Float64
     cluster_p_ceiling::Float64
+    p_bias::Float64
+    bias_predicate::Symbol
+    bias_shells::Int
     function MCGrandCanonicalMoves(;
             p_move::Float64=0.5,
             p_insert::Float64=0.25,
@@ -302,13 +317,32 @@ struct MCGrandCanonicalMoves <: MCRoutine
             target_cluster_accept::Float64=0.3,
             cluster_adjust_interval::Int=50,
             cluster_p_floor::Float64=0.01,
-            cluster_p_ceiling::Float64=1.0)
+            cluster_p_ceiling::Float64=1.0,
+            p_bias::Float64=0.0,
+            bias_predicate::Symbol=:contact,
+            bias_shells::Int=1)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
         end
+        if !(0.0 <= p_bias <= 1.0)
+            throw(ArgumentError("p_bias must satisfy 0 <= p_bias <= 1"))
+        end
+        if bias_predicate !== :contact && bias_predicate !== :cavity
+            throw(ArgumentError("unknown bias_predicate :$bias_predicate; expected :contact or :cavity"))
+        end
+        if bias_shells < 1
+            throw(ArgumentError("bias_shells must be >= 1, got $bias_shells"))
+        end
+        if p_bias == 1.0
+            @warn "p_bias = 1.0: the pure biased insertion channel freezes N whenever " *
+                  "the biased set is empty (every insertion becomes a null proposal and " *
+                  "the matching deletions auto-reject); keep p_bias < 1 so the uniform " *
+                  "sub-channel repairs ergodicity."
+        end
         new(p_move, p_insert, clusters_freq, swaps_freq,
             initial_cluster_p, target_cluster_accept, cluster_adjust_interval,
-            cluster_p_floor, cluster_p_ceiling)
+            cluster_p_floor, cluster_p_ceiling,
+            p_bias, bias_predicate, bias_shells)
     end
 end
 
@@ -336,6 +370,9 @@ for thermodynamic reweighting.
 - `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p after each adjustment.
 - `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adjustment.
 - `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adjustment.
+- `move_stats::Dict{Symbol,Int}`: Run-total per-move-type attempt/accept counters
+  accumulated from every decorrelation walk (keys match the walk's `move_stats`
+  NamedTuple; cleared once at run start, never window-reset).
 """
 mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     mc_steps::Int64
@@ -352,6 +389,7 @@ mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     cluster_p_history::Vector{Float64}
     cluster_accept_history::Vector{Float64}
     cluster_adjust_iterations::Vector{Int}
+    move_stats::Dict{Symbol,Int}
 end
 
 """
@@ -361,7 +399,7 @@ end
         init_occupation_p=0.5, n_max=typemax(Int64),
         cluster_p=0.3, cluster_accepted=0.0, cluster_total=0.0,
         cluster_p_history=Float64[], cluster_accept_history=Float64[],
-        cluster_adjust_iterations=Int[])
+        cluster_adjust_iterations=Int[], move_stats=Dict{Symbol,Int}())
 
 Convenience constructor for `GrandCanonicalNestedSamplingParameters`.
 
@@ -371,6 +409,10 @@ Insertions are rejected when N ≥ n_max. Default is `typemax(Int64)` (no cap).
 The `cluster_*` fields are mutable runtime state for adaptive cluster move tuning.
 They are initialized from the static configuration on `MCGrandCanonicalMoves` at
 the start of `grand_canonical_nested_sampling` when `clusters_freq > 0`.
+
+`move_stats` holds run-total per-move-type attempt/accept counters accumulated
+from every decorrelation walk (keys match the walk's `move_stats` NamedTuple;
+never window-reset, cleared once at the start of each run).
 """
 function GrandCanonicalNestedSamplingParameters(;
     mc_steps::Int64=100,
@@ -387,6 +429,7 @@ function GrandCanonicalNestedSamplingParameters(;
     cluster_p_history::Vector{Float64}=Float64[],
     cluster_accept_history::Vector{Float64}=Float64[],
     cluster_adjust_iterations::Vector{Int}=Int[],
+    move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
 )
     GrandCanonicalNestedSamplingParameters(
         mc_steps, chemical_potential, energy_perturbation,
@@ -394,6 +437,7 @@ function GrandCanonicalNestedSamplingParameters(;
         init_occupation_p, n_max,
         cluster_p, cluster_accepted, cluster_total,
         cluster_p_history, cluster_accept_history, cluster_adjust_iterations,
+        move_stats,
     )
 end
 
@@ -1271,14 +1315,17 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     to_walk = deepcopy(ats[parent_idx])
 
     # Decorrelate via GC MCMC
-    accept, rate, to_walk, cl_accepted, cl_total = MC_grand_canonical_walk!(
+    accept, rate, to_walk, cl_accepted, cl_total, move_stats = MC_grand_canonical_walk!(
         gc_params.mc_steps, to_walk, h, omega_max_val, mu;
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         energy_perturb=gc_params.energy_perturbation,
         n_max=gc_params.n_max,
         clusters_freq=mc_routine.clusters_freq,
         swaps_freq=mc_routine.swaps_freq,
-        cluster_p=gc_params.cluster_p)
+        cluster_p=gc_params.cluster_p,
+        p_bias=mc_routine.p_bias,
+        bias_predicate=mc_routine.bias_predicate,
+        bias_shells=mc_routine.bias_shells)
 
     if accept
         push!(ats, to_walk)
@@ -1295,6 +1342,7 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
 
     # Accumulate cluster acceptance stats and adapt cluster_p
     _accumulate_cluster_stats!(gc_params, mc_routine, cl_accepted, cl_total, ns_iteration)
+    _accumulate_move_stats!(gc_params, move_stats)
 
     return iter, omega_worst, energy_worst, n_worst, liveset, gc_params
 end
@@ -1345,6 +1393,9 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
         empty!(gc_params.cluster_accept_history)
         empty!(gc_params.cluster_adjust_iterations)
     end
+    # Run-total per-move-type counters: always reset, independent of the
+    # cluster-move configuration above
+    empty!(gc_params.move_stats)
 
     df = DataFrame(iter=Int[], omega=Float64[], energy=Float64[], num_particles=Int[])
     if observables !== nothing
@@ -1462,6 +1513,9 @@ truncate the prior support and bias Ξ.
 - `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p after each adjustment.
 - `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adjustment.
 - `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adjustment.
+- `move_stats::Dict{Symbol,Int}`: Run-total per-move-type attempt/accept counters
+  accumulated from every decorrelation walk (keys match the walk's `move_stats`
+  NamedTuple; cleared once at run start, never window-reset).
 """
 mutable struct IdealGasReferencedGCNSParameters <: SamplingParameters
     mc_steps::Int64
@@ -1476,6 +1530,7 @@ mutable struct IdealGasReferencedGCNSParameters <: SamplingParameters
     cluster_p_history::Vector{Float64}
     cluster_accept_history::Vector{Float64}
     cluster_adjust_iterations::Vector{Int}
+    move_stats::Dict{Symbol,Int}
 end
 
 """
@@ -1484,7 +1539,7 @@ end
         random_seed=1234, fail_count=0, allowed_fail_count=10,
         cluster_p=0.3, cluster_accepted=0.0, cluster_total=0.0,
         cluster_p_history=Float64[], cluster_accept_history=Float64[],
-        cluster_adjust_iterations=Int[])
+        cluster_adjust_iterations=Int[], move_stats=Dict{Symbol,Int}())
 
 Convenience constructor for `IdealGasReferencedGCNSParameters`.
 
@@ -1496,6 +1551,10 @@ degrades as `|βμ − ln z0|` grows (roughly beyond `1/√Var(N)`).
 The `cluster_*` fields are mutable runtime state for adaptive cluster move
 tuning, initialized from the static configuration on `MCGrandCanonicalMoves`
 at the start of `ideal_gas_referenced_nested_sampling` when `clusters_freq > 0`.
+
+`move_stats` holds run-total per-move-type attempt/accept counters accumulated
+from every decorrelation walk (keys match the walk's `move_stats` NamedTuple;
+never window-reset, cleared once at the start of each run).
 """
 function IdealGasReferencedGCNSParameters(;
     mc_steps::Int64=100,
@@ -1510,6 +1569,7 @@ function IdealGasReferencedGCNSParameters(;
     cluster_p_history::Vector{Float64}=Float64[],
     cluster_accept_history::Vector{Float64}=Float64[],
     cluster_adjust_iterations::Vector{Int}=Int[],
+    move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
 )
     if reference_fugacity <= 0.0
         throw(ArgumentError("reference_fugacity must be positive"))
@@ -1523,6 +1583,7 @@ function IdealGasReferencedGCNSParameters(;
         random_seed, fail_count, allowed_fail_count,
         cluster_p, cluster_accepted, cluster_total,
         cluster_p_history, cluster_accept_history, cluster_adjust_iterations,
+        move_stats,
     )
 end
 
@@ -1597,14 +1658,17 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     # Decorrelate via GC MCMC: with mu = 0 the Ω ceiling reduces to an energy
     # ceiling, and z0 weights the insert/delete acceptance to preserve the
     # Bernoulli(z0/(1+z0)) prior
-    accept, rate, to_walk, cl_accepted, cl_total = MC_grand_canonical_walk!(
+    accept, rate, to_walk, cl_accepted, cl_total, move_stats = MC_grand_canonical_walk!(
         params.mc_steps, to_walk, h, emax_val, 0.0;
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         energy_perturb=params.energy_perturbation,
         z0=params.reference_fugacity,
         clusters_freq=mc_routine.clusters_freq,
         swaps_freq=mc_routine.swaps_freq,
-        cluster_p=params.cluster_p)
+        cluster_p=params.cluster_p,
+        p_bias=mc_routine.p_bias,
+        bias_predicate=mc_routine.bias_predicate,
+        bias_shells=mc_routine.bias_shells)
 
     if accept
         push!(ats, to_walk)
@@ -1620,6 +1684,7 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
 
     # Accumulate cluster acceptance stats and adapt cluster_p
     _accumulate_cluster_stats!(params, mc_routine, cl_accepted, cl_total, ns_iteration)
+    _accumulate_move_stats!(params, move_stats)
 
     return iter, emax_worst, n_worst, liveset, params
 end
@@ -1679,6 +1744,9 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
         empty!(params.cluster_accept_history)
         empty!(params.cluster_adjust_iterations)
     end
+    # Run-total per-move-type counters: always reset, independent of the
+    # cluster-move configuration above
+    empty!(params.move_stats)
 
     df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
     if observables !== nothing

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -414,6 +414,88 @@
                 @test sum(full_lattice.components[1]) == 4  # Should maintain full occupancy
             end
         end
+
+        @testset "lattice_biased_sites tests" begin
+            biased_lattice() = MLattice{1,SquareLattice}(
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(4, 4, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1, 1.5],   # shell 1: 4 NN at d=1; shell 2: 4 diagonals at d=sqrt(2)
+                components=:equal,
+                adsorptions=:full)
+
+            @testset "empty and full lattices" begin
+                lat = biased_lattice()
+                lat.components[1] .= false
+                @test sort(lattice_biased_sites(lat; predicate=:cavity)) == collect(1:16)
+                @test isempty(lattice_biased_sites(lat; predicate=:contact))
+                lat.components[1] .= true
+                @test isempty(lattice_biased_sites(lat; predicate=:cavity))
+                @test isempty(lattice_biased_sites(lat; predicate=:contact))
+            end
+
+            @testset "single particle shell counts" begin
+                lat = biased_lattice()
+                lat.components[1] .= false
+                lat.components[1][6] = true   # torus: every site equivalent
+                # shells=1: contacts are exactly the 4 NN; cavities 16-1-4 = 11
+                contact1 = lattice_biased_sites(lat; predicate=:contact, shells=1)
+                cavity1 = lattice_biased_sites(lat; predicate=:cavity, shells=1)
+                @test sort(contact1) == sort(lat.neighbors[6][1])
+                @test length(contact1) == 4
+                @test length(cavity1) == 11
+                # shells=2: 4 NN + 4 diagonals; cavities 16-1-8 = 7
+                contact2 = lattice_biased_sites(lat; predicate=:contact, shells=2)
+                cavity2 = lattice_biased_sites(lat; predicate=:cavity, shells=2)
+                @test sort(contact2) == sort(vcat(lat.neighbors[6][1], lat.neighbors[6][2]))
+                @test length(contact2) == 8
+                @test length(cavity2) == 7
+            end
+
+            @testset "contact and cavity partition the empty sites" begin
+                lat = biased_lattice()
+                lat.components[1] .= false
+                lat.components[1][[1, 4, 6, 7, 10, 13, 16]] .= true  # fixed irregular config
+                for shells in (1, 2)
+                    contact = lattice_biased_sites(lat; predicate=:contact, shells=shells)
+                    cavity = lattice_biased_sites(lat; predicate=:cavity, shells=shells)
+                    @test isempty(intersect(contact, cavity))
+                    @test sort(vcat(contact, cavity)) == findall(.!lat.components[1])
+                end
+            end
+
+            @testset "image-multiplicity neighbor lists" begin
+                # Faithful 4x4 cell: multiplicity lists equal min-image lists,
+                # so the counts must be unchanged
+                lat_m = MLattice{1,SquareLattice}(
+                    lattice_constant=1.0, basis=[(0.0, 0.0, 0.0)],
+                    supercell_dimensions=(4, 4, 1), periodicity=(true, true, false),
+                    cutoff_radii=[1.1, 1.5], components=[[false for _ in 1:16]],
+                    adsorptions=:full, image_multiplicity=true)
+                lat_m.components[1][6] = true
+                @test length(lattice_biased_sites(lat_m; predicate=:contact)) == 4
+                @test length(lattice_biased_sites(lat_m; predicate=:cavity)) == 11
+                # 2x2 torus: each site's 4 NN collapse onto 2 distinct sites
+                # (double entries); the predicates read occupancy only, so
+                # duplicated neighbor entries are harmless
+                tiny = MLattice{1,SquareLattice}(
+                    lattice_constant=1.0, basis=[(0.0, 0.0, 0.0)],
+                    supercell_dimensions=(2, 2, 1), periodicity=(true, true, false),
+                    cutoff_radii=[1.1], components=[[false for _ in 1:4]],
+                    adsorptions=:full, image_multiplicity=true)
+                tiny.components[1][1] = true
+                @test sort(lattice_biased_sites(tiny; predicate=:contact)) == [2, 3]
+                @test lattice_biased_sites(tiny; predicate=:cavity) == [4]
+            end
+
+            @testset "argument validation" begin
+                lat = biased_lattice()
+                @test_throws ArgumentError lattice_biased_sites(lat; predicate=:nonsense)
+                @test_throws ArgumentError lattice_biased_sites(lat; shells=0)
+                @test_throws ArgumentError lattice_biased_sites(lat; shells=3)  # lattice has 2 shells
+            end
+        end
     end
 
     @testset "Monte Carlo swap moves tests" begin

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -50,6 +50,10 @@
         @test gc_params.cluster_accept_history == Float64[]
         @test gc_params.cluster_adjust_iterations == Int[]
 
+        # move_stats defaults (issue #158)
+        @test gc_params.move_stats isa Dict{Symbol,Int}
+        @test isempty(gc_params.move_stats)
+
         # Cluster field mutability
         gc_params.cluster_p = 0.5
         @test gc_params.cluster_p == 0.5
@@ -85,6 +89,29 @@
         # Invalid probabilities
         @test_throws ArgumentError MCGrandCanonicalMoves(p_move=0.8, p_insert=0.3)
         @test_throws ArgumentError MCGrandCanonicalMoves(p_move=-0.1, p_insert=0.3)
+
+        # Bias field defaults (issue #158)
+        @test mc.p_bias == 0.0
+        @test mc.bias_predicate == :contact
+        @test mc.bias_shells == 1
+
+        # Bias-enabled construction
+        mc4 = MCGrandCanonicalMoves(p_bias=0.5, bias_predicate=:cavity, bias_shells=2)
+        @test mc4.p_bias == 0.5
+        @test mc4.bias_predicate == :cavity
+        @test mc4.bias_shells == 2
+
+        # Invalid bias parameters
+        @test_throws ArgumentError MCGrandCanonicalMoves(p_bias=-0.1)
+        @test_throws ArgumentError MCGrandCanonicalMoves(p_bias=1.5)
+        @test_throws ArgumentError MCGrandCanonicalMoves(bias_shells=0)
+        @test_throws ArgumentError MCGrandCanonicalMoves(bias_predicate=:nonsense)
+
+        # p_bias = 1.0 constructs but warns (reducible kernel; see the
+        # non-ergodicity pin in test-ideal-gas-ref-gcns.jl) ...
+        @test_logs (:warn, r"p_bias") match_mode = :any MCGrandCanonicalMoves(p_bias=1.0)
+        # ... and stays silent below 1
+        @test_logs min_level = Base.CoreLogging.Warn MCGrandCanonicalMoves(p_bias=0.99)
     end
  
     # ================================================================
@@ -189,6 +216,64 @@
         # Invalid probability should throw
         @test_throws ArgumentError MC_grand_canonical_walk!(
             10, walker, ham, omega_max, mu; p_move=0.8, p_insert=0.3)
+
+        # ---- Move counters: 6th return element (issue #158) ----
+        walker6 = LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0)
+        assign_energy!(walker6, ham)
+        _, _, walker6, _, _, counters = MC_grand_canonical_walk!(
+            100, walker6, ham, 1e3, mu;
+            p_move=0.5, p_insert=0.25, energy_perturb=0.0)
+        @test counters isa NamedTuple
+        @test keys(counters) == (
+            :swap_attempted, :swap_accepted, :cluster_attempted, :cluster_accepted,
+            :insert_uniform_attempted, :insert_uniform_accepted,
+            :insert_biased_attempted, :insert_biased_accepted,
+            :delete_attempted, :delete_accepted)
+        # Default path: the bias and cluster families never fire
+        @test counters.insert_biased_attempted == 0
+        @test counters.insert_biased_accepted == 0
+        @test counters.cluster_attempted == 0
+        # accepted <= attempted per family
+        @test counters.swap_accepted <= counters.swap_attempted
+        @test counters.insert_uniform_accepted <= counters.insert_uniform_attempted
+        @test counters.delete_accepted <= counters.delete_attempted
+    end
+
+    # ================================================================
+    @testset "MC_grand_canonical_walk! counters: exact bookkeeping" begin
+        ham0 = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        # Skip-free by construction: N starts at 8, |dN| <= 1 per step, so
+        # over 8 steps N stays in [1, 15]: insert-at-full and delete-at-empty
+        # can never fire, and with 0 < N < M on a connected lattice the
+        # :contact set is never empty, so the biased branch cannot skip.
+        # Every step assigns a move type, for any RNG stream:
+        # sum(attempted) == n_steps exactly.
+        lat_bk = deepcopy(square_lattice)
+        lat_bk.components[1] .= false
+        lat_bk.components[1][1:8] .= true
+        walker_bk = LatticeWalker(lat_bk, energy=0.0u"eV", iter=0)
+        _, _, _, _, _, c = MC_grand_canonical_walk!(
+            8, walker_bk, ham0, 1e3, 0.0;
+            p_move=0.5, p_insert=0.25, energy_perturb=0.0,
+            p_bias=0.5, bias_predicate=:contact, bias_shells=1)
+        attempted = c.swap_attempted + c.cluster_attempted +
+                    c.insert_uniform_attempted + c.insert_biased_attempted +
+                    c.delete_attempted
+        accepted = c.swap_accepted + c.cluster_accepted +
+                   c.insert_uniform_accepted + c.insert_biased_accepted +
+                   c.delete_accepted
+        @test attempted == 8
+        @test accepted <= attempted
+
+        # kwarg validation on the walk
+        w2 = LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0)
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w2, ham0, 1e3, 0.0; p_bias=-0.1)
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w2, ham0, 1e3, 0.0; p_bias=1.5)
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w2, ham0, 1e3, 0.0; bias_shells=0)
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w2, ham0, 1e3, 0.0; bias_predicate=:nonsense)
+        # bias_shells beyond the lattice fires only when the channel is active
+        @test_throws ArgumentError MC_grand_canonical_walk!(
+            1, w2, ham0, 1e3, 0.0; p_bias=0.5, bias_shells=3)
     end
 
     # ================================================================
@@ -240,6 +325,22 @@
         @test n_par isa Union{Missing,Int}
         @test length(updated_liveset.walkers) == 5
         @test updated_params.fail_count >= 0
+
+        # ---- move_stats accumulation through one NS step (issue #158) ----
+        attempted_keys = (:swap_attempted, :cluster_attempted,
+                          :insert_uniform_attempted, :insert_biased_attempted,
+                          :delete_attempted)
+        ms = updated_params.move_stats
+        @test ms isa Dict{Symbol,Int}
+        @test all(v >= 0 for v in values(ms))
+        att = sum(get(ms, k, 0) for k in attempted_keys)
+        # One NS step walks one replacement walker for mc_steps steps; skips
+        # require a boundary configuration, so at least one step attempts
+        @test 1 <= att <= gc_params.mc_steps
+        @test get(ms, :swap_accepted, 0) <= get(ms, :swap_attempted, 0)
+        @test get(ms, :insert_uniform_accepted, 0) <= get(ms, :insert_uniform_attempted, 0)
+        @test get(ms, :insert_biased_accepted, 0) <= get(ms, :insert_biased_attempted, 0)
+        @test get(ms, :delete_accepted, 0) <= get(ms, :delete_attempted, 0)
     end
  
     # ================================================================
@@ -276,7 +377,35 @@
         rm("test_gc.traj", force=true)
         rm("test_gc.ls", force=true)
     end
- 
+
+    # ================================================================
+    @testset "move_stats: accumulated per run, reset between runs" begin
+        walkers_ms = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:10]
+        liveset_ms = LatticeGasWalkers(walkers_ms, ham; assign_energy=false)
+        params_ms = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05)
+        save_ms = SaveEveryN("test_ms_df.csv", "test_ms.traj", "test_ms.ls", 1000, 1000, 1000)
+        attempted_keys = (:swap_attempted, :cluster_attempted,
+                          :insert_uniform_attempted, :insert_biased_attempted,
+                          :delete_attempted)
+
+        _, _, params1 = grand_canonical_nested_sampling(
+            liveset_ms, params_ms, Int64(20), MCGrandCanonicalMoves(), save_ms)
+        s1 = sum(get(params1.move_stats, k, 0) for k in attempted_keys)
+        @test 0 < s1 <= 20 * 50   # per-run ceiling: n_iters x mc_steps
+
+        # Re-running with the RETURNED params must reset the accumulator: a
+        # carried-over dict would exceed the single-run ceiling
+        _, _, params2 = grand_canonical_nested_sampling(
+            liveset_ms, params1, Int64(20), MCGrandCanonicalMoves(), save_ms)
+        s2 = sum(get(params2.move_stats, k, 0) for k in attempted_keys)
+        @test 0 < s2 <= 20 * 50
+
+        rm("test_ms_df.csv", force=true)
+        rm("test_ms.traj", force=true)
+        rm("test_ms.ls", force=true)
+    end
+
     # ================================================================
     @testset "gc_thermodynamic_stats basic" begin
         # Hand-crafted test: 2 microstates

--- a/test/test-SamplingSchemes/test-hard-core-lattices.jl
+++ b/test/test-SamplingSchemes/test-hard-core-lattices.jl
@@ -432,4 +432,62 @@
         # Kish N_eff degrades away from the run's z0
         @test stats.N_eff[4, 1] < stats.N_eff[2, 1]
     end
+
+    # ================================================================
+    @testset "biased :cavity walk samples the restricted prior (hard squares)" begin
+        # Fixed ceiling J/2 in (0, J) with mu = 0, z0 = 1: the only reachable
+        # states are independent sets (E = J x violations), and the walk's
+        # stationary law is the RESTRICTED Bernoulli prior
+        # P(N) = g_N / sum(g) = g_N / 743.
+        # A fixed-ceiling walk is used instead of an NS dead-point histogram:
+        # dead points are moving-ceiling order statistics with no closed-form
+        # N-marginal, while this chain has an exact target, and it exercises
+        # the composite kernel directly, including the isolated-particle
+        # delete branch (on an independent set every occupied site is
+        # isolated, so every deletion takes that branch).
+        Random.seed!(158)
+        template_bc = hc_square()
+        template_bc.components[1] .= false
+        walker_bc = LatticeWalker(template_bc, energy=0.0u"eV", iter=0)
+        wcap = J / 2
+        gc_walk!(n) = MC_grand_canonical_walk!(n, walker_bc, ham_hc, wcap, 0.0;
+            p_move=0.4, p_insert=0.3, z0=1.0,
+            p_bias=0.9, bias_predicate=:cavity, bias_shells=1)
+        gc_walk!(500)   # burn-in from the empty (allowed) state
+
+        n_samples = 12_000
+        counts = zeros(Int, M_sq + 1)
+        rate_sum = 0.0
+        all_independent = true
+        for _ in 1:n_samples
+            _, r, _, _, _, _ = gc_walk!(15)   # 15-step decorrelation blocks
+            occ = walker_bc.configuration.components[1]
+            all_independent &= violation_count(masks_sq, occ) == 0
+            counts[sum(occ) + 1] += 1
+            rate_sum += r
+        end
+
+        # The ceiling was never breached: every sample is an independent set
+        @test all_independent
+        @test all(counts[10:end] .== 0)   # g_N = 0 for N > 8
+
+        # Multinomial gates: p_N = g_N/743, sigma = sqrt(p(1-p)/n) at
+        # n = 12000, with mild residual autocorrelation from the 15-step
+        # blocks. Three-seed calibration (seeds 158/159/160): max |dev| =
+        # 2.3 iid-sigma, zero tail counts, acceptance rate 0.70 on every
+        # seed; the shipped k = 7 is >= 3x the maximum. Discrimination: an
+        # uncorrected biased kernel distorts P(N) at the tens-of-percent
+        # level, orders above these gates.
+        Zg = sum(g_sq)   # = 743
+        for N in 0:8
+            p = g_sq[N + 1] / Zg
+            sig = sqrt(p * (1 - p) / n_samples)
+            @test abs(counts[N + 1] / n_samples - p) < 7 * sig
+        end
+
+        # Acceptance sanity: cavity insertions never create a violation, so
+        # the ceiling never rejects the biased branch; only the MH factor
+        # can. A soft floor pins that the kernel is not ceiling-starved.
+        @test rate_sum / n_samples > 0.1
+    end
 end

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -16,13 +16,13 @@
         adsorptions=:full
     )
 
-    function igref_run(template, ham, z0, n_walkers, n_steps; seed=7, mc_steps=100)
+    function igref_run(template, ham, z0, n_walkers, n_steps; seed=7, mc_steps=100,
+                       mc_routine=MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3))
         Random.seed!(seed)
         walkers = [LatticeWalker(deepcopy(template), energy=0.0u"eV", iter=0)
                    for _ in 1:n_walkers]
         liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
         params = IdealGasReferencedGCNSParameters(mc_steps=mc_steps, reference_fugacity=z0)
-        mc_routine = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
         save = SaveEveryN("test_igref.csv", "test_igref.traj", "test_igref.ls",
                           100000, 100000, 100000)
         df, final_ls, params = ideal_gas_referenced_nested_sampling(
@@ -45,6 +45,9 @@
         @test params.allowed_fail_count == 10
         @test params.cluster_p == 0.3
         @test isempty(params.cluster_p_history)
+        # move_stats defaults (issue #158)
+        @test params.move_stats isa Dict{Symbol,Int}
+        @test isempty(params.move_stats)
 
         params2 = IdealGasReferencedGCNSParameters(reference_fugacity=0.25, mc_steps=50)
         @test params2.reference_fugacity == 0.25
@@ -109,10 +112,182 @@
             @test isapprox(acc_N / n_samples, igref_n_sites * p0; atol=0.5)
         end
 
+        # ---- Biased-insertion stationarity grid (issue #158) ----
+        # p_bias mixes uniform insertion with insertion restricted to
+        # lattice_biased_sites(; predicate, shells=1); the composite MH
+        # correction must leave the same Bernoulli(p0) product prior
+        # invariant. p_bias = 0.5: the uniform component keeps the chain
+        # irreducible, so a single-chain time average must reproduce
+        # (N) = M p0, per-site occupancy p0, and Var(N) = M p0 (1 - p0).
+        for (cell, (z0, pred)) in enumerate(Iterators.product((0.5, 2.0), (:contact, :cavity)))
+            Random.seed!(4200 + cell)
+            walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+            MC_grand_canonical_walk!(300, walker, ham0, 1e3, 0.0;
+                                     p_move=0.2, p_insert=0.4, z0=z0,
+                                     p_bias=0.5, bias_predicate=pred, bias_shells=1)
+            n_blocks = 1500
+            Nsum = 0.0
+            N2sum = 0.0
+            site_sum = zeros(igref_n_sites)
+            for _ in 1:n_blocks
+                MC_grand_canonical_walk!(10, walker, ham0, 1e3, 0.0;
+                                         p_move=0.2, p_insert=0.4, z0=z0,
+                                         p_bias=0.5, bias_predicate=pred, bias_shells=1)
+                occ = walker.configuration.components[1]
+                Nsum += sum(occ)
+                N2sum += sum(occ)^2
+                site_sum .+= occ
+            end
+            p0 = z0 / (1 + z0)
+            meanN = Nsum / n_blocks
+            varN = N2sum / n_blocks - meanN^2
+            # Tolerance model (10-step blocks, n = 1500 samples; Var(N) =
+            # M p0 (1 - p0) = 3.56 at both z0): sigma((N)) ~ 0.10,
+            # sigma(site) ~ 0.024 iid, SE(Var) ~ 0.26, all inflated by
+            # residual block autocorrelation. Three-seed calibration (seed
+            # bases 4200/5200/6200, all 4 cells): max |d(N)| = 0.145, max
+            # site |d| = 0.052, max |dVar| = 0.361; shipped gates >= 3x the
+            # maxima (0.5, 0.16, 1.2).
+            @test isapprox(meanN, igref_n_sites * p0; atol=0.5)
+            @test maximum(abs.(site_sum ./ n_blocks .- p0)) < 0.16
+            @test isapprox(varN, igref_n_sites * p0 * (1 - p0); atol=1.2)
+        end
+
+        # p_bias = 1.0: the kernel is still prior-invariant (each sub-kernel
+        # is in detailed balance) but REDUCIBLE: :contact cannot leave N = 0
+        # and :cavity can never insert next to the occupied region, so dense
+        # states are unreachable and time averages are meaningless (hence the
+        # constructor warning and the non-ergodicity pin below). Invariance is
+        # what the composite MH factor must guarantee, so test it directly: an
+        # ensemble of chains started from EXACT prior draws must remain
+        # prior-distributed after any number of steps.
+        for (cell, (z0, pred)) in enumerate(Iterators.product((0.5, 2.0), (:contact, :cavity)))
+            Random.seed!(4300 + cell)
+            p0 = z0 / (1 + z0)
+            n_chains = 1200
+            Nsum = 0.0
+            N2sum = 0.0
+            site_sum = zeros(igref_n_sites)
+            for _ in 1:n_chains
+                walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+                random_microstate!(walker.configuration; p=p0)   # exact prior draw
+                MC_grand_canonical_walk!(25, walker, ham0, 1e3, 0.0;
+                                         p_move=0.2, p_insert=0.4, z0=z0,
+                                         p_bias=1.0, bias_predicate=pred, bias_shells=1)
+                occ = walker.configuration.components[1]
+                Nsum += sum(occ)
+                N2sum += sum(occ)^2
+                site_sum .+= occ
+            end
+            meanN = Nsum / n_chains
+            varN = N2sum / n_chains - meanN^2
+            # Chains are iid (fresh prior starts): sigma((N)) = 0.054,
+            # sigma(site) = 0.0136, SE(Var) ~ 0.145 at n = 1200. Three-seed
+            # calibration (seed bases 4300/5300/6300, all 4 cells): max
+            # |d(N)| = 0.083, max site |d| = 0.038, max |dVar| = 0.272;
+            # shipped gates >= 3x the maxima (0.35, 0.12, 0.85).
+            @test isapprox(meanN, igref_n_sites * p0; atol=0.35)
+            @test maximum(abs.(site_sum ./ n_chains .- p0)) < 0.12
+            @test isapprox(varN, igref_n_sites * p0 * (1 - p0); atol=0.85)
+        end
+
         # z0 must be positive
         walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
         @test_throws ArgumentError MC_grand_canonical_walk!(
             1, walker, ham0, 1e3, 0.0; z0=0.0)
+    end
+
+    # ================================================================
+    @testset "Exact microstate distribution on 2x2 (biased kernel)" begin
+        # 2x2 torus: each site's 4 NN collapse onto 2 distinct sites, so the
+        # default min-image construction warns; multiplicity lists are exact
+        # here and the bias predicates only read occupancy, so duplicated
+        # neighbor entries are harmless.
+        tiny_template = MLattice{1,SquareLattice}(
+            lattice_constant=1.0, basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(2, 2, 1), periodicity=(true, true, false),
+            cutoff_radii=[1.1], components=[[false for _ in 1:4]],
+            adsorptions=:full, image_multiplicity=true)
+        ham0 = GenericLatticeHamiltonian(0.0, [0.0], u"eV")
+        z0 = 2.0
+        # Zero Hamiltonian, non-binding ceiling: the walk must sample the
+        # Bernoulli product prior exactly, P(state) = z0^N / (1+z0)^4
+        for (ip, pred) in enumerate((:contact, :cavity))
+            Random.seed!(5150 + ip)
+            walker = LatticeWalker(deepcopy(tiny_template), energy=0.0u"eV", iter=0)
+            MC_grand_canonical_walk!(200, walker, ham0, 1e3, 0.0;
+                                     p_move=0.2, p_insert=0.4, z0=z0,
+                                     p_bias=0.5, bias_predicate=pred, bias_shells=1)
+            n_samples = 20_000
+            counts = zeros(Int, 16)
+            Nsum = 0.0
+            for _ in 1:n_samples
+                # 8-step blocks (~2 sweeps of the 4-site lattice) decorrelate
+                MC_grand_canonical_walk!(8, walker, ham0, 1e3, 0.0;
+                                         p_move=0.2, p_insert=0.4, z0=z0,
+                                         p_bias=0.5, bias_predicate=pred, bias_shells=1)
+                occ = walker.configuration.components[1]
+                mask = sum(Int(occ[s]) << (s - 1) for s in 1:4)
+                counts[mask + 1] += 1
+                Nsum += sum(occ)
+            end
+            # Multinomial gates: per cell sigma = sqrt(p(1-p)/n) at n = 20000;
+            # the max over 16 cells x 2 predicates of ~3 sigma is the
+            # expected extreme of 32 comparisons, inflated by residual block
+            # autocorrelation. Three-seed calibration (seed bases 5150/6150/
+            # 7150): max |dev| = 3.0 iid-sigma, max |d(N)| = 0.023; shipped
+            # gates >= 3x the maxima (k = 9, atol 0.07). Discrimination: a
+            # deliberately broken kernel (reverse density on the pre-delete
+            # configuration, or the uniform-proposal ratio on biased draws)
+            # fails these gates at 20-55 sigma on the discriminating cells;
+            # per-state residuals below ~5e-3 sit under them, the honest
+            # floor at feasible n.
+            for mask in 0:15
+                p = z0^count_ones(mask) / (1 + z0)^4
+                sig = sqrt(p * (1 - p) / n_samples)
+                @test abs(counts[mask + 1] / n_samples - p) < 9 * sig
+            end
+            @test isapprox(Nsum / n_samples, 4 * z0 / (1 + z0); atol=0.07)
+        end
+    end
+
+    # ================================================================
+    @testset "p_bias = 1.0 :contact is non-ergodic from empty" begin
+        # From N = 0 the contact set is empty, the biased branch has no
+        # proposal, and the uniform branch is never selected: N == 0 is an
+        # exact invariant even at z0 = 2 insertion pressure. This is the
+        # reducibility the MCGrandCanonicalMoves constructor warns about.
+        ham0_ne = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        Random.seed!(158)
+        walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+        for _ in 1:10
+            MC_grand_canonical_walk!(200, walker, ham0_ne, 1e3, 0.0;
+                p_move=0.2, p_insert=0.4, z0=2.0,
+                p_bias=1.0, bias_predicate=:contact, bias_shells=1)
+            @test sum(walker.configuration.components[1]) == 0
+        end
+    end
+
+    # ================================================================
+    @testset "insert branch split matches p_bias (counters)" begin
+        ham0_bs = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        Random.seed!(31)
+        lat_bs = deepcopy(igref_template)
+        lat_bs.components[1][1:8] .= true
+        walker = LatticeWalker(lat_bs, energy=0.0u"eV", iter=0)
+        _, _, _, _, _, c = MC_grand_canonical_walk!(
+            6000, walker, ham0_bs, 1e3, 0.0;
+            p_move=0.2, p_insert=0.4, z0=1.0,
+            p_bias=0.5, bias_predicate=:contact, bias_shells=1)
+        k = c.insert_biased_attempted
+        n = k + c.insert_uniform_attempted
+        # n ~ 0.4 x 6000 = 2400 insert-branch trials, branch coin
+        # Bernoulli(1/2): k ~ Binomial(n, 1/2), sigma = sqrt(n/4) ~ 24.5;
+        # gate 4 sigma (~98 counts, alpha ~ 6e-5). :contact skips only at
+        # N = 0 (prior weight 2^-16 at z0 = 1: well under one expected
+        # skipped trial over the run), negligible against the gate.
+        @test n > 2000
+        @test abs(k - n / 2) <= 4 * sqrt(n / 4)
     end
 
     # ================================================================
@@ -223,6 +398,76 @@
     end
 
     # ================================================================
+    @testset "Interacting lattice vs exact enumeration (biased :contact)" begin
+        # Same physics as the unbiased z0 != 1 testset above, driven through
+        # the composite kernel with p_bias = 0.5 :contact via the NS step:
+        # the end-to-end check that biased insertion leaves the ideal-gas
+        # reference bookkeeping (weights, (1+z0)^M normalization) intact.
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        μ_center = -0.05
+        T_center = 300.0
+        z0 = exp(μ_center / (kb * T_center))
+        n_walkers = 100
+
+        mc_bias = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3, p_bias=0.5)
+        df, live_E, live_N = igref_run(igref_template, ham, z0, n_walkers, 4000;
+                                       seed=13, mc_routine=mc_bias)
+        @test nrow(df) > 0
+        @test issorted(df.emax, rev=true)
+        # The ladder reaches deep order (ground state -1.04 eV)
+        @test minimum(df.emax) < -1.0
+
+        # mu grid: two in-window points plus one deliberately out-of-window
+        # point (mu = -0.08) for the Kish N_eff gate
+        μs = [-0.08, -0.06, -0.05]
+        Ts = [300.0, 400.0]
+
+        E_vals = Vector{Float64}(undef, 2^igref_n_sites)
+        N_vals = Vector{Int}(undef, 2^igref_n_sites)
+        lattice = deepcopy(igref_template)
+        for mask in 0:(2^igref_n_sites - 1)
+            for site in 1:igref_n_sites
+                lattice.components[1][site] = ((mask >> (site - 1)) & 1) == 1
+            end
+            E_vals[mask+1] = interacting_energy(lattice, ham).val
+            N_vals[mask+1] = sum(lattice.components[1])
+        end
+
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, z0, μs, Ts, n_walkers;
+            ω0=(n_walkers + 1) / n_walkers, live_emax=live_E, live_numbers=live_N)
+
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            i == 1 && continue  # the out-of-window point feeds only the N_eff gate
+            β = 1 / (kb * T)
+            log_w = β .* μ .* N_vals .- β .* E_vals
+            max_log = maximum(log_w)
+            w = exp.(log_w .- max_log)
+            Z = sum(w)
+            logXi_exact = max_log + log(Z)
+            meanN_exact = sum(w .* N_vals) / Z
+            meanU_exact = sum(w .* E_vals) / Z
+            varN_exact = sum(w .* N_vals .^ 2) / Z - meanN_exact^2
+            # Tolerances recalibrated for the biased kernel over 3 seeds
+            # (13/14/15; every in-window point gated at N_eff >= 1747): max
+            # |d logXi| = 0.45, max relative d(N) = 0.044, d(U) = 0.052;
+            # shipped >= 3x the maxima (1.5, 0.15, 0.16), still below the
+            # ~2.2 shift a missing (1+z0)^M normalization would cause. Var N
+            # is not gated here: at these near-step grid points its
+            # reweighting noise reaches 0.28 relative (a >= 3x gate would be
+            # vacuous), and it is exercised by the unbiased register above.
+            @test isapprox(stats.logXi[i, j], logXi_exact; atol=1.5)
+            @test isapprox(stats.mean_N[i, j], meanN_exact; rtol=0.15)
+            @test isapprox(stats.mean_U[i, j], meanU_exact; rtol=0.16)
+        end
+
+        # Kish N_eff degrades out of the reweighting window; every reweighted
+        # point stays bounded by the sample count
+        @test stats.N_eff[1, 1] < stats.N_eff[3, 1]
+        @test all(stats.N_eff .<= nrow(df) + length(live_E))
+    end
+
+    # ================================================================
     @testset "Exact Skilling closure (E ≡ 0)" begin
         # With a zero Hamiltonian every configuration has E = 0 (up to the
         # 1e-12 tie-breaking tags), so at z = z0 the reweighting factor is 1
@@ -325,5 +570,22 @@
         @test df1.emax == df2.emax
         @test df1.num_particles == df2.num_particles
         @test live_E1 == live_E2
+    end
+
+    # ================================================================
+    @testset "Same-seed A/B: p_bias = 0.0 is RNG-identical to default" begin
+        # The p_bias = 0 code path must draw exactly the same RNG stream as
+        # a routine that never mentions p_bias; any extra rand() would
+        # silently break reproducibility of published runs.
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        mcA = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+        mcB = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3, p_bias=0.0)
+        dfA, live_EA, _ = igref_run(igref_template, ham, 2.0, 30, 300;
+                                    seed=99, mc_steps=50, mc_routine=mcA)
+        dfB, live_EB, _ = igref_run(igref_template, ham, 2.0, 30, 300;
+                                    seed=99, mc_steps=50, mc_routine=mcB)
+        @test dfA.emax == dfB.emax
+        @test dfA.num_particles == dfB.num_particles
+        @test live_EA == live_EB
     end
 end


### PR DESCRIPTION
Implements #158.

## What

- `lattice_biased_sites(lattice; predicate=:contact, shells=1)`, exported: the empty sites selected by an occupancy predicate over neighbor shells 1..`shells`, with `:contact` (at least one occupied neighbor, the productive insertions of attractive adsorption and film models) and `:cavity` (no occupied neighbor, the lattice discretization of Mezei's cavity-biased (T, V, μ) sampling, Mol. Phys. 40, 901 (1980)) partitioning the empty sites. Image-multiplicity neighbor lists compose as-is (any occupied appearance marks contact), and the helper doubles as an observables-hook building block via `cfg -> length(lattice_biased_sites(cfg))`. Guards, all `ArgumentError`: unknown predicate, `shells < 1`, `shells` beyond the lattice's shell count (the shell-count message register).
- `MCGrandCanonicalMoves` gains `p_bias` (default 0.0), `bias_predicate` (`:contact`), `bias_shells` (1), validated in the constructor (`p_bias` in [0, 1], `bias_shells ≥ 1`, known predicate); `p_bias = 1.0` constructs but warns, since the pure biased channel freezes N whenever the biased set is empty and the uniform sub-channel is what repairs ergodicity. `MC_grand_canonical_walk!` takes the same keywords, threaded from both nested-sampling step methods.
- Insertion attempts mix the channels: with probability `p_bias` the site is drawn uniformly from the biased set S(x) (an empty S(x) is a null proposal, counted as attempted), otherwise uniformly from all empty sites; the acceptance divides z₀·p<sub>delete</sub>/(N + 1) by the composite proposal density of the actually chosen site, q = p<sub>insert</sub>·(p_bias·1{i ∈ S(x)}/|S(x)| + (1 − p_bias)/(M − N)). Deletion keeps uniform site selection; its acceptance is N·q′/(z₀·p<sub>delete</sub>) with the reverse density q′ evaluated on the post-deletion configuration (membership of the vacated site in S(x′) and the count |S(x′)|; N is the pre-delete particle count, stated in the docstring). Every set quantity lives on the lower-N member of the pair. A zero reverse density (`p_bias = 1` with the vacated site outside S(x′)) rejects immediately with no Metropolis draw. At `p_bias = 1`, `p_insert = p_delete`, `:cavity`, the pair reduces to the ROADMAP sketch (insert z₀·n<sub>cav</sub>/(N + 1); delete auto-rejects unless the deleted particle was isolated), and detailed balance holds exactly: the delete ratio is the reciprocal of the corresponding insert ratio.
- The `p_bias = 0` default keeps the literal legacy acceptance expressions and draws no channel random number (the short-circuit guard idiom), so the default RNG stream is bit-identical: a 400-block A/B run against the pre-change kernel is exactly equal, and the shipped same-seed regression pins it permanently. Zero biased-set scans on the default path; one scan per biased insertion attempt and one per deletion acceptance when `p_bias > 0`, O(M·z·shells), the same order as the per-step energy recomputation.
- Per-move-type attempt/accept counters (swap, cluster, insert split by sub-channel, delete) return as a trailing NamedTuple: Julia destructuring ignores extra trailing elements, so every existing 5-name call site works untouched. Attempts are counted at proposal (ceiling rejections included, guard skips excluded, empty-set null proposals counted as attempted biased inserts). Both grand-canonical parameter structs gain one `move_stats::Dict{Symbol,Int}` field of run totals, accumulated by a shared `_accumulate_move_stats!` beside the cluster statistics (which stay window-reset; the new counters are cleared once at run start, unconditionally) and exposed through the params struct the drivers already return.

## Tests

- `lattice_biased_sites` pins: empty/full extremes, single-particle counts on the 4×4 two-shell lattice (4/11 at shells = 1, 8/7 at shells = 2), the partition identity on a fixed irregular configuration, image-multiplicity lattices including the 2×2 torus with collapsed bonds, and every guard path. Constructor and walk keyword validation, the `p_bias = 1.0` warning (`@test_logs`), and silence below 1.
- Prior invariance, zero Hamiltonian, non-binding ceiling, z₀ ∈ {0.5, 2.0} × both predicates: at `p_bias = 0.5` single-chain time averages gate ⟨N⟩, per-site occupancy, and Var N; at `p_bias = 1.0` the kernel is prior-invariant but reducible (`:contact` absorbs N = 0, pinned separately as an exact frozen-N invariant; `:cavity` leaves dense states unreachable), so those cells use an ensemble of 1200 chains started from exact prior draws, which must remain prior-distributed under any invariant kernel. This ensemble design replaces a literal single-chain reading of the issue's item 2 grid, which would fail against a correct kernel.
- Exact microstate distribution on the 2×2 torus (M = 4, 16 microstates, z₀ = 2): 20,000 decorrelated samples per predicate against the Bernoulli product law under per-cell multinomial gates. Deliberately broken kernels bind the gates: the reverse density evaluated on the pre-deletion configuration fails at 20-35σ on both predicates, and the uniform-proposal ratio applied to biased draws fails at 55σ on the `:cavity` cell (on this cell size the `:contact` set nearly coincides with the empty set, so the paired-predicate design is what carries the discrimination).
- Restricted-prior exactness, `:cavity`: a fixed-ceiling hard-squares walk (ceiling J/2, z₀ = 1, `p_bias = 0.9`) whose stationary law is exactly P(N) = g<sub>N</sub>/743 against the file's brute-force independent-set counts, under multinomial gates with zero tail counts and every sample verified violation-free; a fixed-ceiling walk is used instead of a nested-sampling dead-point histogram because dead points are moving-ceiling order statistics with no closed-form N-marginal, and on independent sets every deletion exercises the isolated-particle reverse-density branch.
- Restricted-prior exactness, `:contact`: the ideal-gas-referenced route at `p_bias = 0.5` on the attractive NN + NNN lattice against exact 2<sup>16</sup> grand sums (lnΞ, ⟨N⟩, ⟨U⟩) at every in-window grid point, with the out-of-window point feeding the Kish N<sub>eff</sub> gate.
- Same-seed A/B (default routine vs explicit `p_bias = 0.0`, exact equality of ledgers and live energies), counter bookkeeping (a provably skip-free configuration where Σ attempted == n_steps for any RNG stream; accepted ≤ attempted per family; the insert sub-channel split within binomial bounds of `p_bias`), and `move_stats` accumulation, per-run reset, and constructor defaults through both routes.
- Every stochastic gate was calibrated at three seeds and shipped at ≥ 3× the maximum observed deviation with the σ model stated beside it (the near-step Var N of the `:contact` end-to-end is deliberately not gated: its three-seed reweighting noise reaches 0.28 relative, and it is exercised by the unbiased register). The issue's test plan named `test/test-MonteCarloMoves.jl` and `test/test-ideal-gas-ref-gcns.jl`; the constructor, counter, and hard-squares registers actually live in `test/test-SamplingSchemes/test-grand_canonical_ns.jl` and `test/test-SamplingSchemes/test-hard-core-lattices.jl`, so those two files carry the corresponding testsets.

An adversarial verification pass re-derived both composite acceptance ratios from detailed balance including the `p_bias = 0` reductions and the cavity-sketch anchor, confirmed the default path draws a bit-identical RNG stream by direct A/B, verified the implemented kernel reproduces the exact 2×2 Bernoulli law to within 2σ at 40,000 samples, and established by kernel mutation that the shipped gates catch the two canonical implementation errors (pre-deletion reverse density; uniform-ratio acceptance of biased draws) at 20-55σ; an independent review pass then re-derived the acceptance ratios and the counter and RNG-draw bookkeeping from the code with no must-fix findings, and its one suggestion is applied here: the two parameter structs' docstring field lists now include `move_stats`. Full test suite passes (SamplingSchemes 5954, AbstractWalkers 339, AbstractHamiltonians 80, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 114 and 3807, FreeBirdIO 51).
