### PR TITLE
Add `bragg_amplitude` and `order_parameter_p2x2` for the triangular lattice

### DIFF
--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -29,6 +29,7 @@ export order_parameter_c2x2
 export order_parameter_sqrt3
 export bragg_amplitude
 export order_parameter_stripe
+export order_parameter_p2x2
 export site_layers, layer_coverage, occupancy_profile, layer_field
 export enumerate_motif_embeddings, motif_distances
 export view_structure

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -882,6 +882,175 @@ function order_parameter_stripe(lattice::MLattice{1,SquareLattice}; period::Int=
 end
 
 """
+    bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int) -> Float64
+
+Normalized Bragg-peak amplitude of the occupation pattern on a
+single-component triangular lattice:
+
+    |ρ(k)| = |Σ_{occupied sites} e^{ik·r}| / M,   k = 2π·(m/d₁, n/(√3·d₂)),
+
+in units of the inverse lattice constant, where `(d₁, d₂)` are the in-plane
+supercell dimensions of the conventional (centered-rectangular) cell and
+`M = 2·d₁·d₂` is the number of sites; the sum runs over both basis sites,
+so the two-site basis phases are included. Integer indices on the
+conventional-cell reciprocal grid make every representable k commensurate
+by construction, in the same LEED-intensity convention as the square-lattice
+method [Zhang, Blum & Reuter, PRB **75**, 235406 (2007)].
+
+Because the basis sites live on the half-integer grid of the conventional
+cell, amplitudes are periodic under the *primitive* reciprocal lattice
+rather than index-wise:
+`bragg_amplitude(lat, m, n) == bragg_amplitude(lat, m + d1, n - d2) ==
+bragg_amplitude(lat, m, n + 2*d2)` (the two index shifts add the primitive
+reciprocal vectors b₁ = 2π·(1, −1/√3) and b₂ = 2π·(0, 2/√3)), and both
+identities hold exactly. The three M points of the triangular Brillouin
+zone sit at `(m, n) = (0, d2)` (representable on any cell) and
+`(d1 ÷ 2, ∓(d2 ÷ 2))` (integer indices for even in-plane dimensions);
+M-point phases are exactly ±1.0 (u and v share the parity of the basis
+index, so the quarter-turn table entries always combine to half turns), so
+the documented values of [`order_parameter_p2x2`](@ref) hold to full
+precision. The empty lattice gives exactly `0` at every k; the full
+lattice gives `0` for any k that is not a reciprocal-lattice vector of the
+triangular lattice, exactly at the three M points and to floating-point
+roundoff at generic indices (where the phasor components are irrational).
+A single particle gives `1/M`.
+
+Like the named order parameters, |ρ(k)| is not a function of `(E, N)` and
+must be evaluated on configurations (e.g. per culled walker, via the
+`observables` keyword of the nested-sampling loops); see
+[`order_parameter_p2x2`](@ref) for the composed-observable recipes.
+
+Requires the standard two-site centered-rectangular triangular basis
+`[(0, 0, 0), (a/2, √3·a/2, 0)]` consistent with the lattice vectors and a
+strictly two-dimensional supercell (`supercell_dimensions[3] == 1`);
+violations throw an `ArgumentError`.
+"""
+function bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int)
+    if length(lattice.basis) != 2
+        throw(ArgumentError("bragg_amplitude requires the two-site " *
+            "centered-rectangular triangular basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
+    ax, ay = lattice.lattice_vectors[1, 1], lattice.lattice_vectors[2, 2]
+    b1, b2 = lattice.basis
+    if !(isapprox(b1[1], 0.0, atol=1e-9) && isapprox(b1[2], 0.0, atol=1e-9) &&
+         isapprox(b2[1], ax / 2, atol=1e-9) && isapprox(b2[2], ay / 2, atol=1e-9))
+        throw(ArgumentError("bragg_amplitude requires the standard " *
+            "triangular basis [(0, 0, 0), (a/2, √3·a/2, 0)] consistent with " *
+            "the lattice vectors, got $(lattice.basis)"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("bragg_amplitude requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    # Site (b, ci, cj) sits at r = ((ci − 1) + b/2, √3·((cj − 1) + b/2))·a,
+    # so on the half-integer grid u = 2(ci − 1) + b, v = 2(cj − 1) + b the
+    # phase is k·r = π·(m·u·d₂ + n·v·d₁)/(d₁·d₂). The numerator is reduced
+    # as one integer modulo 2·d₁·d₂ before the single cispi call per
+    # occupied site: half- and quarter-turn phases come out exactly
+    # ±1.0/±1.0im, every combined M-point phase is exactly ±1.0, and the
+    # joint reduction makes the b₁/b₂ wrapping identities hold bit-exactly,
+    # since both shifts move the numerator by even multiples of d₁·d₂
+    # (u and v share the parity of the basis index).
+    twoM = 2 * d1 * d2
+    mr = mod(m, 2 * d1)
+    nr = mod(n, 2 * d2)
+    colnum = [mod(mr * u * d2, twoM) for u in 0:2*d1-1]
+    rownum = [mod(nr * v * d1, twoM) for v in 0:2*d2-1]
+    occ = lattice.components[1]
+    z = 0.0 + 0.0im
+    for s in eachindex(occ)
+        if occ[s]
+            # lattice_positions ordering: basis innermost, dimension 1 fastest
+            b = (s - 1) % 2
+            ci0 = ((s - 1) ÷ 2) % d1
+            cj0 = (s - 1) ÷ (2 * d1)
+            num = colnum[2*ci0+b+1] + rownum[2*cj0+b+1]
+            num >= twoM && (num -= twoM)
+            z += cispi(num / (d1 * d2))
+        end
+    end
+    return abs(z) / twoM
+end
+
+"""
+    order_parameter_p2x2(lattice::MLattice{1,TriangularLattice}) -> Float64
+
+Orientation-degenerate M-point order parameter for p(2×2) and p(2×1)/row
+ordering on a single-component triangular lattice: the quadrature sum of
+the three normalized M-point Bragg amplitudes,
+
+    Ψ = √(|ρ(M₁)|² + |ρ(M₂)|² + |ρ(M₃)|²),
+
+i.e. `sqrt(bragg_amplitude(lat, d1 ÷ 2, -(d2 ÷ 2))^2 +
+bragg_amplitude(lat, 0, d2)^2 + bragg_amplitude(lat, d1 ÷ 2, d2 ÷ 2)^2)`
+with the amplitudes of [`bragg_amplitude`](@ref). A perfect p(2×2)
+arrangement at coverage 1/4 contributes exactly `1/4` at every M point,
+giving `√3/4 ≈ 0.4330`; a perfect single-orientation p(2×1) row phase at
+coverage 1/2 puts exactly `1/2` on one M point and `0` on the other two,
+giving `1/2`; the perfect (√3×√3)R30° state (K-point order) and the empty
+and the full lattice give exactly `0`; disordered configurations give
+O(1/√M). Translation and orientation degeneracies are divided out, so all
+degenerate ordered states of each phase give the same value.
+
+The M-point pattern separates the two phases where the scalar cannot: the
+max-to-quadrature ratio of the three amplitudes is `1/√3` for p(2×2)
+(three equal M points) and `1` for a single p(2×1) orientation; compose it
+caller-side from `bragg_amplitude` when needed. [`order_parameter_sqrt3`](@ref)
+is exactly `0` on both M-point phases and this function is exactly `0` on
+the √3×√3 phase, so the two observables are orthogonal discriminators.
+
+Ψ is not a function of `(E, N)` and must be evaluated on configurations
+(e.g. per culled walker, via the `observables` keyword of the
+nested-sampling loops). Higher moments for Binder-cumulant analysis are
+composed caller-side, with no library change:
+
+    observables = [:psi  => order_parameter_p2x2,
+                   :psi2 => cfg -> order_parameter_p2x2(cfg)^2,
+                   :psi4 => cfg -> order_parameter_p2x2(cfg)^4]
+
+Requires the structural guards of [`bragg_amplitude`](@ref) plus even
+in-plane supercell dimensions: the M points sit at half-integer reciprocal
+indices, and even circumferences are exactly the wrap-invariance condition
+of the p(2×2) sublattice. A cell hosting this order parameter and
+[`order_parameter_sqrt3`](@ref) simultaneously needs
+`supercell_dimensions[1]` divisible by 6 with an even second dimension;
+the shipped default `(4, 2, 1)` satisfies this function's guards but not
+the √3×√3 one's.
+"""
+function order_parameter_p2x2(lattice::MLattice{1,TriangularLattice})
+    if length(lattice.basis) != 2
+        throw(ArgumentError("order_parameter_p2x2 requires the two-site " *
+            "centered-rectangular triangular basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
+    ax, ay = lattice.lattice_vectors[1, 1], lattice.lattice_vectors[2, 2]
+    b1, b2 = lattice.basis
+    if !(isapprox(b1[1], 0.0, atol=1e-9) && isapprox(b1[2], 0.0, atol=1e-9) &&
+         isapprox(b2[1], ax / 2, atol=1e-9) && isapprox(b2[2], ay / 2, atol=1e-9))
+        throw(ArgumentError("order_parameter_p2x2 requires the standard " *
+            "triangular basis [(0, 0, 0), (a/2, √3·a/2, 0)] consistent with " *
+            "the lattice vectors, got $(lattice.basis)"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("order_parameter_p2x2 requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    if d1 % 2 != 0 || d2 % 2 != 0
+        bad = d1 % 2 != 0 ? d1 : d2
+        throw(ArgumentError("order_parameter_p2x2 requires even in-plane " *
+            "supercell dimensions, since the M points sit at half-integer " *
+            "reciprocal indices and the p(2×2) sublattice closes on the " *
+            "periodic cell only for even circumferences; got $bad"))
+    end
+    return sqrt(bragg_amplitude(lattice, d1 ÷ 2, -(d2 ÷ 2))^2 +
+                bragg_amplitude(lattice, 0, d2)^2 +
+                bragg_amplitude(lattice, d1 ÷ 2, d2 ÷ 2)^2)
+end
+
+"""
     _check_planar_basis(caller::Symbol, lattice::MLattice)
 
 Shared guard for the layer helpers: throw an `ArgumentError`, naming the

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -403,6 +403,192 @@
         @test all(isapprox.(df.stripe4, df.stripe .^ 4; rtol=1e-12))
     end
 
+    # ================================================================
+    @testset "triangular bragg_amplitude and order_parameter_p2x2" begin
+        # Axial coordinates from the stored positions: r = i·t₁ + j·t₂ with
+        # t₁ = (1, 0)·a and t₂ = (1/2, √3/2)·a, so j = 2y/(√3·a) and
+        # i = x/a − j/2. Occupation predicates on (i, j) build the ordered
+        # phases geometrically, independent of the index arithmetic under
+        # test: p(2×2) = {i, j both even}, a p(2×1) row phase = {j even}
+        # (plus its two rotations), the √3×√3 state = {(i − j) mod 3 == 0}.
+        function axial_ij(lat)
+            a = lat.lattice_vectors[1, 1]
+            map(1:size(lat.positions, 1)) do s
+                x, y = lat.positions[s, 1], lat.positions[s, 2]
+                j = round(Int, 2 * y / (sqrt(3) * a))
+                i = round(Int, x / a - j / 2)
+                (i, j)
+            end
+        end
+        fill_ij!(lat, pred) = (lat.components[1] .=
+            [pred(i, j) for (i, j) in axial_ij(lat)]; lat)
+
+        # Independent oracle: the raw phasor sum over the stored positions,
+        # sharing no code with the integer-table implementation
+        function tri_oracle(lat, m, n)
+            a = lat.lattice_vectors[1, 1]
+            d1, d2 = lat.supercell_dimensions[1], lat.supercell_dimensions[2]
+            kx = 2 * pi * m / (d1 * a)
+            ky = 2 * pi * n / (sqrt(3) * d2 * a)
+            z = sum(exp(im * (kx * lat.positions[s, 1] + ky * lat.positions[s, 2]))
+                    for s in 1:size(lat.positions, 1) if lat.components[1][s];
+                    init=0.0 + 0.0im)
+            return abs(z) / (2 * d1 * d2)
+        end
+
+        # The three M points on an even-dimension cell
+        mpoints(d1, d2) = [(d1 ÷ 2, -(d2 ÷ 2)), (0, d2), (d1 ÷ 2, d2 ÷ 2)]
+
+        # Oracle agreement on random occupations at the M points and at
+        # generic indices, and the primitive-reciprocal wrapping identities,
+        # exact by the joint mod reduction
+        lat = obs_tri_lattice(6, 4)
+        Random.seed!(4164)
+        for _ in 1:20
+            lat.components[1] .= rand(Bool, 48)
+            for (m, n) in vcat(mpoints(6, 4), [(1, 0), (0, 1), (2, 3), (-1, 2)])
+                @test isapprox(bragg_amplitude(lat, m, n), tri_oracle(lat, m, n);
+                               atol=1e-12)
+                @test bragg_amplitude(lat, m, n) == bragg_amplitude(lat, m + 6, n - 4)
+                @test bragg_amplitude(lat, m, n) == bragg_amplitude(lat, m, n + 8)
+            end
+        end
+
+        # Perfect-phase table on (6, 4) and (12, 6): p(2×2) puts exactly 1/4
+        # on every M point (quadrature √3/4); each p(2×1) orientation puts
+        # exactly 1/2 on one M point and 0 on the other two (quadrature
+        # 1/2); the √3×√3 state scatters off the K points only, and the two
+        # order parameters are blind to each other's phase
+        for (d1, d2) in [(6, 4), (12, 6)]
+            latp = obs_tri_lattice(d1, d2)
+            M = 2 * d1 * d2
+
+            fill_ij!(latp, (i, j) -> iseven(i) && iseven(j))
+            @test count(latp.components[1]) == M ÷ 4
+            for (m, n) in mpoints(d1, d2)
+                @test bragg_amplitude(latp, m, n) == 1 / 4
+            end
+            @test order_parameter_p2x2(latp) ≈ sqrt(3) / 4 atol = 1e-12
+            @test order_parameter_sqrt3(latp) == 0.0
+
+            for pred in [(i, j) -> iseven(j), (i, j) -> iseven(i),
+                         (i, j) -> iseven(i - j)]
+                fill_ij!(latp, pred)
+                @test count(latp.components[1]) == M ÷ 2
+                amps = sort([bragg_amplitude(latp, m, n)
+                             for (m, n) in mpoints(d1, d2)])
+                @test amps[1] == 0.0 && amps[2] == 0.0 && amps[3] == 1 / 2
+                @test order_parameter_p2x2(latp) ≈ 1 / 2 atol = 1e-12
+                @test order_parameter_sqrt3(latp) == 0.0
+            end
+
+            fill_ij!(latp, (i, j) -> mod(i - j, 3) == 0)
+            @test count(latp.components[1]) == M ÷ 3
+            for (m, n) in mpoints(d1, d2)
+                @test bragg_amplitude(latp, m, n) == 0.0
+            end
+            @test order_parameter_p2x2(latp) == 0.0
+            @test order_parameter_sqrt3(latp) == 1 / 3
+        end
+
+        # Empty and full lattices scatter nothing off the reciprocal-lattice
+        # rods: exactly at the M points (half-turn phases are exact), to
+        # roundoff at generic indices (the phase rationals are not
+        # representable); a single particle gives 1/M
+        lat.components[1] .= false
+        for (m, n) in vcat(mpoints(6, 4), [(1, 1)])
+            @test bragg_amplitude(lat, m, n) == 0.0
+        end
+        @test order_parameter_p2x2(lat) == 0.0
+        lat.components[1] .= true
+        for (m, n) in mpoints(6, 4)
+            @test bragg_amplitude(lat, m, n) == 0.0
+        end
+        @test bragg_amplitude(lat, 1, 1) < 1e-15
+        @test order_parameter_p2x2(lat) == 0.0
+        lat.components[1] .= false
+        lat.components[1][1] = true
+        @test bragg_amplitude(lat, 1, 1) == 1 / 48
+        @test bragg_amplitude(lat, 0, 4) == 1 / 48
+        @test order_parameter_p2x2(lat) ≈ sqrt(3) / 48 atol = 1e-12
+
+        # Dispatch separation: the square methods are untouched by the new
+        # triangular method
+        sq = obs_square_lattice(4, 4)
+        Random.seed!(4165)
+        sq.components[1] .= rand(Bool, 16)
+        @test bragg_amplitude(sq, 2, 2) == order_parameter_c2x2(sq)
+        @test order_parameter_stripe(sq) == sqrt(bragg_amplitude(sq, 2, 0)^2 +
+                                                 bragg_amplitude(sq, 0, 2)^2)
+
+        # Guard paths: a three-dimensional supercell rejects both functions;
+        # odd in-plane dimensions reject the quadrature while the
+        # always-representable M₂ amplitude still evaluates; a nonstandard
+        # two-site basis rejects the amplitude
+        lat3d = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(6, 4, 2),
+            periodicity=(true, true, true),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:96]],
+            adsorptions=:full)
+        @test_throws ArgumentError bragg_amplitude(lat3d, 1, 0)
+        @test_throws ArgumentError order_parameter_p2x2(lat3d)
+        for (d1, d2) in [(3, 3), (5, 4)]
+            lodd = obs_tri_lattice(d1, d2)
+            @test_throws ArgumentError order_parameter_p2x2(lodd)
+            lodd.components[1][1] = true
+            @test bragg_amplitude(lodd, 0, d2) == 1 / (2 * d1 * d2)
+        end
+        latnb = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.0)],
+            supercell_dimensions=(6, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[0.75],
+            components=[[false for _ in 1:48]],
+            adsorptions=:full,
+            image_multiplicity=true)
+        @test_throws ArgumentError bragg_amplitude(latnb, 1, 0)
+        @test_throws ArgumentError order_parameter_p2x2(latnb)
+
+        # The shipped default (4, 2, 1) cell passes this function's guards
+        # while order_parameter_sqrt3 rejects it (the docstring claim)
+        latdef = obs_tri_lattice(4, 2)
+        latdef.components[1][1] = true
+        @test order_parameter_p2x2(latdef) ≈ sqrt(3) / 16 atol = 1e-12
+        @test_throws ArgumentError order_parameter_sqrt3(latdef)
+
+        # A short seeded canonical NS run records the Binder moments through
+        # the moment-callback pattern from the docstring
+        Random.seed!(4166)
+        tri_ham1 = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        walkers = [LatticeWalker(deepcopy(obs_tri_lattice(6, 2)),
+                                 energy=0.0u"eV", iter=0) for _ in 1:20]
+        # Fixed-N ladder at N = 6: place 6 particles per walker
+        for w in walkers
+            occ = vcat(fill(true, 6), fill(false, 18))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls = LatticeGasWalkers(walkers, tri_ham1; perturb_energy=1e-9)
+        params = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+
+        df, _, _ = nested_sampling(ls, params, Int64(200),
+            MCRandomWalkClone(), obs_save;
+            observables=[:psi => order_parameter_p2x2,
+                         :psi2 => (cfg -> order_parameter_p2x2(cfg)^2),
+                         :psi4 => (cfg -> order_parameter_p2x2(cfg)^4)])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "psi", "psi2", "psi4"]
+        @test nrow(df) > 0
+        @test all(0.0 .<= df.psi .<= 1 / 2)
+        @test all(isapprox.(df.psi2, df.psi .^ 2; rtol=1e-12))
+        @test all(isapprox.(df.psi4, df.psi .^ 4; rtol=1e-12))
+    end
+
     @testset "observable hook: validation" begin
         lat = obs_square_lattice(4, 4)
         walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:8]


### PR DESCRIPTION
Implements #164. A pure insertion of two documented functions after `order_parameter_stripe` in `src/AbstractWalkers/lattice_walkers.jl`, one export line, and one testset in `test/test-SamplingSchemes/test-ns-observables.jl`; no existing line is touched.

## `bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int)`

- The normalized diffraction amplitude |ρ(k)| at k = 2π·(m/d₁, n/(√3·d₂)) in inverse-lattice-constant units, the reciprocal grid of the conventional centered-rectangular supercell, summed over both basis sites; a new method of the exported square-lattice function, same LEED-intensity convention.
- Implementation: the basis sites sit on the half-integer grid u = 2(ci − 1) + b, v = 2(cj − 1) + b, so the phase is π·(m·u·d₂ + n·v·d₁)/(d₁·d₂); the numerator is reduced as one integer modulo 2·d₁·d₂ before a single `cispi` per occupied site. The joint reduction is what makes the primitive-reciprocal wrapping identities (m, n) → (m + d₁, n − d₂) and (m, n) → (m, n + 2·d₂) hold bit-exactly (both shifts move the numerator by even multiples of d₁·d₂, since u and v share the parity of the basis index), and every combined M-point phase comes out exactly ±1.0.
- Guards in the `order_parameter_sqrt3` style: the standard two-site basis validated against the lattice vectors, and `supercell_dimensions[3] == 1`.
- Docstring distinguishes exact from roundoff-level zeros: the full lattice scatters exactly 0 at the three M points and to floating-point roundoff at generic indices; the empty lattice is exactly 0 everywhere.

## `order_parameter_p2x2(lattice::MLattice{1,TriangularLattice})`

- The orientation-degenerate M-point quadrature √(|ρ(M₁)|² + |ρ(M₂)|² + |ρ(M₃)|²): √3/4 on a perfect p(2×2) at coverage 1/4 (exactly 1/4 per M point), 1/2 on a perfect single-orientation p(2×1) row phase (exactly 1/2 on one M point), exactly 0 on the perfect (√3×√3)R30° state, O(1/√M) on disordered configurations.
- Structural guards duplicated under the caller's own name (the `order_parameter_stripe` precedent) plus even in-plane dimensions, which is simultaneously the M-point representability condition and the wrap-invariance condition of the p(2×2) sublattice; the docstring records the joint-cell rule with `order_parameter_sqrt3` (d₁ divisible by 6, even d₂) and the max-to-quadrature ratio recipe (1/√3 versus 1) separating p(2×2) from p(2×1).

## Tests

- One testset with an independent oracle: the raw phasor sum over the stored `lattice.positions`, sharing no code with the integer-table implementation, agreeing within 10<sup>−12</sup> on seeded random occupations at M-point and generic indices, with both wrapping identities pinned as `==`.
- Perfect-phase table on the (6, 4) and (12, 6) cells, built from axial-coordinate predicates derived from the positions: p(2×2) exactly 1/4 at all three M points; each of the three p(2×1) orientations exactly {1/2, 0, 0}; the √3×√3 state exactly 0 at all three; cross-pins that `order_parameter_sqrt3` is exactly 0 on the M-point phases and 1/3 on the √3 state.
- Edge values (empty exact 0, full exact 0 at M points and < 10<sup>−15</sup> at a generic index, single particle 1/M), square-lattice dispatch separation (the c(2×2) identity and the stripe quadrature identity re-asserted on a square control), guard paths (3D cell, odd-dimension cells with the always-representable M₂ amplitude still evaluating, a nonstandard two-site basis, and the shipped default (4, 2, 1) passing this function's guards while `order_parameter_sqrt3` rejects it), and a short seeded canonical nested-sampling run recording `:psi`/`:psi2`/`:psi4` through the observables hook with row-wise moment identities.

An adversarial verification pass ran as three independent reviewers with disjoint charters before filing. The physics reviewer re-derived the site-to-position map, the half-grid phase formula, the bit-exactness argument for both wrapping identities, and the full M-point value table with its own 256-bit-precision oracle over the live positions (57 checks; worst implementation-vs-oracle deviation 2.7·10<sup>−16</sup>), confirmed the guard conditions and the balanced-sublattice argument behind the `order_parameter_sqrt3` orthogonality on both test cells and all three row orientations, and found no convention errors; its two docstring-precision corrections are applied (M-point phases are exactly ±1.0, never ±1.0im; the empty lattice is exactly 0 everywhere). The API reviewer verified every docstring claim against a shipped test or probe, the export wiring, dispatch non-ambiguity with the square methods, RNG neutrality, and the issue round-trip; its one must-fix (the square control exercised only `bragg_amplitude`, where the issue promises `order_parameter_stripe` too) is fixed, and its guard-naming and untested-claim findings are applied (structural guards duplicated under `order_parameter_p2x2`'s name; the (4, 2, 1) claim now pinned by a test). The determinism reviewer ran the observables file twice with identical pass counts, verified the diff is a pure insertion, and accounted the new assertion count against the source loop trip counts; its vacuity finding (no row-count pin on the NS-run ledger) is fixed.

Full test suite passes (SamplingSchemes 6674, AbstractWalkers 339, AbstractHamiltonians 80, AbstractLiveSets 80, AbstractPotentials 106, AnalysisTools 61, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 114 and 3807, FreeBirdIO 51).
