### PR TITLE
Rectangular-adlattice and fixed-N assembly regression coverage: anisotropic in-plane recipe, Langmuir and ideal-adsorbate closures, observables passthrough

### DIFF
--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -1130,3 +1130,440 @@ end
         @test out.mean_N[2, 1] > out.mean_N[1, 1]
     end
 end
+
+
+@testset "Atomistic GC-NS, fixed-N ideal-adsorbate closure (LJ fcc(100) slab)" begin
+    using Random
+
+    # ===== Substrate: fcc(100) slab, all frozen ==========================
+    # 3×3 in-plane square supercell with side 3·2^(1/6)·σ (the LJ-minimum
+    # spacing), 3 layers in ABA stacking with the fcc(100) interlayer
+    # spacing a/√2, box height 25 Å, fully periodic. Adsorbate-adsorbate
+    # interactions are switched OFF (ε_aa = 0 in the composite parameter
+    # set), so each adsorbate sees only the frozen slab field U_s(r): an
+    # ideal gas in an external field, exactly solvable by quadrature. This
+    # makes the block the one end-to-end surface fixture that closes
+    # against exact references rather than shape and monotonicity checks
+    # alone.
+    σ_val = 2.5
+    ε_val = 0.01
+    a = 2^(1/6) * σ_val
+    Lx = 3.0 * a
+    Ly = 3.0 * a
+    Lz = 25.0
+    dz_layer = a / sqrt(2.0)
+    z_base = 4.0
+
+    slab_positions = Pair{Symbol,Vector{Float64}}[]
+    for l in 0:2
+        off = (l % 2 == 0) ? 0.0 : 0.5
+        z = z_base + l * dz_layer
+        for i in 0:2, j in 0:2
+            push!(slab_positions, :Ar => [(i + off) / 3.0, (j + off) / 3.0, z / Lz])
+        end
+    end
+
+    box = [[Lx * u"Å", 0u"Å", 0u"Å"],
+           [0u"Å", Ly * u"Å", 0u"Å"],
+           [0u"Å", 0u"Å", Lz * u"Å"]]
+    V_box = (Lx * Ly * Lz) * u"Å^3"
+    mass = 40.0u"u"
+
+    lj = LJParameters(epsilon=ε_val, sigma=σ_val, cutoff=3.0, shift=true)
+    # [aa, as, ss] upper-triangle order: the aa channel gets ε = 0.
+    lj_zero = LJParameters(epsilon=0.0, sigma=σ_val, cutoff=3.0, shift=true)
+    ljs = CompositeParameterSets(2, [lj_zero, lj, lj])
+
+    substrate_sys = FastSystem(periodic_system(slab_positions, box, fractional=true))
+    surface = AtomWalker(substrate_sys; freeze_species=[:Ar])
+    surface.energy_frozen_part = interacting_energy(surface.configuration, lj)
+    E_slab = ustrip(u"eV", surface.energy_frozen_part)
+
+    T_val = 200.0u"K"
+    T_grid = [T_val]
+    kb = 8.617333262e-5
+    β = 1.0 / (kb * ustrip(u"K", T_val))
+
+    # ===== Quadrature reference ==========================================
+    # Midpoint rule over the box for the per-particle field integrals
+    # I = ∫ e^{−βU_s} d³r, I_u = ∫ U_s e^{−βU_s} d³r, I_u2 = ∫ U_s² e^{−βU_s} d³r,
+    # plus the prior-retention fraction m₁ = |{r : U_s(r) < E_thresh}| / V
+    # (see the walker-init note below). The pair kernel replicates the
+    # shifted, 3σ-truncated lj_energy exactly; U is clamped at 50 eV, where
+    # e^{−βU} is already 0, so the U²e^{−βU} accumuland stays finite inside
+    # the hard cores. Grid (32, 32, 96) is the smallest rung of the halving
+    # ladder (16, 16, 48) → (32, 32, 96) whose refinement step changes I by
+    # < 1e-3 relative (measured: 2.3×10⁻⁵ on I and < 1e-3 on both U-moments
+    # against (40, 40, 120)); the coarser rung (16, 16, 48) still moves the
+    # U-moments by several ×10⁻³.
+    slab_xyz = Matrix{Float64}(undef, 3, length(substrate_sys))
+    for i in 1:length(substrate_sys)
+        slab_xyz[:, i] .= ustrip.(u"Å", position(substrate_sys, i))
+    end
+
+    function _slab_field_moments(slab_xyz::Matrix{Float64}, Lx, Ly, Lz, σ, ε, β,
+                                 nx::Int, ny::Int, nz::Int, E_thresh::Float64)
+        rc = 3.0 * σ
+        shift_e = 4.0 * ε * ((σ / rc)^12 - (σ / rc)^6)
+        mind(d, L) = min(abs(d), L - abs(d))
+        npos = size(slab_xyz, 2)
+        hx, hy, hz = Lx / nx, Ly / ny, Lz / nz
+        dV = hx * hy * hz
+        I = 0.0; Iu = 0.0; Iu2 = 0.0; n_below = 0
+        for iz in 1:nz
+            z = (iz - 0.5) * hz
+            for ix in 1:nx
+                x = (ix - 0.5) * hx
+                for iy in 1:ny
+                    y = (iy - 0.5) * hy
+                    U = 0.0
+                    @inbounds for s in 1:npos
+                        dx = mind(x - slab_xyz[1, s], Lx)
+                        dy = mind(y - slab_xyz[2, s], Ly)
+                        dz = mind(z - slab_xyz[3, s], Lz)
+                        r = sqrt(dx * dx + dy * dy + dz * dz)
+                        if r <= rc
+                            sr6 = (σ / r)^6
+                            U += 4.0 * ε * (sr6 * sr6 - sr6) - shift_e
+                        end
+                    end
+                    U < E_thresh && (n_below += 1)
+                    Uc = U > 50.0 ? 50.0 : U
+                    e = exp(-β * Uc)
+                    I += e
+                    Iu += Uc * e
+                    Iu2 += Uc * Uc * e
+                end
+            end
+        end
+        return I * dV, Iu * dV, Iu2 * dV, n_below / (nx * ny * nz)
+    end
+
+    E_init_thresh = 1.0e9
+    I_ref, Iu, Iu2, m1 = _slab_field_moments(slab_xyz, Lx, Ly, Lz, σ_val, ε_val, β,
+                                             32, 32, 96, E_init_thresh)
+    ubar = Iu / I_ref          # per-particle ⟨U_s⟩ under e^{−βU_s}/I
+    sig_u2 = Iu2 / I_ref - ubar^2
+    Λ = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass, T_val))
+    kT = kb * ustrip(u"K", T_val)
+    # μ placed so the occupancy parameter q = e^{βμ}·I/Λ³ — the Poisson
+    # rate of the untruncated ideal-adsorbate grand ensemble — lands at
+    # 0.5 (dilute) and 1.0; both fall near −0.22 eV here.
+    μ_grid = [kT * log(0.5 * Λ^3 / I_ref), kT * log(1.0 * Λ^3 / I_ref)] .* u"eV"
+
+    # ===== Canonical NS ladders, N = 1..4 ================================
+    # Walker-init rejection threshold: 1e9 eV, deliberately NOT the 100 eV
+    # used by the LJ(111) block above. Rejecting E_ads ≥ 100 eV draws
+    # truncates the uniform prior by a per-particle fraction worth ≈ 0.153
+    # nats, so every per-N evidence would sit ≈ 0.153·N nats above the
+    # reference — the bias alone exceeds the N = 4 gate, and combined with
+    # the NS noise it erodes the others. At 1e9 eV only the hard-core
+    # region is excluded, and the retained fraction m₁ ≈ 0.9972 (measured
+    # on the quadrature grid) is folded into the reference as −N·ln m₁.
+    K = 64
+    mc_steps = 400
+    n_ns_steps = 1200
+    N_values = collect(0:4)
+    seedbase = 3000   # gates calibrated at seedbases 3000 and 4000; 3000 ships
+
+    function _uniform_walker_ideal(N::Int)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            w = AtomWalker(FastSystem(periodic_system(coor, box, fractional=true)))
+            E_ads = ustrip(u"eV", interacting_energy(w.configuration, ljs,
+                        w.list_num_par, w.frozen, surface.configuration))
+            (isfinite(E_ads) && E_ads < E_init_thresh) && return w
+        end
+    end
+
+    tmpdir = mktempdir()
+    function _run_ns_ideal(N::Int, seed::Int)
+        Random.seed!(seed)
+        walkers = [_uniform_walker_ideal(N) for _ in 1:K]
+        liveset = LJSurfaceWalkers(walkers, ljs, surface)
+        ns_params = NestedSamplingParameters(
+            mc_steps=mc_steps,
+            initial_step_size=0.3,
+            step_size=0.3,
+            step_size_lo=0.01,
+            step_size_up=2.0,
+            accept_range=(0.25, 0.75),
+            allowed_fail_count=1000,
+            energy_perturbation=1e-12,
+        )
+        save_strategy = SaveEveryN(
+            df_filename=joinpath(tmpdir, "_test_ideal_ns_$(N).csv"),
+            wk_filename=joinpath(tmpdir, "_test_ideal_ns_$(N).traj.extxyz"),
+            ls_filename=joinpath(tmpdir, "_test_ideal_ns_$(N).ls.extxyz"),
+            n_traj=100_000,
+            n_snap=100_000,
+            n_info=100_000,
+        )
+        df, final_liveset, _ = nested_sampling(
+            liveset, ns_params, n_ns_steps, MCRandomWalkClone(), save_strategy)
+        live_emax_N = [ustrip(u"eV", w.energy) for w in final_liveset.walkers]
+        return df, live_emax_N
+    end
+
+    ns_outputs = Vector{DataFrame}(undef, length(N_values))
+    live_emax_all = Vector{Vector{Float64}}(undef, length(N_values))
+    ns_outputs[1] = DataFrame(iter=Int[], emax=Float64[])
+    live_emax_all[1] = Float64[]
+    for (idx, N) in enumerate(N_values)
+        N == 0 && continue
+        df, live_emax_N = _run_ns_ideal(N, seedbase + N)
+        ns_outputs[idx] = df
+        live_emax_all[idx] = live_emax_N
+    end
+    rm(tmpdir; recursive=true, force=true)
+
+    # ===== Stitch and exact references ===================================
+    # empty_energy = E_slab: the N = 0 sector is the bare slab at its
+    # frozen self-energy, which puts all five sectors on one energy scale.
+    out_fix = gc_thermodynamic_stats_fixed_N(
+        ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+        n_walkers=K, live_emax=live_emax_all, empty_energy=E_slab)
+
+    # Truncated-Poisson reference over the SAME N = 0..4 sector set, with
+    # the corrected rate q_corr = q/m₁ (the NS prior per particle is the
+    # m₁ fraction of the box). Ideal adsorbates make the sector energy
+    # E_slab + Σᵢuᵢ with uᵢ i.i.d. (mean ubar, variance sig_u2), so
+    #   ⟨U⟩ = E_slab + ubar·⟨N⟩,
+    #   var_U = ubar²·Var N + sig_u2·⟨N⟩   (law of total variance),
+    #   cov_UN = ubar·Var N.
+    q_phys = [exp(β * ustrip(u"eV", μ)) * I_ref / Λ^3 for μ in μ_grid]
+    q_corr = q_phys ./ m1
+    function _trunc_poisson(q::Float64)
+        Ns = 0:4
+        w = [q^N / factorial(N) for N in Ns]
+        S = sum(w)
+        p = w ./ S
+        mN = sum(p .* Ns)
+        vN = sum(p .* Ns .^ 2) - mN^2
+        return (S=S, mean_N=mN, var_N=vN,
+                mean_U=E_slab + ubar * mN,
+                var_U=ubar^2 * vN + sig_u2 * mN,
+                cov_UN=ubar * vN)
+    end
+
+    @testset "per-N evidence vs quadrature reference" begin
+        # Exact: log Z_N = −βE_slab + N·ln(I/(Λ³m₁)) − ln N! (the log_Z_N
+        # return already carries the N·ln(V/Λ³) − ln N! part, so the
+        # reference is stated on the same scale). Gates: ≥ 3× the larger
+        # two-seedbase |deviation| per N — measured 0.0112/0.1030 (N = 1),
+        # 0.1928/0.1310 (N = 2), 0.2889/0.0120 (N = 3), 0.1551/0.0077
+        # (N = 4) nats at seedbases 3000/4000, consistent with the √(3N/K)
+        # NS noise scale.
+        tol_logZ = [0.35, 0.60, 0.90, 0.50]
+        for (i, N) in enumerate(N_values)
+            N == 0 && continue
+            exact = -β * E_slab + N * (log(I_ref / Λ^3) - log(m1)) -
+                    sum(log, 1:N; init=0.0)
+            @test abs(out_fix.log_Z_N[i, 1] - exact) <= tol_logZ[N]
+        end
+    end
+
+    @testset "stitched grand stats vs truncated Poisson" begin
+        # Gates: ≥ 3× the max two-seedbase |deviation| per stat across both
+        # μ — measured maxima: logXi 0.0647 nats, mean_N 0.0850 rel,
+        # var_N 0.1055 rel, mean_U 1.55e-3 eV, var_U 0.1490 rel,
+        # cov_UN 0.1390 rel. mean_U is gated absolutely: E_slab dominates
+        # its magnitude, so a relative gate on the total would be
+        # insensitive to the adsorbate part.
+        for k in eachindex(μ_grid)
+            tp = _trunc_poisson(q_corr[k])
+            @test abs(out_fix.logXi[k, 1] - (-β * E_slab + log(tp.S))) <= 0.20
+            @test abs(out_fix.mean_N[k, 1] / tp.mean_N - 1) <= 0.26
+            @test abs(out_fix.var_N[k, 1] / tp.var_N - 1) <= 0.32
+            @test abs(out_fix.mean_U[k, 1] - tp.mean_U) <= 5.0e-3
+            @test abs(out_fix.var_U[k, 1] / tp.var_U - 1) <= 0.45
+            @test abs(out_fix.cov_UN[k, 1] / tp.cov_UN - 1) <= 0.42
+        end
+    end
+
+    @testset "default empty sector overstates ⟨N⟩" begin
+        # Without empty_energy the N = 0 sector enters the grand sum at
+        # weight 1 instead of e^{−βE_slab} = e^{+85.9}: it effectively
+        # vanishes, and ⟨N⟩ collapses toward the N ≥ 1 conditional mean.
+        # Measured gaps above the corrected ⟨N⟩ at the dilute μ: +0.778 and
+        # +0.810 at seedbases 3000/4000 (the corrected values are ≈ 0.54
+        # and ≈ 0.50); the margin ships at 0.25, ≥ 3× inside the measured
+        # gaps while still asserting a ≥ +45% bias on the corrected ⟨N⟩.
+        out_def = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_emax_all)
+        @test out_def.mean_N[1, 1] > out_fix.mean_N[1, 1] + 0.25
+    end
+end
+
+
+@testset "Atomistic observables ledger and passthrough (LJ on LJ(111) surface)" begin
+    using Random
+
+    # Same LJ(111) slab geometry as the block above, at reduced cost
+    # (N = 2 free adsorbates, K = 32, 300 iterations): every assertion here
+    # is a deterministic recording or passthrough closure given the seeded
+    # run, not a sampling-quality gate. Covered: the per-dead-point
+    # `observables` hook on an atomistic canonical run, the dead-point
+    # callback's bit-exact pairing with the ledger, and `observable_cols`
+    # passthrough of the recorded column through the fixed-N assembly.
+    σ_val = 2.5
+    ε_val = 0.01
+    a = 2^(1/6) * σ_val
+    Δz_layer = a * sqrt(2/3)
+    Lx = 2.0 * a
+    Ly = 2.0 * a * sqrt(3.0)
+    Lz = 22.0
+
+    layer_offsets = [
+        [(0.0, 0.0), (0.5, 0.5)],         # A
+        [(0.5, 1.0/6.0), (0.0, 2.0/3.0)], # B
+        [(0.5, 5.0/6.0), (0.0, 1.0/3.0)], # C
+    ]
+
+    substrate_positions = Pair{Symbol,Vector{Float64}}[]
+    for (l, layer) in enumerate(layer_offsets)
+        z_frac = (l - 1) * Δz_layer / Lz
+        for (fx_prim, fy_prim) in layer
+            for ix in 0:1, iy in 0:1
+                push!(substrate_positions,
+                      :Ar => [(ix + fx_prim) / 2.0, (iy + fy_prim) / 2.0, z_frac])
+            end
+        end
+    end
+
+    box = [[Lx * u"Å", 0u"Å", 0u"Å"],
+           [0u"Å", Ly * u"Å", 0u"Å"],
+           [0u"Å", 0u"Å", Lz * u"Å"]]
+    V_box = (Lx * Ly * Lz) * u"Å^3"
+    mass = 40.0u"u"
+
+    lj = LJParameters(epsilon=ε_val, sigma=σ_val, cutoff=3.0, shift=true)
+    ljs = CompositeParameterSets(2, [lj, lj, lj])
+
+    substrate_sys = FastSystem(periodic_system(substrate_positions, box, fractional=true))
+    surface = AtomWalker(substrate_sys; freeze_species=[:Ar])
+    surface.energy_frozen_part = interacting_energy(surface.configuration, lj)
+
+    T_val = 200.0u"K"
+    kb = 8.617333262e-5
+    β = 1.0 / (kb * ustrip(u"K", T_val))
+
+    N_free = 2
+    K = 32
+    mc_steps = 500
+    n_ns_steps = 300
+
+    function _uniform_walker_obs(N::Int)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            w = AtomWalker(FastSystem(periodic_system(coor, box, fractional=true)))
+            E_ads = ustrip(u"eV", interacting_energy(w.configuration, ljs,
+                        w.list_num_par, w.frozen, surface.configuration))
+            (isfinite(E_ads) && E_ads < 100.0) && return w
+        end
+    end
+
+    # z_com: configuration-mean z of the free adsorbates in Å as a Float64 —
+    # the adsorption-height observable natural to a slab geometry.
+    z_com = function (cfg)
+        s = 0.0
+        for i in 1:length(cfg)
+            s += ustrip(u"Å", position(cfg, i)[3])
+        end
+        return s / length(cfg)
+    end
+
+    callback_log = Tuple{Int,Float64}[]
+    record_dead = (iter, w) -> push!(callback_log, (iter, ustrip(u"eV", w.energy)))
+
+    Random.seed!(42)
+    walkers = [_uniform_walker_obs(N_free) for _ in 1:K]
+    liveset = LJSurfaceWalkers(walkers, ljs, surface)
+    ns_params = NestedSamplingParameters(
+        mc_steps=mc_steps,
+        initial_step_size=0.3,
+        step_size=0.3,
+        step_size_lo=0.01,
+        step_size_up=2.0,
+        accept_range=(0.25, 0.75),
+        allowed_fail_count=1000,
+        energy_perturbation=1e-12,
+    )
+    tmpdir = mktempdir()
+    save_strategy = SaveEveryN(
+        df_filename=joinpath(tmpdir, "_test_obs_ns.csv"),
+        wk_filename=joinpath(tmpdir, "_test_obs_ns.traj.extxyz"),
+        ls_filename=joinpath(tmpdir, "_test_obs_ns.ls.extxyz"),
+        n_traj=100_000,
+        n_snap=100_000,
+        n_info=100_000,
+    )
+    df, final_liveset, _ = nested_sampling(
+        liveset, ns_params, n_ns_steps, MCRandomWalkClone(), save_strategy;
+        observables=[:z_com => z_com],
+        dead_point_callback=record_dead)
+    rm(tmpdir; recursive=true, force=true)
+
+    @testset "observables ledger column" begin
+        @test "z_com" in names(df)
+        @test eltype(df.z_com) === Float64
+        @test all(isfinite, df.z_com)
+        @test all(0.0 .< df.z_com .< Lz)
+    end
+
+    @testset "dead-point callback pairing" begin
+        # One invocation per recorded dead point, in ledger order, with the
+        # culled walker's energy matching the emax column bit-exactly.
+        @test length(callback_log) == nrow(df)
+        @test all(callback_log[i][1] == df.iter[i] for i in eachindex(callback_log))
+        @test all(callback_log[i][2] === df.emax[i] for i in eachindex(callback_log))
+    end
+
+    @testset "observable passthrough vs direct reweighting" begin
+        # Single-sector demonstration: the run's N = 2 sector plus the
+        # empty sector (whose live_observables entry declares the empty
+        # configuration's observable value, 0.0 here). The reference is a
+        # direct log-space reweighting of the same ledger column — dead
+        # points at ω_i·e^{−βE_i}, live tail at the shared tail weight —
+        # accumulated in BigFloat: a different decomposition of the same
+        # sum, so agreement is deterministic given the run.
+        live_emax_N = [ustrip(u"eV", w.energy) for w in final_liveset.walkers]
+        live_z = [z_com(w.configuration) for w in final_liveset.walkers]
+
+        N_values = [0, 2]
+        μ_grid = [-0.22u"eV"]
+        T_grid = [T_val]
+        ns_outputs = [DataFrame(iter=Int[], emax=Float64[]), df]
+        live_emax_all = [Float64[], live_emax_N]
+        live_obs = [Dict(:z_com => [0.0]), Dict(:z_com => live_z)]
+
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_emax_all,
+            observable_cols=[:z_com], live_observables=live_obs)
+
+        Λ = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass, T_val))
+        log_zV = β * ustrip(u"eV", μ_grid[1]) + log(ustrip(u"Å^3", V_box)) - 3 * log(Λ)
+        log_r = log(BigFloat(K) / (K + 1))
+        S0 = BigFloat(1)          # N = 0 sector: weight e^{−β·0}·(zV)⁰/0! = 1
+        SA = BigFloat(0)          # its declared z_com is 0.0
+        sector = 2 * BigFloat(log_zV) - log(BigFloat(2))   # N·ln zV − ln N!, N = 2
+        for row in 1:nrow(df)
+            lw = df.iter[row] * log_r - log(BigFloat(K + 1))
+            w = exp(lw - BigFloat(β) * BigFloat(df.emax[row]) + sector)
+            S0 += w
+            SA += w * df.z_com[row]
+        end
+        n_it = maximum(df.iter)
+        lw_tail = n_it * log_r - log(BigFloat(K))
+        for (s, E) in enumerate(live_emax_N)
+            w = exp(lw_tail - BigFloat(β) * BigFloat(E) + sector)
+            S0 += w
+            SA += w * live_z[s]
+        end
+        z_direct = Float64(SA / S0)
+
+        @test isapprox(out.observables[:z_com][1, 1], z_direct, rtol=1e-10)
+    end
+end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -2926,4 +2926,342 @@
         @test all(isfinite, hc3_N)
         @test 0 <= hc3_N[1] <= 24
     end
+
+    # ================================================================
+    @testset "end-to-end: rectangular adlattice through the SquareLattice tag" begin
+        # The rectangular adlattice -- the adsorption geometry of the
+        # fcc(110) facet in the nested-sampling study of Lennard-Jones
+        # surface adsorption [Yang, Partay & Wexler, Phys. Chem. Chem.
+        # Phys. 26, 13862 (2024)] -- through the MLattice inner
+        # constructor with the SquareLattice tag retained: lattice
+        # vectors diag(a, sqrt(2) a, c), single-site basis. Every
+        # square-tag kernel is either metric-true (neighbor shells from
+        # image distances) or index-space (the geometric cluster move
+        # is a point inversion, valid on any Bravais lattice), so the
+        # tag carries the anisotropic in-plane metric; this testset is
+        # the regression pinning cluster-move correctness on an
+        # anisotropic in-plane metric. On the 1 x sqrt(2) cell the
+        # first four shell distances are d_k = sqrt(k) a, k = 1..4,
+        # with coordinations [2, 2, 4, 2], so a 12-6 pair potential
+        # tabulates to exactly rational couplings
+        # J_k / eps = k^-6 - 2 k^-3 at the shell distances.
+        ra_sq2 = sqrt(2.0)
+        ra_lv = [1.0 0.0 0.0; 0.0 ra_sq2 0.0; 0.0 0.0 1.0]
+        ra_radii = [1.05, 1.45, 1.8, 2.05]
+        ra_J = 0.01 .* [-1.0, -0.234375, -0.0727023319615912, -0.031005859375]
+        ra_ham = GenericLatticeHamiltonian(-0.03, ra_J, u"eV")
+        ra_z = [2, 2, 4, 2]
+
+        # (6, 4, 1): no shell wraps the cell (x-circumference 6a > 2 d_4,
+        # y-circumference 4 sqrt(2) a > 2 d_2), so the default
+        # minimum-image lists are exact and construction is warning-free
+        ra6 = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,SquareLattice}(
+            ra_lv, [(0.0, 0.0, 0.0)], (6, 4, 1), (true, true, false),
+            ra_radii, [fill(false, 24)], fill(true, 24))
+        @test num_sites(ra6) == 24
+        @test all(nb -> length.(nb) == ra_z, ra6.neighbors)
+
+        # Independent geometry: explicit-image bond multiset from the
+        # stored positions (coupling/2 per ordered entry, images counted
+        # individually), sharing no code with compute_neighbors
+        function ra_bonds(pos, Lx, Ly)
+            bonds = Tuple{Int,Int,Int}[]
+            for i in eachindex(pos), j in eachindex(pos)
+                for ix in -3:3, iy in -3:3
+                    (j == i && ix == 0 && iy == 0) && continue
+                    d = hypot(pos[i][1] - pos[j][1] + ix * Lx,
+                              pos[i][2] - pos[j][2] + iy * Ly)
+                    d > ra_radii[end] && continue
+                    sh = findfirst(r -> d <= r, ra_radii)
+                    sh === nothing || push!(bonds, (i, j, sh))
+                end
+            end
+            return bonds
+        end
+        rp6 = [(ra6.positions[s, 1], ra6.positions[s, 2]) for s in 1:24]
+        ra6_bonds = ra_bonds(rp6, 6.0, 4 * ra_sq2)
+        @test all(sort(ra6.neighbors[s][k]) ==
+                  sort([b[2] for b in ra6_bonds if b[1] == s && b[3] == k])
+                  for s in 1:24, k in 1:4)
+
+        # Configuration-resolved energy identity over random occupation
+        # masks: interacting_energy against the explicit-image truncated
+        # pair sum. The RNG draws here precede the seeded run below,
+        # which re-seeds
+        ra_brute(occ, bonds) = -0.03 * count(occ) +
+            sum((occ[b[1]] && occ[b[2]]) ? ra_J[b[3]] / 2 : 0.0 for b in bonds)
+        Random.seed!(7300)
+        ra_worst6 = 0.0
+        for _ in 1:100
+            mask = rand(0:(2^24 - 1))
+            occ = ra6.components[1]
+            for s in 1:24
+                occ[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            ra_worst6 = max(ra_worst6,
+                abs(ustrip(u"eV", interacting_energy(ra6, ra_ham)) -
+                    ra_brute(occ, ra6_bonds)))
+        end
+        @test ra_worst6 <= 1e-12
+
+        # Full coverage: on-site plus half the coordination-weighted
+        # couplings per site
+        ra6.components[1] .= true
+        ra_full6 = 24 * (-0.03) + 24 / 2 * sum(ra_z .* ra_J)
+        @test abs(ustrip(u"eV", interacting_energy(ra6, ra_ham)) - ra_full6) < 1e-12
+
+        # (4, 4, 1): the d_4 = 2a shell wraps the 4a x-circumference
+        # (the +2a and -2a images of the same partner both sit at
+        # distance 2a), so the cell is built with image_multiplicity =
+        # true; the bulk-tiled shell entries stay [2, 2, 4, 2] with the
+        # fourth shell listing one unique partner twice
+        ra4 = MLattice{1,SquareLattice}(ra_lv, [(0.0, 0.0, 0.0)], (4, 4, 1),
+            (true, true, false), ra_radii, [fill(false, 16)], fill(true, 16);
+            image_multiplicity=true)
+        @test all(nb -> length.(nb) == ra_z, ra4.neighbors)
+        @test all(length(unique(ra4.neighbors[s][4])) == 1 for s in 1:16)
+        rp4 = [(ra4.positions[s, 1], ra4.positions[s, 2]) for s in 1:16]
+        ra4_bonds = ra_bonds(rp4, 4.0, 4 * ra_sq2)
+        @test all(sort(ra4.neighbors[s][k]) ==
+                  sort([b[2] for b in ra4_bonds if b[1] == s && b[3] == k])
+                  for s in 1:16, k in 1:4)
+        ra_worst4 = 0.0
+        for _ in 1:100
+            mask = rand(0:(2^16 - 1))
+            occ = ra4.components[1]
+            for s in 1:16
+                occ[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            ra_worst4 = max(ra_worst4,
+                abs(ustrip(u"eV", interacting_energy(ra4, ra_ham)) -
+                    ra_brute(occ, ra4_bonds)))
+        end
+        @test ra_worst4 <= 1e-12
+
+        # Full 2^16 own-energy table from the bond multiset; the N = 4
+        # spectrum and every grand reference below derive from it
+        ra_e = zeros(2^16)
+        ra_n = zeros(Int, 2^16)
+        ra_occ = fill(false, 16)
+        for mask in 0:(2^16 - 1)
+            for s in 1:16
+                ra_occ[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            e = -0.03 * count(ra_occ)
+            for (i, j, sh) in ra4_bonds
+                (ra_occ[i] && ra_occ[j]) && (e += ra_J[sh] / 2)
+            end
+            ra_e[mask + 1] = e
+            ra_n[mask + 1] = count_ones(mask)
+        end
+
+        # exact_enumeration closure at N = 4: the C(16, 4) spectrum
+        ra_lat4 = deepcopy(ra4)
+        ra_lat4.components[1] .= false
+        ra_lat4.components[1][1:4] .= true
+        ra_df4, _ = exact_enumeration(ra_lat4, ra_ham)
+        @test nrow(ra_df4) == binomial(16, 4)
+        @test sort([ustrip(u"eV", e) for e in ra_df4.energy]) ≈
+              sort([ra_e[m + 1] for m in 0:(2^16 - 1) if count_ones(m) == 4]) atol = 1e-12
+
+        ra_kb = 8.617333262e-5
+        function ra_exact(mu, T)
+            beta = 1 / (ra_kb * T)
+            lt = beta .* (mu .* ra_n .- ra_e)
+            mx = maximum(lt)
+            w = exp.(lt .- mx)
+            Z = sum(w)
+            mN = sum(w .* ra_n) / Z
+            (logXi=mx + log(Z), mean_N=mN,
+             var_N=sum(w .* ra_n .^ 2) / Z - mN^2,
+             mean_U=sum(w .* ra_e) / Z)
+        end
+        # Particle-hole symmetry pins half coverage at mu* = eps_0 +
+        # (1/2) sum_k z_k J_k at every temperature. The mu grid is mu*
+        # rounded to 10^-5 plus the two mu values that bracket coverage
+        # 0.2 and 0.8 at 80 K, so the grid spans coverage ~0.2-0.8;
+        # beta |J_1| runs from 0.93 (125 K) to 1.45 (80 K)
+        ra_mu_sym = -0.03 + 0.5 * sum(ra_z .* ra_J)
+        @test ra_exact(ra_mu_sym, 80.0).mean_N ≈ 8.0 atol = 1e-9
+        @test ra_exact(ra_mu_sym, 125.0).mean_N ≈ 8.0 atol = 1e-9
+        ra_mus = [-0.04694, -0.04411, -0.04127]
+        ra_Ts = [80.0, 100.0, 125.0]
+        @test ra_mus[2] ≈ ra_mu_sym atol = 5e-6
+        @test ra_exact(ra_mus[1], ra_Ts[1]).mean_N ≈ 0.2 * 16 atol = 0.2
+        @test ra_exact(ra_mus[3], ra_Ts[1]).mean_N ≈ 0.8 * 16 atol = 0.2
+
+        # Seeded ideal-gas-referenced route with geometric cluster moves
+        # in the decorrelation loop (clusters_freq = swaps_freq = 1):
+        # K = 200 walkers, 20000 steps ~ 1.2 K M log1p(1/z0) at the
+        # full-descent depth M log1p(1/z0) ~ 82 nats, z0 = e^{beta mu*}
+        # at 100 K centering the reference on the grid; sigma(lnXi) ~
+        # sqrt(82/200) ~ 0.64 at the full-descent depth. K and the
+        # step count are doubled from the first cut of this closure
+        # because gates must be able to fail: the K = 100 run's
+        # grid-wide spread exceeded the attainable deviation range for
+        # <N> and <U>, whose estimators are confined to [0, 16] and
+        # [E_gs, 0] with E_gs = -0.70572568 eV. The global RNG is
+        # seeded here (the parameters' random_seed field is not
+        # consumed) and the gates run after all RNG use.
+        #
+        # Tolerances: three-seed calibrated (seeds 7301/7302/7303),
+        # per stat per temperature row (gate arrays indexed by the
+        # 80/100/125 K rows), >= 3x the three-seed maximum deviation
+        # from the exact grand sums over that row's gated points.
+        # Every gated-set maximum is set by seed 7303, whose 80 K row
+        # (beta |J_1| = 1.45) converges worst; the lnXi and mean_N
+        # maxima all sit at the coverage-0.8 flank. Per-point
+        # attainable sups: max(<N>, 16 - <N>) for mean_N and
+        # max(|E_gs - <U>|, |<U>|) for mean_U; gated points are (mu
+        # index, T index) pairs.
+        #   lnXi: gates 10.6/7.9/5.9 on all points (maxima 3.50/2.62/
+        #   1.96); failable low everywhere, the log-sum estimator
+        #   being unbounded below.
+        #   mean_N: gates 7.9/9.7/8.6 on the flanking-mu points only
+        #   (flank maxima 2.62/3.20/2.84 vs flank sups 12.80/11.27/
+        #   10.20). At the symmetric mu the sup is 16 - 8 = 8, below
+        #   every row's 3x spread (seed 7303 deviates 5.01 there at
+        #   80 K), so those points carry no mean_N gate and stay
+        #   closed by the exact particle-hole pins above, lnXi, and
+        #   the Kish floor.
+        #   mean_U: gates 0.41/0.21/0.33 on gated points (1,1),(3,1) /
+        #   (1,2) / (1,3),(2,3) (gated maxima 0.136/0.068/0.108 vs
+        #   minimum gated sups 0.54/0.53/0.40); the ungated points'
+        #   sups (0.39-0.46) sit below the 3x spread seed 7303 forces
+        #   (deviations up to 0.24).
+        #   var_N: no deviation gate at this effort level -- a >= 3x
+        #   gate would sit at 12.0-26.4 while the exact values span
+        #   6.9-15.2, so it could never fail low at any point (the
+        #   best point, the symmetric mu at 100 K, would leave a 3x
+        #   gate of 10.7 only 0.35 below the exact 11.06); Var N
+        #   mis-convergence still trips the lnXi gates and the Kish
+        #   floor.
+        # Shipped seed 7301, row maxima on the gated points: lnXi
+        # 0.997/0.325/0.133, mean_N 2.19/1.89/0.933, mean_U 0.115/
+        # 0.0129/0.0145; its Kish minimum is N_eff 805 at the
+        # coverage-0.8 corner of the 80 K row -- the same corner binds
+        # for all three seeds (three-seed minimum 709) -- on a floor
+        # of 100.
+        ra_z0 = exp(ra_mus[2] / (ra_kb * 100.0))
+        Random.seed!(7301)
+        ra_walkers = [LatticeWalker(deepcopy(ra4), energy=0.0u"eV", iter=0)
+                      for _ in 1:200]
+        ra_ls = LatticeGasWalkers(ra_walkers, ra_ham; assign_energy=false)
+        ra_params = IdealGasReferencedGCNSParameters(mc_steps=60,
+            reference_fugacity=ra_z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        ra_df, ra_out, ra_pout = ideal_gas_referenced_nested_sampling(
+            ra_ls, ra_params, Int64(20000),
+            MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25,
+                clusters_freq=1, swaps_freq=1), obs_save)
+        obs_cleanup()
+        @test names(ra_df) == ["iter", "emax", "num_particles"]
+        @test issorted(ra_df.emax, rev=true)
+        # The fixed-N branch really alternated local swaps and cluster
+        # moves, and cluster proposals were accepted on the anisotropic
+        # metric
+        @test ra_pout.move_stats[:swap_attempted] > 0
+        @test ra_pout.move_stats[:cluster_attempted] > 0
+        @test ra_pout.move_stats[:cluster_accepted] > 0
+        ra_liveE = [w.energy.val for w in ra_out.walkers]
+        ra_liveN = [Int(sum(w.configuration.components[1])) for w in ra_out.walkers]
+        ra_st = gc_thermodynamic_stats_ideal_ref(ra_df, 16, ra_z0, ra_mus, ra_Ts,
+            200; ω0=201 / 200, live_emax=ra_liveE, live_numbers=ra_liveN)
+        ra_lnXi_tol = [10.6, 7.9, 5.9]
+        ra_N_tol = [7.9, 9.7, 8.6]
+        ra_U_tol = [0.41, 0.21, 0.33]
+        ra_U_gated = ((1, 1), (3, 1), (1, 2), (1, 3), (2, 3))
+        for (i, mu) in enumerate(ra_mus), (j, T) in enumerate(ra_Ts)
+            ex = ra_exact(mu, T)
+            @test ra_st.N_eff[i, j] >= 100
+            @test abs(ra_st.logXi[i, j] - ex.logXi) < ra_lnXi_tol[j]
+            i == 2 || @test abs(ra_st.mean_N[i, j] - ex.mean_N) < ra_N_tol[j]
+            (i, j) in ra_U_gated &&
+                @test abs(ra_st.mean_U[i, j] - ex.mean_U) < ra_U_tol[j]
+        end
+    end
+
+    # ================================================================
+    @testset "Langmuir closure off the keyword-square path" begin
+        # On-site term only (zero couplings): E = eps N exactly, so
+        # Xi(mu, T) = (1 + z e^{-beta eps})^M with z = e^{beta mu}, and
+        # with x = z e^{-beta eps}: <N> = M x / (1 + x), Var N =
+        # M x / (1 + x)^2, <U> = eps <N>. The closed forms are
+        # geometry-free, so closing them on the rectangular
+        # inner-constructor cell and on the keyword triangular cell
+        # pins the on-site/mu composition of the grand-canonical walk
+        # and the ideal-gas-referenced stats as geometry-independent.
+        lm_eps = -0.05
+        lm_ham = GenericLatticeHamiltonian(-0.05u"eV", [0.0u"eV"])
+        lm_kb = 8.617333262e-5
+        # Rectangular 1 x sqrt(2) cell through the inner constructor,
+        # nearest-neighbor shell only (2 partners at distance a);
+        # construction is warning-free
+        lm_rect = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,SquareLattice}(
+            [1.0 0.0 0.0; 0.0 sqrt(2.0) 0.0; 0.0 0.0 1.0], [(0.0, 0.0, 0.0)],
+            (6, 4, 1), (true, true, false), [1.05],
+            [fill(false, 24)], fill(true, 24))
+        @test num_sites(lm_rect) == 24
+        @test all(nb -> length.(nb) == [2], lm_rect.neighbors)
+        # Keyword triangular cell
+        lm_tri = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(4, 2, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.05],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full)
+        @test num_sites(lm_tri) == 16
+        @test all(nb -> length.(nb) == [6], lm_tri.neighbors)
+
+        # mu/T grid and gate structure of the keyword-square Langmuir
+        # closure (test-ideal-gas-ref-gcns.jl): z0 = 1, the first mu
+        # deliberately out of the reweighting window, skipped in the
+        # closure loop and used for the N_eff collapse check. The
+        # global RNG is seeded per run (the parameters' random_seed
+        # field is not consumed) and the gates run after all RNG use.
+        # Tolerances: three-seed calibrated (seeds 7501/7502/7503, both
+        # geometries), per stat over the nine in-window grid points and
+        # both geometries, >= 3x the maximum deviation from the closed
+        # forms (lnXi 0.209 absolute; N 0.0228, Var N 0.161, U 0.0228
+        # relative); in-window Kish N_eff >= 303 across the
+        # calibration, floor 100.
+        lm_mus = [-0.08, -0.04, -0.03, -0.02]
+        lm_Ts = [200.0, 300.0, 500.0]
+        for (lm_lat, lm_M) in ((lm_rect, 24), (lm_tri, 16))
+            Random.seed!(7501)
+            lm_walkers = [LatticeWalker(deepcopy(lm_lat), energy=0.0u"eV", iter=0)
+                          for _ in 1:100]
+            lm_ls = LatticeGasWalkers(lm_walkers, lm_ham; assign_energy=false)
+            lm_params = IdealGasReferencedGCNSParameters(mc_steps=100,
+                reference_fugacity=1.0, allowed_fail_count=100_000)
+            lm_df, lm_out, _ = ideal_gas_referenced_nested_sampling(lm_ls,
+                lm_params, Int64(3000),
+                MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3), obs_save)
+            obs_cleanup()
+            @test nrow(lm_df) > 0
+            @test names(lm_df) == ["iter", "emax", "num_particles"]
+            @test issorted(lm_df.emax, rev=true)
+            # Ledger-level composition pin: every dead point sits on
+            # E = eps N
+            @test maximum(abs.(lm_df.emax .- lm_eps .* lm_df.num_particles)) < 1e-9
+            lm_liveE = [w.energy.val for w in lm_out.walkers]
+            lm_liveN = [Int(sum(w.configuration.components[1])) for w in lm_out.walkers]
+            lm_st = gc_thermodynamic_stats_ideal_ref(lm_df, lm_M, 1.0, lm_mus,
+                lm_Ts, 100; ω0=101 / 100, live_emax=lm_liveE, live_numbers=lm_liveN)
+            for (j, T) in enumerate(lm_Ts), (i, mu) in enumerate(lm_mus)
+                i == 1 && continue      # the out-of-window point
+                beta = 1 / (lm_kb * T)
+                x = exp(beta * mu) * exp(-beta * lm_eps)
+                @test lm_st.N_eff[i, j] >= 100
+                @test abs(lm_st.logXi[i, j] - lm_M * log1p(x)) < 0.65
+                @test isapprox(lm_st.mean_N[i, j], lm_M * x / (1 + x); rtol=0.07)
+                @test isapprox(lm_st.var_N[i, j], lm_M * x / (1 + x)^2; rtol=0.5)
+                @test isapprox(lm_st.mean_U[i, j], lm_eps * lm_M * x / (1 + x); rtol=0.07)
+            end
+            # Out-of-window N_eff collapse, as in the keyword-square
+            # closure
+            @test lm_st.N_eff[1, 1] < lm_st.N_eff[4, 1] / 10
+        end
+    end
 end


### PR DESCRIPTION
Implements #175. Test-only: four regression testsets across the two end-to-end files, consuming the empty-sector keyword (#176), the atomistic parity fields (#177), and exercising cluster moves under the basis-guarded square method (#178). 0 src + 775 test LOC against the issue's ≈ 350 estimate — the growth is fixture comments, the in-test quadrature reference, and the two slab constructions, not scope.

## Testsets

**Rectangular adlattice through the SquareLattice tag** (in `test-ns-observables.jl`). The inner-constructor recipe (single-site basis, vectors diag(1, √2, 1)): warning-free (6, 4, 1) construction with per-site shell counts [2, 2, 4, 2] at {1, √2, √3, 2}·a cross-checked against an explicit-image bond multiset; the four-shell distance-tabulated Hamiltonian exact against explicit-image truncated pair sums (200 random masks + the full-coverage closed form, 10<sup>−12</sup>); a C(16, 4) `exact_enumeration` spectrum closure on the (4, 4, 1) `image_multiplicity = true` cell (the 2a shell wraps the 4a circumference — asserted directly); exact particle-hole pins; and the seeded ideal-gas-referenced route with geometric cluster moves in the decorrelation loop (`move_stats` asserts cluster proposals were attempted and accepted — this is the regression pinning cluster-move correctness on an anisotropic in-plane metric), gated against exact 2<sup>16</sup> grand sums on a 3×3 (μ, T) grid with a Kish floor. One stated deviation from the issue's item (a): the closure's statistical gates are shaped by bindability, found and fixed during the adversarial pass. The first calibration (K = 100) produced gates that were arithmetically honest (≥ 3× the three-seed spread) but provably unfailable — the estimators are range-bound on a 16-site cell, and the spread exceeded the attainable deviation. The shipped run doubles the effort (K = 200, 20,000 steps, seeds 7301/7302/7303, seed 7301 shipped, weld reproducing digit for digit) and gates per temperature row: ln Ξ at all nine points (failable low everywhere), ⟨N⟩ at the flanking-μ points (bindability margins 1.6-4.9× inside the attainable sups; the symmetric-μ points are held by the exact particle-hole pins, ln Ξ, and the Kish floor), ⟨U⟩ at the five points where a ≥ 3× gate sits inside the attainable range, and Var N carries no deviation gate at this effort level — a ≥ 3× gate could never fail low, as the fixture comment documents — with Var N mis-convergence still tripping ln Ξ and the Kish floor.

**Langmuir closure off the keyword-square path** (same file). The rectangular inner-constructor lattice (M = 24) and the keyword triangular lattice (M = 16), on-site term only, ideal-gas-referenced route against Ξ = (1 + z·e<sup>−βε</sup>)<sup>M</sup> and its moments, three-seed calibrated gates (recalibrated at ≥ 3× per the house rule rather than inheriting the keyword-square testset's literals, adding a Var N pin and an N<sub>eff</sub> floor that testset lacks), plus out-of-window Kish-collapse checks — pinning the on-site/μ composition as geometry-independent.

**Ideal-adsorbate closure on an LJ fcc(100) slab** (in `test-atomistic-gcns-fixed-n.jl`). Frozen 3×3×3 slab, adsorbate-adsorbate interactions off, so the grand-canonical thermodynamics is exactly solvable by quadrature: per-N evidences against −βE<sub>frozen</sub> + N·(ln(I/Λ³) − ln m₁) − ln N! (deviations ≤ 0.29 nats, gates ≥ 3× the two-seedbase spread), and the stitched `logXi`, `mean_N`, `var_N`, `mean_U`, `var_U`, `cov_UN` against truncated-Poisson identities at two chemical potentials, all through `empty_energy = E_frozen`. The walker-init rejection threshold is raised to 10<sup>9</sup> eV — the shipped surface block's 100 eV threshold truncates the uniform prior by ≈ 0.153 nats per particle, a bias alone exceeding the N = 4 gate — and the residual hard-core fraction m₁ ≈ 0.9972 is folded into the reference, applying both of the issue's alternative remedies at once. One default-keyword call regression-locks the empty-sector inconsistency (#172): the uncorrected ⟨N⟩ sits ≥ 0.25 above the corrected ≈ 0.52 (measured gaps +0.78/+0.81 across the calibration seedbases). Per the issue's pre-agreed trim, one of the two calibrated surface seedbases ships.

**Atomistic observables ledger and passthrough** (same file). The LJ(111) fixture: per-dead-point `observables` column recorded (Float64, finite, in-range), dead-point callback invocation count equal to the ledger rows with bit-exact energy pairing, and `observable_cols` passthrough through the extended assembly closing against an independent BigFloat direct reweighting of the same ledger column at rtol 10<sup>−10</sup> (measured agreement 2×10<sup>−16</sup>).

An adversarial verification pass ran as three independent reviewers with disjoint charters before filing. The round-trip reviewer checked every item of the issue's proposed changes and methodology against the shipped testsets and caught the headline must-fix — the unfailable-gate proof that drove the K = 200 recalibration and the per-row, bindability-restricted gate structure described above. The oracle reviewer re-ran the shipped seeds and welded every calibration number in the fixture comments digit for digit, verified the exact 2<sup>16</sup> references, the quadrature values, and the truncated-Poisson identities independently, and corrected two comment figures (the threshold-bias figure to ≈ 0.153 nats; the quadrature refinement ladder now names its rungs) and one below-floor margin (the bias-lock floor now ships at 0.25, ≥ 3× inside the measured gaps). The determinism reviewer reconciled the assertion arithmetic, verified the additions are append-only with each testset re-seeding (no pre-existing stream is touched), and confirmed temp-file hygiene. All fixes were applied and the full suite re-run on the shipped bytes.

Full test suite passes (SamplingSchemes 7346, AbstractWalkers 339, AbstractHamiltonians 80, AbstractLiveSets 111, AbstractPotentials 106, AnalysisTools 61, Energy Evaluation 340, Cluster lattice Hamiltonian 678, Monte Carlo Moves 114 and 3810, FreeBirdIO 51). Added CI cost is ≈ 2.5 minutes on the reference machine (the K = 200 ladder ≈ 24 s, the four surface ladders ≈ 90 s, the rest seconds); the issue's remaining trim, if CI cost matters later, is the surface ladder's N = 4 sector.
