### PR TITLE
Tighten LJSurfaceWalkers construction and document the frozen-part energy convention

### DIFF
--- a/src/AbstractLiveSets/atomistic_livesets.jl
+++ b/src/AbstractLiveSets/atomistic_livesets.jl
@@ -173,37 +173,67 @@ with the presence of an external surface object wrapped in an `AtomWalker`.
 
 # Fields
 - `walkers::Vector{AtomWalker{C}}`: A vector of atom walkers, where `C` is the number of components.
-- `pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}`: The Lennard-Jones potential parameters.
+- `pot::CompositeParameterSets{CP, LJParameters}`: The Lennard-Jones parameter sets. The surface
+  energy paths evaluate walker components against the surface as an appended LAST component, so
+  the parameter set must carry `CP = C + 1` components (walker components first, surface last);
+  the constructors validate this and throw an `ArgumentError` on a mismatch. A bare
+  `LJParameters` is not accepted: no surface energy path can evaluate it.
 - `surface::AtomWalker{CS}`: An atom walker representing the surface, where `CS` is the number of components of the surface.
 
+# The frozen-part energy convention
+The constructors READ `surface.energy_frozen_part` and copy it into every walker; they do not
+compute it unless asked. Callers must either assign the adsorbent self-energy before
+construction (idiom: `surface.energy_frozen_part = interacting_energy(surface.configuration, lj)`)
+or pass `compute_frozen_energy=true`, which computes it from the surface configuration with the
+parameter set's surface-surface entry. Under the field's `0.0u"eV"` default, walker energies
+silently omit the entire adsorbent self-energy: within one liveset that is a constant shift, but
+any quantity comparing totals across systems or conventions inherits it as an error.
+
 # Constructor
-- `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                    pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}, 
-                    surface::AtomWalker{CS}; assign_energy=true)`
+- `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                    pot::CompositeParameterSets{CP, LJParameters},
+                    surface::AtomWalker{CS}; assign_energy=true, compute_frozen_energy=false)`
 
-    Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones potential parameters, and a single surface walker. 
-    If `assign_energy=true`, the energy of each walker is assigned using the Lennard-Jones potential and the surface.
+    Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones parameter
+    sets, and a single surface walker. If `assign_energy=true`, the energy of each walker is
+    assigned using the Lennard-Jones parameters and the surface.
 
-- `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                            pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}},
-                            surface::AtomWalker{CS}, 
-                            assign_energy_parallel::Symbol,
+- `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                            pot::CompositeParameterSets{CP, LJParameters},
+                            surface::AtomWalker{CS},
+                            assign_energy_parallel::Symbol;
+                            compute_frozen_energy=false,
                             ) where {C, CP, CS}
 
-    Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones potential parameters, and a single surface walker.
-    The `assign_energy_parallel` argument determines whether to assign energy in parallel using threads (`:threads`) or distributed 
+    Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones parameter
+    sets, and a single surface walker.
+    The `assign_energy_parallel` argument determines whether to assign energy in parallel using threads (`:threads`) or distributed
     processes (`:distributed`).
 """
 struct LJSurfaceWalkers <: AtomWalkers
     walkers::Vector{AtomWalker{C}} where C
-    potential::Union{LJParameters, CompositeParameterSets{CP, LJParameters}} where CP
+    potential::CompositeParameterSets{CP, LJParameters} where CP
     surface::AtomWalker{CS} where CS
-    function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                                pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}, 
-                                surface::AtomWalker{CS}; 
+    function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                                pot::CompositeParameterSets{CP, LJParameters},
+                                surface::AtomWalker{CS};
                                 assign_energy = true,
+                                compute_frozen_energy = false,
                                 ) where {C, CP, CS}
+        # The surface energy paths append the surface as the LAST component, so
+        # the parameter set must carry exactly one more component than the
+        # walkers (walker components first, surface last); a mismatch would
+        # make the total-energy and single-site paths read different
+        # parameter-set entries with no error.
+        CP == C + 1 || throw(ArgumentError(
+            "LJSurfaceWalkers requires a parameter set with one component per " *
+            "walker component plus one for the surface (walker components " *
+            "first, surface last): got $CP-component parameters over " *
+            "$C-component walkers, expected $(C + 1)"))
         update_walker!(surface, :frozen, ones(Bool, length(surface.list_num_par)))
+        if compute_frozen_energy
+            surface.energy_frozen_part = interacting_energy(surface.configuration, pot.param_sets[end, end])
+        end
         frozen_part_energy = surface.energy_frozen_part # assuming (only) the surface is frozen
         if assign_energy
             Threads.@threads for walker in walkers
@@ -216,31 +246,45 @@ struct LJSurfaceWalkers <: AtomWalkers
 end
 
 """
-    LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                            pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}},
-                            surface::AtomWalker{CS}, 
-                            assign_energy_parallel::Symbol,
+    LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                            pot::CompositeParameterSets{CP, LJParameters},
+                            surface::AtomWalker{CS},
+                            assign_energy_parallel::Symbol;
+                            compute_frozen_energy=false,
                             ) where {C, CP, CS}
 
-Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones potential parameters, and a single surface walker.
-The `assign_energy_parallel` argument determines whether to assign energy in parallel using threads (`:threads`) or distributed 
-processes (`:distributed`).
+Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones parameter sets, and a single surface walker.
+The `assign_energy_parallel` argument determines whether to assign energy in parallel using threads (`:threads`) or distributed
+processes (`:distributed`). The parameter set must carry `CP = C + 1` components (walker
+components first, surface last; validated with an `ArgumentError`), and
+`surface.energy_frozen_part` is read, not computed, unless `compute_frozen_energy=true`; see
+[`LJSurfaceWalkers`](@ref).
 
 # Arguments
 - `walkers::Vector{AtomWalker{C}}`: A vector of atom walkers, where `C` is the number of components.
-- `pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}`: The Lennard-Jones potential parameters.
+- `pot::CompositeParameterSets{CP, LJParameters}`: The Lennard-Jones parameter sets.
 - `surface::AtomWalker{CS}`: An atom walker representing the surface, where `CS` is the number of components of the surface.
 - `assign_energy_parallel::Symbol`: The method to use for parallel energy assignment. Can be `:threads` or `:distributed`.
+- `compute_frozen_energy::Bool`: Whether to compute `surface.energy_frozen_part` from the surface configuration before assigning walker energies. Default is `false` (the field is read as-is).
 
 # Returns
 - `LJSurfaceWalkers`: A new `LJSurfaceWalkers` object with the assigned energy.
 """
-function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                            pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}, 
-                            surface::AtomWalker{CS}, 
-                            assign_energy_parallel::Symbol,
+function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                            pot::CompositeParameterSets{CP, LJParameters},
+                            surface::AtomWalker{CS},
+                            assign_energy_parallel::Symbol;
+                            compute_frozen_energy = false,
                             ) where {C, CP, CS}
+    CP == C + 1 || throw(ArgumentError(
+        "LJSurfaceWalkers requires a parameter set with one component per " *
+        "walker component plus one for the surface (walker components " *
+        "first, surface last): got $CP-component parameters over " *
+        "$C-component walkers, expected $(C + 1)"))
     update_walker!(surface, :frozen, ones(Bool, length(surface.list_num_par)))
+    if compute_frozen_energy
+        surface.energy_frozen_part = interacting_energy(surface.configuration, pot.param_sets[end, end])
+    end
     frozen_part_energy = surface.energy_frozen_part
     if assign_energy_parallel == :threads
         @info "Assigning energy to walkers in parallel using $(Threads.nthreads()) threads..."

--- a/test/test-AbstractLiveSets.jl
+++ b/test/test-AbstractLiveSets.jl
@@ -135,6 +135,110 @@ FreeBird.EnergyEval.interacting_energy(lattice::SLattice, h::ExtBadHam) = 1.6
             end
         end
 
+        @testset "LJSurfaceWalkers constructor validation tests" begin
+            # These testsets build fresh fixtures rather than sharing the
+            # `surface` above: the constructors mutate the surface walker
+            # (frozen flags, and `energy_frozen_part` under
+            # `compute_frozen_energy=true`), and the keyword tests need a
+            # surface whose `energy_frozen_part` still sits at its
+            # 0.0u"eV" default.
+            ads_list = [:H => [0.5, 0.5, 0.35]]
+            # one-component adsorbate walkers
+            make_adsorbates(n) = [AtomWalker(FastSystem(periodic_system(ads_list, box, fractional=true))) for _ in 1:n]
+            make_surface() = AtomWalker(FastSystem(periodic_system(surf_list, box, fractional=true)); freeze_species=[:H])
+            ljs2 = CompositeParameterSets(2, [lj, lj, lj])  # adsorbate + surface
+
+            @testset "bare LJParameters rejected at dispatch" begin
+                # No surface energy path can evaluate a bare LJParameters
+                # (the five-argument interacting_energy and the same-surface
+                # single_site_energy methods exist only for
+                # CompositeParameterSets), so both constructor forms accept
+                # only the composite type and a bare parameter set fails at
+                # dispatch, before any energy work.
+                walkers = make_adsorbates(1)
+                surface = make_surface()
+                @test_throws MethodError LJSurfaceWalkers(walkers, lj, surface)
+                @test_throws MethodError LJSurfaceWalkers(walkers, lj, surface, :threads)
+            end
+
+            @testset "component-count validation" begin
+                # The surface energy paths append the surface as the LAST
+                # parameter-set component, so the parameter set must carry
+                # C + 1 components over C-component walkers; a mismatch
+                # raises a descriptive ArgumentError on both constructor
+                # forms. The matching layouts need no new coverage here:
+                # the LJSurfaceWalkers testsets above construct
+                # three-over-two (`ljs` over the two-component H/O
+                # walkers), and the sampling-scheme suites construct
+                # two-over-one.
+                walkers = make_adsorbates(1)
+                surface = make_surface()
+                @test_throws ArgumentError LJSurfaceWalkers(walkers, ljs, surface)
+                @test_throws ArgumentError LJSurfaceWalkers(walkers, ljs, surface, :threads)
+                err = try
+                    LJSurfaceWalkers(walkers, ljs, surface)
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa ArgumentError
+                @test occursin("3-component parameters", err.msg)
+                @test occursin("1-component walkers", err.msg)
+                @test occursin("expected 2", err.msg)
+            end
+
+            @testset "frozen-part energy bookkeeping" begin
+                # With the adsorbent self-energy assigned by hand (the
+                # documented idiom), every walker total is the
+                # walker-surface interacting energy plus the surface
+                # self-energy, carried through the copied
+                # energy_frozen_part: the self-energy enters each total
+                # exactly once.
+                surface = make_surface()
+                surface.energy_frozen_part = interacting_energy(surface.configuration, lj)
+                ls = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface)
+                for w in ls.walkers
+                    @test w.energy == interacting_energy(w.configuration, ljs2, w.list_num_par, w.frozen, surface.configuration) + surface.energy_frozen_part
+                    @test w.energy_frozen_part == surface.energy_frozen_part
+                end
+            end
+
+            @testset "compute_frozen_energy keyword" begin
+                # Reference construction: the hand-assigned idiom.
+                surface_hand = make_surface()
+                surface_hand.energy_frozen_part = interacting_energy(surface_hand.configuration, lj)
+                ls_hand = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface_hand)
+
+                # compute_frozen_energy=true starts from an unset surface
+                # and must reproduce the hand-assigned construction
+                # bit-identically, on both constructor forms.
+                surface_kw = make_surface()
+                ls_kw = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface_kw; compute_frozen_energy=true)
+                @test surface_kw.energy_frozen_part === surface_hand.energy_frozen_part
+                surface_kwp = make_surface()
+                ls_kwp = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface_kwp, :threads; compute_frozen_energy=true)
+                @test surface_kwp.energy_frozen_part === surface_hand.energy_frozen_part
+                for i in 1:3
+                    @test ls_kw.walkers[i].energy === ls_hand.walkers[i].energy
+                    @test ls_kw.walkers[i].energy_frozen_part === ls_hand.walkers[i].energy_frozen_part
+                    @test ls_kwp.walkers[i].energy === ls_hand.walkers[i].energy
+                    @test ls_kwp.walkers[i].energy_frozen_part === ls_hand.walkers[i].energy_frozen_part
+                end
+
+                # The default leaves an unset surface at 0.0u"eV" (the
+                # silent omission the docstring documents): construction
+                # succeeds, no walker carries the self-energy, and the two
+                # constructions differ by exactly the surface self-energy.
+                surface_def = make_surface()
+                ls_def = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface_def)
+                @test surface_def.energy_frozen_part == 0.0u"eV"
+                for i in 1:3
+                    @test ls_def.walkers[i].energy_frozen_part == 0.0u"eV"
+                    @test ls_def.walkers[i].energy + surface_hand.energy_frozen_part === ls_hand.walkers[i].energy
+                end
+            end
+        end
+
         @testset "LJAtomWalkers struct and functions tests" begin
             
             # Create multiple walkers with different configurations


### PR DESCRIPTION
Implements #183, fix 1 plus both optional items (fix 2, adding bare-parameter surface energy methods, is deliberately not taken: the issue established that no working caller exists, so the tightened type is the honest contract). Two commits: `Tighten LJSurfaceWalkers construction and document the frozen-part energy convention.` (src) and `Test the LJSurfaceWalkers construction contract.` (tests).

- Hazard 1 (a potential no surface energy path can evaluate): the struct field and both constructors now accept `CompositeParameterSets{CP, LJParameters}` only, so a bare `LJParameters` is rejected at dispatch instead of failing later as a `MethodError` buried in a threaded loop or, with `assign_energy = false`, on the first walk. Breaking only in the type domain: no shipped test, example, or documentation constructs the liveset with a bare `LJParameters`, and no such construction has ever survived its first energy evaluation.
- Adjacent gap (the surface must be the last parameter-set component): both constructors validate `CP = C + 1` and throw a descriptive `ArgumentError` naming the expected layout (walker components first, surface last), converting the silent cross-path divergence, where the total-energy and single-site paths read different parameter-set entries, into a setup error in the spirit of the lattice-liveset checks.
- Hazard 2 (`energy_frozen_part` read, never computed): the struct docstring now carries the convention paragraph (the constructors read the field and copy it into every walker; callers assign the adsorbent self-energy first, or walker energies silently omit it under the `0.0u"eV"` default), and both constructors gain `compute_frozen_energy::Bool = false`, which when `true` computes the self-energy from the surface configuration with the parameter set's surface-surface entry; the default keeps every existing construction bit-identical.
- Tests, in the liveset construction testsets: dispatch rejection of a bare `LJParameters` on both constructor forms; the energy-bookkeeping identity (each walker total equals the five-argument interaction energy plus the surface self-energy, entering exactly once); `compute_frozen_energy = true` bit-identical to the hand-assigned idiom and the default's silent-omission contrast pinned as documented; the component-count `ArgumentError` on both forms with the message asserted, with the shipped two-over-one and three-over-two constructions passing unchanged.

Adversarially checked pre-PR (all four constructor behaviors verified by direct execution before the tests were written; every in-repo `LJSurfaceWalkers` construction audited for the new contract) and the full test suite passes on the shipped bytes: AbstractLiveSets 146 (= 111 + 35 new assertions, reconciled against the testset's arithmetic), SamplingSchemes 7504, Monte Carlo Moves 3817 and 114, FreeBirdIO 51, and every other testset at their `dev` @ 1fdbc77 counts.
