### PR TITLE
Add a GenericLattice guard method to the geometric cluster move

### DIFF
--- a/src/MonteCarloMoves/cluster_moves.jl
+++ b/src/MonteCarloMoves/cluster_moves.jl
@@ -266,3 +266,18 @@ function geometric_cluster_swap!(lattice::MLattice{C,TriangularLattice}, p::Floa
 
     return lattice
 end
+
+"""
+    geometric_cluster_swap!(lattice::MLattice{C,GenericLattice}, p::Float64)
+
+Guard method: geometric cluster moves are defined only for the square and triangular
+geometries, whose reflection maps are integer grid involutions on the site indices; a
+`GenericLattice` carries no such map, so this method always throws a descriptive
+`ArgumentError` before drawing any randomness. Use swap-only decorrelation
+(`clusters_freq = 0`) for generic geometries.
+"""
+function geometric_cluster_swap!(lattice::MLattice{C,GenericLattice}, p::Float64) where C
+    throw(ArgumentError("geometric_cluster_swap! supports square and triangular " *
+        "lattices only, got a GenericLattice configuration; use swap-only " *
+        "decorrelation (clusters_freq = 0) for generic geometries"))
+end

--- a/test/test-lattice-random-walks.jl
+++ b/test/test-lattice-random-walks.jl
@@ -284,6 +284,60 @@
             @test sl.components == replica.components
         end
 
+        @testset "GenericLattice guard" begin
+            using Random
+            # Geometric cluster moves carry square and triangular reflection
+            # maps only; a GenericLattice configuration gets the same loud
+            # guard so a cluster-armed routine fails at the move's definition
+            # with a descriptive ArgumentError instead of a raw MethodError
+            # from inside the sampling loop (the keyword MCMixedMoves
+            # constructor arms cluster moves by default).
+            gen = MLattice{1,GenericLattice}(
+                [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0],
+                [(0.0, 0.0, 0.0)],
+                (3, 1, 1),
+                (false, false, false),
+                [1.1],
+                [[true, false, false]],
+                fill(false, 3))
+            err = try
+                geometric_cluster_swap!(gen, 0.3)
+                nothing
+            catch e
+                e
+            end
+            @test err isa ArgumentError
+            @test occursin("square and triangular", err.msg)
+            @test occursin("GenericLattice", err.msg)
+
+            # The guard consumes no randomness: a guarded throw leaves the
+            # global RNG stream untouched.
+            Random.seed!(11)
+            probe = rand(UInt64)
+            Random.seed!(11)
+            try
+                geometric_cluster_swap!(gen, 0.3)
+            catch
+            end
+            @test rand(UInt64) === probe
+
+            # End to end: the cluster-armed keyword routine surfaces the
+            # guard's ArgumentError through the sampling step, while the
+            # positional back-compat form stays clusters-free and completes.
+            ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+            walkers = [LatticeWalker(deepcopy(gen), energy=0.0u"eV", iter=0) for _ in 1:4]
+            ls = LatticeGasWalkers(walkers, ham)
+            params = NestedSamplingParameters(mc_steps=10)
+            @test_throws ArgumentError SamplingSchemes.nested_sampling_step!(ls, params, MCMixedMoves())
+            Random.seed!(99)
+            walkers2 = [LatticeWalker(deepcopy(gen), energy=0.0u"eV", iter=0) for _ in 1:4]
+            ls2 = LatticeGasWalkers(walkers2, ham)
+            save_strategy = SaveEveryN(n_traj=10^6, n_snap=10^6, n_info=10^6)
+            df, ls3, _ = nested_sampling(ls2, NestedSamplingParameters(mc_steps=10), 30, MCMixedMoves(5, 1), save_strategy)
+            @test size(df, 1) >= 1
+            @test length(ls3.walkers) == 4
+        end
+
         # ---- triangular lattice (two-site centered-rectangular basis) ----
 
         @testset "triangular reflection: half-grid round-trip" begin


### PR DESCRIPTION
Implements #184 with the recommended single-guard shape: a `geometric_cluster_swap!(lattice::MLattice{C,GenericLattice}, p::Float64)` method whose body is one descriptive `ArgumentError` naming the supported geometries, plus a docstring recording the exclusion. Two commits: `Add a GenericLattice guard method to the geometric cluster move.` (src) and `Test the GenericLattice cluster-move guard and the clusters-free positional routine.` (tests).

- One method covers both call paths (the fixed-N mixed-moves arm and the grand-canonical cluster arm), self-documents through `methods(geometric_cluster_swap!)`, and adds no branch to any hot loop; a cluster-armed routine on a `GenericLattice` liveset now fails with the guard's `ArgumentError` naming the supported geometries and the `clusters_freq = 0` remedy, replacing the raw mid-run `MethodError` from inside the sampling loop. We considered the alternative (entry checks in the sampling-scheme drivers) in the issue and did not adopt it for the reasons stated there.
- The guard throws before drawing any randomness, matching the square and triangular basis-guard precedent; the error wording mirrors the existing guards.
- Tests, beside the square-lattice basis-guard testset: the guard-attributable throw with the message content asserted (an `ArgumentError` naming the geometries, not a `MethodError`); the RNG-stream-neutrality probe (seed, draw, reseed, guarded call, next draw identical); the end-to-end assertion that `nested_sampling_step!` with the keyword `MCMixedMoves()` (which arms cluster moves by default) surfaces the guard's `ArgumentError`; and a short seeded run with the positional `MCMixedMoves(5, 1)` back-compat form completing clusters-free with a well-formed ledger. The test fixture is the issue's three-site chain built non-periodically, so its construction stays warning-free in the suite; the guard is geometry-tag-dispatched, so periodicity plays no role in what it locks.
- The square and triangular methods are byte-untouched, and the existing cluster-move testsets pass unchanged, pinning their same-seed streams.

Adversarially checked pre-PR (guard behavior, RNG neutrality, and both end-to-end paths verified by direct execution; the existing guard testsets untouched) and the full test suite passes on the shipped bytes: Monte Carlo Moves 3817 (= dev 3810 + 7 new assertions), SamplingSchemes 7491, FreeBirdIO 51, and every other testset at their `dev` @ f2acac0 counts.
