### PR TITLE
Fix the N = 0 sector of the atomistic fixed-N assembly for offset-energy ledgers

### DIFF
--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -736,7 +736,8 @@ end
 """
     gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
                                    n_walkers=120, n_cull=1, ω0=1.0,
-                                   live_emax=nothing, kb=8.617333262e-5)
+                                   live_emax=nothing, empty_energy=0.0,
+                                   kb=8.617333262e-5)
 
 Atomistic method: compute grand-canonical thermodynamic averages from a stack
 of canonical nested-sampling outputs, one per fixed particle number `N`, using
@@ -761,10 +762,20 @@ The grand partition function is assembled as
 
 with the thermal wavelength `Λ(T) = h / sqrt(2π m k_B T)` computed from `atomic_mass`.
 The sum runs over the supplied `N_values`, which must include `0`. The `N=0` sector
-is treated specially: `Z_{NS}^{(0)} = 1` by definition (the empty configuration has no
-spatial integral), so the corresponding DataFrame contents are ignored. Truncation
+is treated specially: the empty configuration has no spatial integral, so
+`Z_{NS}^{(0)} = exp(-β·empty_energy)` — exactly `1` at the default
+`empty_energy = 0` — and the corresponding DataFrame contents are ignored. Truncation
 error at the upper end of `N_values` is bounded by the tail of `(zV)^N / N!` for the
 largest `⟨N⟩` requested.
+
+All sectors must share one zero of energy. When the recorded energies carry a
+configuration-independent offset — for surface systems, the frozen substrate's
+self-energy, which every `N ≥ 1` walker records via `energy_frozen_part` — pass that
+offset as `empty_energy` so the `N = 0` sector sits on the same scale. Otherwise the
+empty sector's weight in the grand sum is misstated by the factor `exp(+β·offset)`,
+and for an attractive substrate the assembly silently returns `N ≥ 1`-conditional
+statistics wherever the empty sector carries weight (dilute coverage, strong binding,
+low temperature).
 
 A log-sum-exp pass is used both inside each per-N evidence and across the
 grand sum for numerical stability.
@@ -808,6 +819,14 @@ does not cancel.
 - `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
   when supplied, one vector of `K = n_walkers` live walker energies (in eV) per
   `N`. The entry for `N=0` is ignored. See "Live-set tail correction" above.
+- `empty_energy::Float64=0.0`: total energy (in eV) of the `N=0` configuration on
+  the same energy scale as the ledger energies. Leave at `0` when the empty
+  simulation box has zero energy (free clusters and fluids); for adsorption on a
+  frozen substrate pass the substrate self-energy. Must be finite. At very large
+  offsets (`β·|empty_energy|` beyond about `709`) the linear-space `Xi` return
+  over- or underflows while the ratio observables (`mean_N`, `var_N`, `mean_U`)
+  remain valid; when the absolute `Ξ` is needed in that regime, shift all ledger
+  and live energies to the empty-configuration reference externally instead.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
@@ -827,6 +846,7 @@ function gc_thermodynamic_stats_fixed_N(
     n_cull::Int=1,
     ω0::Float64=1.0,
     live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
+    empty_energy::Float64=0.0,
     kb::Float64=8.617333262e-5,
 )
     if length(ns_outputs) != length(N_values)
@@ -840,6 +860,9 @@ function gc_thermodynamic_stats_fixed_N(
     end
     if live_emax !== nothing && length(live_emax) != length(N_values)
         throw(DimensionMismatch("live_emax and N_values must have the same length"))
+    end
+    if !isfinite(empty_energy)
+        throw(ArgumentError("empty_energy must be finite"))
     end
     if !all(T -> ustrip(u"K", T) > 0, T_grid)
         throw(ArgumentError("every temperature in T_grid must be positive"))
@@ -855,11 +878,15 @@ function gc_thermodynamic_stats_fixed_N(
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
 
     for (i, df) in enumerate(ns_outputs)
-        # The N = 0 sector is the empty configuration: Z_NS^{(0)} = 1 by
-        # definition. The corresponding DataFrame contents are ignored.
+        # The N = 0 sector is the empty configuration: no spatial integral, so
+        # Z_NS^{(0)} = exp(-β·empty_energy), the Boltzmann weight of its total
+        # energy on the ledgers' energy scale (exactly 1 at the default
+        # empty_energy = 0). The corresponding DataFrame contents are ignored.
         if N_int[i] == 0
-            log_Z_NS[i, :] .= 0.0
-            mean_E_N[i, :] .= 0.0
+            for (j, T) in enumerate(T_grid)
+                log_Z_NS[i, j] = -empty_energy / (kb * ustrip(u"K", T))
+            end
+            mean_E_N[i, :] .= empty_energy
             continue
         end
 

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -144,6 +144,126 @@
             n_walkers=K)
     end
 
+    @testset "empty_energy: offset invariance, empty-sector restoration, guards" begin
+        # Deterministic synthetic ladders — no NS runs. Sector N carries a
+        # linearly descending emax ladder ending at its floor, plus K live
+        # energies at the floor.
+        K = 64
+        n_iters = 400
+        ω0_test = (K + 1) / K
+        N_values = collect(0:4)
+
+        V = 1000.0u"Å^3"
+        m = 40.0u"u"
+        T = 200.0u"K"
+        T_grid = [T]
+        kb = 8.617333262e-5
+        β = 1.0 / (kb * ustrip(u"K", T))
+        Λ_val = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+        V_val = ustrip(u"Å^3", V)
+        μ_for_zV(zV_target) = (log(zV_target * Λ_val^3 / V_val) / β) * u"eV"
+
+        E_floor(N) = -0.02 * N
+        ladder(N) = E_floor(N) .+ 0.05 .* (1.0 .- collect(1:n_iters) ./ n_iters)
+        empty_df() = DataFrame(iter=Int[], emax=Float64[])
+        ns_outputs = [N == 0 ? empty_df() :
+                      DataFrame(iter=collect(1:n_iters), emax=ladder(N))
+                      for N in N_values]
+        live_all = [N == 0 ? Float64[] : fill(E_floor(N), K) for N in N_values]
+
+        μ_grid = [μ_for_zV(0.3), μ_for_zV(1.0)]
+
+        out0 = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all)
+
+        @testset "offset invariance" begin
+            # Shifting every ledger and live energy by a constant E0 while
+            # declaring the same E0 as the empty-sector energy leaves ⟨N⟩ and
+            # Var N unchanged, scales Ξ by exp(−βE0), and offsets ⟨U⟩ by
+            # exactly E0.
+            E0 = -1.5
+            ns_shift = [N == 0 ? empty_df() :
+                        DataFrame(iter=collect(1:n_iters), emax=ladder(N) .+ E0)
+                        for N in N_values]
+            live_shift = [N == 0 ? Float64[] : fill(E_floor(N) + E0, K)
+                          for N in N_values]
+
+            outE = gc_thermodynamic_stats_fixed_N(
+                ns_shift, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_shift, empty_energy=E0)
+
+            @test all(abs.(outE.mean_N .- out0.mean_N) .<= 1e-12)
+            @test all(abs.(outE.var_N .- out0.var_N) .<= 1e-12)
+            @test all(isapprox.(outE.Xi, out0.Xi .* exp(-β * E0), rtol=1e-10))
+            @test all(abs.(outE.mean_U .- (out0.mean_U .+ E0)) .<= 1e-12)
+        end
+
+        @testset "empty-sector restoration" begin
+            # Constant-energy sectors E ≡ E0 + N·u make the truncated grand sum
+            # exactly computable: Z_NS^{(N)} = M · exp(−β(E0 + N·u)) for N ≥ 1,
+            # with the prior mass M = Σᵢ ωᵢ + tail replicated analytically. The
+            # default call reproduces the biased sum in which the empty sector
+            # enters with weight 1 instead of exp(−βE0); empty_energy = E0
+            # reproduces the exact sum.
+            E0 = -1.5
+            u1 = -0.013
+            E_N(N) = E0 + N * u1
+            ns_const = [N == 0 ? empty_df() :
+                        DataFrame(iter=collect(1:n_iters), emax=fill(E_N(N), n_iters))
+                        for N in N_values]
+            live_const = [N == 0 ? Float64[] : fill(E_N(N), K) for N in N_values]
+
+            r = K / (K + 1)
+            M_dead = sum(ω0_test * (1 / (K + 1)) * r^i for i in 1:n_iters)
+            M_tail = ω0_test * r^n_iters
+            M = M_dead + M_tail
+
+            out_def = gc_thermodynamic_stats_fixed_N(
+                ns_const, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_const)
+            out_fix = gc_thermodynamic_stats_fixed_N(
+                ns_const, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_const, empty_energy=E0)
+
+            wavg(w, x) = sum(w .* x) / sum(w)
+            Ns = collect(0:4)
+
+            for (k, μ) in enumerate(μ_grid)
+                zV = exp(β * ustrip(u"eV", μ)) * V_val / Λ_val^3
+                terms = [zV^N / factorial(N) * M * exp(-β * E_N(N)) for N in 1:4]
+                w_ex = vcat(exp(-β * E0), terms)   # exact: N = 0 at exp(−βE0)
+                w_b = vcat(1.0, terms)             # biased: N = 0 at weight 1
+                Es_ex = vcat(E0, [E_N(N) for N in 1:4])
+                Es_b = vcat(0.0, [E_N(N) for N in 1:4])  # default: mean_E(0) = 0
+
+                @test isapprox(out_fix.Xi[k, 1], sum(w_ex), rtol=1e-10)
+                @test isapprox(out_fix.mean_N[k, 1], wavg(w_ex, Ns), rtol=1e-10)
+                @test isapprox(out_fix.var_N[k, 1],
+                               wavg(w_ex, Ns .^ 2) - wavg(w_ex, Ns)^2, rtol=1e-10)
+                @test isapprox(out_fix.mean_U[k, 1], wavg(w_ex, Es_ex), rtol=1e-10)
+
+                @test isapprox(out_def.Xi[k, 1], sum(w_b), rtol=1e-10)
+                @test isapprox(out_def.mean_N[k, 1], wavg(w_b, Ns), rtol=1e-10)
+                @test isapprox(out_def.var_N[k, 1],
+                               wavg(w_b, Ns .^ 2) - wavg(w_b, Ns)^2, rtol=1e-10)
+                @test isapprox(out_def.mean_U[k, 1], wavg(w_b, Es_b), rtol=1e-10)
+
+                # The bias is material at these μ: the default overstates ⟨N⟩.
+                @test out_def.mean_N[k, 1] > out_fix.mean_N[k, 1] + 0.1
+            end
+        end
+
+        @testset "guards" begin
+            @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+                ns_outputs, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=NaN)
+            @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+                ns_outputs, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=Inf)
+        end
+    end
+
 end
 
 

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -155,13 +155,14 @@
 
         V = 1000.0u"Å^3"
         m = 40.0u"u"
-        T = 200.0u"K"
-        T_grid = [T]
+        T_grid = [200.0u"K", 350.0u"K"]
         kb = 8.617333262e-5
-        β = 1.0 / (kb * ustrip(u"K", T))
-        Λ_val = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+        βs = [1.0 / (kb * ustrip(u"K", T)) for T in T_grid]
+        Λs = [ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T)) for T in T_grid]
         V_val = ustrip(u"Å^3", V)
-        μ_for_zV(zV_target) = (log(zV_target * Λ_val^3 / V_val) / β) * u"eV"
+        # μ targets are set at the first (coldest) temperature; the second
+        # temperature exercises the per-T empty-sector row at the same μ.
+        μ_for_zV(zV_target) = (log(zV_target * Λs[1]^3 / V_val) / βs[1]) * u"eV"
 
         E_floor(N) = -0.02 * N
         ladder(N) = E_floor(N) .+ 0.05 .* (1.0 .- collect(1:n_iters) ./ n_iters)
@@ -195,7 +196,10 @@
 
             @test all(abs.(outE.mean_N .- out0.mean_N) .<= 1e-12)
             @test all(abs.(outE.var_N .- out0.var_N) .<= 1e-12)
-            @test all(isapprox.(outE.Xi, out0.Xi .* exp(-β * E0), rtol=1e-10))
+            for j in eachindex(T_grid)
+                @test all(isapprox.(outE.Xi[:, j], out0.Xi[:, j] .* exp(-βs[j] * E0),
+                                    rtol=1e-10))
+            end
             @test all(abs.(outE.mean_U .- (out0.mean_U .+ E0)) .<= 1e-12)
         end
 
@@ -229,28 +233,32 @@
             wavg(w, x) = sum(w .* x) / sum(w)
             Ns = collect(0:4)
 
-            for (k, μ) in enumerate(μ_grid)
-                zV = exp(β * ustrip(u"eV", μ)) * V_val / Λ_val^3
-                terms = [zV^N / factorial(N) * M * exp(-β * E_N(N)) for N in 1:4]
-                w_ex = vcat(exp(-β * E0), terms)   # exact: N = 0 at exp(−βE0)
+            for (k, μ) in enumerate(μ_grid), j in eachindex(T_grid)
+                βj = βs[j]
+                zV = exp(βj * ustrip(u"eV", μ)) * V_val / Λs[j]^3
+                terms = [zV^N / factorial(N) * M * exp(-βj * E_N(N)) for N in 1:4]
+                w_ex = vcat(exp(-βj * E0), terms)  # exact: N = 0 at exp(−βE0)
                 w_b = vcat(1.0, terms)             # biased: N = 0 at weight 1
                 Es_ex = vcat(E0, [E_N(N) for N in 1:4])
                 Es_b = vcat(0.0, [E_N(N) for N in 1:4])  # default: mean_E(0) = 0
 
-                @test isapprox(out_fix.Xi[k, 1], sum(w_ex), rtol=1e-10)
-                @test isapprox(out_fix.mean_N[k, 1], wavg(w_ex, Ns), rtol=1e-10)
-                @test isapprox(out_fix.var_N[k, 1],
+                @test isapprox(out_fix.Xi[k, j], sum(w_ex), rtol=1e-10)
+                @test isapprox(out_fix.mean_N[k, j], wavg(w_ex, Ns), rtol=1e-10)
+                @test isapprox(out_fix.var_N[k, j],
                                wavg(w_ex, Ns .^ 2) - wavg(w_ex, Ns)^2, rtol=1e-10)
-                @test isapprox(out_fix.mean_U[k, 1], wavg(w_ex, Es_ex), rtol=1e-10)
+                @test isapprox(out_fix.mean_U[k, j], wavg(w_ex, Es_ex), rtol=1e-10)
 
-                @test isapprox(out_def.Xi[k, 1], sum(w_b), rtol=1e-10)
-                @test isapprox(out_def.mean_N[k, 1], wavg(w_b, Ns), rtol=1e-10)
-                @test isapprox(out_def.var_N[k, 1],
+                @test isapprox(out_def.Xi[k, j], sum(w_b), rtol=1e-10)
+                @test isapprox(out_def.mean_N[k, j], wavg(w_b, Ns), rtol=1e-10)
+                @test isapprox(out_def.var_N[k, j],
                                wavg(w_b, Ns .^ 2) - wavg(w_b, Ns)^2, rtol=1e-10)
-                @test isapprox(out_def.mean_U[k, 1], wavg(w_b, Es_b), rtol=1e-10)
+                @test isapprox(out_def.mean_U[k, j], wavg(w_b, Es_b), rtol=1e-10)
 
-                # The bias is material at these μ: the default overstates ⟨N⟩.
-                @test out_def.mean_N[k, 1] > out_fix.mean_N[k, 1] + 0.1
+                # The bias is material in the cold dilute column: the default
+                # overstates ⟨N⟩ (analytic gaps 0.713 and 0.277 at 200 K).
+                if j == 1
+                    @test out_def.mean_N[k, 1] > out_fix.mean_N[k, 1] + 0.05
+                end
             end
         end
 
@@ -261,6 +269,9 @@
             @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
                 ns_outputs, N_values, V, m, μ_grid, T_grid;
                 n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=Inf)
+            @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+                ns_outputs, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=-Inf)
         end
     end
 


### PR DESCRIPTION
Implements #172. Adds an `empty_energy::Float64 = 0.0` keyword to the atomistic (V-based) method of `gc_thermodynamic_stats_fixed_N`: the total energy of the `N = 0` configuration on the same energy scale as the ledgers, entering the assembly as `Z_NS^(0)(β) = e^{−β·empty_energy}` with the sector mean energy set to `empty_energy`. This closes the inconsistency reported in #172 — with total-energy ledgers (the shipped surface idiom, where every N ≥ 1 walker carries `energy_frozen_part`), the hardcoded `Z_NS^(0) = 1` misstated the empty sector's weight by e<sup>+βE<sub>frozen</sub></sup>, so the assembly silently returned N ≥ 1-conditional statistics wherever the empty sector carried weight.

## Implementation

- The `N = 0` sector row becomes `log_Z_NS = −β·empty_energy` per temperature, with the same `kb` convention as the `N ≥ 1` sectors; the sector's mean energy is `empty_energy`. The default `0.0` keeps the documented `Z_NS^(0) = 1` semantics and is bit-identical to the previous behavior (verified below), so existing callers are unaffected.
- A non-finite `empty_energy` raises a descriptive `ArgumentError` alongside the existing argument validation.
- The docstring now states the ledger energy-zero convention (all sectors must share one zero of energy; for surface systems pass the frozen substrate's self-energy), the misstatement factor and its direction for attractive substrates, and the linear-space `Xi` overflow caveat at β·|empty_energy| beyond ≈ 709 (the ratio observables `mean_N`, `var_N`, `mean_U` remain valid there; the keyword bullet gives the external-shift recipe when the absolute Ξ is needed).
- The lattice-gas (`n_sites`) method is deliberately unchanged: every shipped lattice Hamiltonian assigns the empty lattice E = 0 exactly, so its hardcoded sector is already on the ledgers' scale.

## Tests

One new testset of deterministic synthetic ladders (no NS runs) in the atomistic fixed-N test file, 42 assertions.

- Offset invariance: shifting every ledger and live energy by E₀ = −1.5 eV while declaring `empty_energy = E₀` leaves ⟨N⟩ and Var N unchanged to 10<sup>−12</sup>, scales Ξ by e<sup>−βE₀</sup> per temperature column (rtol 10<sup>−10</sup>), and offsets ⟨U⟩ by E₀ to 10<sup>−12</sup>. Measured deviations sit at the ~10<sup>−15</sup> float-noise floor, four to five orders inside the gates.
- Empty-sector restoration: constant-energy sectors E ≡ E₀ + N·u make the truncated grand sum exactly computable, with the prior mass (Σωᵢ plus the live-set tail) reconstructed analytically term for term from the ledger weights. The default call reproduces the biased sum (empty sector at weight 1, mean energy 0) and the `empty_energy = E₀` call the exact one, each gated at rtol 10<sup>−10</sup> per (μ, T) point over a 2×2 grid — the second temperature pins the per-temperature dependence of the new sector row, the first place that row is not constant across T. A materiality floor asserts the default overstates ⟨N⟩ by more than 0.05 in the cold column (analytic gaps 0.713 and 0.277 at 200 K).
- Guards: `NaN`, `Inf`, and `-Inf` each raise the `ArgumentError`.
- The 27 pre-existing assertions in the same block pass unchanged. The delivered test volume (131 lines) exceeds the issue's ≈ 60-line estimate because the restoration closure gates the biased and the corrected sums per grid point rather than spot-checking; the seeded surface end-to-end stays with the regression issue filed alongside, per the issue's delegation.

An adversarial verification pass ran as three independent reviewers with disjoint charters before filing. The round-trip reviewer checked every commitment of the issue against the diff (semantics, tolerances at the promised per-entry granularity, the delegation of the seeded surface closure) and verified the bit-preservation promise empirically: default-keyword outputs on ladders spanning live and no-live tails, both signs of log zV, and multi-temperature grids are raw-UInt64-identical to a worktree at the base commit. The physics oracle re-derived `Z_NS^(0) = e^{−β·empty_energy}` from the grand-sum gauge argument, verified the test's analytic prior-mass formula term for term against the log-space ledger weights including the live-tail split, instrumented every tolerance (all measured deviations at the 10<sup>−15</sup> floor), and confirmed each new docstring claim against the source. The determinism reviewer reconciled the assertion delta against the testset loop arithmetic, confirmed the new tests consume no randomness, and re-ran the file twice with identical counts. Zero must-fix findings; four hardening nits (the second temperature column, the `-Inf` guard case, a sturdier materiality floor, and the Xi-overflow docstring sentence) were applied before filing.

Full test suite passes (SamplingSchemes 7064, AbstractWalkers 339, AbstractHamiltonians 80, AbstractLiveSets 111, AbstractPotentials 106, AnalysisTools 61, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 114 and 3807, FreeBirdIO 51).
