### PR TITLE
Fix the parallel surface 2D dispatch and forward dims in the parallel walks

### DIFF
--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -704,15 +704,17 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
 
     if length(mc_routine.dims) == 3
         random_walk_function = MC_random_walk!
+        walk_kwargs = NamedTuple()
     elseif length(mc_routine.dims) == 2
         random_walk_function = MC_random_walk_2D!
+        walk_kwargs = (dims = mc_routine.dims,)
     else
         error("Unsupported dimensions: $(mc_routine.dims)")
     end
 
     mc_steps_per_worker = ceil(Int, ns_params.mc_steps / nworkers()) # distribute the total MC steps among workers
 
-    walking = [remotecall(random_walk_function, workers()[i], mc_steps_per_worker, to_walk, lj, ns_params.step_size, emax[mc_routine.n_cull]) for (i,to_walk) in enumerate(to_walks)]
+    walking = [remotecall(random_walk_function, workers()[i], mc_steps_per_worker, to_walk, lj, ns_params.step_size, emax[mc_routine.n_cull]; walk_kwargs...) for (i,to_walk) in enumerate(to_walks)]
     walked = fetch.(walking)
     finalize.(walking) # finalize the remote calls, clear the memory
 
@@ -771,14 +773,16 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
 
     if length(mc_routine.dims) == 3
         random_walk_function = MC_random_walk!
+        walk_kwargs = NamedTuple()
     elseif length(mc_routine.dims) == 2
         random_walk_function = MC_random_walk_2D!
+        walk_kwargs = (dims = mc_routine.dims,)
     else
         error("Unsupported dimensions: $(mc_routine.dims)")
     end
 
 
-    walking = [remotecall(random_walk_function, workers()[i], ns_params.mc_steps, to_walk, lj, ns_params.step_size, emax[end]) for (i,to_walk) in enumerate(to_walks)]
+    walking = [remotecall(random_walk_function, workers()[i], ns_params.mc_steps, to_walk, lj, ns_params.step_size, emax[end]; walk_kwargs...) for (i,to_walk) in enumerate(to_walks)]
     walked = fetch.(walking)
     finalize.(walking) # finalize the remote calls, clear the memory
 
@@ -823,9 +827,10 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSampl
 
     if length(mc_routine.dims) == 3
         random_walk_function = MC_random_walk!
-    elseif length(mc_routine.dims) == 2
-        random_walk_function = MC_random_walk_2D!
     else
+        # The surface walks are 3D-only, matching the serial surface step's
+        # restriction: a length-2 dims would select a walk method with no
+        # surface variant and fail as a MethodError on the worker.
         error("Unsupported dimensions: $(mc_routine.dims)")
     end
 

--- a/test/test-SamplingSchemes/test-nested_sampling.jl
+++ b/test/test-SamplingSchemes/test-nested_sampling.jl
@@ -265,13 +265,17 @@
 
                     original_ls = deepcopy(liveset)
 
-                    if !(liveset isa LJSurfaceWalkers) # TODO: LJSurfaceWalkers does not support 2D walks yet
+                    if !(liveset isa LJSurfaceWalkers)
                         iter, emax, updated_liveset, updated_params = nested_sampling_step!(deepcopy(original_ls), ns_params, mc_routine)
-                        
+
                         @test iter isa Union{Missing,Int}
                         @test emax isa Union{Missing,typeof(0.0u"eV")}
                         @test length(updated_liveset.walkers) == length(original_ls.walkers)
                         @test updated_params.fail_count >= 0
+                    else
+                        # Surface walks are 3D-only: the step refuses a 2D dims
+                        # explicitly (issue #185, option 1).
+                        @test_throws ErrorException nested_sampling_step!(deepcopy(original_ls), ns_params, mc_routine)
                     end
 
                 end
@@ -306,6 +310,57 @@
                     @test_throws ErrorException begin
                         nested_sampling_step!(liveset, ns_params, Unsupported())
                     end
+                end
+            end
+
+            @testset "2D dims dispatch and forwarding (issue #185)" begin
+                using Random
+                # The serial surface refusal supplies the reference message for
+                # the parallel surface dispatch (issue #185, option 1).
+                serial_err = try
+                    nested_sampling_step!(deepcopy(liveset_surf), deepcopy(ns_params), MCRandomWalkClone(dims=[1, 2]))
+                    nothing
+                catch err
+                    err
+                end
+                @test serial_err isa ErrorException
+                @test occursin("Unsupported dimensions", serial_err.msg)
+
+                for mc_routine in [MCRandomWalkCloneParallel(dims=[1, 2]), MCRandomWalkMaxEParallel(dims=[1, 2])]
+                    @test_throws ErrorException nested_sampling_step!(deepcopy(liveset_surf), deepcopy(ns_params), mc_routine)
+                    parallel_err = try
+                        nested_sampling_step!(deepcopy(liveset_surf), deepcopy(ns_params), mc_routine)
+                        nothing
+                    catch err
+                        err
+                    end
+                    @test parallel_err isa ErrorException && parallel_err.msg == serial_err.msg
+                end
+
+                # Distinct-coordinate walkers: a dims=[1, 3] walk must leave every
+                # dim-2 coordinate bit-identical, so after any number of steps each
+                # liveset coordinate must stay inside the starting per-dimension
+                # value set of its dimension.
+                coor_lists = [[:H => [0.20, 0.11, 0.30], :H => [0.40, 0.17, 0.48]],
+                              [:H => [0.60, 0.23, 0.40], :H => [0.42, 0.29, 0.58]],
+                              [:H => [0.70, 0.35, 0.50], :H => [0.50, 0.41, 0.28]]]
+                walkers_2d = [AtomWalker(FastSystem(periodic_system(cl, box, fractional=true))) for cl in coor_lists]
+                coords(ls, d) = Set(ustrip(u"Å", position(w.configuration, i)[d]) for w in ls.walkers for i in 1:2)
+                start_ls = LJAtomWalkers(deepcopy(walkers_2d), lj)
+                xs0, ys0, zs0 = coords(start_ls, 1), coords(start_ls, 2), coords(start_ls, 3)
+
+                for (seed, mc_routine) in [(4661, MCRandomWalkCloneParallel(dims=[1, 3])),
+                                           (4662, MCDistributed(dims=[1, 3])),
+                                           (4663, MCRandomWalkClone(dims=[1, 3]))]
+                    Random.seed!(seed)
+                    ls = LJAtomWalkers(deepcopy(walkers_2d), lj)
+                    params = deepcopy(ns_params)
+                    for _ in 1:4
+                        nested_sampling_step!(ls, params, mc_routine)
+                    end
+                    @test issubset(coords(ls, 2), ys0)
+                    # Non-vacuity: at least one dim-1 or dim-3 coordinate moved.
+                    @test !issubset(coords(ls, 1), xs0) || !issubset(coords(ls, 3), zs0)
                 end
             end
         end


### PR DESCRIPTION
Implements #185, option 1 (the recommended immediate correction): the parallel surface step now refuses what it cannot perform, and the non-surface parallel steps forward the `dims` components they previously only counted. Two commits: `Fix the parallel surface 2D dispatch and forward dims in the parallel walks.` (src) and `Test the parallel dims handling on the surface and non-surface nested-sampling paths.` (tests).

- The parallel `LJSurfaceWalkers` step's length-2 dispatch branch, which selected `MC_random_walk_2D!` and then remotecalled it with six positional arguments no method accepts, is replaced with the same explicit `error("Unsupported dimensions: ...")` the serial surface step raises, with a comment recording why (the surface walks are 3D-only; a length-2 `dims` would reach a method with no surface variant and surface as a `MethodError` on the worker). Serial and parallel surface paths now agree on supported inputs.
- Both non-surface parallel blocks (`MCDistributed` and `MCRoutineParallel`) build `walk_kwargs = (dims = mc_routine.dims,)` in their length-2 branch and splat it into the remotecall, so a run with `dims = [1, 3]` walks the requested plane instead of silently substituting the keyword default `[1, 2]`; the 3D branches pass an empty `NamedTuple` and are byte-equivalent in behavior.
- Option 2 (a surface-aware `MC_random_walk_2D!` as a capability) is deliberately not taken here, per the issue's framing: if in-plane surface walks are wanted later, they should land as one change covering the serial and parallel surface paths together.
- Tests: the parallel surface step with `dims = [1, 2]` asserts the explicit error with the serial path's message (no `MethodError`), retiring the 2D-walk testset's surface skip; the non-surface parallel and serial paths with `dims = [1, 3]` assert every dim-2 coordinate bit-identical across steps on distinct-position walkers, with in-plane motion asserted so the invariant is not vacuous; the mixed-moves surface skip is unchanged, as that capability is out of this issue's scope.

Adversarially checked pre-PR (both fixed behaviors verified by direct execution before the tests were written; the issue's option-1 promises checked one by one; the new testsets run twice with identical outcomes) and the full test suite passes on the shipped bytes: SamplingSchemes 7504 (= 7491 + 13 new assertions), Monte Carlo Moves 3817 and 114, FreeBirdIO 51, and every other testset at their `dev` @ 9ef0d4e counts.
