### PR TITLE
Add return-field parity to the atomistic fixed-N grand-canonical assembly

### DIFF
--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -736,14 +736,16 @@ end
 """
     gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
                                    n_walkers=120, n_cull=1, ω0=1.0,
-                                   live_emax=nothing, empty_energy=0.0,
-                                   kb=8.617333262e-5)
+                                   live_emax=nothing,
+                                   observable_cols=Symbol[], live_observables=nothing,
+                                   empty_energy=0.0, kb=8.617333262e-5)
 
 Atomistic method: compute grand-canonical thermodynamic averages from a stack
 of canonical nested-sampling outputs, one per fixed particle number `N`, using
-the simulation-box volume `V` and the thermal wavelength. Returns `Xi` in
-linear space (contrast the lattice-gas method of this function, which takes
-`n_sites` and returns `logXi`).
+the simulation-box volume `V` and the thermal wavelength. Returns the same
+field set as the lattice-gas method of this function (which takes `n_sites`),
+with the linear-space `Xi` retained in the leading position alongside its
+log-space companion `logXi`.
 
 For each `N`, the canonical NS evidence at inverse temperature `β` is
 
@@ -819,21 +821,54 @@ does not cancel.
 - `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
   when supplied, one vector of `K = n_walkers` live walker energies (in eV) per
   `N`. The entry for `N=0` is ignored. See "Live-set tail correction" above.
+- `observable_cols::AbstractVector{Symbol}=Symbol[]`: names of extra ledger
+  columns to average grand-canonically; each `N ≥ 1` DataFrame must carry
+  them. Requires `live_emax` and `live_observables`.
+- `live_observables=nothing`: one `Dict{Symbol,<:AbstractVector{<:Real}}` per
+  `N` sector, holding each observable's values on the surviving live walkers.
+  The `N = 0` entry supplies the observable value of the empty configuration
+  directly (averaged over the given values), unlike its ignored `live_emax`
+  entry.
 - `empty_energy::Float64=0.0`: total energy (in eV) of the `N=0` configuration on
   the same energy scale as the ledger energies. Leave at `0` when the empty
   simulation box has zero energy (free clusters and fluids); for adsorption on a
   frozen substrate pass the substrate self-energy. Must be finite. At very large
   offsets (`β·|empty_energy|` beyond about `709`) the linear-space `Xi` return
   over- or underflows while the ratio observables (`mean_N`, `var_N`, `mean_U`)
-  remain valid; when the absolute `Ξ` is needed in that regime, shift all ledger
-  and live energies to the empty-configuration reference externally instead.
+  remain valid — as does `logXi`; when the absolute `Ξ` is needed in that
+  regime, read `logXi`.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
-A `NamedTuple` `(Xi, mean_N, var_N, mean_U)`. Each field is a `Matrix{Float64}`
-of size `(length(μ_grid), length(T_grid))` indexed `[i_μ, i_T]`. `Xi` is the
-absolute grand partition function, `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
-and `mean_U` is `⟨E⟩` (grand-canonical, in eV).
+A `NamedTuple` `(Xi, mean_N, var_N, mean_U, logXi, var_U, cov_UN, log_Z_N,
+N_values, observables)`; the first four fields keep their historical leading
+positions. `Xi`, `mean_N`, `var_N`, `mean_U`, `logXi`, `var_U`, and `cov_UN`
+are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))` indexed
+`[i_μ, i_T]`. `Xi` is the absolute grand partition function in linear space —
+`Inf` once `ln Ξ` exceeds ≈ 709; `logXi`, its log-space companion, stays
+finite there. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`, and `mean_U` is
+`⟨E⟩` (grand-canonical, in eV). `var_U` is the grand-canonical energy variance
+`⟨E²⟩ − ⟨E⟩²` and `cov_UN` the covariance `⟨EN⟩ − ⟨E⟩⟨N⟩`, both assembled by
+the law of total expectation over the `N` sectors. At fixed `μ` the
+configurational heat capacity follows as
+`C_config = k_B β² (var_U − μ · cov_UN) + (3/2) k_B β · cov_UN`: the extra
+term carries the `Λ(T)^{3N}` temperature dependence of the atomistic
+activity and is absent from the lattice-gas method's identity; kinetic
+contributions must be added separately for the total-energy heat capacity.
+Both fields are accurate to roughly machine epsilon times their natural
+scales, which near their zero crossings is absolute rather than relative
+precision. `log_Z_N` is the
+`(length(N_values), length(T_grid))` matrix of per-`N` log canonical partition
+functions `log Z_N(T) = log Z_NS^{(N)}(β) + N·log(V/Λ³) − log N!` — the
+μ-independent evidence the assembly is built from — and `N_values` echoes the
+particle counts (as `Vector{Int}`) indexing its rows; the particle-number
+distribution follows as `P(N | μ, T) ∝ exp.(log_Z_N[:, j] .+ β .* μ .* N_values)`,
+normalized over the supplied sectors. `observables` is a
+`Dict{Symbol,Matrix{Float64}}` mapping each requested column to ⟨A⟩(μ, T);
+empty when no columns are requested. No Kish effective sample size is
+returned: the fixed-`N` route introduces no importance reweighting (`μ`
+enters the assembly exactly), so there is no sampling fidelity for it to
+diagnose.
 """
 function gc_thermodynamic_stats_fixed_N(
     ns_outputs::AbstractVector{<:DataFrame},
@@ -846,6 +881,8 @@ function gc_thermodynamic_stats_fixed_N(
     n_cull::Int=1,
     ω0::Float64=1.0,
     live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
+    observable_cols::AbstractVector{Symbol}=Symbol[],
+    live_observables::Union{Nothing,AbstractVector{<:AbstractDict{Symbol}}}=nothing,
     empty_energy::Float64=0.0,
     kb::Float64=8.617333262e-5,
 )
@@ -874,8 +911,72 @@ function gc_thermodynamic_stats_fixed_N(
     n_T = length(T_grid)
     V_val = ustrip(u"Å^3", V)
 
+    allunique(observable_cols) || throw(ArgumentError(
+        "observable_cols must not contain duplicate entries"))
+    if !isempty(observable_cols)
+        if live_emax === nothing || live_observables === nothing
+            throw(ArgumentError(
+                "observable recording requires both live_emax and " *
+                "live_observables: the N = 0 and single-configuration sectors " *
+                "have no dead points, so their per-sector observable averages " *
+                "come from the live entries"))
+        end
+        if length(live_observables) != length(N_values)
+            throw(DimensionMismatch(
+                "live_observables must have one Dict per N sector " *
+                "(length(N_values) = $(length(N_values)))"))
+        end
+        for (i, d) in enumerate(live_observables)
+            Set(keys(d)) == Set(observable_cols) || throw(ArgumentError(
+                "live_observables[$i] keys must match observable_cols exactly"))
+            for col in observable_cols
+                v = d[col]
+                (v isa AbstractVector && all(x -> x isa Real, v)) || throw(ArgumentError(
+                    "live_observables[$i][:$col] must be a vector of Real values"))
+                isempty(v) && throw(ArgumentError(
+                    "live_observables[$i][:$col] is empty"))
+                if N_int[i] != 0 && length(v) != length(live_emax[i])
+                    throw(DimensionMismatch(
+                        "live_observables[$i][:$col] must have one entry per " *
+                        "live walker (length(live_emax[$i]) = " *
+                        "$(length(live_emax[i])))"))
+                end
+            end
+        end
+        for (i, dfi) in enumerate(ns_outputs)
+            (N_int[i] == 0 || nrow(dfi) == 0) && continue
+            for col in observable_cols
+                hasproperty(dfi, col) || throw(ArgumentError(
+                    "ns_outputs[$i] (N = $(N_int[i])) has no observable " *
+                    "column :$col"))
+                any(ismissing, dfi[!, col]) && throw(ArgumentError(
+                    "ns_outputs[$i] column :$col contains missing values"))
+            end
+        end
+    elseif live_observables !== nothing
+        throw(ArgumentError(
+            "live_observables was given but observable_cols is empty"))
+    end
+
+    # One global energy shift for all sector second moments (the cv()
+    # convention): variances and covariances are shift-invariant, and forming
+    # them on E - E_shift avoids the ~eps*E^2 one-pass cancellation floor.
+    # The N = 0 sector pins E = empty_energy into the spectrum, hence the min
+    # with empty_energy.
+    E_shift = empty_energy
+    for (i, dfi) in enumerate(ns_outputs)
+        N_int[i] == 0 && continue
+        nrow(dfi) > 0 && (E_shift = min(E_shift, minimum(dfi.emax)))
+        if live_emax !== nothing && !isempty(live_emax[i])
+            E_shift = min(E_shift, minimum(live_emax[i]))
+        end
+    end
+
     log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
+    mean_E2_N = Matrix{Float64}(undef, n_N, n_T)   # shifted: <(E - E_shift)^2>
+    obs_N = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_N, n_T) for col in observable_cols)
 
     for (i, df) in enumerate(ns_outputs)
         # The N = 0 sector is the empty configuration: no spatial integral, so
@@ -887,14 +988,30 @@ function gc_thermodynamic_stats_fixed_N(
                 log_Z_NS[i, j] = -empty_energy / (kb * ustrip(u"K", T))
             end
             mean_E_N[i, :] .= empty_energy
+            mean_E2_N[i, :] .= (empty_energy - E_shift)^2
+            for col in observable_cols
+                # Unlike its ignored live_emax entry, the N = 0 sector's
+                # live_observables entry is used: it supplies the observable
+                # value of the single empty configuration directly (averaged
+                # over the given values)
+                vals = live_observables[i][col]
+                obs_N[col][i, :] .= sum(Float64, vals) / length(vals)
+            end
             continue
         end
 
         live = live_emax === nothing ? nothing : live_emax[i]
-        log_Z_NS[i, :], mean_E_N[i, :] = _fixed_N_log_evidence(
+        live_obs = isempty(observable_cols) ? nothing : live_observables[i]
+        log_Z_NS[i, :], mean_E_N[i, :], sector_E2, sector_obs = _fixed_N_log_evidence(
             df, T_grid;
             n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
-            live_energies=live, kb=kb)
+            live_energies=live, kb=kb,
+            observable_cols=observable_cols, live_observables=live_obs,
+            energy_shift=E_shift)
+        mean_E2_N[i, :] = sector_E2
+        for col in observable_cols
+            obs_N[col][i, :] = sector_obs[col]
+        end
     end
 
     log_fact = [_log_factorial(N) for N in N_int]
@@ -903,11 +1020,20 @@ function gc_thermodynamic_stats_fixed_N(
     mean_N = Matrix{Float64}(undef, n_mu, n_T)
     var_N = Matrix{Float64}(undef, n_mu, n_T)
     mean_U = Matrix{Float64}(undef, n_mu, n_T)
+    logXi = Matrix{Float64}(undef, n_mu, n_T)
+    var_U = Matrix{Float64}(undef, n_mu, n_T)
+    cov_UN = Matrix{Float64}(undef, n_mu, n_T)
+    log_Z_N = Matrix{Float64}(undef, n_N, n_T)
+    obs_out = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
         Λ_val = ustrip(u"Å", _thermal_wavelength(atomic_mass, T))
         log_V_over_Λ3 = log(V_val) - 3 * log(Λ_val)
+        # Per-N log canonical partition functions at this temperature:
+        # log Z_N(T) = log Z_NS^{(N)}(β) + N·log(V/Λ³) − log N!, μ-independent
+        log_Z_N[:, j] = log_Z_NS[:, j] .+ N_int .* log_V_over_Λ3 .- log_fact
         for (k, μ) in enumerate(μ_grid)
             μ_val = ustrip(u"eV", μ)
             log_zV = β * μ_val + log_V_over_Λ3
@@ -918,14 +1044,28 @@ function gc_thermodynamic_stats_fixed_N(
             sum_w = sum(ws)
 
             Xi[k, j] = exp(max_log) * sum_w
+            logXi[k, j] = max_log + log(sum_w)
             mean_N[k, j] = sum(ws .* N_int) / sum_w
             mean_N2 = sum(ws .* (N_int .^ 2)) / sum_w
             var_N[k, j] = mean_N2 - mean_N[k, j]^2
-            mean_U[k, j] = sum(ws .* view(mean_E_N, :, j)) / sum_w
+            u_avg = sum(ws .* view(mean_E_N, :, j)) / sum_w
+            mean_U[k, j] = u_avg
+            # Law of total expectation over the N sectors, formed on shifted
+            # energies (mean_E2_N holds <(E - E_shift)^2>_N; variances and
+            # covariances are shift-invariant)
+            u_c = u_avg - E_shift
+            var_U[k, j] = sum(ws .* view(mean_E2_N, :, j)) / sum_w - u_c^2
+            cov_UN[k, j] = sum(ws .* N_int .* (view(mean_E_N, :, j) .- E_shift)) / sum_w -
+                           u_c * mean_N[k, j]
+            for col in observable_cols
+                obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
+            end
         end
     end
 
-    return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
+    return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
+            logXi=logXi, var_U=var_U, cov_UN=cov_UN,
+            log_Z_N=log_Z_N, N_values=N_int, observables=obs_out)
 end
 
 """
@@ -1024,9 +1164,9 @@ A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values, var_U,
 cov_UN, observables)`. The first
 four fields are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))`
 indexed `[i_μ, i_T]`. `logXi` is the natural log of the absolute grand
-partition function — returned in log space (unlike the atomistic method's
-`Xi`) because the binomial prior mass grows like `2^M` and `Ξ` overflows
-`Float64` for modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
+partition function — returned in log space (the atomistic method returns
+linear-space `Xi` alongside the same `logXi`) because the binomial prior mass
+grows like `2^M` and `Ξ` overflows `Float64` for modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
 and `mean_U` is `⟨E⟩` (grand-canonical, in eV). `log_Z_N` is the
 `(length(N_values), length(T_grid))` matrix of log canonical
 partition-function slices `log[C(M,N) · Z_NS^{(N)}(β)]` — the per-`N`

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -369,16 +369,18 @@ end
             # unshifted-first-moment floor (u_avg accumulates ~|E|·eps of
             # absolute error before the E_shift subtraction; the lattice
             # method shares the structure): measured ≤ 1.5e-8 relative here,
-            # against ~2e-5 with the cancellation guard disabled. The offset
-            # variant therefore gates them at 1e-7; everything else holds
-            # 1e-10.
-            rtol_uu = base == 0.0 ? 1e-10 : 1e-7
+            # against ≈5e-6 with the cancellation guard disabled — the guard
+            # stays load-bearing even at the relaxed gate. The offset variant
+            # therefore gates var_U/cov_UN at 3e-7 and mean_N/var_N at 1e-9;
+            # everything else holds 1e-10.
+            rtol_uu = base == 0.0 ? 1e-10 : 3e-7
+            rtol_nn = base == 0.0 ? 1e-10 : 1e-9
             for (k, μ) in enumerate(μ_grid), (j, T) in enumerate(T_grid)
                 ref = brute_reference(ns_outputs, live_all, N_values, E0,
                                       Symbol[], nothing, μ, T)
                 @test isapprox(out.logXi[k, j], ref.logXi, rtol=1e-10)
-                @test isapprox(out.mean_N[k, j], ref.mean_N, rtol=1e-10)
-                @test isapprox(out.var_N[k, j], ref.var_N, rtol=1e-10)
+                @test isapprox(out.mean_N[k, j], ref.mean_N, rtol=rtol_nn)
+                @test isapprox(out.var_N[k, j], ref.var_N, rtol=rtol_nn)
                 @test isapprox(out.mean_U[k, j], ref.mean_U, rtol=1e-10)
                 @test isapprox(out.var_U[k, j], ref.var_U, rtol=rtol_uu)
                 @test isapprox(out.cov_UN[k, j], ref.cov_UN, rtol=rtol_uu)
@@ -439,7 +441,7 @@ end
             if N == 0
                 ns_outputs[i] = empty_df()
                 live_all[i] = Float64[]
-                live_obs[i] = Dict(:A => [7.5], :B => [0.0])
+                live_obs[i] = Dict(:A => [7.0, 8.0], :B => [0.0])
                 continue
             end
             Es = ladder(0.0, N)

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -278,6 +278,279 @@
 end
 
 
+@testset "Atomistic GC-NS, fixed-N parity fields" begin
+    # Deterministic synthetic ladders — no NS runs. Every closure is gated
+    # against an independent reference: direct sample-level reweighting of the
+    # raw ledger weights accumulated in BigFloat (no energy shift needed at
+    # that precision), a different decomposition than the library's
+    # law-of-total-expectation assembly.
+    K = 64
+    n_iters = 400
+    ω0_test = (K + 1) / K
+    N_values = collect(0:4)
+
+    V = 1000.0u"Å^3"
+    m = 40.0u"u"
+    T_grid = [200.0u"K", 350.0u"K"]
+    kb = 8.617333262e-5
+    βs = [1.0 / (kb * ustrip(u"K", T)) for T in T_grid]
+    Λs = [ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T)) for T in T_grid]
+    V_val = ustrip(u"Å^3", V)
+    μ_for_zV(zV_target) = (log(zV_target * Λs[1]^3 / V_val) / βs[1]) * u"eV"
+    μ_grid = [μ_for_zV(0.3), μ_for_zV(1.0)]
+    empty_df() = DataFrame(iter=Int[], emax=Float64[])
+    r = K / (K + 1)
+
+    ladder(base, N) = base + N * (-0.02) .+ 0.05 .* (1.0 .- collect(1:n_iters) ./ n_iters)
+    floor_of(base, N) = base + N * (-0.02)
+
+    function brute_reference(ns_outs, live_all, N_vals, empty_E, obs_cols,
+                             live_obs, μ, T)
+        β = 1.0 / (kb * ustrip(u"K", T))
+        Λ = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+        log_zV = β * ustrip(u"eV", μ) + log(V_val) - 3 * log(Λ)
+        S0 = BigFloat(0); SN = BigFloat(0); SN2 = BigFloat(0)
+        SE = BigFloat(0); SE2 = BigFloat(0); SEN = BigFloat(0)
+        SA = Dict(col => BigFloat(0) for col in obs_cols)
+        function add!(E, lw, N, avals)
+            w = exp(BigFloat(lw) - BigFloat(β) * BigFloat(E) +
+                    N * BigFloat(log_zV) - log(BigFloat(factorial(N))))
+            S0 += w; SN += w * N; SN2 += w * N^2
+            SE += w * E; SE2 += w * E^2; SEN += w * E * N
+            for col in obs_cols
+                SA[col] += w * avals[col]
+            end
+            return nothing
+        end
+        for (i, N) in enumerate(N_vals)
+            if N == 0
+                a0 = Dict(col => sum(Float64, live_obs[i][col]) / length(live_obs[i][col])
+                          for col in obs_cols)
+                add!(empty_E, 0.0, 0, a0)
+                continue
+            end
+            df = ns_outs[i]
+            for row in 1:nrow(df)
+                lw = log(ω0_test) + log(1 / (K + 1)) + df.iter[row] * log(r)
+                arow = Dict(col => Float64(df[row, col]) for col in obs_cols)
+                add!(df.emax[row], lw, N, arow)
+            end
+            n_it = maximum(df.iter)
+            lw_tail = log(ω0_test) + n_it * log(r) - log(K)
+            for (s, E) in enumerate(live_all[i])
+                atail = Dict(col => Float64(live_obs === nothing ? 0.0 :
+                                            live_obs[i][col][s]) for col in obs_cols)
+                add!(E, lw_tail, N, atail)
+            end
+        end
+        mN = SN / S0; mE = SE / S0
+        return (logXi=Float64(log(S0)), mean_N=Float64(mN),
+                var_N=Float64(SN2 / S0 - mN^2), mean_U=Float64(mE),
+                var_U=Float64(SE2 / S0 - mE^2),
+                cov_UN=Float64(SEN / S0 - mE * mN),
+                obs=Dict(col => Float64(SA[col] / S0) for col in obs_cols))
+    end
+
+    @testset "brute-force closure, ordinary and offset ladders" begin
+        # Variant (a): energies of ordinary magnitude, default empty_energy.
+        # Variant (b): every energy carries a -1000 eV offset with
+        # empty_energy to match — the E_shift cancellation guard is the only
+        # thing keeping var_U/cov_UN at rtol 1e-10 there.
+        for (base, E0) in ((0.0, 0.0), (-1000.0, -1000.0))
+            ns_outputs = [N == 0 ? empty_df() :
+                          DataFrame(iter=collect(1:n_iters), emax=ladder(base, N))
+                          for N in N_values]
+            live_all = [N == 0 ? Float64[] : fill(floor_of(base, N), K)
+                        for N in N_values]
+            out = gc_thermodynamic_stats_fixed_N(
+                ns_outputs, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=E0)
+            # var_U/cov_UN at the 10³ eV offset sit on the assembly's
+            # unshifted-first-moment floor (u_avg accumulates ~|E|·eps of
+            # absolute error before the E_shift subtraction; the lattice
+            # method shares the structure): measured ≤ 1.5e-8 relative here,
+            # against ~2e-5 with the cancellation guard disabled. The offset
+            # variant therefore gates them at 1e-7; everything else holds
+            # 1e-10.
+            rtol_uu = base == 0.0 ? 1e-10 : 1e-7
+            for (k, μ) in enumerate(μ_grid), (j, T) in enumerate(T_grid)
+                ref = brute_reference(ns_outputs, live_all, N_values, E0,
+                                      Symbol[], nothing, μ, T)
+                @test isapprox(out.logXi[k, j], ref.logXi, rtol=1e-10)
+                @test isapprox(out.mean_N[k, j], ref.mean_N, rtol=1e-10)
+                @test isapprox(out.var_N[k, j], ref.var_N, rtol=1e-10)
+                @test isapprox(out.mean_U[k, j], ref.mean_U, rtol=1e-10)
+                @test isapprox(out.var_U[k, j], ref.var_U, rtol=rtol_uu)
+                @test isapprox(out.cov_UN[k, j], ref.cov_UN, rtol=rtol_uu)
+            end
+        end
+    end
+
+    @testset "overflow: logXi finite where Xi is Inf" begin
+        ns_outputs = [N == 0 ? empty_df() :
+                      DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for N in N_values]
+        live_all = [N == 0 ? Float64[] : zeros(K) for N in N_values]
+        μ_deep = [μ_for_zV(exp(180.0))]
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_deep, T_grid[1:1];
+            n_walkers=K, ω0=ω0_test, live_emax=live_all)
+        @test out.Xi[1, 1] == Inf
+        ref = brute_reference(ns_outputs, live_all, N_values, 0.0,
+                              Symbol[], nothing, μ_deep[1], T_grid[1])
+        @test isapprox(out.logXi[1, 1], ref.logXi, rtol=1e-12)
+    end
+
+    @testset "P(N | μ, T) recipe from log_Z_N" begin
+        # E ≡ 0 ladders: the truncated weights are (zV)^N/N! · M with the
+        # prior mass M = Σᵢ ωᵢ + tail, and M = 1 for the empty sector.
+        ns_outputs = [N == 0 ? empty_df() :
+                      DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for N in N_values]
+        live_all = [N == 0 ? Float64[] : zeros(K) for N in N_values]
+        M_dead = sum(ω0_test * (1 / (K + 1)) * r^i for i in 1:n_iters)
+        M_tail = ω0_test * r^n_iters
+        M = M_dead + M_tail
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all)
+        @test out.N_values == N_values
+        @test size(out.log_Z_N) == (length(N_values), length(T_grid))
+        for (k, μ) in enumerate(μ_grid), (j, T) in enumerate(T_grid)
+            β = βs[j]
+            logP = out.log_Z_N[:, j] .+ β .* ustrip(u"eV", μ) .* out.N_values
+            P = exp.(logP .- maximum(logP))
+            P ./= sum(P)
+            zV = exp(β * ustrip(u"eV", μ)) * V_val / Λs[j]^3
+            w_ref = [N == 0 ? 1.0 : zV^N / factorial(N) * M for N in N_values]
+            @test isapprox(P, w_ref ./ sum(w_ref), rtol=1e-12)
+            @test isapprox(sum(P .* out.N_values), out.mean_N[k, j], rtol=1e-12)
+            @test isapprox(sum(P .* out.N_values .^ 2) - sum(P .* out.N_values)^2,
+                           out.var_N[k, j], rtol=1e-12)
+        end
+    end
+
+    @testset "observables passthrough" begin
+        obs_cols = [:A, :B]
+        ns_outputs = Vector{DataFrame}(undef, length(N_values))
+        live_all = Vector{Vector{Float64}}(undef, length(N_values))
+        live_obs = Vector{Dict{Symbol,Vector{Float64}}}(undef, length(N_values))
+        for (i, N) in enumerate(N_values)
+            if N == 0
+                ns_outputs[i] = empty_df()
+                live_all[i] = Float64[]
+                live_obs[i] = Dict(:A => [7.5], :B => [0.0])
+                continue
+            end
+            Es = ladder(0.0, N)
+            ns_outputs[i] = DataFrame(iter=collect(1:n_iters), emax=Es,
+                                      A=2.0 .* Es .+ 1.0, B=fill(Float64(N), n_iters))
+            live_all[i] = fill(floor_of(0.0, N), K)
+            live_obs[i] = Dict(:A => 2.0 .* live_all[i] .+ 1.0,
+                               :B => fill(Float64(N), K))
+        end
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all,
+            observable_cols=obs_cols, live_observables=live_obs)
+        for (k, μ) in enumerate(μ_grid), (j, T) in enumerate(T_grid)
+            ref = brute_reference(ns_outputs, live_all, N_values, 0.0,
+                                  obs_cols, live_obs, μ, T)
+            @test isapprox(out.observables[:A][k, j], ref.obs[:A], rtol=1e-10)
+            @test isapprox(out.observables[:B][k, j], ref.obs[:B], rtol=1e-10)
+            # B ≡ N per sector, except the empty sector's declared 0.0 — the
+            # grand average must therefore reproduce ⟨N⟩ exactly.
+            @test isapprox(out.observables[:B][k, j], out.mean_N[k, j], rtol=1e-12)
+        end
+        # Guards, mirroring the lattice method's validation.
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all, live_observables=live_obs)
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, observable_cols=obs_cols)
+        bad_obs = [Dict(:A => d[:A]) for d in live_obs]
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all,
+            observable_cols=obs_cols, live_observables=bad_obs)
+    end
+
+    @testset "cross-method pin on the coinciding two-sector ladder" begin
+        # N_values = [0, 1] with E ≡ 0 is the one ladder where the atomistic
+        # (zV/Λ³)^N/N! and lattice C(M,N)·e^{βμN} priors coincide exactly
+        # under zV = M·e^{βμ_lat}.
+        M_sites = 8
+        N2 = [0, 1]
+        ns2 = [empty_df(), DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))]
+        live2 = [Float64[], zeros(K)]
+        T1 = T_grid[1:1]
+        μ_lat = [-0.05u"eV"]
+        μ_atom = [μ_lat[1] + (log(M_sites * Λs[1]^3 / V_val) / βs[1]) * u"eV"]
+        out_lat = gc_thermodynamic_stats_fixed_N(
+            ns2, N2, M_sites, μ_lat, T1;
+            n_walkers=K, ω0=ω0_test, live_emax=live2)
+        out_atom = gc_thermodynamic_stats_fixed_N(
+            ns2, N2, V, m, μ_atom, T1;
+            n_walkers=K, ω0=ω0_test, live_emax=live2)
+        @test abs(out_atom.mean_N[1, 1] - out_lat.mean_N[1, 1]) <= 1e-12
+        @test abs(out_atom.var_N[1, 1] - out_lat.var_N[1, 1]) <= 1e-12
+        @test isapprox(out_atom.logXi[1, 1], out_lat.logXi[1, 1], rtol=1e-12)
+    end
+
+    @testset "leading positions and legacy expressions" begin
+        ns_outputs = [N == 0 ? empty_df() :
+                      DataFrame(iter=collect(1:n_iters), emax=ladder(0.0, N))
+                      for N in N_values]
+        live_all = [N == 0 ? Float64[] : fill(floor_of(0.0, N), K)
+                    for N in N_values]
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all)
+        @test propertynames(out) == (:Xi, :mean_N, :var_N, :mean_U, :logXi,
+                                     :var_U, :cov_UN, :log_Z_N, :N_values,
+                                     :observables)
+        @test out[1] === out.Xi && out[2] === out.mean_N &&
+              out[3] === out.var_N && out[4] === out.mean_U
+        @test isempty(out.observables)
+        # The four legacy fields must be bit-identical to the pre-extension
+        # assembly, replicated here expression for expression.
+        n = length(N_values)
+        log_Z_NS = Matrix{Float64}(undef, n, length(T_grid))
+        mean_E_N = Matrix{Float64}(undef, n, length(T_grid))
+        for (i, N) in enumerate(N_values)
+            if N == 0
+                log_Z_NS[i, :] .= 0.0
+                mean_E_N[i, :] .= 0.0
+                continue
+            end
+            log_Z_NS[i, :], mean_E_N[i, :] = FreeBird.AnalysisTools._fixed_N_log_evidence(
+                ns_outputs[i], T_grid;
+                n_walkers=K, n_cull=1, ω0=ω0_test,
+                live_energies=live_all[i], kb=kb)
+        end
+        log_fact = [FreeBird.AnalysisTools._log_factorial(N) for N in N_values]
+        for (j, T) in enumerate(T_grid)
+            β = 1.0 / (kb * ustrip(u"K", T))
+            Λ_val = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+            log_V_over_Λ3 = log(V_val) - 3 * log(Λ_val)
+            for (k, μ) in enumerate(μ_grid)
+                log_zV = β * ustrip(u"eV", μ) + log_V_over_Λ3
+                log_w = log_Z_NS[:, j] .+ N_values .* log_zV .- log_fact
+                max_log = maximum(log_w)
+                ws = exp.(log_w .- max_log)
+                sum_w = sum(ws)
+                @test out.Xi[k, j] === exp(max_log) * sum_w
+                @test out.mean_N[k, j] === sum(ws .* N_values) / sum_w
+                mean_N2 = sum(ws .* (N_values .^ 2)) / sum_w
+                @test out.var_N[k, j] === mean_N2 - (sum(ws .* N_values) / sum_w)^2
+                @test out.mean_U[k, j] === sum(ws .* view(mean_E_N, :, j)) / sum_w
+            end
+        end
+    end
+end
+
+
 @testset "Atomistic GC-NS, fixed-N construction (3D LJ fluid)" begin
     using Random
 


### PR DESCRIPTION
Implements #173. Extends the atomistic (V-based) method of `gc_thermodynamic_stats_fixed_N` to return `(Xi, mean_N, var_N, mean_U, logXi, var_U, cov_UN, log_Z_N, N_values, observables)` — the full field set of the lattice-gas method, with the four existing fields keeping their leading positions so positional destructuring of the current return is unaffected and the extension is strictly additive.

## Implementation

- `logXi` comes from the log-sum-exp pass the assembly already performs; `Xi` keeps its exact pre-extension expression, so it remains available (and remains `Inf` once ln Ξ exceeds ≈ 709, where `logXi` stays finite).
- `var_U` and `cov_UN` are assembled by the lattice method's shifted law of total expectation, transplanted expression for expression (global `E_shift`, sector second moments from the shared helper's previously discarded returns, shift-invariant assembly) with the ideal-gas activity in place of the binomial prior. The `E_shift` bookkeeping composes with the `empty_energy` keyword from #176: the empty sector pins `empty_energy` into the spectrum and contributes its shifted second moment `(empty_energy − E_shift)²`.
- The docstring states the fixed-μ configurational heat-capacity identity for this method, `C_config = k_B β² (var_U − μ · cov_UN) + (3/2) k_B β · cov_UN` — the extra term carries the `Λ(T)³ᴺ` temperature dependence of the atomistic activity and is absent from the lattice method's identity, a distinction caught by the adversarial pass and verified by finite differences; kinetic contributions must be added separately for the total-energy heat capacity. A precision note records that `var_U`/`cov_UN` carry roughly machine epsilon times their natural scales, absolute rather than relative near zero crossings.
- `log_Z_N` is the `(length(N_values), length(T_grid))` matrix of per-N log canonical partition functions `log Z_NS^(N)(β) + N·log(V/Λ³) − log N!`, μ-independent, with `N_values` echoing the counts; `P(N | μ, T)` follows as the documented softmax recipe rather than a returned field, matching the lattice method. No Kish N<sub>eff</sub> is returned — the fixed-N route introduces no importance reweighting, and the docstring says so to close the question.
- `observable_cols`/`live_observables` passthrough mirrors the lattice method verbatim, including its validation block and the N = 0 convention that the empty sector's observable value comes from its `live_observables` entry (averaged over the given values).
- The lattice method's docstring contrast ("unlike the atomistic method's `Xi`") is updated now that both methods return `logXi`.

## Tests

One new testset of deterministic synthetic ladders (no NS runs), 101 assertions, every closure gated against an independent reference: direct sample-level reweighting of the raw ledger weights accumulated in BigFloat — a different decomposition than the library's law-of-total-expectation assembly.

- Brute-force closure, ordinary and offset ladders: `logXi`, `mean_N`, `var_N`, `mean_U`, `var_U`, `cov_UN` over a 2×2 (μ, T) grid at rtol 10<sup>−10</sup>, in two variants — ordinary magnitudes, and every energy carrying a −1000 eV offset with `empty_energy` to match. One stated deviation from the issue's test plan: in the offset variant, `var_U`/`cov_UN` are gated at 3×10<sup>−7</sup> (and `mean_N`/`var_N` at 10<sup>−9</sup>) rather than 10<sup>−10</sup>, against a measured structural floor of 1.48×10<sup>−8</sup> — the sector first moments accumulate ~|E|·eps of absolute error before the `E_shift` subtraction, a limit shared with the lattice method whose assembly the issue mandated transplanting. The floor is documented in a test comment together with the guard-disabled counterfactual (≈5×10<sup>−6</sup>, measured by re-running the assembly with the shift forced to zero), so the cancellation guard is provably load-bearing even at the relaxed gate.
- Overflow: at ln Ξ ≈ 720, `Xi == Inf` while `logXi` matches the BigFloat reference at rtol 10<sup>−12</sup>.
- P(N | μ, T) recipe: the softmax over `log_Z_N` reproduces the analytically warped truncated Poisson at rtol 10<sup>−12</sup> (prior mass Σωᵢ + tail reconstructed term for term; empty-sector mass exactly 1), and its moments reproduce the returned `mean_N`/`var_N`.
- Observables passthrough: two columns (one energy-correlated, one equal to N per sector) closed against the BigFloat reference at rtol 10<sup>−10</sup>; the N-valued column reproduces `mean_N` at 10<sup>−12</sup>, exercising the N = 0 declared-value convention with a two-entry averaged live vector; three validation guards.
- Cross-method pin on the one ladder where the two priors coincide exactly: a two-sector E ≡ 0 ladder with `zV/Λ³ = M·e^{βμ}` — ⟨N⟩ and Var N agree between the atomistic and lattice methods to 10<sup>−12</sup> absolute, and `logXi` to rtol 10<sup>−12</sup>.
- Leading positions and legacy expressions: the full property-name tuple, positional identity of the four legacy fields, and bit-level (`===`) equality of `Xi`, `mean_N`, `var_N`, and `mean_U` against the pre-extension assembly replicated expression for expression in-test.

An adversarial verification pass ran as three independent reviewers with disjoint charters before filing. The round-trip reviewer checked every Proposed-API bullet and test-plan item against the diff, reproduced the offset-variant floor digit-for-digit (1.4759×10<sup>−8</sup>), and caught the two must-fixes applied before filing: the guard-disabled counterfactual in the test comment restated at its reproducible value, and the tolerance relaxation disclosed here. The physics oracle re-derived the law-of-total-expectation assembly and its shift invariance, verified the sector-permutation independence and the `log_Z_N` convention on non-trivial ladders, measured every gate margin (all ≥ 12.5× after the margin hardening it requested), and caught the heat-capacity identity error — the lattice identity transplanted to the atomistic docstring silently dropped the thermal-wavelength term, confirmed by central finite differences and corrected. The determinism reviewer verified the four legacy fields raw-UInt64 bit-identical to the base commit across ladder shapes including nonzero `empty_energy` compositions, swept kwarg interactions (observables with `empty_energy`, unsorted `N_values` bit-identical under sector permutation), and reconciled the 101-assertion delta against the testset loop arithmetic exactly.

Full test suite passes (SamplingSchemes 7165, AbstractWalkers 339, AbstractHamiltonians 80, AbstractLiveSets 111, AbstractPotentials 106, AnalysisTools 61, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 114 and 3807, FreeBirdIO 51).
