### PR TITLE
Document and validate the custom-Hamiltonian extension contract for lattice sampling

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,7 @@ makedocs(;
     pages=[
             "FreeBird.jl" => "index.md",
             "Tutorials" => "tutorials.md",
+            "Custom Hamiltonians" => "CustomHamiltonians.md",
             "Examples" => "examples.md",
             "Interface with Python for MLIPs" => "MLIPs.md",
             "Modules and Documentation" => [

--- a/docs/src/CustomHamiltonians.md
+++ b/docs/src/CustomHamiltonians.md
@@ -1,0 +1,58 @@
+# Custom Hamiltonians
+
+The lattice sampling stack accepts user-defined Hamiltonians through a small extension contract: `interacting_energy(lattice, hamiltonian)` is the only place the stack evaluates a Hamiltonian, so one method serves `LatticeGasWalkers` construction, all of the nested-sampling loops, and `exact_enumeration`, on every single-component lattice geometry. Externally defined energies on fixed site sets are standard practice, machine-learned potentials among them, and this page records what a custom type must provide.
+
+## The contract
+
+1. Subtype `ClassicalHamiltonian`. Fields are yours, including caches: nothing in the stack copies or introspects the Hamiltonian.
+2. Define one energy method returning an energy-dimensioned `Unitful.Quantity` (eV-convertible; a molar energy such as kJ/mol carries a different dimension and is rejected). A method returning a plain number raises a descriptive `ArgumentError` at walker setup. The validation lives on the walker-setup surface; the raw-lattice `wang_landau` and `nvt_monte_carlo` entry points evaluate the Hamiltonian directly and sit outside it.
+3. Optionally, opt into two integrations: `AbstractHamiltonians._coupling_type(::MyHam)` to compose under `SiteFieldLatticeHamiltonian` (its absence produces a self-explanatory `ArgumentError`), and `AbstractLiveSets._n_coupled_shells(::MyHam)` to participate in the uncoupled-shell warning at setup.
+
+A worked example, a coordination-dependent energy no shipped pair, cluster, or site-field type expresses directly:
+
+````julia
+using FreeBird
+using Unitful
+
+struct CoordinationHamiltonian <: ClassicalHamiltonian
+    j::Float64
+end
+
+import FreeBird.EnergyEval: interacting_energy
+
+function interacting_energy(lattice::SLattice, h::CoordinationHamiltonian)
+    occ = lattice.components[1]
+    doubly = count(s -> occ[s] &&
+                        count(n -> occ[n], lattice.neighbors[s][1]) == 2,
+                   eachindex(occ))
+    return h.j * doubly^2 * u"eV"
+end
+````
+
+With that in place, the type is a drop-in for the shipped Hamiltonians:
+
+````julia
+walkers = [LatticeWalker(deepcopy(lattice), energy=0.0u"eV", iter=0) for _ in 1:32]
+ls = LatticeGasWalkers(walkers, CoordinationHamiltonian(0.1))
+df, ls, params = grand_canonical_nested_sampling(ls, gc_params, 1000, mc_routine, save_strategy)
+````
+
+and `exact_enumeration(lattice, CoordinationHamiltonian(0.1))` enumerates its fixed-particle-number spectrum.
+
+## Caching expensive energies
+
+The evaluation path is serial (walker setup is a plain loop, and the nested-sampling loops evaluate one proposal at a time), so a plain `Dict` memoization keyed by the occupation vector is safe:
+
+````julia
+struct CachedHamiltonian <: ClassicalHamiltonian
+    cache::Dict{Vector{Bool},typeof(1.0u"eV")}
+end
+
+function interacting_energy(lattice::SLattice, h::CachedHamiltonian)
+    get!(h.cache, copy(lattice.components[1])) do
+        expensive_energy(lattice)
+    end
+end
+````
+
+Two practical notes. First, define `Base.show` for cache-carrying types: the default struct `show` prints the entire cache whenever a liveset is displayed. Second, the serial-evaluation guarantee is what makes the unsynchronized `Dict` safe; wrap the cache before using any future parallel evaluation path.

--- a/src/AbstractLiveSets/AbstractLiveSets.jl
+++ b/src/AbstractLiveSets/AbstractLiveSets.jl
@@ -8,6 +8,7 @@ module AbstractLiveSets
 
 using Distributed
 
+import Unitful
 import Unitful: unit
 
 using ..AbstractWalkers

--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -3,21 +3,33 @@ abstract type LatticeWalkers <: AbstractLiveSet end
 
 
 """
-    assign_energy!(walker::LatticeWalker{C}, hamiltonian::LatticeGasHamiltonian; perturb_energy::Float64=0.0)
+    assign_energy!(walker::LatticeWalker{C}, hamiltonian::ClassicalHamiltonian; perturb_energy::Float64=0.0)
 
 Assigns energy to the given `walker` based on the `hamiltonian`. If `perturb_energy` is non-zero, a small random perturbation is added to the energy.
 
+The energy comes from `interacting_energy(walker.configuration, hamiltonian)`, which must return an energy-dimensioned `Unitful.Quantity` (eV-convertible); a method returning anything else, e.g. a plain `Float64` from a custom Hamiltonian, raises a descriptive `ArgumentError` here rather than a `DimensionError` from the assignment arithmetic. This is the one return-type obligation of the custom-Hamiltonian extension contract (see the Custom Hamiltonians documentation page).
+
 # Arguments
 - `walker::LatticeWalker{C}`: The walker to assign energy to.
-- `hamiltonian::LatticeGasHamiltonian`: The Hamiltonian used to calculate the energy.
+- `hamiltonian::ClassicalHamiltonian`: The Hamiltonian used to calculate the energy.
 - `perturb_energy::Float64=0.0`: The amount of random perturbation to add to the energy.
 
 # Returns
 - `walker::LatticeWalker{C}`: The walker with the assigned energy.
 """
 function assign_energy!(walker::LatticeWalker{C}, hamiltonian::ClassicalHamiltonian; perturb_energy::Float64=0.0) where C
+    raw = interacting_energy(walker.configuration, hamiltonian)
+    if !(raw isa Unitful.Energy)
+        throw(ArgumentError(
+            "interacting_energy must return an energy-dimensioned " *
+            "Unitful.Quantity (eV-convertible) for walker energies; got " *
+            "$(typeof(raw)) from the $(nameof(typeof(hamiltonian))) " *
+            "Hamiltonian. Custom Hamiltonians subtype ClassicalHamiltonian " *
+            "and return e.g. `x * u\"eV\"` from their interacting_energy " *
+            "method."))
+    end
     # Assign the energy to the walker and, if perturb_energy is non-zero, give all walkers a small random (positive or negative) perturbation
-    walker.energy = interacting_energy(walker.configuration, hamiltonian) + perturb_energy * (rand() - 0.5) * unit(walker.energy)
+    walker.energy = raw + perturb_energy * (rand() - 0.5) * unit(walker.energy)
     return walker
 end
 
@@ -125,10 +137,10 @@ The `LatticeGasWalkers` struct represents a collection of lattice walkers for a 
 
 # Fields
 - `walkers::Vector{LatticeWalker{C}}`: A vector of lattice walkers.
-- `hamiltonian::LatticeGasHamiltonian`: The lattice gas Hamiltonian associated with the walkers.
+- `hamiltonian::ClassicalHamiltonian`: The lattice Hamiltonian associated with the walkers.
 
 # Constructors
-- `LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::LatticeGasHamiltonian; assign_energy=true, perturb_energy::Float64=0.0)`: Constructs a new `LatticeGasWalkers` object with the given walkers and Hamiltonian. If `assign_energy` is `true`, the energy of each walker is assigned using the provided Hamiltonian. The optional `perturb_energy` parameter can be used to add a small perturbation to the assigned energy.
+- `LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::ClassicalHamiltonian; assign_energy=true, perturb_energy::Float64=0.0)`: Constructs a new `LatticeGasWalkers` object with the given walkers and Hamiltonian. If `assign_energy` is `true`, the energy of each walker is assigned using the provided Hamiltonian. The optional `perturb_energy` parameter can be used to add a small perturbation to the assigned energy.
 
 """
 struct  LatticeGasWalkers <: LatticeWalkers

--- a/test/test-AbstractLiveSets.jl
+++ b/test/test-AbstractLiveSets.jl
@@ -1,3 +1,29 @@
+# Custom-Hamiltonian fixtures for the extension-contract testset at the
+# bottom of this file; type definitions must sit at the file's top level.
+# ExtCoordHam: a coordination-dependent global functional no shipped pair,
+# cluster, or site-field type expresses (the documentation page's example).
+struct ExtCoordHam <: ClassicalHamiltonian
+    j::Float64
+end
+function FreeBird.EnergyEval.interacting_energy(lattice::SLattice, h::ExtCoordHam)
+    occ = lattice.components[1]
+    doubly = count(s -> occ[s] &&
+                        count(n -> occ[n], lattice.neighbors[s][1]) == 2,
+                   eachindex(occ))
+    return h.j * doubly^2 * u"eV"
+end
+# ExtDelegatingHam: wraps a shipped Hamiltonian unchanged, so a same-seed
+# run must be bit-identical to the shipped type (stream neutrality of the
+# extension path, including the setup validation)
+struct ExtDelegatingHam <: ClassicalHamiltonian
+    inner
+end
+FreeBird.EnergyEval.interacting_energy(lattice::SLattice, h::ExtDelegatingHam) =
+    interacting_energy(lattice, h.inner)
+# ExtBadHam: violates the return-type contract (plain Float64)
+struct ExtBadHam <: ClassicalHamiltonian end
+FreeBird.EnergyEval.interacting_energy(lattice::SLattice, h::ExtBadHam) = 1.6
+
 @testset "AbstractLiveSets Tests" begin
     @testset "atomistic_livesets.jl tests" begin
 
@@ -400,6 +426,136 @@
                 @test occursin("$comp", output)
             end
         end
+    end
+
+    @testset "custom-Hamiltonian extension contract" begin
+        using Random
+        ext_sq = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full)
+        ext_tri = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(3, 3, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:18]],
+            adsorptions=:full)
+        ext_ham = ExtCoordHam(0.1)
+
+        # Negative path: the return-type contract violation raises the
+        # descriptive ArgumentError at walker setup, naming the method and
+        # the required dimension, both at construction and through
+        # exact_enumeration (which constructs a liveset internally)
+        bad_walkers = [LatticeWalker(deepcopy(ext_sq), energy=0.0u"eV", iter=0)]
+        @test_throws ArgumentError LatticeGasWalkers(bad_walkers, ExtBadHam())
+        err = try
+            LatticeGasWalkers(bad_walkers, ExtBadHam())
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("interacting_energy", err.msg)
+        @test occursin("energy-dimensioned", err.msg)
+        @test occursin("Float64", err.msg)
+        @test_throws ArgumentError exact_enumeration(deepcopy(ext_sq), ExtBadHam())
+
+        # Positive path: one interacting_energy method serves construction
+        # on both geometries, with energies matching an independent
+        # re-evaluation of the same rule
+        Random.seed!(4661)
+        function ext_independent(lat)
+            occ = lat.components[1]
+            c = 0
+            for s in eachindex(occ)
+                occ[s] || continue
+                nb = count(n -> occ[n], lat.neighbors[s][1])
+                c += (nb == 2) ? 1 : 0
+            end
+            return 0.1 * c^2
+        end
+        for lat in (ext_sq, ext_tri)
+            walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                       for _ in 1:6]
+            for w in walkers
+                w.configuration.components[1] .= rand(Bool, length(w.configuration.components[1]))
+            end
+            ls = LatticeGasWalkers(walkers, ext_ham)
+            for w in ls.walkers
+                @test w.energy.val == ext_independent(w.configuration)
+            end
+        end
+
+        # Positive path, sampled: a short seeded grand-canonical run drives
+        # the custom Hamiltonian through the full loop
+        Random.seed!(4662)
+        walkers = [LatticeWalker(deepcopy(ext_sq), energy=0.0u"eV", iter=0)
+                   for _ in 1:8]
+        ls = LatticeGasWalkers(walkers, ext_ham; assign_energy=false)
+        gc = GrandCanonicalNestedSamplingParameters(mc_steps=20,
+            chemical_potential=-0.05, energy_perturbation=1e-9)
+        ext_save = SaveEveryN("t_ext.csv", "t_ext.traj", "t_ext.ls",
+                              1000000, 1000000, 1000000)
+        df, _, _ = grand_canonical_nested_sampling(ls, gc, Int64(100),
+            MCGrandCanonicalMoves(), ext_save;
+            observables=[:n_occ => (cfg -> Float64(sum(cfg.components[1])))])
+        # The 10^6-step save intervals guarantee no t_ext.* file is written
+        # in these short runs; the rm calls are defensive cleanup only
+        rm.(["t_ext.csv", "t_ext.traj", "t_ext.ls"], force=true)
+        @test nrow(df) > 0
+        @test all(isfinite, df.energy)
+        @test "n_occ" in names(df)
+        @test all(isfinite, df.n_occ)
+        @test df.n_occ == Float64.(df.num_particles)
+
+        # Positive path, enumerated: the fixed-N spectra match a brute force
+        # over all occupations of the independent rule, on the square
+        # C(16, 4) and the triangular C(18, 3) sectors
+        for (lat0, M, N) in [(ext_sq, 16, 4), (ext_tri, 18, 3)]
+            latN = deepcopy(lat0)
+            latN.components[1] .= vcat(fill(true, N), fill(false, M - N))
+            dfe, _ = exact_enumeration(latN, ext_ham)
+            @test nrow(dfe) == binomial(M, N)
+            probe = deepcopy(lat0)
+            brute = Float64[]
+            for mask in 0:(2^M-1)
+                count_ones(mask) == N || continue
+                for s in 1:M
+                    probe.components[1][s] = ((mask >> (s - 1)) & 1) == 1
+                end
+                push!(brute, ext_independent(probe))
+            end
+            @test sort([ustrip(u"eV", e) for e in dfe.energy]) == sort(brute)
+        end
+
+        # Shipped types still construct through the validated path with
+        # bit-identical energies (the validation is a no-op for them), and
+        # a delegating custom Hamiltonian is a same-seed drop-in for the
+        # shipped type it wraps: identical ideal-gas-referenced ledgers
+        ext_gham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        function ext_igref(seed, h)
+            Random.seed!(seed)
+            ws = [LatticeWalker(deepcopy(ext_sq), energy=0.0u"eV", iter=0)
+                  for _ in 1:12]
+            l = LatticeGasWalkers(ws, h; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=20,
+                reference_fugacity=1.0, energy_perturbation=1e-9)
+            d, fl, _ = ideal_gas_referenced_nested_sampling(l, p, Int64(80),
+                MCGrandCanonicalMoves(), ext_save)
+            rm.(["t_ext.csv", "t_ext.traj", "t_ext.ls"], force=true)
+            return d, [w.energy.val for w in fl.walkers]
+        end
+        dfS, liveS = ext_igref(4663, ext_gham)
+        dfD, liveD = ext_igref(4663, ExtDelegatingHam(ext_gham))
+        @test dfS.iter == dfD.iter
+        @test dfS.emax == dfD.emax
+        @test dfS.num_particles == dfD.num_particles
+        @test liveS == liveD
     end
 
 end


### PR DESCRIPTION
Implements #166. Documents and hardens the custom-Hamiltonian extension contract for lattice sampling: a caller-defined `ClassicalHamiltonian` subtype with one `interacting_energy` method already runs the whole stack via open dispatch, and this PR makes the contract visible and its one failure mode descriptive.

## Changes

- A new documentation page, Custom Hamiltonians, placed after the tutorials: the three-part contract (subtype; one `interacting_energy(::SLattice, ::MyHam)` method returning an energy-dimensioned `Unitful.Quantity`, serving `LatticeGasWalkers` construction, every nested-sampling loop, and `exact_enumeration` on all single-component geometries; the optional `_coupling_type`/`_n_coupled_shells` opt-ins), a worked coordination-dependent example inexpressible by the shipped pair/cluster/site-field types, the caller-side memoization pattern with the serial-evaluation note that makes a plain `Dict` cache safe, and the `Base.show` recommendation for cache-carrying types.
- A descriptive validation in `assign_energy!`: the first `interacting_energy` return is checked for energy dimension, and a plain-number return now raises an `ArgumentError` naming the method, the required dimension, and the offending type, where previously the failure surfaced as a `DimensionError` deep in the assignment arithmetic with the perturbation operand printed first. The check is a compile-time no-op for the shipped types, and the RNG draw order of the assignment is unchanged. The predicate is dimension-based: any true energy unit passes and converts (mJ, J, hartree), while a molar energy such as kJ/mol carries a different dimension and is rejected, exactly as the eV-typed walker field always required.
- Docstring repairs: the nonexistent `LatticeGasHamiltonian` replaced by `ClassicalHamiltonian` at all four mentions across the `assign_energy!` and `LatticeGasWalkers` docstrings, and the `assign_energy!` docstring now states the return-type obligation.

## Tests

One testset in `test/test-AbstractLiveSets.jl`, with the custom types defined at the file's top level.

- Negative path: a `Float64`-returning Hamiltonian raises the new `ArgumentError` at `LatticeGasWalkers` construction and through `exact_enumeration`, with the message pinned to name `interacting_energy`, the energy dimension, and the offending type.
- Positive path: the documentation page's coordination-dependent example constructs livesets on square and triangular cells with every walker energy matching an independent re-evaluation of the same rule, runs a short seeded grand-canonical ladder end to end with one observables entry (the recorded column pinned against the ledger's particle count), and its fixed-N `exact_enumeration` spectra match a dependency-free brute force on both geometries (C(16, 4) square, C(18, 3) triangular).
- Stream neutrality and shipped-type regression in one pin: a custom Hamiltonian delegating to a shipped `GenericLatticeHamiltonian` produces a bit-identical same-seed ideal-gas-referenced ledger and final live set, so the validated path neither perturbs streams nor treats the extension differently from the shipped type it wraps.

An adversarial verification pass ran as three independent reviewers with disjoint charters before filing. The semantics reviewer verified the rewritten `assign_energy!` preserves the evaluation and RNG-draw order (a same-seed ideal-gas-referenced ladder is bit-identical against the pre-change body), that the predicate accepts every shipped Hamiltonian's concretely inferred return plus any true energy unit while rejecting plain numbers, wrong dimensions, and molar energies with a sensibly rendered message, that the check is branch-elided for concrete return types and sits on init-only call sites, and that no atomistic caller can reach the lattice method. The round-trip reviewer verified all four docstring repairs (a repo-wide grep finds zero stale mentions), probed both documentation snippets at runtime, source-anchored every claim on the page, and confirmed the confidentiality of the diff; its one must-fix (the issue's seeded run promised an observables entry the test omitted) is fixed, and its scope finding is addressed with a second, triangular enumeration closure. The semantics reviewer's boundary findings are folded into the page (the raw-lattice `wang_landau`/`nvt_monte_carlo` entry points sit outside the validated surface) and this description (molar energies). The determinism reviewer ran the file twice with identical pass counts, confirmed the top-level fixture types collide with nothing and re-include cleanly, and accounted the assertion delta.

Full test suite passes (AbstractLiveSets 111, SamplingSchemes 6674, AbstractWalkers 339, AbstractHamiltonians 80, AbstractPotentials 106, AnalysisTools 61, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 114 and 3807, FreeBirdIO 51), and the documentation builds clean with the new page.
