### PR TITLE
Add the single-site-basis guard to the square-lattice geometric cluster move

### DIFF
--- a/src/MonteCarloMoves/cluster_moves.jl
+++ b/src/MonteCarloMoves/cluster_moves.jl
@@ -28,12 +28,19 @@ The parameter `p` controls the average cluster size: `p ≈ 0` gives single-site
   restores the original configuration.
 - Supports 2D (`supercell_dimensions[3] == 1`) and 3D lattices. In 3D, the reflection
   operates in the periodic xy-plane; the z-coordinate is preserved.
+- Requires the single-site basis (the site-index reflection assumes single-basis,
+  x-fastest ordering); a multi-site basis throws an `ArgumentError`.
 
 # References
 - Heringa & Blöte, Phys. Rev. E 57, 4976 (1998) — geometric cluster MC framework.
 - Adaptation uses fixed growth probability (configuration-independent) for symmetric proposals.
 """
 function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64) where C
+    if length(lattice.basis) != 1
+        throw(ArgumentError("geometric_cluster_swap! on a square lattice " *
+            "requires the single-site basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
     Lx = lattice.supercell_dimensions[1]
     Ly = lattice.supercell_dimensions[2]
     Lz = lattice.supercell_dimensions[3]

--- a/test/test-lattice-random-walks.jl
+++ b/test/test-lattice-random-walks.jl
@@ -228,6 +228,62 @@
             @test changed
         end
 
+        @testset "multi-site basis guard" begin
+            using Random
+            # The keyword constructor admits an arbitrary basis, so the
+            # index-space reflection's single-basis contract gets the same
+            # loud guard the triangular method has. (Basis offset and cutoff
+            # chosen so the intra-basis shell is unambiguous — a warning-free
+            # construction.)
+            two_site = MLattice{1,SquareLattice}(
+                basis=[(0.0, 0.0, 0.0), (0.25, 0.25, 0.0)],
+                supercell_dimensions=(4, 4, 1),
+                cutoff_radii=[0.5],
+                components=[[1, 2, 3]]
+            )
+            @test_throws ArgumentError geometric_cluster_swap!(two_site, 0.3)
+
+            # The guard consumes no randomness: a guarded throw leaves the
+            # global RNG stream untouched.
+            Random.seed!(7)
+            probe = rand(UInt64)
+            Random.seed!(7)
+            try
+                geometric_cluster_swap!(two_site, 0.3)
+            catch
+            end
+            @test rand(UInt64) === probe
+
+            # On a single-site-basis lattice the guarded method's same-seed
+            # trajectory is identical to the pre-guard body, replicated here
+            # through the same internal helpers.
+            sl = SLattice{SquareLattice}(
+                supercell_dimensions=(8, 8, 1),
+                components=[[1, 2, 3, 10, 15, 20, 30, 40, 50, 60]]
+            )
+            replica = deepcopy(sl)
+            Random.seed!(4242)
+            for _ in 1:25
+                geometric_cluster_swap!(sl, 0.3)
+            end
+            Random.seed!(4242)
+            for _ in 1:25
+                Lx, Ly, Lz = replica.supercell_dimensions
+                pivot_gx = rand(0:Lx-1)
+                pivot_gy = rand(0:Ly-1)
+                seed_site = rand(1:num_sites(replica))
+                reflect = s -> MonteCarloMoves._reflect_site(s, pivot_gx, pivot_gy, Lx, Ly, Lz)
+                cluster = MonteCarloMoves._build_geometric_cluster(replica, seed_site, reflect, 0.3)
+                for (a, b) in cluster
+                    if a != b
+                        replica.components[1][a], replica.components[1][b] =
+                            replica.components[1][b], replica.components[1][a]
+                    end
+                end
+            end
+            @test sl.components == replica.components
+        end
+
         # ---- triangular lattice (two-site centered-rectangular basis) ----
 
         @testset "triangular reflection: half-grid round-trip" begin


### PR DESCRIPTION
Implements #174. Adds the single-site-basis guard to `geometric_cluster_swap!` for `MLattice{C,SquareLattice}`: an `ArgumentError` at method entry when `length(lattice.basis) != 1`, with wording mirroring the triangular sibling's guard, plus one docstring sentence stating the requirement. A square-tagged lattice with a multi-site basis previously reached the index-space reflection arithmetic silently, where the swap pairs are no longer point-inversion images of the physical lattice; it now fails loudly, matching the triangular method's behavior. No supercell guard is added — the square method's z-preserving three-dimensional behavior is documented and exercised, and stays as it was.

## Implementation

- The guard sits before the first RNG draw and before any mutation, so a guarded throw leaves both the lattice and the global RNG stream untouched.
- The guard fires on every square-tag route to the reflection arithmetic — the direct call and both sampler entry points — for arbitrary component count `C`.
- Actual size: 7 src lines (5-line guard + a 2-line docstring bullet) and 56 test lines, against the issue's ≈ 5 + 25 estimate; the overshoot is the trajectory-identity fixture.

## Tests

One new testset in the cluster-move test file, three assertions.

- Throw: a two-site-basis square-tagged lattice (built through the keyword constructor's `basis` keyword, with the basis offset and cutoff chosen so the construction is warning-free) raises the `ArgumentError`. The identical call is accepted silently on the base commit, so the throw is guard-attributable.
- RNG-stream neutrality: a seeded probe shows a guarded throw consumes no randomness — the next draw after the throw equals the draw at the same stream position without it.
- Same-seed trajectory identity: on a single-site-basis lattice, 25 seeded moves through the guarded method reproduce, occupation for occupation, the pre-guard body replicated in-test through the same internal helpers. The issue phrased this item as byte-identity to the pre-change method; the committed test delivers the in-test replication form, and the literal dev comparison was closed in review — a worktree A/B at the base commit found trajectories and RNG tails byte-identical across the 2D, 3D z-preserving, and two-component cases, including the shipped test's exact seed and cell.
- The existing cluster-move testsets pass unchanged (3810 = 3807 + 3 in the file's summary).

An adversarial verification pass ran as three independent reviewers with disjoint charters before filing. The round-trip reviewer checked each issue promise against the diff, verified the guard-message mirroring side by side with the triangular wording, confirmed the throw is guard-attributable by probing the identical call on the base commit, and set the drafting constraint above for the trajectory-identity bullet. The semantics reviewer proved the throw leaves lattice and RNG untouched, audited every caller of the reflection helpers to confirm no unguarded square-tag route remains, and swept multi-component cases. The determinism reviewer ran same-seed dev-versus-branch trajectories over 6,480 moves across cell shapes, seeds, and growth probabilities with an empty diff, confirmed bit-identical RNG states across 54 cells, and reconciled the three-assertion delta. Zero must-fix findings against the code across all three charters.

Full test suite passes (SamplingSchemes 7165, AbstractWalkers 339, AbstractHamiltonians 80, AbstractLiveSets 111, AbstractPotentials 106, AnalysisTools 61, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 114 and 3810, FreeBirdIO 51).
