### PR TITLE
Add an opt-in dead-point callback to the nested-sampling drivers

### DIFF
--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1138,6 +1138,23 @@ Perform a nested sampling loop for a given number of steps.
   front with an `ArgumentError`; a bit-exact pairing guard additionally
   raises an error if a step ever culls a different walker than the one the
   row records. The default `nothing` leaves the ledger schema unchanged.
+- `dead_point_callback`: Optional function called once per recorded dead
+  point as `dead_point_callback(iter, walker)`, immediately after the
+  ledger row is pushed, with the same culled walker the row describes
+  (protected by the same bit-exact pairing guard as `observables`, which is
+  engaged whenever either keyword is supplied). Iterations that record no
+  dead point invoke no callback, so the invocation count equals `nrow(df)`.
+  The walker is the loop's live object: treat it as read-only and copy
+  anything kept, e.g. `copy(walker.configuration.components[1])` or
+  `deepcopy(walker.configuration)`. Composes freely with `observables`; the
+  surviving live set needs no callback because the loop returns it.
+  Parallel and multi-cull MC routines are rejected up front. Typical uses:
+  collecting occupation vectors for batch post-processing, and re-evaluating
+  each dead point under a second Hamiltonian, whose energies substitute for
+  the ledger energy column in the grand-canonical stats functions (the
+  prior-volume weights depend only on the iteration index, so the
+  substituted column is a valid estimator over the same ladder). The
+  default `nothing` changes nothing.
 
 # Returns
 - `df`: A DataFrame containing the iteration number and maximum energy for each step,
@@ -1150,7 +1167,8 @@ function nested_sampling(liveset::AbstractLiveSet,
                                 n_steps::Int64,
                                 mc_routine::MCRoutine,
                                 save_strategy::DataSavingStrategy;
-                                observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
+                                observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
+                                dead_point_callback::Union{Nothing,Function}=nothing)
     # Initialize cluster_p and reset counters from MCMixedMoves if applicable
     if mc_routine isa MCMixedMoves && mc_routine.clusters_freq > 0
         ns_params.cluster_p = mc_routine.initial_cluster_p
@@ -1171,11 +1189,18 @@ function nested_sampling(liveset::AbstractLiveSet,
             df[!, name] = Float64[]
         end
     end
+    if dead_point_callback !== nothing
+        mc_routine isa MCRoutineParallel && throw(ArgumentError(
+            "dead_point_callback: parallel/multi-cull MC routines are not " *
+            "supported — each accepted iteration culls multiple walkers but " *
+            "invokes a single callback, so per-dead-point pairing is " *
+            "undefined"))
+    end
     culled = nothing
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
-        if observables !== nothing
+        if observables !== nothing || dead_point_callback !== nothing
             # Pre-sort with the step's own comparator and hold the walker the
             # step will cull: the step re-sorts (stable sort, so the identity
             # permutation here) and culls walkers[1] on accept. `popfirst!`
@@ -1192,17 +1217,21 @@ function nested_sampling(liveset::AbstractLiveSet,
             ns_params.step_size = ns_params.initial_step_size
         end
         if !(iter isa typeof(missing))
-            if observables === nothing
-                push!(df, (iter, emax.val))
-            else
+            if culled !== nothing
                 emax == culled.energy || error(
                     "NS observable recording: dead-point/observable pairing " *
                     "lost (step culled a walker with energy $emax, but the " *
                     "pre-sorted worst walker had $(culled.energy)); this MC " *
-                    "routine is not supported with `observables`")
+                    "routine is not supported with `observables`/" *
+                    "`dead_point_callback`")
+            end
+            if observables === nothing
+                push!(df, (iter, emax.val))
+            else
                 push!(df, (iter, emax.val,
                            (Float64(f(culled.configuration)) for (_, f) in observables)...))
             end
+            dead_point_callback === nothing || dead_point_callback(iter, culled)
         end
         print_message(i, iter, emax, ns_params.step_size, print_info, liveset)
         write_df_every_n(df, i, save_strategy)
@@ -1368,6 +1397,9 @@ highest-Ω walker, record (Ω, E, N), replace with a decorrelated clone.
 - `observables`: Optional vector of `name::Symbol => callback` pairs
   recording per-dead-point observables as extra ledger columns; see
   [`nested_sampling`](@ref).
+- `dead_point_callback`: Optional per-dead-point callback
+  `(iter, walker) -> ...` invoked with the culled walker immediately after
+  its ledger row is pushed; see [`nested_sampling`](@ref) for the contract.
 
 # Returns
 - `df::DataFrame`: Columns `[:iter, :omega, :energy, :num_particles]`,
@@ -1380,7 +1412,8 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
                                          n_steps::Int64,
                                          mc_routine::MCGrandCanonicalMoves,
                                          save_strategy::DataSavingStrategy;
-                                         observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
+                                         observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
+                                         dead_point_callback::Union{Nothing,Function}=nothing)
     # Initialize walkers with random microstates
     _init_gc_walkers!(liveset, gc_params)
 
@@ -1410,7 +1443,7 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
 
-        if observables !== nothing
+        if observables !== nothing || dead_point_callback !== nothing
             # Pre-sort with the step's own comparator (Ω = E − μN, descending)
             # and hold the walker the step will cull; see `nested_sampling`.
             sort!(liveset.walkers,
@@ -1430,17 +1463,20 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
         end
 
         if !(iter isa typeof(missing))
-            if observables === nothing
-                push!(df, (iter, omega.val, energy.val, n_par))
-            else
+            if culled !== nothing
                 omega == _grand_potential(culled, gc_params.chemical_potential) || error(
                     "GC-NS observable recording: dead-point/observable " *
                     "pairing lost (step culled a walker with Ω = $omega, but " *
                     "the pre-sorted worst walker had Ω = " *
                     "$(_grand_potential(culled, gc_params.chemical_potential)))")
+            end
+            if observables === nothing
+                push!(df, (iter, omega.val, energy.val, n_par))
+            else
                 push!(df, (iter, omega.val, energy.val, n_par,
                            (Float64(f(culled.configuration)) for (_, f) in observables)...))
             end
+            dead_point_callback === nothing || dead_point_callback(iter, culled)
         end
 
         if print_info && !(iter isa typeof(missing))
@@ -1719,6 +1755,15 @@ extract them from the returned liveset.
   extra ledger columns; see [`nested_sampling`](@ref). The recorded columns
   feed the `observable_cols` machinery of
   `gc_thermodynamic_stats_ideal_ref`.
+- `dead_point_callback`: Optional per-dead-point callback
+  `(iter, walker) -> ...` invoked with the culled walker immediately after
+  its ledger row is pushed; see [`nested_sampling`](@ref) for the contract.
+  Configurations collected here support post-run re-evaluation under a
+  second Hamiltonian, whose energies substitute for the `emax` column (and
+  the live tail) in `gc_thermodynamic_stats_ideal_ref`: the prior-volume
+  weights depend only on the iteration index, so the substituted column is
+  a valid estimator of the second Hamiltonian's grand potential over the
+  same ladder, with the returned Kish N_eff as its fidelity diagnostic.
 
 # Returns
 - `df::DataFrame`: Columns `[:iter, :emax, :num_particles]`,
@@ -1731,7 +1776,8 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
                                               n_steps::Int64,
                                               mc_routine::MCGrandCanonicalMoves,
                                               save_strategy::DataSavingStrategy;
-                                              observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
+                                              observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
+                                              dead_point_callback::Union{Nothing,Function}=nothing)
     # Initialize walkers as i.i.d. draws from the Bernoulli(z0/(1+z0)) prior
     _init_ideal_gas_ref_walkers!(liveset, params)
 
@@ -1761,7 +1807,7 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
 
-        if observables !== nothing
+        if observables !== nothing || dead_point_callback !== nothing
             # Pre-sort with the step's own comparator (energy, descending)
             # and hold the walker the step will cull; see `nested_sampling`.
             sort_by_energy!(liveset)
@@ -1779,16 +1825,19 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
         end
 
         if !(iter isa typeof(missing))
-            if observables === nothing
-                push!(df, (iter, emax.val, n_par))
-            else
+            if culled !== nothing
                 emax == culled.energy || error(
                     "IG-ref GC-NS observable recording: dead-point/observable " *
                     "pairing lost (step culled a walker with energy $emax, " *
                     "but the pre-sorted worst walker had $(culled.energy))")
+            end
+            if observables === nothing
+                push!(df, (iter, emax.val, n_par))
+            else
                 push!(df, (iter, emax.val, n_par,
                            (Float64(f(culled.configuration)) for (_, f) in observables)...))
             end
+            dead_point_callback === nothing || dead_point_callback(iter, culled)
         end
 
         if print_info && !(iter isa typeof(missing))

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -658,4 +658,44 @@
         rm("test_val_cl.traj", force=true)
         rm("test_val_cl.ls", force=true)
     end
+
+    @testset "dead-point callback (Ω-sorted route)" begin
+        using Random
+        dpc_save = SaveEveryN("t_dpc_gc.csv", "t_dpc_gc.traj", "t_dpc_gc.ls",
+                              1000000, 1000000, 1000000)
+        dpc_cleanup() = rm.(["t_dpc_gc.csv", "t_dpc_gc.traj", "t_dpc_gc.ls"],
+                            force=true)
+
+        function dpc_run(seed, cb)
+            Random.seed!(seed)
+            walkers = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV",
+                                     iter=0) for _ in 1:10]
+            ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+            gc = GrandCanonicalNestedSamplingParameters(mc_steps=30,
+                chemical_potential=-0.05, energy_perturbation=1e-9)
+            d, _, _ = grand_canonical_nested_sampling(ls, gc, Int64(150),
+                MCGrandCanonicalMoves(), dpc_save; dead_point_callback=cb)
+            dpc_cleanup()
+            return d
+        end
+
+        # Invocation count equals nrow(df); the (iter, energy, N) triple seen
+        # by the callback matches the ledger row bit-exactly
+        seen = Tuple{Int,Float64,Int}[]
+        df = dpc_run(4271, (iter, w) -> push!(seen,
+            (iter, w.energy.val, sum(w.configuration.components[1]))))
+        @test nrow(df) > 0
+        @test length(seen) == nrow(df)
+        @test [t[1] for t in seen] == df.iter
+        @test [t[2] for t in seen] == df.energy
+        @test [t[3] for t in seen] == df.num_particles
+
+        # Stream neutrality: same-seed A/B with and without the callback
+        dfA = dpc_run(4272, nothing)
+        dfB = dpc_run(4272, (iter, w) -> nothing)
+        @test dfA.iter == dfB.iter
+        @test dfA.omega == dfB.omega
+        @test dfA.energy == dfB.energy
+        @test dfA.num_particles == dfB.num_particles
+    end
 end

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -588,4 +588,130 @@
         @test dfA.num_particles == dfB.num_particles
         @test live_EA == live_EB
     end
+
+    # ================================================================
+    @testset "dead-point callback and energy substitution (IG-ref route)" begin
+        using Random
+        dpc_lat = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full)
+        dpc_ham_a = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        dpc_ham_b = GenericLatticeHamiltonian(-0.04, [-0.02, -0.0025], u"eV")
+        dpc_save = SaveEveryN("t_dpc_ig.csv", "t_dpc_ig.traj", "t_dpc_ig.ls",
+                              1000000, 1000000, 1000000)
+        dpc_cleanup() = rm.(["t_dpc_ig.csv", "t_dpc_ig.traj", "t_dpc_ig.ls"],
+                            force=true)
+
+        # Exact grand sums for both Hamiltonians by per-sector enumeration
+        # over all 2^16 configurations, computed before any seeding because
+        # exact_enumeration consumes the global RNG
+        dpc_kb = 8.617333262e-5
+        dpc_T = 600.0
+        dpc_mu = 0.0
+        dpc_beta = 1 / (dpc_kb * dpc_T)
+        function dpc_exact_lnXi(h)
+            lnZs = Float64[]
+            for N in 0:16
+                occ = vcat(fill(true, N), fill(false, 16 - N))
+                latN = deepcopy(dpc_lat)
+                latN.components[1] .= occ
+                dfe, _ = exact_enumeration(latN, h)
+                Es = [ustrip(u"eV", e) for e in dfe.energy]
+                Emin = minimum(Es)
+                push!(lnZs, dpc_beta * dpc_mu * N - dpc_beta * Emin +
+                            log(sum(exp.(-dpc_beta .* (Es .- Emin)))))
+            end
+            m = maximum(lnZs)
+            return m + log(sum(exp.(lnZs .- m)))
+        end
+        lnXi_a = dpc_exact_lnXi(dpc_ham_a)
+        lnXi_b = dpc_exact_lnXi(dpc_ham_b)
+
+        # One seeded ladder under Hamiltonian A, configurations collected
+        # through the callback; K = 64, full descent against the
+        # 16·ln 2 ≈ 11.1 nat reference depth
+        dpc_K = 64
+        Random.seed!(4371)
+        walkers = [LatticeWalker(deepcopy(dpc_lat), energy=0.0u"eV", iter=0)
+                   for _ in 1:dpc_K]
+        ls = LatticeGasWalkers(walkers, dpc_ham_a; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(mc_steps=40,
+            reference_fugacity=1.0, energy_perturbation=1e-9)
+        configs = Vector{Bool}[]
+        seen = Tuple{Int,Float64,Int}[]
+        df, ls_out, _ = ideal_gas_referenced_nested_sampling(ls, params,
+            Int64(820), MCGrandCanonicalMoves(), dpc_save;
+            dead_point_callback=(iter, w) -> begin
+                push!(configs, copy(w.configuration.components[1]))
+                push!(seen, (iter, w.energy.val,
+                             sum(w.configuration.components[1])))
+            end)
+        dpc_cleanup()
+
+        # Invocation count equals nrow(df); the (iter, energy, N) triple seen
+        # by the callback matches the ledger row bit-exactly
+        @test nrow(df) > 0
+        @test length(seen) == nrow(df)
+        @test [t[1] for t in seen] == df.iter
+        @test [t[2] for t in seen] == df.emax
+        @test [t[3] for t in seen] == df.num_particles
+
+        # Energy faithfulness: recomputing Hamiltonian A on a collected
+        # configuration matches the ledger energy within the perturbation
+        # half-width (uniform on ±energy_perturbation/2)
+        dpc_probe = deepcopy(dpc_lat)
+        function dpc_recompute(h, c)
+            dpc_probe.components[1] .= c
+            return ustrip(u"eV", interacting_energy(dpc_probe, h))
+        end
+        @test all(abs(dpc_recompute(dpc_ham_a, c) - e) <= 5.1e-10
+                  for (c, e) in zip(configs, df.emax))
+
+        # Substitution closure: Hamiltonian B's energies, recomputed offline
+        # from the collected configurations, replace the ledger column and
+        # the live tail, and gc_thermodynamic_stats_ideal_ref then closes
+        # against Hamiltonian B's exact grand sum with the SAME Skilling
+        # weights; the control route closes against Hamiltonian A's.
+        # Tolerances calibrated at seeds 4371/4372/4373: max |dev| 0.236 (A)
+        # and 0.343 (B) against σ = √(16·ln 2/64) ≈ 0.42; shipped at ≥ 3×.
+        live_Ea = [w.energy.val for w in ls_out.walkers]
+        live_N = [Int(sum(w.configuration.components[1])) for w in ls_out.walkers]
+        sa = gc_thermodynamic_stats_ideal_ref(df, 16, 1.0, [dpc_mu], [dpc_T],
+            dpc_K; ω0=(dpc_K + 1) / dpc_K, live_emax=live_Ea, live_numbers=live_N)
+        df_b = copy(df)
+        df_b.emax = [dpc_recompute(dpc_ham_b, c) for c in configs]
+        live_Eb = [dpc_recompute(dpc_ham_b, w.configuration.components[1])
+                   for w in ls_out.walkers]
+        sb = gc_thermodynamic_stats_ideal_ref(df_b, 16, 1.0, [dpc_mu], [dpc_T],
+            dpc_K; ω0=(dpc_K + 1) / dpc_K, live_emax=live_Eb, live_numbers=live_N)
+        @test abs(sa.logXi[1, 1] - lnXi_a) < 0.75
+        @test abs(sb.logXi[1, 1] - lnXi_b) < 1.1
+        # The substituted estimator's Kish N_eff is a real diagnostic: finite,
+        # positive, and no larger than the control's at the same grid point
+        @test 0 < sb.N_eff[1, 1] <= sa.N_eff[1, 1]
+
+        # Stream neutrality: same-seed A/B with and without the callback
+        function dpc_ab(seed, cb)
+            Random.seed!(seed)
+            ws = [LatticeWalker(deepcopy(dpc_lat), energy=0.0u"eV", iter=0)
+                  for _ in 1:16]
+            l = LatticeGasWalkers(ws, dpc_ham_a; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=20,
+                reference_fugacity=1.0, energy_perturbation=1e-9)
+            d, _, _ = ideal_gas_referenced_nested_sampling(l, p, Int64(100),
+                MCGrandCanonicalMoves(), dpc_save; dead_point_callback=cb)
+            dpc_cleanup()
+            return d
+        end
+        dfA = dpc_ab(4373, nothing)
+        dfB = dpc_ab(4373, (iter, w) -> nothing)
+        @test dfA.iter == dfB.iter
+        @test dfA.emax == dfB.emax
+        @test dfA.num_particles == dfB.num_particles
+    end
 end

--- a/test/test-SamplingSchemes/test-nested_sampling.jl
+++ b/test/test-SamplingSchemes/test-nested_sampling.jl
@@ -800,4 +800,99 @@
             @test ns_params.cluster_accept_history == [0.1, 0.5, 0.0, 0.5]
         end
     end
+
+    @testset "dead-point callback (canonical route)" begin
+        using Random
+        dpc_lat = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full)
+        dpc_ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        dpc_save = SaveEveryN("t_dpc.csv", "t_dpc.traj", "t_dpc.ls",
+                              1000000, 1000000, 1000000)
+        dpc_cleanup() = rm.(["t_dpc.csv", "t_dpc.traj", "t_dpc.ls"], force=true)
+
+        # Fixed-N liveset at N = 6, freshly seeded per run so A/B pairs share
+        # their streams
+        function dpc_fresh(seed)
+            Random.seed!(seed)
+            walkers = [LatticeWalker(deepcopy(dpc_lat), energy=0.0u"eV", iter=0)
+                       for _ in 1:12]
+            for w in walkers
+                occ = vcat(fill(true, 6), fill(false, 10))
+                shuffle!(occ)
+                w.configuration.components[1] .= occ
+            end
+            ls = LatticeGasWalkers(walkers, dpc_ham; perturb_energy=1e-9)
+            params = LatticeNestedSamplingParameters(mc_steps=20,
+                energy_perturbation=1e-9, allowed_fail_count=100000)
+            return ls, params
+        end
+
+        # Invocation count equals nrow(df), and the (iter, energy) pair seen
+        # by the callback matches the ledger row bit-exactly (the pairing
+        # guard's contract, from the caller's side)
+        ls, params = dpc_fresh(31)
+        seen = Tuple{Int,Float64}[]
+        df, _, _ = nested_sampling(ls, params, Int64(150),
+            MCRandomWalkClone(), dpc_save;
+            dead_point_callback=(iter, w) -> push!(seen, (iter, w.energy.val)))
+        dpc_cleanup()
+        @test nrow(df) > 0
+        @test length(seen) == nrow(df)
+        @test [t[1] for t in seen] == df.iter
+        @test [t[2] for t in seen] == df.emax
+
+        # Offline reproduction and energy faithfulness: occupation vectors
+        # collected through the callback re-evaluate the run's recorded
+        # observable column exactly, and recomputing the Hamiltonian on a
+        # collected configuration matches the ledger energy within the
+        # energy_perturbation half-width (the perturbation is uniform on
+        # ±energy_perturbation/2)
+        ls, params = dpc_fresh(32)
+        configs = Vector{Bool}[]
+        df2, _, _ = nested_sampling(ls, params, Int64(150),
+            MCRandomWalkClone(), dpc_save;
+            observables=[:nocc => (cfg -> Float64(sum(cfg.components[1])))],
+            dead_point_callback=(iter, w) ->
+                push!(configs, copy(w.configuration.components[1])))
+        dpc_cleanup()
+        @test length(configs) == nrow(df2)
+        @test [Float64(sum(c)) for c in configs] == df2.nocc
+        dpc_probe = deepcopy(dpc_lat)
+        for (c, e) in zip(configs, df2.emax)
+            dpc_probe.components[1] .= c
+            @test abs(ustrip(u"eV", interacting_energy(dpc_probe, dpc_ham)) - e) <= 5.1e-10
+        end
+
+        # Stream neutrality: a same-seed A/B pair with and without the
+        # callback leaves the ledger byte-identical (the callback path draws
+        # no randomness)
+        lsA, paramsA = dpc_fresh(33)
+        dfA, _, _ = nested_sampling(lsA, paramsA, Int64(120),
+            MCRandomWalkClone(), dpc_save)
+        dpc_cleanup()
+        lsB, paramsB = dpc_fresh(33)
+        dfB, _, _ = nested_sampling(lsB, paramsB, Int64(120),
+            MCRandomWalkClone(), dpc_save;
+            dead_point_callback=(iter, w) -> nothing)
+        dpc_cleanup()
+        @test dfA.iter == dfB.iter
+        @test dfA.emax == dfB.emax
+
+        # Guards: a non-Function argument fails at the keyword's type
+        # boundary; parallel/multi-cull routines are rejected up front when
+        # only the callback is requested
+        ls, params = dpc_fresh(34)
+        @test_throws TypeError nested_sampling(ls, params, Int64(1),
+            MCRandomWalkClone(), dpc_save; dead_point_callback=42)
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(1),
+            MCRandomWalkMaxEParallel(), dpc_save;
+            dead_point_callback=(i, w) -> nothing)
+        dpc_cleanup()
+    end
 end


### PR DESCRIPTION
Implements #165. Adds an opt-in `dead_point_callback::Union{Nothing,Function} = nothing` keyword to the three nested-sampling drivers (`nested_sampling`, `grand_canonical_nested_sampling`, `ideal_gas_referenced_nested_sampling`): called once per recorded dead point as `dead_point_callback(iter, walker)`, immediately after the ledger row is pushed, with the same culled walker the row describes.

## Implementation

- The callback rides the existing observables machinery: the pre-sort that holds the to-be-culled walker is engaged whenever either keyword is supplied, and the bit-exact pairing guard is hoisted to protect both consumers (previously it lived inside the observables branch; it now fires whenever a culled walker is held, with unchanged messages except the canonical driver's trailing clause, which now names both keywords).
- Iterations that record no dead point (failed replacement) invoke no callback, so the invocation count equals `nrow(df)`. The callback composes freely with `observables`, and the surviving live set needs no callback because the drivers return it.
- A non-`Function` argument fails at the keyword's type boundary. Parallel/multi-cull routines are rejected up front in the canonical driver when the callback is requested (the grand-canonical drivers' signatures already constrain the routine type).
- The docstrings state the read-only contract (the walker is the loop's live object; copy anything kept) and the substituted-energy recipe: per-dead-point energies recomputed under a second Hamiltonian replace the ledger energy column (and the live tail) in `gc_thermodynamic_stats_ideal_ref`, a valid estimator over the same ladder because the prior-volume weights depend only on the iteration index, with the returned Kish N<sub>eff</sub> as its fidelity diagnostic.

## Tests

One testset per driver, in the driver's own test file.

- Pairing, all three drivers: invocation count equals `nrow(df)`, and the (iter, energy) pair seen by the callback, plus the particle number on the two grand-canonical drivers, matches the ledger row bit-exactly.
- Offline reproduction (canonical): occupation vectors collected through the callback re-evaluate the run's recorded observable column to elementwise equality; recomputing the Hamiltonian on a collected configuration matches the ledger energy within `energy_perturbation`/2.
- Substitution closure (ideal-gas-referenced): a seeded K = 64 ladder on the enumerable 4×4 nearest- plus next-nearest-neighbor lattice gas under Hamiltonian A, with a second Hamiltonian B differing in its nearest-neighbor coupling; B's energies recomputed offline from the collected configurations replace the `emax` column and the live tail, and `gc_thermodynamic_stats_ideal_ref` closes against B's exact grand sum (full 2<sup>16</sup> per-sector enumeration, computed in-test) at the same time the untouched ledger closes against A's. Tolerances three-seed calibrated (seeds 4371/4372/4373; max deviations 0.236 and 0.343 against σ = √(16·ln 2/64) ≈ 0.42; shipped at ≥ 3×, 0.75 and 1.1, with the shipped seed one of the calibrated). The substituted route's Kish N<sub>eff</sub> is pinned finite, positive, and no larger than the control's (measured 436–474 against 541–561 across the calibration seeds).
- Stream neutrality, all three drivers: a same-seed A/B pair with and without the callback leaves the ledger byte-identical (the callback path draws no randomness; the pre-sort it engages is the same stable sort the step itself performs).
- Guards: a non-`Function` argument raises a `TypeError` at the keyword boundary; a parallel routine with only the callback requested raises the up-front `ArgumentError` in the canonical driver.

The ideal-gas-referenced testset carries the full substitution closure with its in-test per-sector enumeration, so the delivered test volume exceeds the issue's ≈ 130-line estimate (261 lines); the closure seemed worth owning at unit scale rather than deferring entirely to the regression issue filed alongside.

An adversarial verification pass ran as three independent reviewers with disjoint charters before filing. The semantics reviewer enumerated all four keyword states per driver against the pre-change code, extracted the pre-change driver bodies and ran same-seed probes on all three routes (neither-state ledgers, final live sets, and configurations bit-identical to the pre-change drivers), verified the callback receives the exact walker object the pairing assertion validated (removed from the live set before survivor mutation; the Ω recomputation on the grand-canonical route is bit-exact), confirmed the driver-versus-step comparator identity and the empirical stable-sort identity permutation behind the stream-neutrality claim, and re-verified the legacy p_bias same-seed stream pin on the branch. The round-trip reviewer checked every Proposed-API and test-plan element of the issue against the diff, source-anchored the iteration-only-weights and perturbation-half-width claims, re-ran the shipped fixture with the calibration deviations reproducing digit-for-digit, and confirmed the N<sub>eff</sub> pin's margin. The determinism reviewer ran the three files twice with identical pass counts, accounted every deleted line of the recording-block restructure as semantically re-added, and reconciled the per-file assertion deltas against the new testsets' loop arithmetic. Zero must-fix findings across all three charters.

Full test suite passes (SamplingSchemes 6812, AbstractWalkers 339, AbstractHamiltonians 80, AbstractLiveSets 80, AbstractPotentials 106, AnalysisTools 61, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 114 and 3807, FreeBirdIO 51).
