### PR TITLE
Finite-lattice and non-periodic-surface regression coverage for generic-lattice cluster models, the ideal-gas-referenced route, and all-false-periodicity livesets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test*.*
 input*
 output*
 !test/*
+!test/**/*.jl
 *.extxyz
 *.swp
 .DS_Store

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,7 @@ makedocs(;
     pages=[
             "FreeBird.jl" => "index.md",
             "Tutorials" => "tutorials.md",
+            "Custom Hamiltonians" => "CustomHamiltonians.md",
             "Examples" => "examples.md",
             "Interface with Python for MLIPs" => "MLIPs.md",
             "Modules and Documentation" => [

--- a/docs/src/AnalysisTools.md
+++ b/docs/src/AnalysisTools.md
@@ -13,7 +13,7 @@ free. Along the contiguous cull index ``i`` the enclosed prior volume is
 energy ladder ``E(i)``,
 
 ```math
-S(E) = i\,\ln\!\frac{K}{K+1} - \ln\left|\frac{dE}{di}\right| ,
+S(E) = i\,\ln\!\frac{K}{K+1} - \ln\left|\frac{dE}{di}\right| + \mathrm{const} ,
 ```
 
 where derivatives are taken against the dense, uniform ``i``-axis (local cubic
@@ -23,7 +23,7 @@ Phys. Rev. E **84**, 011127 (2011) and Qi & Bachmann, Phys. Rev. Lett. **120**,
 the inverse caloric temperature ``\beta(E) = dS/dE``, and their **order** follows
 from the higher derivatives:
 
-| transition order | signature in ``S^{(n)}(E)`` |
+| transition order | *independent* signature in ``S^{(n)}(E)`` |
 |:--|:--|
 | 1 (first-order)  | ``\beta = S'`` has a positive local **minimum** (``\beta`` backbends; latent heat) |
 | 2 (second-order) | ``\gamma = S''`` has a negative local **maximum** |
@@ -31,10 +31,14 @@ from the higher derivatives:
 | odd ``n``        | positive local minimum of ``S^{(n)}`` |
 | even ``n``       | negative local maximum of ``S^{(n)}`` |
 
-The transition temperature is ``T_\mathrm{tr} = 1/\beta(E_\mathrm{tr})``. This is a
-purely microcanonical route: it needs no temperature grid, returns transition
-**energies and orders** directly, and can resolve transitions that broad canonical
-`cv(T)` peaks blur.
+*Dependent* transitions carry the swapped signatures (odd ``n``: negative local
+maximum; even ``n``: positive local minimum) and are reported with
+`kind = :dependent` when accompanied by an independent transition of lower order
+at lower energy. The transition temperature is
+``T_\mathrm{tr} = 1/(k_B\,\beta(E_\mathrm{tr}))`` — in Kelvin with the default
+`kb` in eV/K, or in energy units with `kb = 1`. This is a purely microcanonical
+route: it needs no temperature grid, returns transition **energies and orders**
+directly, and can resolve transitions that broad canonical `cv(T)` peaks blur.
 
 ### Workflow
 
@@ -70,6 +74,7 @@ conv = transition_convergence(dfs, [320, 640, 1280])   # flags drifting transiti
     divergence as ``E \to E_\mathrm{ground}``.
 
 ## Functions
+
 ```@autodocs
 Modules = [AnalysisTools]
 ```

--- a/docs/src/AnalysisTools.md
+++ b/docs/src/AnalysisTools.md
@@ -1,5 +1,74 @@
 # Analysis Tools
 
+The `AnalysisTools` module post-processes sampling output into thermodynamic
+quantities: phase-space weights (`ωᵢ`), the partition function, internal energy,
+constant-volume heat capacity (`cv`), grand-canonical reweighting, and — described
+below — microcanonical inflection-point analysis of phase transitions.
+
+## Microcanonical inflection-point analysis
+
+Nested sampling yields the microcanonical entropy ``S(E) = \ln g(E)`` almost for
+free. Along the contiguous cull index ``i`` the enclosed prior volume is
+``X_i = (K/(K+1))^i``, so ``\ln X_i = i\,\ln(K/(K+1))`` and, with the recorded
+energy ladder ``E(i)``,
+
+```math
+S(E) = i\,\ln\!\frac{K}{K+1} - \ln\left|\frac{dE}{di}\right| ,
+```
+
+where derivatives are taken against the dense, uniform ``i``-axis (local cubic
+fits) rather than a binned ``\ln g`` in energy space. Following Schnabel *et al.*,
+Phys. Rev. E **84**, 011127 (2011) and Qi & Bachmann, Phys. Rev. Lett. **120**,
+180601 (2018), phase transitions in finite systems appear as *inflection points* of
+the inverse caloric temperature ``\beta(E) = dS/dE``, and their **order** follows
+from the higher derivatives:
+
+| transition order | signature in ``S^{(n)}(E)`` |
+|:--|:--|
+| 1 (first-order)  | ``\beta = S'`` has a positive local **minimum** (``\beta`` backbends; latent heat) |
+| 2 (second-order) | ``\gamma = S''`` has a negative local **maximum** |
+| 3                | ``\delta = S'''`` has a positive local minimum |
+| odd ``n``        | positive local minimum of ``S^{(n)}`` |
+| even ``n``       | negative local maximum of ``S^{(n)}`` |
+
+The transition temperature is ``T_\mathrm{tr} = 1/\beta(E_\mathrm{tr})``. This is a
+purely microcanonical route: it needs no temperature grid, returns transition
+**energies and orders** directly, and can resolve transitions that broad canonical
+`cv(T)` peaks blur.
+
+### Workflow
+
+```julia
+using FreeBird
+
+df = read_output("ladder.csv")            # canonical NS output (columns :iter, :emax)
+K  = 320                                   # number of live walkers used to produce it
+
+E, S = microcanonical_entropy(df, K)               # S(E) = ln g(E)
+d    = caloric_derivatives(df, K; max_order = 2)   # d.E, d.β, d.γ
+ts   = inflection_transitions(df, K; max_order = 2) # → (E_tr, T_tr, order, kind, strength)
+
+# Recommended: confirm each transition is converged in the walker count K
+dfs = [read_output("ladder_K320.csv"),
+       read_output("ladder_K640.csv"),
+       read_output("ladder_K1280.csv")]
+conv = transition_convergence(dfs, [320, 640, 1280])   # flags drifting transitions
+```
+
+### Convergence and smoothing
+
+!!! warning "Use enough walkers, and check convergence"
+    The derivative ``\gamma = d^2S/dE^2`` amplifies the finite-walker "staircase"
+    granularity of the NS ladder (step ``\sim 1/(K\,g)``). This roughness is
+    *deterministic* in the walker count ``K`` — it does **not** average out over
+    independent runs — so a transition should only be trusted once its temperature
+    and order stop drifting as ``K`` grows; use [`transition_convergence`](@ref).
+    Near-ground transitions converge last. The light internal smoothing
+    (`halfwidth`) is a necessary differentiation aid, **not** a substitute for
+    adequate ``K``: smoothing heavily to mask too-few walkers biases the transition
+    temperatures. Energy-window/`ground_trim` controls remove the ``\beta``
+    divergence as ``E \to E_\mathrm{ground}``.
+
 ## Functions
 ```@autodocs
 Modules = [AnalysisTools]

--- a/docs/src/CustomHamiltonians.md
+++ b/docs/src/CustomHamiltonians.md
@@ -1,0 +1,58 @@
+# Custom Hamiltonians
+
+The lattice sampling stack accepts user-defined Hamiltonians through a small extension contract: `interacting_energy(lattice, hamiltonian)` is the only place the stack evaluates a Hamiltonian, so one method serves `LatticeGasWalkers` construction, all of the nested-sampling loops, and `exact_enumeration`, on every single-component lattice geometry. Externally defined energies on fixed site sets are standard practice, machine-learned potentials among them, and this page records what a custom type must provide.
+
+## The contract
+
+1. Subtype `ClassicalHamiltonian`. Fields are yours, including caches: nothing in the stack copies or introspects the Hamiltonian.
+2. Define one energy method returning an energy-dimensioned `Unitful.Quantity` (eV-convertible; a molar energy such as kJ/mol carries a different dimension and is rejected). A method returning a plain number raises a descriptive `ArgumentError` at walker setup. The validation lives on the walker-setup surface; the raw-lattice `wang_landau` and `nvt_monte_carlo` entry points evaluate the Hamiltonian directly and sit outside it.
+3. Optionally, opt into two integrations: `AbstractHamiltonians._coupling_type(::MyHam)` to compose under `SiteFieldLatticeHamiltonian` (its absence produces a self-explanatory `ArgumentError`), and `AbstractLiveSets._n_coupled_shells(::MyHam)` to participate in the uncoupled-shell warning at setup.
+
+A worked example, a coordination-dependent energy no shipped pair, cluster, or site-field type expresses directly:
+
+````julia
+using FreeBird
+using Unitful
+
+struct CoordinationHamiltonian <: ClassicalHamiltonian
+    j::Float64
+end
+
+import FreeBird.EnergyEval: interacting_energy
+
+function interacting_energy(lattice::SLattice, h::CoordinationHamiltonian)
+    occ = lattice.components[1]
+    doubly = count(s -> occ[s] &&
+                        count(n -> occ[n], lattice.neighbors[s][1]) == 2,
+                   eachindex(occ))
+    return h.j * doubly^2 * u"eV"
+end
+````
+
+With that in place, the type is a drop-in for the shipped Hamiltonians:
+
+````julia
+walkers = [LatticeWalker(deepcopy(lattice), energy=0.0u"eV", iter=0) for _ in 1:32]
+ls = LatticeGasWalkers(walkers, CoordinationHamiltonian(0.1))
+df, ls, params = grand_canonical_nested_sampling(ls, gc_params, 1000, mc_routine, save_strategy)
+````
+
+and `exact_enumeration(lattice, CoordinationHamiltonian(0.1))` enumerates its fixed-particle-number spectrum.
+
+## Caching expensive energies
+
+The evaluation path is serial (walker setup is a plain loop, and the nested-sampling loops evaluate one proposal at a time), so a plain `Dict` memoization keyed by the occupation vector is safe:
+
+````julia
+struct CachedHamiltonian <: ClassicalHamiltonian
+    cache::Dict{Vector{Bool},typeof(1.0u"eV")}
+end
+
+function interacting_energy(lattice::SLattice, h::CachedHamiltonian)
+    get!(h.cache, copy(lattice.components[1])) do
+        expensive_energy(lattice)
+    end
+end
+````
+
+Two practical notes. First, define `Base.show` for cache-carrying types: the default struct `show` prints the entire cache whenever a liveset is displayed. Second, the serial-evaluation guarantee is what makes the unsynchronized `Dict` safe; wrap the cache before using any future parallel evaluation path.

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -235,6 +235,7 @@ The `components=[[1,2,3,4]]` argument specifies that the system has a single com
 and the first four sites are occupied.
 ```julia
 MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
+    interlayer_spacing::Union{Nothing,Float64}=nothing,
     basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0)],
     supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 4, 1),
     periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -214,9 +214,10 @@ MLattice{C,G}(
     basis::Vector{Tuple{Float64, Float64, Float64}},
     supercell_dimensions::Tuple{Int64, Int64, Int64},
     periodicity::Tuple{Bool, Bool, Bool},
-    components::Vector{Vector{Bool}},
-    adsorptions::Vector{Bool},
     cutoff_radii::Vector{Float64},
+    components::Vector{Vector{Bool}},
+    adsorptions::Vector{Bool};
+    image_multiplicity::Bool=false,
 ) where {C,G}
 ```
 The `C` parameter is the number of components in the system, and the `G` parameter defines the geometry of the lattice.
@@ -239,7 +240,8 @@ MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
     periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
     cutoff_radii::Vector{Float64}=[1.1, 1.5],
     components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
-    adsorptions::Union{Vector{Int},Symbol}=:full)
+    adsorptions::Union{Vector{Int},Symbol}=:full,
+    image_multiplicity::Bool=false)
 ```
 
 You may notice that the code above returns a `SLattice` type.

--- a/scripts/tutorials.jl
+++ b/scripts/tutorials.jl
@@ -131,9 +131,10 @@ MLattice{C,G}(
     basis::Vector{Tuple{Float64, Float64, Float64}},
     supercell_dimensions::Tuple{Int64, Int64, Int64},
     periodicity::Tuple{Bool, Bool, Bool},
-    components::Vector{Vector{Bool}},
-    adsorptions::Vector{Bool},
     cutoff_radii::Vector{Float64},
+    components::Vector{Vector{Bool}},
+    adsorptions::Vector{Bool};
+    image_multiplicity::Bool=false,
 ) where {C,G}
 ```
 =====================#
@@ -150,12 +151,14 @@ The `components=[[1,2,3,4]]` argument specifies that the system has a single com
 and the first four sites are occupied.
 ```julia
 MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
+    interlayer_spacing::Union{Nothing,Float64}=nothing,
     basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0)],
     supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 4, 1),
     periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
     cutoff_radii::Vector{Float64}=[1.1, 1.5],
     components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
-    adsorptions::Union{Vector{Int},Symbol}=:full)
+    adsorptions::Union{Vector{Int},Symbol}=:full,
+    image_multiplicity::Bool=false)
 ```
 ==#
 

--- a/src/AbstractHamiltonians/AbstractHamiltonians.jl
+++ b/src/AbstractHamiltonians/AbstractHamiltonians.jl
@@ -12,6 +12,7 @@ using StaticArrays
 export AbstractHamiltonian
 export ClassicalHamiltonian
 export GenericLatticeHamiltonian, MLatticeHamiltonian
+export ClusterInteraction, ClusterLatticeHamiltonian
 
 abstract type AbstractHamiltonian end
 
@@ -175,6 +176,141 @@ function Base.show(io::IO, hamiltonian::MLatticeHamiltonian{C,N,U}) where {C,N,U
        for j in 1:C
            println(io, "    Hamiltonians[$i, $j]: ", hamiltonian.Hamiltonians[i,j])
        end
+    end
+end
+
+"""
+    struct ClusterInteraction{K,U}
+
+A single multi-body (cluster) interaction figure on a lattice: one coupling
+plus the explicit list of the figure's embeddings, each an ordered `K`-tuple
+of site indices. The coupling is the energy contributed per fully occupied
+embedding. Each unordered site set appears exactly once, in canonical
+(strictly increasing) form, so double counting of symmetric motifs is
+structurally impossible. Embedding lists are typically produced by
+`enumerate_motif_embeddings` under the torus (minimum-image) convention,
+matching how the pair shells count neighbors.
+
+Only orders `K ≥ 3` are represented: on-site and pair terms belong in the
+wrapped `GenericLatticeHamiltonian` of a [`ClusterLatticeHamiltonian`](@ref).
+
+Note: "cluster" here names an interaction figure of a cluster expansion,
+not the geometric cluster Monte Carlo moves elsewhere in FreeBird.
+
+# Constructor
+```julia
+ClusterInteraction(coupling, embeddings::Vector{NTuple{K,Int}})
+```
+Throws `ArgumentError` on `K < 3`, a non-finite coupling, an embedding that
+is not strictly increasing or contains a non-positive index, or a duplicate
+embedding; warns on an empty embedding list (which contributes exactly
+zero energy).
+"""
+struct ClusterInteraction{K,U}
+    coupling::U
+    embeddings::Vector{NTuple{K,Int}}
+
+    function ClusterInteraction{K,U}(coupling::U, embeddings::Vector{NTuple{K,Int}}) where {K,U}
+        if K < 3
+            throw(ArgumentError(
+                "ClusterInteraction is for 3-body and higher motifs (got K = $K); " *
+                "on-site and pair terms belong in the wrapped GenericLatticeHamiltonian"))
+        end
+        if !isfinite(coupling)
+            throw(ArgumentError(
+                "non-finite cluster couplings are not supported; model hard " *
+                "constraints with finite couplings (see the hard-core recipe " *
+                "in the GenericLatticeHamiltonian docstring)"))
+        end
+        isempty(embeddings) &&
+            @warn "ClusterInteraction with an empty embedding list contributes exactly zero energy"
+        seen = Set{NTuple{K,Int}}()
+        for e in embeddings
+            if e[1] < 1
+                throw(ArgumentError("embedding $e contains a non-positive site index"))
+            end
+            for k in 1:K-1
+                if e[k] >= e[k+1]
+                    throw(ArgumentError(
+                        "embedding $e is not in canonical (strictly increasing) " *
+                        "order; each unordered site set must appear exactly once"))
+                end
+            end
+            if e in seen
+                throw(ArgumentError("duplicate embedding $e would double-count its energy"))
+            end
+            push!(seen, e)
+        end
+        return new(coupling, embeddings)
+    end
+end
+
+function ClusterInteraction(coupling::U, embeddings::Vector{NTuple{K,Int}}) where {K,U}
+    return ClusterInteraction{K,U}(coupling, embeddings)
+end
+
+function Base.show(io::IO, c::ClusterInteraction{K,U}) where {K,U}
+    print(io, "ClusterInteraction{$K}: coupling = ", c.coupling,
+          ", ", length(c.embeddings), " embeddings")
+end
+
+"""
+    struct ClusterLatticeHamiltonian{N,U} <: ClassicalHamiltonian
+
+A lattice Hamiltonian with on-site, pair-shell, and multi-body (cluster)
+terms: a `GenericLatticeHamiltonian{N,U}` carrying the on-site energy and
+the `N` pair-shell couplings, plus a vector of [`ClusterInteraction`](@ref)
+figures of arbitrary orders `K ≥ 3`. The total energy is the pair part
+plus, for every figure, the coupling times the number of its fully
+occupied embeddings.
+
+Sign and unit conventions follow `GenericLatticeHamiltonian`: positive
+couplings are repulsive. Published binding-energy parameter sets (e.g. the
+O-Pd(100) lattice-gas Hamiltonian of Zhang, Blum & Reuter, PRB 75, 235406
+(2007), whose optimum expansion carries four pair shells, four trios, and
+one quattro) map onto FreeBird by negating every parameter.
+
+Evaluated by `interacting_energy(lattice, h)` for single-component
+(`SLattice`) configurations, and therefore usable in every sampler that
+calls it generically.
+
+# Constructor
+```julia
+ClusterLatticeHamiltonian(pair_ham::GenericLatticeHamiltonian{N,U}, clusters)
+```
+`clusters` is a vector of `ClusterInteraction`s whose coupling type matches
+`U`; heterogeneous orders `K` are allowed.
+"""
+struct ClusterLatticeHamiltonian{N,U} <: ClassicalHamiltonian
+    pair_ham::GenericLatticeHamiltonian{N,U}
+    clusters::Vector{ClusterInteraction{K,U} where K}
+
+    function ClusterLatticeHamiltonian(pair_ham::GenericLatticeHamiltonian{N,U},
+                                       clusters::AbstractVector) where {N,U}
+        converted = Vector{ClusterInteraction{K,U} where K}()
+        for (i, c) in enumerate(clusters)
+            if !(c isa ClusterInteraction)
+                throw(ArgumentError(
+                    "clusters[$i] is a $(typeof(c)); expected a ClusterInteraction"))
+            end
+            if !(typeof(c.coupling) == U)
+                throw(ArgumentError(
+                    "clusters[$i] has coupling type $(typeof(c.coupling)), which " *
+                    "does not match the pair Hamiltonian's $U; construct every " *
+                    "coupling with the same units and value type"))
+            end
+            push!(converted, c)
+        end
+        return new{N,U}(pair_ham, converted)
+    end
+end
+
+function Base.show(io::IO, h::ClusterLatticeHamiltonian{N,U}) where {N,U}
+    println(io, "ClusterLatticeHamiltonian{$N,$U}:")
+    println(io, "    pair part: ", h.pair_ham)
+    println(io, "    clusters:")
+    for c in h.clusters
+        println(io, "        ", c)
     end
 end
 

--- a/src/AbstractHamiltonians/AbstractHamiltonians.jl
+++ b/src/AbstractHamiltonians/AbstractHamiltonians.jl
@@ -34,6 +34,37 @@ Units of energy `U` is also specified.
 GenericLatticeHamiltonian(on_site_interaction::Float64, nth_neighbor_interactions::Vector{Float64}, energy_units::Unitful.Units)
 GenericLatticeHamiltonian(on_site_interaction::U, nth_neighbor_interactions::Vector{U}) where U
 ```
+
+All couplings must be finite; `Inf` is rejected by the constructor because it
+stalls nested sampling silently (every ceiling comparison becomes `Inf >= Inf`).
+
+## Hard-core (athermal) lattice models
+
+Nearest-neighbor exclusion models — hard squares on the square lattice, hard
+hexagons on the triangular lattice — are expressed with a *finite* repulsive
+coupling on a lattice built with a single cutoff shell, e.g.
+`GenericLatticeHamiltonian(0.0, [1.0], u"eV")` with `cutoff_radii=[1.1]`.
+The energy is then `J × (number of excluded-neighbor pairs)`, an
+integer-leveled ladder whose `E = 0` manifold is exactly the hard-core
+configuration space, and the nested-sampling descent through the violating
+levels measures the hard-core partition function against the full,
+unrestricted prior (the `(1+z0)^M` normalization stays valid). Two numerical
+windows apply:
+
+- **Sampling**: choose the NS `energy_perturbation` δ with
+  `eps(E_max) ≪ δ ≪ J`, where `E_max = J·M·c/2` is the maximal violation
+  energy on `M` sites with excluded-shell coordination `c`. Concretely, keep
+  `δ / eps(E_max)` above ~`K²` so the `K` walkers draw distinct tie-breaking
+  values on a plateau: δ = `1e-9` at `J = 1 eV` is safe through
+  `E_max ≈ 10³ eV` (hard squares near `M ≈ 500`, hard hexagons near
+  `M ≈ 330`); scale δ proportionally for larger lattices.
+- **Post-processing**: evaluate at a temperature low enough that
+  `β·J ≥ (ladder depth in nats) + ~40`, with the depth
+  `n_iters · ln((K + n_cull)/K)`, while keeping `β·δ ≪ 1`; every violating
+  level's Boltzmann factor is then an exact zero to double precision, the
+  allowed levels' deviate from 1 only by `O(β·δ)`, and all observables are
+  athermal (functions of the activity `z = exp(βμ)` alone).
+
 ## Examples
 ```jldoctest
 julia> ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
@@ -54,6 +85,13 @@ struct GenericLatticeHamiltonian{N,U} <: ClassicalHamiltonian
     function GenericLatticeHamiltonian{N,U}(on_site_interaction::U, nth_neighbor_interactions::Vector{U}) where {N,U}
         if length(nth_neighbor_interactions) != N
             throw(ArgumentError("Length of nth_neighbor_interactions must match the number of neighbors"))
+        end
+        if !isfinite(on_site_interaction) || any(!isfinite, nth_neighbor_interactions)
+            throw(ArgumentError("non-finite couplings are not supported: an Inf coupling " *
+                "makes every nested-sampling ceiling comparison degenerate (Inf >= Inf) and " *
+                "the sampler stalls silently. Model hard-core exclusion with a finite " *
+                "repulsive coupling instead — see the hard-core recipe in the " *
+                "GenericLatticeHamiltonian docstring."))
         end
         return new(on_site_interaction, SVector{N, U}(nth_neighbor_interactions))
     end

--- a/src/AbstractHamiltonians/AbstractHamiltonians.jl
+++ b/src/AbstractHamiltonians/AbstractHamiltonians.jl
@@ -13,6 +13,7 @@ export AbstractHamiltonian
 export ClassicalHamiltonian
 export GenericLatticeHamiltonian, MLatticeHamiltonian
 export ClusterInteraction, ClusterLatticeHamiltonian
+export SiteFieldLatticeHamiltonian
 
 abstract type AbstractHamiltonian end
 
@@ -109,7 +110,7 @@ end
 function Base.show(io::IO, hamiltonian::GenericLatticeHamiltonian{N,U}) where {N,U}
     println(io, "GenericLatticeHamiltonian{$N,$U}:")
     println(io, "    on_site_interaction:      ", hamiltonian.on_site_interaction)
-    println(io, "    nth_neighbor_interactions: ", [hamiltonian.nth_neighbor_interactions[i].val for i in 1:N], " ", unit(U))
+    println(io, "    nth_neighbor_interactions: ", [ustrip(hamiltonian.nth_neighbor_interactions[i]) for i in 1:N], " ", unit(U))
 end
     
     """
@@ -312,6 +313,154 @@ function Base.show(io::IO, h::ClusterLatticeHamiltonian{N,U}) where {N,U}
     for c in h.clusters
         println(io, "        ", c)
     end
+end
+
+"""
+    _coupling_type(hamiltonian)
+
+Internal trait returning the concrete coupling type `U` of a lattice
+Hamiltonian (the exact `typeof` shared by its on-site, pair, and cluster
+couplings), or `nothing` for Hamiltonian types that do not declare one. The
+[`SiteFieldLatticeHamiltonian`](@ref) constructor uses it to require that
+every field entry's type equals the base's coupling type (same units and
+value type; no promotion), mirroring the per-cluster coupling check of
+[`ClusterLatticeHamiltonian`](@ref). New `ClassicalHamiltonian` types opt
+in by adding a method.
+"""
+_coupling_type(hamiltonian) = nothing
+_coupling_type(::GenericLatticeHamiltonian{N,U}) where {N,U} = U
+_coupling_type(::MLatticeHamiltonian{C,N,U}) where {C,N,U} = U
+_coupling_type(::ClusterLatticeHamiltonian{N,U}) where {N,U} = U
+
+"""
+    struct SiteFieldLatticeHamiltonian{H,U} <: ClassicalHamiltonian
+
+A wrapper Hamiltonian adding a site-resolved on-site energy (a "field") to
+a lattice Hamiltonian: the total energy is the wrapped base Hamiltonian's
+energy plus `Σ field[i]` over every occupied site `i`. One number per site
+breaks the site equivalence the base Hamiltonians assume, which is what
+layered adsorption physics needs: a substrate potential decaying with
+height, canonically a contact term plus an inverse-cube tail in the
+multilayer lattice-gas models of de Oliveira and Griffiths
+[Surf. Sci. 71, 687 (1978)] and Pandit, Schick and Wortis
+[Phys. Rev. B 26, 5112 (1982)], is expressed as a per-layer profile
+broadcast over sites with `layer_field`.
+
+# Fields
+- `base::H`: the wrapped Hamiltonian (`GenericLatticeHamiltonian`,
+  `MLatticeHamiltonian`, or `ClusterLatticeHamiltonian`).
+- `field::Vector{U}`: one on-site energy per site, added once per occupied
+  site; `U` equals the base's coupling type exactly.
+
+# Additive contract
+
+The field adds on top of the base's own on-site term: a base with
+`on_site_interaction = ε` still contributes `ε × (number of occupied
+adsorption sites)` through `lattice.adsorptions`. The two on-site channels
+compose additively, so supplying a full per-site field while the base
+carries a nonzero on-site energy double-counts every occupied adsorption
+site. When a full field is supplied, zero the base's on-site energy and
+put the entire on-site physics in the field.
+
+The wrapper subsumes the adsorption mechanism exactly: for a lattice with
+adsorption mask `A = lattice.adsorptions`,
+
+    GenericLatticeHamiltonian(ε, J)   # ε once per occupied adsorption site
+    ≡ SiteFieldLatticeHamiltonian(GenericLatticeHamiltonian(zero(ε), J), ε .* A)
+
+since the masked field `ε .* A` carries `ε` on each adsorption site and an
+exact zero elsewhere.
+
+## Layer-profile recipe
+
+    lat = SLattice{SquareLattice}(supercell_dimensions=(4, 4, 3),
+                                  periodicity=(true, true, false),
+                                  cutoff_radii=[1.1])
+    field = layer_field(lat, [-0.27, -0.03375, -0.01] .* u"eV")  # inverse-cube tail
+    h = SiteFieldLatticeHamiltonian(GenericLatticeHamiltonian(0.0, [-0.01], u"eV"), field)
+
+# Constructors
+```julia
+SiteFieldLatticeHamiltonian(base::ClassicalHamiltonian, field::Vector)
+SiteFieldLatticeHamiltonian(base::ClassicalHamiltonian, field::Vector{Float64}, energy_units::Unitful.Units)
+```
+
+The three-argument form attaches `energy_units` to a plain `Float64`
+vector, like the units convenience constructor of
+[`GenericLatticeHamiltonian`](@ref). The field vector is copied.
+
+Throws an `ArgumentError` when the base is itself a
+`SiteFieldLatticeHamiltonian` (compose site fields by adding the vectors,
+not by nesting wrappers), when the field is empty, when the base's
+coupling type cannot be determined, when any entry's type differs from the
+base's coupling type (exact `typeof` equality: same units and value type,
+no promotion), or when any entry is non-finite (an `Inf` makes every
+nested-sampling ceiling comparison degenerate and the sampler stalls
+silently; see the hard-core recipe in the
+[`GenericLatticeHamiltonian`](@ref) docstring).
+
+The field length is *not* checked here (no lattice is in scope at
+construction) but once per run at setup, in the `LatticeGasWalkers`
+constructor and the raw-lattice `wang_landau`/`nvt_monte_carlo` entry
+points, where a length differing from the lattice's site count throws.
+"""
+struct SiteFieldLatticeHamiltonian{H<:ClassicalHamiltonian,U} <: ClassicalHamiltonian
+    base::H
+    field::Vector{U}
+
+    function SiteFieldLatticeHamiltonian(base::ClassicalHamiltonian, field::AbstractVector)
+        if base isa SiteFieldLatticeHamiltonian
+            throw(ArgumentError(
+                "nesting SiteFieldLatticeHamiltonian wrappers is not supported; " *
+                "compose site fields by adding the vectors: " *
+                "SiteFieldLatticeHamiltonian(base.base, base.field .+ field)"))
+        end
+        if isempty(field)
+            throw(ArgumentError(
+                "field is empty; supply one on-site energy per lattice site " *
+                "(build a layer profile with layer_field)"))
+        end
+        U = _coupling_type(base)
+        if U === nothing
+            throw(ArgumentError(
+                "cannot determine the coupling type of a $(typeof(base)); " *
+                "SiteFieldLatticeHamiltonian supports GenericLatticeHamiltonian, " *
+                "MLatticeHamiltonian and ClusterLatticeHamiltonian bases, or any " *
+                "Hamiltonian type that defines AbstractHamiltonians._coupling_type"))
+        end
+        for (i, v) in enumerate(field)
+            if !(typeof(v) == U)
+                throw(ArgumentError(
+                    "field[$i] has type $(typeof(v)), which does not match the " *
+                    "base Hamiltonian's coupling type $U; construct every field " *
+                    "entry with the same units and value type as the base couplings"))
+            end
+            if !isfinite(v)
+                throw(ArgumentError(
+                    "field[$i] is not finite; non-finite on-site energies are not " *
+                    "supported: an Inf makes every nested-sampling ceiling " *
+                    "comparison degenerate (Inf >= Inf) and the sampler stalls " *
+                    "silently. Model site exclusion with a finite repulsive value " *
+                    "instead; see the hard-core recipe in the " *
+                    "GenericLatticeHamiltonian docstring."))
+            end
+        end
+        return new{typeof(base),U}(base, collect(U, field))
+    end
+end
+
+function SiteFieldLatticeHamiltonian(base::ClassicalHamiltonian, field::Vector{Float64}, energy_units::Unitful.Units)
+    return SiteFieldLatticeHamiltonian(base, field .* energy_units)
+end
+
+_coupling_type(::SiteFieldLatticeHamiltonian{H,U}) where {H,U} = U
+
+function Base.show(io::IO, h::SiteFieldLatticeHamiltonian{H,U}) where {H,U}
+    println(io, "SiteFieldLatticeHamiltonian{$H,$U}:")
+    lo, hi = extrema(h.field)
+    println(io, "    field: ", length(h.field), " sites, extrema [",
+            ustrip(lo), ", ", ustrip(hi), "] ", unit(U))
+    println(io, "    base: ", h.base)
 end
 
 end # module Hamiltonians

--- a/src/AbstractLiveSets/AbstractLiveSets.jl
+++ b/src/AbstractLiveSets/AbstractLiveSets.jl
@@ -21,6 +21,7 @@ export LJAtomWalkers, LatticeGasWalkers
 export LJSurfaceWalkers
 export MLIPAtomWalkers
 export GuptaAtomWalkers
+export assign_energy!
 
 abstract type AbstractLiveSet end
 

--- a/src/AbstractLiveSets/AbstractLiveSets.jl
+++ b/src/AbstractLiveSets/AbstractLiveSets.jl
@@ -8,6 +8,7 @@ module AbstractLiveSets
 
 using Distributed
 
+import Unitful
 import Unitful: unit
 
 using ..AbstractWalkers

--- a/src/AbstractLiveSets/atomistic_livesets.jl
+++ b/src/AbstractLiveSets/atomistic_livesets.jl
@@ -173,37 +173,67 @@ with the presence of an external surface object wrapped in an `AtomWalker`.
 
 # Fields
 - `walkers::Vector{AtomWalker{C}}`: A vector of atom walkers, where `C` is the number of components.
-- `pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}`: The Lennard-Jones potential parameters.
+- `pot::CompositeParameterSets{CP, LJParameters}`: The Lennard-Jones parameter sets. The surface
+  energy paths evaluate walker components against the surface as an appended LAST component, so
+  the parameter set must carry `CP = C + 1` components (walker components first, surface last);
+  the constructors validate this and throw an `ArgumentError` on a mismatch. A bare
+  `LJParameters` is not accepted: no surface energy path can evaluate it.
 - `surface::AtomWalker{CS}`: An atom walker representing the surface, where `CS` is the number of components of the surface.
 
+# The frozen-part energy convention
+The constructors READ `surface.energy_frozen_part` and copy it into every walker; they do not
+compute it unless asked. Callers must either assign the adsorbent self-energy before
+construction (idiom: `surface.energy_frozen_part = interacting_energy(surface.configuration, lj)`)
+or pass `compute_frozen_energy=true`, which computes it from the surface configuration with the
+parameter set's surface-surface entry. Under the field's `0.0u"eV"` default, walker energies
+silently omit the entire adsorbent self-energy: within one liveset that is a constant shift, but
+any quantity comparing totals across systems or conventions inherits it as an error.
+
 # Constructor
-- `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                    pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}, 
-                    surface::AtomWalker{CS}; assign_energy=true)`
+- `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                    pot::CompositeParameterSets{CP, LJParameters},
+                    surface::AtomWalker{CS}; assign_energy=true, compute_frozen_energy=false)`
 
-    Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones potential parameters, and a single surface walker. 
-    If `assign_energy=true`, the energy of each walker is assigned using the Lennard-Jones potential and the surface.
+    Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones parameter
+    sets, and a single surface walker. If `assign_energy=true`, the energy of each walker is
+    assigned using the Lennard-Jones parameters and the surface.
 
-- `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                            pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}},
-                            surface::AtomWalker{CS}, 
-                            assign_energy_parallel::Symbol,
+- `LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                            pot::CompositeParameterSets{CP, LJParameters},
+                            surface::AtomWalker{CS},
+                            assign_energy_parallel::Symbol;
+                            compute_frozen_energy=false,
                             ) where {C, CP, CS}
 
-    Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones potential parameters, and a single surface walker.
-    The `assign_energy_parallel` argument determines whether to assign energy in parallel using threads (`:threads`) or distributed 
+    Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones parameter
+    sets, and a single surface walker.
+    The `assign_energy_parallel` argument determines whether to assign energy in parallel using threads (`:threads`) or distributed
     processes (`:distributed`).
 """
 struct LJSurfaceWalkers <: AtomWalkers
     walkers::Vector{AtomWalker{C}} where C
-    potential::Union{LJParameters, CompositeParameterSets{CP, LJParameters}} where CP
+    potential::CompositeParameterSets{CP, LJParameters} where CP
     surface::AtomWalker{CS} where CS
-    function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                                pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}, 
-                                surface::AtomWalker{CS}; 
+    function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                                pot::CompositeParameterSets{CP, LJParameters},
+                                surface::AtomWalker{CS};
                                 assign_energy = true,
+                                compute_frozen_energy = false,
                                 ) where {C, CP, CS}
+        # The surface energy paths append the surface as the LAST component, so
+        # the parameter set must carry exactly one more component than the
+        # walkers (walker components first, surface last); a mismatch would
+        # make the total-energy and single-site paths read different
+        # parameter-set entries with no error.
+        CP == C + 1 || throw(ArgumentError(
+            "LJSurfaceWalkers requires a parameter set with one component per " *
+            "walker component plus one for the surface (walker components " *
+            "first, surface last): got $CP-component parameters over " *
+            "$C-component walkers, expected $(C + 1)"))
         update_walker!(surface, :frozen, ones(Bool, length(surface.list_num_par)))
+        if compute_frozen_energy
+            surface.energy_frozen_part = interacting_energy(surface.configuration, pot.param_sets[end, end])
+        end
         frozen_part_energy = surface.energy_frozen_part # assuming (only) the surface is frozen
         if assign_energy
             Threads.@threads for walker in walkers
@@ -216,31 +246,45 @@ struct LJSurfaceWalkers <: AtomWalkers
 end
 
 """
-    LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                            pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}},
-                            surface::AtomWalker{CS}, 
-                            assign_energy_parallel::Symbol,
+    LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                            pot::CompositeParameterSets{CP, LJParameters},
+                            surface::AtomWalker{CS},
+                            assign_energy_parallel::Symbol;
+                            compute_frozen_energy=false,
                             ) where {C, CP, CS}
 
-Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones potential parameters, and a single surface walker.
-The `assign_energy_parallel` argument determines whether to assign energy in parallel using threads (`:threads`) or distributed 
-processes (`:distributed`).
+Constructs a new `LJSurfaceWalkers` object with the given walkers, Lennard-Jones parameter sets, and a single surface walker.
+The `assign_energy_parallel` argument determines whether to assign energy in parallel using threads (`:threads`) or distributed
+processes (`:distributed`). The parameter set must carry `CP = C + 1` components (walker
+components first, surface last; validated with an `ArgumentError`), and
+`surface.energy_frozen_part` is read, not computed, unless `compute_frozen_energy=true`; see
+[`LJSurfaceWalkers`](@ref).
 
 # Arguments
 - `walkers::Vector{AtomWalker{C}}`: A vector of atom walkers, where `C` is the number of components.
-- `pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}`: The Lennard-Jones potential parameters.
+- `pot::CompositeParameterSets{CP, LJParameters}`: The Lennard-Jones parameter sets.
 - `surface::AtomWalker{CS}`: An atom walker representing the surface, where `CS` is the number of components of the surface.
 - `assign_energy_parallel::Symbol`: The method to use for parallel energy assignment. Can be `:threads` or `:distributed`.
+- `compute_frozen_energy::Bool`: Whether to compute `surface.energy_frozen_part` from the surface configuration before assigning walker energies. Default is `false` (the field is read as-is).
 
 # Returns
 - `LJSurfaceWalkers`: A new `LJSurfaceWalkers` object with the assigned energy.
 """
-function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}}, 
-                            pot::Union{LJParameters, CompositeParameterSets{CP, LJParameters}}, 
-                            surface::AtomWalker{CS}, 
-                            assign_energy_parallel::Symbol,
+function LJSurfaceWalkers(walkers::Vector{AtomWalker{C}},
+                            pot::CompositeParameterSets{CP, LJParameters},
+                            surface::AtomWalker{CS},
+                            assign_energy_parallel::Symbol;
+                            compute_frozen_energy = false,
                             ) where {C, CP, CS}
+    CP == C + 1 || throw(ArgumentError(
+        "LJSurfaceWalkers requires a parameter set with one component per " *
+        "walker component plus one for the surface (walker components " *
+        "first, surface last): got $CP-component parameters over " *
+        "$C-component walkers, expected $(C + 1)"))
     update_walker!(surface, :frozen, ones(Bool, length(surface.list_num_par)))
+    if compute_frozen_energy
+        surface.energy_frozen_part = interacting_energy(surface.configuration, pot.param_sets[end, end])
+    end
     frozen_part_energy = surface.energy_frozen_part
     if assign_energy_parallel == :threads
         @info "Assigning energy to walkers in parallel using $(Threads.nthreads()) threads..."

--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -29,11 +29,16 @@ _n_coupled_shells(h) = nothing
 """
     _check_cluster_sites(hamiltonian, cfg)
 
-One-time check at liveset construction: a `ClusterLatticeHamiltonian`
-whose embeddings reference site indices beyond the lattice was built for a
-different lattice; failing here with a descriptive `ArgumentError` beats a
-`BoundsError` from deep inside the energy kernel. A no-op for every other
-Hamiltonian type.
+One-time check at run setup (the `LatticeGasWalkers` constructor and the
+raw-lattice `wang_landau`/`nvt_monte_carlo` entry points): a
+`ClusterLatticeHamiltonian` whose embeddings reference site indices beyond
+the lattice was built for a different lattice; failing here with a
+descriptive `ArgumentError` beats a `BoundsError` from deep inside the
+energy kernel. A no-op for every other Hamiltonian type. The converse
+mismatch — a Hamiltonian enumerated on a *smaller* lattice, whose indices
+all exist but whose embeddings have wrong geometry — is undetectable from
+indices alone and remains the caller's responsibility: always enumerate on
+the lattice being sampled.
 """
 _check_cluster_sites(hamiltonian, cfg) = nothing
 function _check_cluster_sites(h::ClusterLatticeHamiltonian, cfg::AbstractLattice)

--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -24,6 +24,7 @@ end
 _n_coupled_shells(h::GenericLatticeHamiltonian{N,U}) where {N,U} = N
 _n_coupled_shells(h::MLatticeHamiltonian{C,N,U}) where {C,N,U} = N
 _n_coupled_shells(h::ClusterLatticeHamiltonian{N,U}) where {N,U} = N
+_n_coupled_shells(h::SiteFieldLatticeHamiltonian) = _n_coupled_shells(h.base)
 _n_coupled_shells(h) = nothing
 
 """
@@ -34,7 +35,8 @@ raw-lattice `wang_landau`/`nvt_monte_carlo` entry points): a
 `ClusterLatticeHamiltonian` whose embeddings reference site indices beyond
 the lattice was built for a different lattice; failing here with a
 descriptive `ArgumentError` beats a `BoundsError` from deep inside the
-energy kernel. A no-op for every other Hamiltonian type. The converse
+energy kernel. A `SiteFieldLatticeHamiltonian` delegates the check to its
+wrapped base; a no-op for every other Hamiltonian type. The converse
 mismatch — a Hamiltonian enumerated on a *smaller* lattice, whose indices
 all exist but whose embeddings have wrong geometry — is undetectable from
 indices alone and remains the caller's responsibility: always enumerate on
@@ -52,6 +54,33 @@ function _check_cluster_sites(h::ClusterLatticeHamiltonian, cfg::AbstractLattice
                     "built for a different lattice"))
             end
         end
+    end
+    return nothing
+end
+_check_cluster_sites(h::SiteFieldLatticeHamiltonian, cfg::AbstractLattice) =
+    _check_cluster_sites(h.base, cfg)
+
+"""
+    _check_field_length(hamiltonian, cfg)
+
+One-time check at run setup (the `LatticeGasWalkers` constructor and the
+raw-lattice `wang_landau`/`nvt_monte_carlo` entry points): a
+`SiteFieldLatticeHamiltonian` whose field length differs from the number
+of lattice sites was built for a different lattice; failing here with a
+descriptive `ArgumentError` beats a `DimensionMismatch` from inside the
+energy kernel. A no-op for every other Hamiltonian type. A field of the
+*right* length built for a different lattice of the same size is
+undetectable from the length alone and remains the caller's
+responsibility: always build the field (e.g. with `layer_field`) on the
+lattice being sampled.
+"""
+_check_field_length(hamiltonian, cfg) = nothing
+function _check_field_length(h::SiteFieldLatticeHamiltonian, cfg::AbstractLattice)
+    M = num_sites(cfg)
+    if length(h.field) != M
+        throw(ArgumentError(
+            "the site field has $(length(h.field)) entries but the lattice " *
+            "has $M sites; the Hamiltonian was built for a different lattice"))
     end
     return nothing
 end
@@ -108,6 +137,7 @@ struct  LatticeGasWalkers <: LatticeWalkers
     function LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::ClassicalHamiltonian; assign_energy=true, perturb_energy::Float64=0.0) where C
         _warn_uncoupled_shells(walkers, hamiltonian)
         isempty(walkers) || _check_cluster_sites(hamiltonian, walkers[1].configuration)
+        isempty(walkers) || _check_field_length(hamiltonian, walkers[1].configuration)
         if assign_energy
             [assign_energy!(walker, hamiltonian; perturb_energy=perturb_energy) for walker in walkers]
         end

--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -21,6 +21,43 @@ function assign_energy!(walker::LatticeWalker{C}, hamiltonian::ClassicalHamilton
     return walker
 end
 
+_n_coupled_shells(h::GenericLatticeHamiltonian{N,U}) where {N,U} = N
+_n_coupled_shells(h::MLatticeHamiltonian{C,N,U}) where {C,N,U} = N
+_n_coupled_shells(h) = nothing
+
+"""
+    _warn_uncoupled_shells(cfg_or_walkers, hamiltonian)
+
+One-time check at run setup: warn when the lattice carries more neighbor
+shells (`cutoff_radii`) than the Hamiltonian couples, since the outer
+shells then contribute exactly zero energy — silently, if unnoticed. The
+converse mismatch (more coupled shells than the lattice provides) throws
+an `ArgumentError` at energy evaluation instead. Complements the
+empty-shell warning emitted by `compute_neighbors` at lattice
+construction. Called from the `LatticeGasWalkers` constructor and from the
+lattice entry points of `wang_landau` and `nvt_monte_carlo`, which take a
+raw lattice and never build a liveset.
+"""
+function _warn_uncoupled_shells(cfg::AbstractLattice, hamiltonian)
+    cfg isa MLattice || return nothing
+    n_coupled = _n_coupled_shells(hamiltonian)
+    n_coupled === nothing && return nothing
+    n_shells = length(cfg.cutoff_radii)
+    if n_coupled < n_shells
+        @warn "the lattice carries $n_shells neighbor shells (cutoff_radii) " *
+              "but the Hamiltonian couples only the first $n_coupled; the " *
+              "outer $(n_shells - n_coupled) shell(s) contribute zero " *
+              "energy. Drop the unused cutoff_radii or extend " *
+              "nth_neighbor_interactions if this is unintended."
+    end
+    return nothing
+end
+
+function _warn_uncoupled_shells(walkers::Vector{<:LatticeWalker}, hamiltonian)
+    isempty(walkers) && return nothing
+    return _warn_uncoupled_shells(walkers[1].configuration, hamiltonian)
+end
+
 """
     struct LatticeGasWalkers <: LatticeWalkers
 
@@ -38,6 +75,7 @@ struct  LatticeGasWalkers <: LatticeWalkers
     walkers::Vector{LatticeWalker{C}} where C
     hamiltonian::ClassicalHamiltonian
     function LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::ClassicalHamiltonian; assign_energy=true, perturb_energy::Float64=0.0) where C
+        _warn_uncoupled_shells(walkers, hamiltonian)
         if assign_energy
             [assign_energy!(walker, hamiltonian; perturb_energy=perturb_energy) for walker in walkers]
         end

--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -23,7 +23,33 @@ end
 
 _n_coupled_shells(h::GenericLatticeHamiltonian{N,U}) where {N,U} = N
 _n_coupled_shells(h::MLatticeHamiltonian{C,N,U}) where {C,N,U} = N
+_n_coupled_shells(h::ClusterLatticeHamiltonian{N,U}) where {N,U} = N
 _n_coupled_shells(h) = nothing
+
+"""
+    _check_cluster_sites(hamiltonian, cfg)
+
+One-time check at liveset construction: a `ClusterLatticeHamiltonian`
+whose embeddings reference site indices beyond the lattice was built for a
+different lattice; failing here with a descriptive `ArgumentError` beats a
+`BoundsError` from deep inside the energy kernel. A no-op for every other
+Hamiltonian type.
+"""
+_check_cluster_sites(hamiltonian, cfg) = nothing
+function _check_cluster_sites(h::ClusterLatticeHamiltonian, cfg::AbstractLattice)
+    M = num_sites(cfg)
+    for (i, c) in enumerate(h.clusters)
+        for e in c.embeddings
+            if e[end] > M   # canonical form: the last index is the maximum
+                throw(ArgumentError(
+                    "clusters[$i] embedding $e references site $(e[end]) but " *
+                    "the lattice has only $M sites; the Hamiltonian was " *
+                    "built for a different lattice"))
+            end
+        end
+    end
+    return nothing
+end
 
 """
     _warn_uncoupled_shells(cfg_or_walkers, hamiltonian)
@@ -76,6 +102,7 @@ struct  LatticeGasWalkers <: LatticeWalkers
     hamiltonian::ClassicalHamiltonian
     function LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::ClassicalHamiltonian; assign_energy=true, perturb_energy::Float64=0.0) where C
         _warn_uncoupled_shells(walkers, hamiltonian)
+        isempty(walkers) || _check_cluster_sites(hamiltonian, walkers[1].configuration)
         if assign_energy
             [assign_energy!(walker, hamiltonian; perturb_energy=perturb_energy) for walker in walkers]
         end

--- a/src/AbstractLiveSets/lattice_livesets.jl
+++ b/src/AbstractLiveSets/lattice_livesets.jl
@@ -3,21 +3,33 @@ abstract type LatticeWalkers <: AbstractLiveSet end
 
 
 """
-    assign_energy!(walker::LatticeWalker{C}, hamiltonian::LatticeGasHamiltonian; perturb_energy::Float64=0.0)
+    assign_energy!(walker::LatticeWalker{C}, hamiltonian::ClassicalHamiltonian; perturb_energy::Float64=0.0)
 
 Assigns energy to the given `walker` based on the `hamiltonian`. If `perturb_energy` is non-zero, a small random perturbation is added to the energy.
 
+The energy comes from `interacting_energy(walker.configuration, hamiltonian)`, which must return an energy-dimensioned `Unitful.Quantity` (eV-convertible); a method returning anything else, e.g. a plain `Float64` from a custom Hamiltonian, raises a descriptive `ArgumentError` here rather than a `DimensionError` from the assignment arithmetic. This is the one return-type obligation of the custom-Hamiltonian extension contract (see the Custom Hamiltonians documentation page).
+
 # Arguments
 - `walker::LatticeWalker{C}`: The walker to assign energy to.
-- `hamiltonian::LatticeGasHamiltonian`: The Hamiltonian used to calculate the energy.
+- `hamiltonian::ClassicalHamiltonian`: The Hamiltonian used to calculate the energy.
 - `perturb_energy::Float64=0.0`: The amount of random perturbation to add to the energy.
 
 # Returns
 - `walker::LatticeWalker{C}`: The walker with the assigned energy.
 """
 function assign_energy!(walker::LatticeWalker{C}, hamiltonian::ClassicalHamiltonian; perturb_energy::Float64=0.0) where C
+    raw = interacting_energy(walker.configuration, hamiltonian)
+    if !(raw isa Unitful.Energy)
+        throw(ArgumentError(
+            "interacting_energy must return an energy-dimensioned " *
+            "Unitful.Quantity (eV-convertible) for walker energies; got " *
+            "$(typeof(raw)) from the $(nameof(typeof(hamiltonian))) " *
+            "Hamiltonian. Custom Hamiltonians subtype ClassicalHamiltonian " *
+            "and return e.g. `x * u\"eV\"` from their interacting_energy " *
+            "method."))
+    end
     # Assign the energy to the walker and, if perturb_energy is non-zero, give all walkers a small random (positive or negative) perturbation
-    walker.energy = interacting_energy(walker.configuration, hamiltonian) + perturb_energy * (rand() - 0.5) * unit(walker.energy)
+    walker.energy = raw + perturb_energy * (rand() - 0.5) * unit(walker.energy)
     return walker
 end
 
@@ -125,10 +137,10 @@ The `LatticeGasWalkers` struct represents a collection of lattice walkers for a 
 
 # Fields
 - `walkers::Vector{LatticeWalker{C}}`: A vector of lattice walkers.
-- `hamiltonian::LatticeGasHamiltonian`: The lattice gas Hamiltonian associated with the walkers.
+- `hamiltonian::ClassicalHamiltonian`: The lattice Hamiltonian associated with the walkers.
 
 # Constructors
-- `LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::LatticeGasHamiltonian; assign_energy=true, perturb_energy::Float64=0.0)`: Constructs a new `LatticeGasWalkers` object with the given walkers and Hamiltonian. If `assign_energy` is `true`, the energy of each walker is assigned using the provided Hamiltonian. The optional `perturb_energy` parameter can be used to add a small perturbation to the assigned energy.
+- `LatticeGasWalkers(walkers::Vector{LatticeWalker{C}}, hamiltonian::ClassicalHamiltonian; assign_energy=true, perturb_energy::Float64=0.0)`: Constructs a new `LatticeGasWalkers` object with the given walkers and Hamiltonian. If `assign_energy` is `true`, the energy of each walker is assigned using the provided Hamiltonian. The optional `perturb_energy` parameter can be used to add a small perturbation to the assigned energy.
 
 """
 struct  LatticeGasWalkers <: LatticeWalkers

--- a/src/AbstractPotentials/AbstractPotentials.jl
+++ b/src/AbstractPotentials/AbstractPotentials.jl
@@ -23,6 +23,7 @@ export CompositeParameterSets
 export LJParameters, lj_energy
 export LennardJonesParameterSets
 export GuptaParameters
+export IdealGasParameters
 export PyCalculator
 
 
@@ -102,6 +103,8 @@ include("composite_paramsets.jl")
 include("lennardjones.jl")
 
 include("gupta.jl")
+
+include("ideal_gas.jl")
 
 include("ase_calculators.jl")
 

--- a/src/AbstractPotentials/ideal_gas.jl
+++ b/src/AbstractPotentials/ideal_gas.jl
@@ -1,0 +1,23 @@
+"""
+    struct IdealGasParameters
+
+A zero-interaction potential representing a classical ideal gas.
+
+`IdealGasParameters` is a `SingleComponentPotential{Pairwise}` whose `pair_energy`
+is identically zero at any separation. All existing pairwise dispatch paths
+(`intra_component_energy`, `inter_component_energy`, `interacting_energy`,
+`frozen_energy`) therefore evaluate to `0.0u"eV"` without any further methods.
+
+The intended use is as an analytical reference for grand-canonical post-processing:
+the ideal-gas grand partition function has the closed form `Ξ(μ, T) = exp(zV)` with
+`z = exp(βμ)/Λ(T)³`, which provides the cleanest possible check of normalization,
+fugacity, and thermal-wavelength conventions in downstream analysis code.
+"""
+struct IdealGasParameters <: SingleComponentPotential{Pairwise} end
+
+"""
+    pair_energy(r::typeof(1.0u"Å"), ::IdealGasParameters)
+
+Return `0.0u"eV"` at any separation `r`. The ideal gas has no pair interactions.
+"""
+pair_energy(::typeof(1.0u"Å"), ::IdealGasParameters) = 0.0u"eV"

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -29,6 +29,7 @@ export order_parameter_c2x2
 export order_parameter_sqrt3
 export bragg_amplitude
 export order_parameter_stripe
+export order_parameter_p2x2
 export site_layers, layer_coverage, occupancy_profile, layer_field
 export enumerate_motif_embeddings, motif_distances
 export view_structure

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -27,6 +27,8 @@ export update_walker!
 export num_sites, occupied_site_count
 export order_parameter_c2x2
 export order_parameter_sqrt3
+export bragg_amplitude
+export order_parameter_stripe
 export enumerate_motif_embeddings, motif_distances
 export view_structure
 

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -26,6 +26,7 @@ export MLattice, SLattice, GLattice
 export update_walker!
 export num_sites, occupied_site_count
 export order_parameter_c2x2
+export order_parameter_sqrt3
 export enumerate_motif_embeddings, motif_distances
 export view_structure
 

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -26,6 +26,7 @@ export MLattice, SLattice, GLattice
 export update_walker!
 export num_sites, occupied_site_count
 export order_parameter_c2x2
+export enumerate_motif_embeddings, motif_distances
 export view_structure
 
 abstract type AbstractWalker end

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -25,6 +25,7 @@ export LatticeGeometry, SquareLattice, TriangularLattice, GenericLattice
 export MLattice, SLattice, GLattice
 export update_walker!
 export num_sites, occupied_site_count
+export order_parameter_c2x2
 export view_structure
 
 abstract type AbstractWalker end

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -29,6 +29,7 @@ export order_parameter_c2x2
 export order_parameter_sqrt3
 export bragg_amplitude
 export order_parameter_stripe
+export site_layers, layer_coverage, occupancy_profile, layer_field
 export enumerate_motif_embeddings, motif_distances
 export view_structure
 

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -75,7 +75,18 @@ function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
         
         neighbors[i] = nth_neighbors
     end
-    
+
+    for k in 1:layers_of_neighbors
+        if all(isempty(nbrs[k]) for nbrs in neighbors)
+            @warn "Neighbor shell $k (cutoff radius $(cutoff_radii[k])) is empty on every " *
+                  "site; a Hamiltonian coupling for this shell silently contributes zero. " *
+                  "Check cutoff_radii against the actual neighbor distances — e.g. on a " *
+                  "triangular lattice the second-neighbor distance is √3 ≈ 1.732 lattice " *
+                  "constants, beyond the square-lattice cutoff of 1.5 — or whether the " *
+                  "supercell is too small to contain this shell."
+        end
+    end
+
     return neighbors
 end
 
@@ -194,7 +205,7 @@ Throws an `ArgumentError` if the number of components does not match `C`.
                                   basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
                                   supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 2, 1),
                                   periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
-                                  cutoff_radii::Vector{Float64}=[1.1, 1.5],
+                                  cutoff_radii::Vector{Float64}=[1.1, 1.8],
                                   components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                   adsorptions::Union{Vector{Int},Symbol}=:full)
 
@@ -362,7 +373,9 @@ function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
                                         basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
                                         supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 2, 1),
                                         periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
-                                        cutoff_radii::Vector{Float64}=[1.1, 1.5],
+                                        # The triangular second-neighbor distance is √3 ≈ 1.732, so the
+                                        # square-lattice default [1.1, 1.5] would leave shell 2 empty.
+                                        cutoff_radii::Vector{Float64}=[1.1, 1.8],
                                         components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                         adsorptions::Union{Vector{Int},Symbol}=:full,
                                     ) where C

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -835,6 +835,146 @@ function order_parameter_stripe(lattice::MLattice{1,SquareLattice}; period::Int=
 end
 
 """
+    _check_planar_basis(caller::Symbol, lattice::MLattice)
+
+Shared guard for the layer helpers: throw an `ArgumentError`, naming the
+public entry point `caller`, unless all basis z-components are equal.
+Layers along dimension 3 are geometrically well defined only for a planar
+basis.
+"""
+function _check_planar_basis(caller::Symbol, lattice::MLattice)
+    zs = [b[3] for b in lattice.basis]
+    if any(z -> z != zs[1], zs)
+        throw(ArgumentError("$caller requires a planar basis (all basis " *
+            "z-components equal) so layers along dimension 3 are " *
+            "geometrically well defined, got basis z-components $zs"))
+    end
+    return nothing
+end
+
+"""
+    site_layers(lattice::MLattice) -> Vector{Int}
+
+Layer index of every site along the third supercell dimension: site `s`
+belongs to layer `(s − 1) ÷ B + 1` with `B = length(basis) · d₁ · d₂`,
+exact because `lattice_positions` orders sites with dimension 3 outermost
+(basis innermost, dimension 1 fastest), making each layer one contiguous
+block of `B` sites. The result has `num_sites(lattice)` entries with
+values in `1:d₃`.
+
+Requires a planar basis (all basis z-components equal), so that "layer" is
+geometrically unambiguous; violations throw an `ArgumentError`.
+"""
+function site_layers(lattice::MLattice)
+    _check_planar_basis(:site_layers, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    B = length(lattice.basis) * d1 * d2
+    # lattice_positions ordering: dimension 3 outermost, so layers are
+    # contiguous blocks of B sites
+    return [(s - 1) ÷ B + 1 for s in 1:(B * d3)]
+end
+
+"""
+    layer_coverage(lattice::MLattice{1,G}, layer::Int) -> Float64
+
+Occupied fraction of one layer of a single-component lattice: the number
+of occupied sites in layer `layer`'s contiguous block of
+`B = length(basis) · d₁ · d₂` sites (see [`site_layers`](@ref)), divided
+by `B`. This is the layer-resolved complement of the in-plane order
+parameters for three-dimensional supercells; the per-layer coverages
+θ_k are the order parameters of lattice-gas layering transitions. It
+returns a scalar `Real`, so `cfg -> layer_coverage(cfg, k)`
+is directly usable as an `observables` callback in the nested-sampling
+loops: like the shipped order parameters, θ is not a function of `(E, N)`
+and must be evaluated per configuration rather than reconstructed from an
+energy ledger. At `d₃ == 1` it degenerates to the total coverage `N/M`,
+which is legal and intentional, so no two-dimensionality guard applies.
+
+Requires a planar basis (all basis z-components equal) and
+`1 ≤ layer ≤ d₃`; violations throw an `ArgumentError`.
+"""
+function layer_coverage(lattice::MLattice{1,G}, layer::Int) where G
+    _check_planar_basis(:layer_coverage, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    if !(1 <= layer <= d3)
+        throw(ArgumentError("layer_coverage requires 1 <= layer <= $d3 " *
+            "(= supercell_dimensions[3]), got $layer"))
+    end
+    B = length(lattice.basis) * d1 * d2
+    occ = lattice.components[1]
+    n = 0
+    for s in ((layer - 1) * B + 1):(layer * B)
+        n += occ[s] ? 1 : 0
+    end
+    return n / B
+end
+
+"""
+    occupancy_profile(lattice::MLattice{1,G}) -> Vector{Float64}
+
+Vector of layer coverages, `[layer_coverage(lattice, k) for k in 1:d₃]`,
+computed in one pass. Every layer holds `B = length(basis) · d₁ · d₂`
+sites, so `mean(occupancy_profile(lat)) == N/M` exactly (`N` occupied
+sites, `M` total sites).
+
+The return value is a `Vector`, not a scalar, so `occupancy_profile` is
+*not* directly usable as an `observables` callback (callbacks must return
+a `Real`); record per-layer coverages by composing scalar callbacks
+caller-side, with no library change:
+
+    observables = [Symbol(:theta, k) => (cfg -> layer_coverage(cfg, k)) for k in 1:d₃]
+
+after which ⟨θ₁⟩ … ⟨θ_d₃⟩ come from `observable_cols=[:theta1, :theta2, …]`
+in the grand-canonical stats functions.
+
+Requires a planar basis (all basis z-components equal); violations throw
+an `ArgumentError`.
+"""
+function occupancy_profile(lattice::MLattice{1,G}) where G
+    _check_planar_basis(:occupancy_profile, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    B = length(lattice.basis) * d1 * d2
+    occ = lattice.components[1]
+    counts = zeros(Int, d3)
+    for s in eachindex(occ)
+        if occ[s]
+            counts[(s - 1) ÷ B + 1] += 1
+        end
+    end
+    return counts ./ B
+end
+
+"""
+    layer_field(lattice::MLattice, per_layer::AbstractVector) -> Vector
+
+Broadcast a per-layer value over every site of its layer: the result has
+`num_sites(lattice)` entries, with `per_layer[k]` at every site of layer
+`k` (see [`site_layers`](@ref)). The element type of `per_layer` is
+preserved, so a `Unitful` profile feeds a `SiteFieldLatticeHamiltonian`
+directly:
+
+    field = layer_field(lat, [-0.27, -0.03375, -0.01] .* u"eV")
+    h = SiteFieldLatticeHamiltonian(GenericLatticeHamiltonian(0.0, [-0.01], u"eV"), field)
+
+A height profile is physically meaningful only when dimension 3 is
+non-periodic (`periodicity[3] == false`); this is not checked.
+
+Requires a planar basis (all basis z-components equal) and
+`length(per_layer) == d₃` (= `supercell_dimensions[3]`); violations throw
+an `ArgumentError`.
+"""
+function layer_field(lattice::MLattice, per_layer::AbstractVector)
+    _check_planar_basis(:layer_field, lattice)
+    d3 = lattice.supercell_dimensions[3]
+    if length(per_layer) != d3
+        throw(ArgumentError("layer_field requires one value per layer " *
+            "(length(per_layer) == supercell_dimensions[3] == $d3), got " *
+            "$(length(per_layer)) values"))
+    end
+    return per_layer[site_layers(lattice)]
+end
+
+"""
     motif_distances(coords::AbstractVector{<:Tuple}) -> Vector{Float64}
 
 Sorted multiset of the pairwise Euclidean distances of a coordinate

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -882,6 +882,175 @@ function order_parameter_stripe(lattice::MLattice{1,SquareLattice}; period::Int=
 end
 
 """
+    bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int) -> Float64
+
+Normalized Bragg-peak amplitude of the occupation pattern on a
+single-component triangular lattice:
+
+    |ρ(k)| = |Σ_{occupied sites} e^{ik·r}| / M,   k = 2π·(m/d₁, n/(√3·d₂)),
+
+in units of the inverse lattice constant, where `(d₁, d₂)` are the in-plane
+supercell dimensions of the conventional (centered-rectangular) cell and
+`M = 2·d₁·d₂` is the number of sites; the sum runs over both basis sites,
+so the two-site basis phases are included. Integer indices on the
+conventional-cell reciprocal grid make every representable k commensurate
+by construction, in the same LEED-intensity convention as the square-lattice
+method [Zhang, Blum & Reuter, PRB **75**, 235406 (2007)].
+
+Because the basis sites live on the half-integer grid of the conventional
+cell, amplitudes are periodic under the *primitive* reciprocal lattice
+rather than index-wise:
+`bragg_amplitude(lat, m, n) == bragg_amplitude(lat, m + d1, n - d2) ==
+bragg_amplitude(lat, m, n + 2*d2)` (the two index shifts add the primitive
+reciprocal vectors b₁ = 2π·(1, −1/√3) and b₂ = 2π·(0, 2/√3)), and both
+identities hold exactly. The three M points of the triangular Brillouin
+zone sit at `(m, n) = (0, d2)` (representable on any cell) and
+`(d1 ÷ 2, ∓(d2 ÷ 2))` (integer indices for even in-plane dimensions);
+M-point phases are exactly ±1.0 (u and v share the parity of the basis
+index, so the quarter-turn table entries always combine to half turns), so
+the documented values of [`order_parameter_p2x2`](@ref) hold to full
+precision. The empty lattice gives exactly `0` at every k; the full
+lattice gives `0` for any k that is not a reciprocal-lattice vector of the
+triangular lattice, exactly at the three M points and to floating-point
+roundoff at generic indices (where the phasor components are irrational).
+A single particle gives `1/M`.
+
+Like the named order parameters, |ρ(k)| is not a function of `(E, N)` and
+must be evaluated on configurations (e.g. per culled walker, via the
+`observables` keyword of the nested-sampling loops); see
+[`order_parameter_p2x2`](@ref) for the composed-observable recipes.
+
+Requires the standard two-site centered-rectangular triangular basis
+`[(0, 0, 0), (a/2, √3·a/2, 0)]` consistent with the lattice vectors and a
+strictly two-dimensional supercell (`supercell_dimensions[3] == 1`);
+violations throw an `ArgumentError`.
+"""
+function bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int)
+    if length(lattice.basis) != 2
+        throw(ArgumentError("bragg_amplitude requires the two-site " *
+            "centered-rectangular triangular basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
+    ax, ay = lattice.lattice_vectors[1, 1], lattice.lattice_vectors[2, 2]
+    b1, b2 = lattice.basis
+    if !(isapprox(b1[1], 0.0, atol=1e-9) && isapprox(b1[2], 0.0, atol=1e-9) &&
+         isapprox(b2[1], ax / 2, atol=1e-9) && isapprox(b2[2], ay / 2, atol=1e-9))
+        throw(ArgumentError("bragg_amplitude requires the standard " *
+            "triangular basis [(0, 0, 0), (a/2, √3·a/2, 0)] consistent with " *
+            "the lattice vectors, got $(lattice.basis)"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("bragg_amplitude requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    # Site (b, ci, cj) sits at r = ((ci − 1) + b/2, √3·((cj − 1) + b/2))·a,
+    # so on the half-integer grid u = 2(ci − 1) + b, v = 2(cj − 1) + b the
+    # phase is k·r = π·(m·u·d₂ + n·v·d₁)/(d₁·d₂). The numerator is reduced
+    # as one integer modulo 2·d₁·d₂ before the single cispi call per
+    # occupied site: half- and quarter-turn phases come out exactly
+    # ±1.0/±1.0im, every combined M-point phase is exactly ±1.0, and the
+    # joint reduction makes the b₁/b₂ wrapping identities hold bit-exactly,
+    # since both shifts move the numerator by even multiples of d₁·d₂
+    # (u and v share the parity of the basis index).
+    twoM = 2 * d1 * d2
+    mr = mod(m, 2 * d1)
+    nr = mod(n, 2 * d2)
+    colnum = [mod(mr * u * d2, twoM) for u in 0:2*d1-1]
+    rownum = [mod(nr * v * d1, twoM) for v in 0:2*d2-1]
+    occ = lattice.components[1]
+    z = 0.0 + 0.0im
+    for s in eachindex(occ)
+        if occ[s]
+            # lattice_positions ordering: basis innermost, dimension 1 fastest
+            b = (s - 1) % 2
+            ci0 = ((s - 1) ÷ 2) % d1
+            cj0 = (s - 1) ÷ (2 * d1)
+            num = colnum[2*ci0+b+1] + rownum[2*cj0+b+1]
+            num >= twoM && (num -= twoM)
+            z += cispi(num / (d1 * d2))
+        end
+    end
+    return abs(z) / twoM
+end
+
+"""
+    order_parameter_p2x2(lattice::MLattice{1,TriangularLattice}) -> Float64
+
+Orientation-degenerate M-point order parameter for p(2×2) and p(2×1)/row
+ordering on a single-component triangular lattice: the quadrature sum of
+the three normalized M-point Bragg amplitudes,
+
+    Ψ = √(|ρ(M₁)|² + |ρ(M₂)|² + |ρ(M₃)|²),
+
+i.e. `sqrt(bragg_amplitude(lat, d1 ÷ 2, -(d2 ÷ 2))^2 +
+bragg_amplitude(lat, 0, d2)^2 + bragg_amplitude(lat, d1 ÷ 2, d2 ÷ 2)^2)`
+with the amplitudes of [`bragg_amplitude`](@ref). A perfect p(2×2)
+arrangement at coverage 1/4 contributes exactly `1/4` at every M point,
+giving `√3/4 ≈ 0.4330`; a perfect single-orientation p(2×1) row phase at
+coverage 1/2 puts exactly `1/2` on one M point and `0` on the other two,
+giving `1/2`; the perfect (√3×√3)R30° state (K-point order) and the empty
+and the full lattice give exactly `0`; disordered configurations give
+O(1/√M). Translation and orientation degeneracies are divided out, so all
+degenerate ordered states of each phase give the same value.
+
+The M-point pattern separates the two phases where the scalar cannot: the
+max-to-quadrature ratio of the three amplitudes is `1/√3` for p(2×2)
+(three equal M points) and `1` for a single p(2×1) orientation; compose it
+caller-side from `bragg_amplitude` when needed. [`order_parameter_sqrt3`](@ref)
+is exactly `0` on both M-point phases and this function is exactly `0` on
+the √3×√3 phase, so the two observables are orthogonal discriminators.
+
+Ψ is not a function of `(E, N)` and must be evaluated on configurations
+(e.g. per culled walker, via the `observables` keyword of the
+nested-sampling loops). Higher moments for Binder-cumulant analysis are
+composed caller-side, with no library change:
+
+    observables = [:psi  => order_parameter_p2x2,
+                   :psi2 => cfg -> order_parameter_p2x2(cfg)^2,
+                   :psi4 => cfg -> order_parameter_p2x2(cfg)^4]
+
+Requires the structural guards of [`bragg_amplitude`](@ref) plus even
+in-plane supercell dimensions: the M points sit at half-integer reciprocal
+indices, and even circumferences are exactly the wrap-invariance condition
+of the p(2×2) sublattice. A cell hosting this order parameter and
+[`order_parameter_sqrt3`](@ref) simultaneously needs
+`supercell_dimensions[1]` divisible by 6 with an even second dimension;
+the shipped default `(4, 2, 1)` satisfies this function's guards but not
+the √3×√3 one's.
+"""
+function order_parameter_p2x2(lattice::MLattice{1,TriangularLattice})
+    if length(lattice.basis) != 2
+        throw(ArgumentError("order_parameter_p2x2 requires the two-site " *
+            "centered-rectangular triangular basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
+    ax, ay = lattice.lattice_vectors[1, 1], lattice.lattice_vectors[2, 2]
+    b1, b2 = lattice.basis
+    if !(isapprox(b1[1], 0.0, atol=1e-9) && isapprox(b1[2], 0.0, atol=1e-9) &&
+         isapprox(b2[1], ax / 2, atol=1e-9) && isapprox(b2[2], ay / 2, atol=1e-9))
+        throw(ArgumentError("order_parameter_p2x2 requires the standard " *
+            "triangular basis [(0, 0, 0), (a/2, √3·a/2, 0)] consistent with " *
+            "the lattice vectors, got $(lattice.basis)"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("order_parameter_p2x2 requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    if d1 % 2 != 0 || d2 % 2 != 0
+        bad = d1 % 2 != 0 ? d1 : d2
+        throw(ArgumentError("order_parameter_p2x2 requires even in-plane " *
+            "supercell dimensions, since the M points sit at half-integer " *
+            "reciprocal indices and the p(2×2) sublattice closes on the " *
+            "periodic cell only for even circumferences; got $bad"))
+    end
+    return sqrt(bragg_amplitude(lattice, d1 ÷ 2, -(d2 ÷ 2))^2 +
+                bragg_amplitude(lattice, 0, d2)^2 +
+                bragg_amplitude(lattice, d1 ÷ 2, d2 ÷ 2)^2)
+end
+
+"""
     _check_planar_basis(caller::Symbol, lattice::MLattice)
 
 Shared guard for the layer helpers: throw an `ArgumentError`, naming the

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -478,6 +478,89 @@ function order_parameter_c2x2(lattice::MLattice{1,SquareLattice})
 end
 
 """
+    order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice}) -> Float64
+
+Three-sublattice order parameter for (√3×√3)R30° ordering on a
+single-component triangular lattice:
+
+    Ψ = |Σ_{occupied sites} ω^{c(s)}| / M,   ω = e^{2πi/3},
+
+where `c(s) ∈ {0,1,2}` is the site's sublattice label under the standard
+tripartition of the triangular lattice and `M` is the number of sites. This
+is the modulus of the complex three-state Potts order parameter: the Z₃
+phase distinguishing the three degenerate ordered states is divided out, so
+all three give the same value. A perfect √3×√3 arrangement at coverage 1/3
+gives `1/3`; the empty and the full lattice give `0` (1 + ω + ω² = 0).
+
+Ψ is not a function of `(E, N)`: degenerate energy levels contain ordered
+and disordered configurations alike, so it must be evaluated on
+configurations (e.g. per culled walker, via the `observables` keyword of
+the nested-sampling loops). Higher moments for Binder-cumulant analysis are
+composed caller-side, with no library change:
+
+    observables = [:psi  => order_parameter_sqrt3,
+                   :psi2 => cfg -> order_parameter_sqrt3(cfg)^2,
+                   :psi4 => cfg -> order_parameter_sqrt3(cfg)^4]
+
+after which ⟨Ψ⟩, ⟨Ψ²⟩, ⟨Ψ⁴⟩ come from `observable_cols=[:psi, :psi2, :psi4]`
+in the grand-canonical stats functions.
+
+Requires the standard two-site centered-rectangular triangular basis
+`[(0, 0, 0), (a/2, √3·a/2, 0)]` consistent with the lattice vectors, a
+strictly two-dimensional supercell (`supercell_dimensions[3] == 1`), and
+`supercell_dimensions[1]` divisible by 3 (the tripartition closes on the
+periodic cell iff the a₁ circumference is a multiple of 3; the a₂ dimension
+is unconstrained); violations throw an `ArgumentError`. Note the shipped
+default `supercell_dimensions = (4, 2, 1)` is *not* commensurate.
+"""
+function order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice})
+    if length(lattice.basis) != 2
+        throw(ArgumentError("order_parameter_sqrt3 requires the two-site " *
+            "centered-rectangular triangular basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
+    ax, ay = lattice.lattice_vectors[1, 1], lattice.lattice_vectors[2, 2]
+    b1, b2 = lattice.basis
+    if !(isapprox(b1[1], 0.0, atol=1e-9) && isapprox(b1[2], 0.0, atol=1e-9) &&
+         isapprox(b2[1], ax / 2, atol=1e-9) && isapprox(b2[2], ay / 2, atol=1e-9))
+        throw(ArgumentError("order_parameter_sqrt3 requires the standard " *
+            "triangular basis [(0, 0, 0), (a/2, √3·a/2, 0)] consistent with " *
+            "the lattice vectors, got $(lattice.basis)"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("order_parameter_sqrt3 requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    if d1 % 3 != 0
+        throw(ArgumentError("order_parameter_sqrt3 requires " *
+            "supercell_dimensions[1] divisible by 3 so the three √3×√3 " *
+            "sublattices close on the periodic cell, got $d1"))
+    end
+    occ = lattice.components[1]
+    # Sublattice occupations n[c+1], c ∈ {0,1,2}. lattice_positions ordering:
+    # basis innermost, dimension 1 next. In triangular integer coordinates
+    # (m, n) with r = m·t₁ + n·t₂, a valid tripartition is c = (m − n) mod 3;
+    # the basis-0 site of cell column ci sits at (ci − cj, 2cj), giving
+    # c = ci mod 3, and the basis-1 site adds one t₂ step, giving
+    # c = (ci + 2) mod 3. Wrapping the a₁ circumference shifts c by d1 mod 3,
+    # hence the commensurability guard above.
+    n = zeros(Int, 3)
+    for s in eachindex(occ)
+        occ[s] || continue
+        b = (s - 1) % 2
+        ci = ((s - 1) ÷ 2) % d1
+        c = b == 0 ? ci % 3 : (ci + 2) % 3
+        n[c+1] += 1
+    end
+    M = 2 * d1 * d2
+    # |n₀ + n₁·ω + n₂·ω²|² = n₀² + n₁² + n₂² − n₀n₁ − n₁n₂ − n₂n₀, exact in
+    # integers; one final square root, no complex arithmetic.
+    s2 = n[1]^2 + n[2]^2 + n[3]^2 - n[1] * n[2] - n[2] * n[3] - n[3] * n[1]
+    return sqrt(Float64(s2)) / M
+end
+
+"""
     motif_distances(coords::AbstractVector{<:Tuple}) -> Vector{Float64}
 
 Sorted multiset of the pairwise Euclidean distances of a coordinate

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -534,6 +534,15 @@ Diagnostics:
 Note: for a pair signature (`K = 2`) this reproduces the sites of a
 neighbor shell as unordered pairs — useful as a counting diagnostic; pair
 couplings themselves belong in `GenericLatticeHamiltonian`.
+
+**Homometry caveat**: for `K ≥ 4`, non-congruent figures can share a
+distance multiset (homometric figures), and this method then enumerates
+the embeddings of every such figure together — it warns about this. Pass
+the coordinate template instead (the `coords` method) to enumerate only
+embeddings whose full distance *matrix* matches the template under some
+site permutation, which excludes homometric aliases while preserving the
+torus counting convention. For `K ≤ 3` the multiset determines the figure
+and the two methods agree.
 """
 function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector{<:Real};
                                     tol::Float64=1e-6,
@@ -545,7 +554,79 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
             "distances must be the full pairwise multiset of a K-site motif " *
             "— 1 (K = 2), 3 (K = 3), 6 (K = 4), or 10 (K = 5) entries — got $npairs"))
     end
-    sig = sort(collect(Float64, distances))
+    if K >= 4
+        @warn "a distance multiset does not determine a figure for K ≥ 4 " *
+              "(homometric figures share multisets); embeddings of every " *
+              "figure with this multiset are enumerated together. Pass the " *
+              "coordinate template to enumerate_motif_embeddings to select " *
+              "the congruent embeddings only."
+    end
+    return _enumerate_motif_core(lattice, collect(Float64, distances), K,
+                                 nothing, tol, expected_count)
+end
+
+"""
+    enumerate_motif_embeddings(lattice::MLattice, coords::AbstractVector{<:Tuple};
+                               tol=1e-6, expected_count=nothing)
+
+Template method: declare the motif by its site coordinates (as accepted by
+[`motif_distances`](@ref)) and enumerate only the embeddings whose full
+minimum-image distance matrix matches the template's under some site
+permutation. This is the recommended method for `K ≥ 4`, where a distance
+multiset alone does not determine the figure (homometric figures).
+"""
+function enumerate_motif_embeddings(lattice::MLattice, coords::AbstractVector{<:Tuple};
+                                    tol::Float64=1e-6,
+                                    expected_count::Union{Int,Nothing}=nothing)
+    K = length(coords)
+    2 <= K <= 5 || throw(ArgumentError(
+        "the motif template must have 2 to 5 sites, got $K"))
+    to3(t) = (Float64(t[1]), Float64(t[2]), length(t) >= 3 ? Float64(t[3]) : 0.0)
+    pts = [to3(t) for t in coords]
+    T = zeros(K, K)
+    for a in 1:K, b in 1:K
+        T[a, b] = sqrt((pts[a][1] - pts[b][1])^2 +
+                       (pts[a][2] - pts[b][2])^2 +
+                       (pts[a][3] - pts[b][3])^2)
+    end
+    sig = sort([T[a, b] for a in 1:K for b in (a+1):K])
+    return _enumerate_motif_core(lattice, sig, K, T, tol, expected_count)
+end
+
+# Does some permutation of `sites` match the template distance matrix `T`
+# entrywise within tol? Backtracking assignment with early pruning; K ≤ 5,
+# so at most 120 permutations are ever considered.
+function _matches_template(sites::Vector{Int}, dist, T::Matrix{Float64}, tol::Float64)
+    K = length(sites)
+    perm = zeros(Int, K)
+    used = falses(K)
+    function assign(a)
+        a > K && return true
+        for b in 1:K
+            used[b] && continue
+            ok = true
+            for a2 in 1:(a-1)
+                if abs(dist(sites[perm[a2]], sites[b]) - T[a2, a]) > tol
+                    ok = false
+                    break
+                end
+            end
+            ok || continue
+            used[b] = true
+            perm[a] = b
+            assign(a + 1) && return true
+            used[b] = false
+        end
+        return false
+    end
+    return assign(1)
+end
+
+function _enumerate_motif_core(lattice::MLattice, distances::Vector{Float64}, K::Int,
+                               template::Union{Nothing,Matrix{Float64}},
+                               tol::Float64, expected_count::Union{Int,Nothing})
+    npairs = length(distances)
+    sig = sort(distances)
     all(>(0.0), sig) || throw(ArgumentError("motif distances must be positive"))
     tol > 0 || throw(ArgumentError("tol must be positive"))
 
@@ -556,19 +637,25 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
     pos = lattice.positions
     per = lattice.periodicity
 
-    # Wrap-around guard: a periodic circumference not exceeding K·d_max
-    # admits winding embeddings; counts then follow the torus convention
+    # Wrap-around guard: the shortest periodic translation (over small
+    # integer combinations of the periodic supercell vectors, which covers
+    # reasonably reduced cells; extreme shear beyond ±1 combinations is not
+    # detected) must exceed K·d_max, else winding embeddings are admitted
+    # and counts follow the torus convention
     d_max = sig[end]
-    for k in 1:3
-        per[k] || continue
-        C = norm(scv[:, k])
-        if C <= K * d_max + tol
-            @warn "periodic circumference $(round(C, digits=4)) along axis $k " *
-                  "does not exceed K·d_max = $(K * d_max); the cell is not a " *
-                  "faithful quotient and embeddings follow the torus " *
-                  "(minimum-image) convention"
-            break
-        end
+    C_min = Inf
+    for n1 in -1:1, n2 in -1:1, n3 in -1:1
+        (n1 == 0 && n2 == 0 && n3 == 0) && continue
+        (!per[1] && n1 != 0) && continue
+        (!per[2] && n2 != 0) && continue
+        (!per[3] && n3 != 0) && continue
+        C_min = min(C_min, norm(n1 * scv[:, 1] + n2 * scv[:, 2] + n3 * scv[:, 3]))
+    end
+    if isfinite(C_min) && C_min <= K * d_max + tol
+        @warn "shortest periodic translation $(round(C_min, digits=4)) does " *
+              "not exceed K·d_max = $(K * d_max); the cell is not a faithful " *
+              "quotient and embeddings follow the torus (minimum-image) " *
+              "convention"
     end
 
     uniq = Float64[]
@@ -581,11 +668,14 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
 
     # Per-site candidates at any signature distance, restricted to j > i:
     # anchored strictly increasing enumeration makes each unordered set
-    # appear exactly once, with the anchor as its minimum index
+    # appear exactly once, with the anchor as its minimum index. Pruning
+    # measures 2·tol from the merged uniq representatives so it stays a
+    # relaxation of the elementwise acceptance below (a representative can
+    # sit up to tol away from the signature entry it absorbed).
     cand = [Int[] for _ in 1:M]
     for i in 1:M, j in (i+1):M
         d = dist(i, j)
-        if any(u -> abs(u - d) <= tol, uniq)
+        if any(u -> abs(u - d) <= 2 * tol, uniq)
             push!(cand[i], j)
         end
     end
@@ -600,7 +690,9 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
             end
             sort!(ds)
             if all(abs(ds[t] - sig[t]) <= tol for t in 1:npairs)
-                push!(embeddings, NTuple{K,Int}(partial))
+                if template === nothing || _matches_template(partial, dist, template, tol)
+                    push!(embeddings, NTuple{K,Int}(partial))
+                end
             end
             return nothing
         end
@@ -609,7 +701,7 @@ function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector
             ok = true
             for s in partial
                 dj = dist(s, j)
-                if !any(u -> abs(u - dj) <= tol, uniq)
+                if !any(u -> abs(u - dj) <= 2 * tol, uniq)
                     ok = false
                     break
                 end

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -1,23 +1,4 @@
 """
-compute_neighbors(supercell_lattice_vectors::Matrix{Float64}, 
-                  positions::Matrix{Float64}, 
-                  cutoff_radii::Vector{Float64}, 
-                  periodicity::Tuple{Bool, Bool, Bool})
-
-Compute the nearest and next-nearest neighbors for each atom in a 3D lattice.
-
-# Arguments
-- `supercell_lattice_vectors::Matrix{Float64}`: The lattice vectors of the supercell.
-- `positions::Matrix{Float64}`: The positions of the atoms in the supercell.
-- `periodicity::Tuple{Bool, Bool, Bool}`: A Boolean tuple of length three indicating periodicity in each dimension (true for periodic, false for non-periodic).
-- `cutoff_radii::Vector{Float64}`: The cutoff radii for the *index*-th nearest neighbors.
-
-# Returns
-- `neighbors::Vector{Tuple{Vector{Int}, Vector{Int}}}`: A vector of tuples containing the indices of the first and second nearest neighbors for each atom.
-
-"""
-
-"""
     _minimum_image_distance(supercell_lattice_vectors, reciprocal_lattice_vectors,
                             periodicity, pos_i, pos_j)
 
@@ -40,11 +21,59 @@ cluster embeddings follow the identical torus convention.
     return norm(supercell_lattice_vectors * fractional_dr)
 end
 
+"""
+    compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
+                      positions::Matrix{Float64},
+                      periodicity::Tuple{Bool, Bool, Bool},
+                      cutoff_radii::Vector{Float64};
+                      image_multiplicity::Bool=false)
+
+Compute the neighbor shells of every site in a supercell. Each in-cutoff
+distance is assigned to the first shell whose cutoff admits it (a nested
+`<=` cutoff ladder), so `cutoff_radii` must be non-empty, finite, strictly
+positive, and strictly increasing; anything else throws an
+`ArgumentError`.
+
+# Arguments
+- `supercell_lattice_vectors::Matrix{Float64}`: The lattice vectors of the supercell, one cell vector per column.
+- `positions::Matrix{Float64}`: The Cartesian positions of the sites, one site per row.
+- `periodicity::Tuple{Bool, Bool, Bool}`: A Boolean tuple of length three indicating periodicity in each dimension (true for periodic, false for non-periodic).
+- `cutoff_radii::Vector{Float64}`: The cutoff radii for the *index*-th nearest neighbors, strictly increasing.
+- `image_multiplicity::Bool=false`: The neighbor-counting convention, see below.
+
+# Returns
+- `neighbors::Vector{Vector{Vector{Int}}}`: For each site, one vector of neighbor indices per shell.
+
+# Conventions
+
+With `image_multiplicity=false` (the default), each site pair is counted
+once, in the shell of its minimum-image distance. On a cell whose periodic
+circumference does not exceed twice a shell cutoff, pairs connected
+through more than one periodic image are still counted once — the affected
+shells sit below their bulk-tiled coordination — and one warning listing
+every such shell and its collapsed-image count is emitted per call.
+Detection is exact (the periodic images are enumerated), so faithful cells
+never warn.
+
+With `image_multiplicity=true`, a neighbor index is pushed once per
+in-cutoff periodic image, including a site's own images (self-entries,
+`j == i`, which arise when a periodic circumference is within the cutoff):
+the cluster-expansion small-cell convention, under which the periodic
+cell's energy equals the bulk energy per cell of the tiled configuration.
+"""
 function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
                            positions::Matrix{Float64},
                            periodicity::Tuple{Bool, Bool, Bool},
-                           cutoff_radii::Vector{Float64}
+                           cutoff_radii::Vector{Float64};
+                           image_multiplicity::Bool=false,
                            )
+
+    if isempty(cutoff_radii) || any(r -> !(isfinite(r) && r > 0.0), cutoff_radii) ||
+       !all(cutoff_radii[k] < cutoff_radii[k+1] for k in 1:length(cutoff_radii)-1)
+        throw(ArgumentError(
+            "cutoff_radii must be finite, positive, and strictly increasing " *
+            "(shells are assigned by a nested cutoff ladder), got $cutoff_radii"))
+    end
 
     neighbors = Vector{Vector{Vector{Int}}}(undef, size(positions, 1))
     num_atoms = size(positions, 1)
@@ -56,6 +85,45 @@ function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
     reciprocal_lattice_vectors = inv([a1 a2 a3])
 
     layers_of_neighbors = length(cutoff_radii)
+    r_max = last(cutoff_radii)
+
+    # First shell whose cutoff admits the distance (the nested `<=` ladder);
+    # 0 when the distance is beyond the outermost cutoff.
+    function shell_of(distance::Float64)
+        for k in 1:layers_of_neighbors
+            if distance <= cutoff_radii[k]
+                return k
+            end
+        end
+        return 0
+    end
+
+    # Periodic-image offsets that can reach into the outermost cutoff:
+    # n_k in -N_k:N_k with N_k = floor(r_max·‖row k of inv(scv)‖ + 1/2) + 1.
+    # The inverse-cell row norm is the reciprocal of the perpendicular cell
+    # height, so this range provably contains every in-cutoff image on
+    # skewed cells too. Non-periodic directions contribute only n_k = 0.
+    offset_ranges = map(1:3) do k
+        if periodicity[k]
+            N = floor(Int, r_max * norm(view(reciprocal_lattice_vectors, k, :)) + 0.5) + 1
+            -N:N
+        else
+            0:0
+        end
+    end
+    # Precomputed Cartesian offsets; the Bool marks the zero offset (the
+    # central image, which is the kept image for j != i and the null term
+    # for j == i).
+    offsets = Tuple{Float64,Float64,Float64,Bool}[]
+    for n1 in offset_ranges[1], n2 in offset_ranges[2], n3 in offset_ranges[3]
+        push!(offsets, (n1 * a1[1] + n2 * a2[1] + n3 * a3[1],
+                        n1 * a1[2] + n2 * a2[2] + n3 * a3[2],
+                        n1 * a1[3] + n2 * a2[3] + n3 * a3[3],
+                        n1 == 0 && n2 == 0 && n3 == 0))
+    end
+
+    # Discarded in-cutoff images per shell (default mode only)
+    collapsed = zeros(Int, layers_of_neighbors)
 
     for i in 1:num_atoms
         nth_neighbors = Vector{Int}[]
@@ -64,21 +132,67 @@ function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
         end
 
         for j in 1:num_atoms
-            if i != j
-                distance = _minimum_image_distance(
-                    supercell_lattice_vectors, reciprocal_lattice_vectors,
-                    periodicity, view(positions, i, :), view(positions, j, :))
+            # Central image: the same rounding reduction as
+            # _minimum_image_distance, so `dmin` below is bit-identical to
+            # the per-pair minimum-image distance used before this rewrite —
+            # neighbor-list order feeds seeded RNG streams, so the default
+            # path must reproduce the previous lists element-for-element.
+            dr = [positions[j, 1] - positions[i, 1],
+                  positions[j, 2] - positions[i, 2],
+                  positions[j, 3] - positions[i, 3]]
+            fractional_dr = reciprocal_lattice_vectors * dr
+            for k in 1:3
+                if periodicity[k]
+                    fractional_dr[k] -= round(fractional_dr[k])
+                end
+            end
+            dr_c = supercell_lattice_vectors * fractional_dr
 
-                for k in 1:layers_of_neighbors
-                    if distance <= cutoff_radii[k]
-                        push!(nth_neighbors[k], j)
-                        break
-                    end
+            if image_multiplicity
+                # Push j once per in-cutoff periodic image (self-images
+                # included); only the single zero-displacement self term is
+                # skipped — it is not a bond.
+                for (ox, oy, oz, central) in offsets
+                    (j == i && central) && continue
+                    d = sqrt((dr_c[1] + ox)^2 + (dr_c[2] + oy)^2 + (dr_c[3] + oz)^2)
+                    k = shell_of(d)
+                    k != 0 && push!(nth_neighbors[k], j)
+                end
+            else
+                # Minimum-image convention: for j != i push j once, into the
+                # shell of the central (minimum-image) distance, exactly as
+                # before; tally every other in-cutoff image — the collapsed
+                # images of j != i pairs and all in-cutoff self-images — per
+                # that image's own shell.
+                if j != i
+                    kept_shell = shell_of(norm(dr_c))
+                    kept_shell != 0 && push!(nth_neighbors[kept_shell], j)
+                end
+                for (ox, oy, oz, central) in offsets
+                    central && continue
+                    d = sqrt((dr_c[1] + ox)^2 + (dr_c[2] + oy)^2 + (dr_c[3] + oz)^2)
+                    k = shell_of(d)
+                    k != 0 && (collapsed[k] += 1)
                 end
             end
         end
 
         neighbors[i] = nth_neighbors
+    end
+
+    if any(>(0), collapsed)
+        wrapped = ["$k (cutoff $(cutoff_radii[k])): $(collapsed[k]) collapsed image bond(s)"
+                   for k in 1:layers_of_neighbors if collapsed[k] > 0]
+        @warn "neighbor shell(s) [" * join(wrapped, ", ") * "] wrap the " *
+              "periodic cell: some pairs (or a site and its own periodic " *
+              "image) are connected through more than one image within the " *
+              "cutoff but are counted once under the minimum-image " *
+              "convention, so per-site coordination, and any energy " *
+              "coupling these shells, is below the bulk-tiled value. " *
+              "Enlarge the supercell so every periodic circumference " *
+              "exceeds twice the shell cutoff, or construct the lattice " *
+              "with `image_multiplicity=true` to count every image (the " *
+              "cluster-expansion small-cell convention)."
     end
 
     for k in 1:layers_of_neighbors
@@ -182,9 +296,10 @@ A mutable struct representing a lattice with the following fields:
         basis::Vector{Tuple{Float64, Float64, Float64}},
         supercell_dimensions::Tuple{Int64, Int64, Int64},
         periodicity::Tuple{Bool, Bool, Bool},
-        components::Vector{Vector{Bool}},
-        adsorptions::Vector{Bool},
         cutoff_radii::Vector{Float64},
+        components::Vector{Vector{Bool}},
+        adsorptions::Vector{Bool};
+        image_multiplicity::Bool=false,
     ) where {C,G}
 
 Creates an `MLattice` instance with the specified parameters. The constructor performs the following steps:
@@ -192,7 +307,7 @@ Creates an `MLattice` instance with the specified parameters. The constructor pe
 1. Validates that the number of components matches the expected value `C`.
 2. Computes the positions of the lattice points using `lattice_positions`.
 3. Computes the supercell lattice vectors.
-4. Computes the neighbors of each lattice point using `compute_neighbors`.
+4. Computes the neighbors of each lattice point using `compute_neighbors`, passing the `image_multiplicity` keyword through.
 
 Throws an `ArgumentError` if the number of components does not match `C`.
 
@@ -204,7 +319,8 @@ Throws an `ArgumentError` if the number of components does not match `C`.
                                periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
                                cutoff_radii::Vector{Float64}=[1.1, 1.5],
                                components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
-                               adsorptions::Union{Vector{Int},Symbol}=:full)
+                               adsorptions::Union{Vector{Int},Symbol}=:full,
+                               image_multiplicity::Bool=false)
 
     MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
                                   basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
@@ -212,11 +328,25 @@ Throws an `ArgumentError` if the number of components does not match `C`.
                                   periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
                                   cutoff_radii::Vector{Float64}=[1.1, 1.8],
                                   components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
-                                  adsorptions::Union{Vector{Int},Symbol}=:full)
+                                  adsorptions::Union{Vector{Int},Symbol}=:full,
+                                  image_multiplicity::Bool=false)
 
 Constructs a square/triangular lattice with the specified parameters. The `components` and `adsorptions` arguments can be a vector of integers specifying
-the indices of the occupied sites, or a symbol. If `components` is `:equal`, the lattice is divided into `C` equal components when possible, or 
+the indices of the occupied sites, or a symbol. If `components` is `:equal`, the lattice is divided into `C` equal components when possible, or
 nearest to equal components otherwise. If `adsorptions` is `:full`, all sites are classified as adsorption sites.
+
+The `image_multiplicity` keyword selects the neighbor-counting convention of
+[`compute_neighbors`](@ref): under the default minimum-image convention each
+site pair is counted once and a warning reports any shells that wrap the
+periodic cell; with `image_multiplicity=true` every in-cutoff periodic image
+is counted, self-image entries included (the cluster-expansion small-cell
+convention, under which the cell's energy equals the bulk energy per cell of
+the tiled configuration). The duplicated entries compose correctly
+downstream: the energy kernels add `coupling/2` per ordered-pair entry, so a
+doubled bond reaches the full bond energy and a self-image entry passes the
+occupation test exactly when the site is occupied; geometric-cluster growth
+reads only the first shell, and growth across a duplicated bond remains a
+configuration-independent symmetric proposal.
 
 ## Returns
 - `MLattice{C,G}`: A square/triangular lattice object with `C` components.
@@ -240,7 +370,8 @@ mutable struct MLattice{C,G} <: AbstractLattice
         periodicity::Tuple{Bool, Bool, Bool},
         cutoff_radii::Vector{Float64},
         components::Vector{Vector{Bool}},
-        adsorptions::Vector{Bool},
+        adsorptions::Vector{Bool};
+        image_multiplicity::Bool=false,
     ) where {C,G}
 
         num_components = length(components)
@@ -252,7 +383,8 @@ mutable struct MLattice{C,G} <: AbstractLattice
         positions = lattice_positions(lattice_vectors, basis, supercell_dimensions)
 
         supercell_lattice_vectors = lattice_vectors * Diagonal([supercell_dimensions[1], supercell_dimensions[2], supercell_dimensions[3]])
-        neighbors = compute_neighbors(supercell_lattice_vectors, positions, periodicity, cutoff_radii)
+        neighbors = compute_neighbors(supercell_lattice_vectors, positions, periodicity, cutoff_radii;
+                                      image_multiplicity=image_multiplicity)
         
         return new{C,G}(lattice_vectors, positions, basis, supercell_dimensions, periodicity, cutoff_radii, components, neighbors, adsorptions)
     end
@@ -366,12 +498,14 @@ function MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
                                     cutoff_radii::Vector{Float64}=[1.1, 1.5],
                                     components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                     adsorptions::Union{Vector{Int},Symbol}=:full,
+                                    image_multiplicity::Bool=false,
                                 ) where C
 
     lattice_vectors = [lattice_constant 0.0 0.0; 0.0 lattice_constant 0.0; 0.0 0.0 1.0]
     lattice_comp, lattice_adsorptions = mlattice_setup(C, basis, supercell_dimensions, components, adsorptions)
 
-    return MLattice{C,SquareLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions)
+    return MLattice{C,SquareLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions;
+                                     image_multiplicity=image_multiplicity)
 end
 
 function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
@@ -383,13 +517,15 @@ function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
                                         cutoff_radii::Vector{Float64}=[1.1, 1.8],
                                         components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                         adsorptions::Union{Vector{Int},Symbol}=:full,
+                                        image_multiplicity::Bool=false,
                                     ) where C
 
     lattice_vectors = [lattice_constant 0.0 0.0; 0.0 sqrt(3)*lattice_constant 0.0; 0.0 0.0 1.0]
     lattice_comp, lattice_adsorptions = mlattice_setup(C, basis, supercell_dimensions, components, adsorptions)
 
-    return MLattice{C,TriangularLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions)
-    
+    return MLattice{C,TriangularLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions;
+                                         image_multiplicity=image_multiplicity)
+
 end
 
 

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -561,6 +561,144 @@ function order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice})
 end
 
 """
+    bragg_amplitude(lattice::MLattice{1,SquareLattice}, m::Int, n::Int) -> Float64
+
+Normalized Bragg-peak amplitude of the occupation pattern on a
+single-component square lattice:
+
+    |ρ(k)| = |Σ_{occupied sites} e^{ik·r}| / M,   k = 2π·(m/d₁, n/d₂),
+
+in units of the inverse lattice constant, where `(d₁, d₂)` are the in-plane
+supercell dimensions and `M = d₁·d₂` is the number of sites. This is the
+LEED-intensity convention of Zhang, Blum & Reuter
+[PRB **75**, 235406 (2007)]; [`order_parameter_c2x2`](@ref) is the
+k = (π, π) member of the family, and
+`bragg_amplitude(lat, d1 ÷ 2, d2 ÷ 2) == order_parameter_c2x2(lat)` on
+even-dimension cells. Integer indices on the supercell reciprocal grid make
+every representable k commensurate by construction; indices wrap modulo the
+dimensions, so negative and out-of-range values are valid:
+`bragg_amplitude(lat, m, n) == bragg_amplitude(lat, m + d1, n)`. The empty
+and the full lattice give `0` for any `(m, n)` not both `≡ 0` modulo the
+dimensions; a single particle gives `1/M`.
+
+Like the named order parameters, |ρ(k)| is not a function of `(E, N)` and
+must be evaluated on configurations (e.g. per culled walker, via the
+`observables` keyword of the nested-sampling loops); see
+[`order_parameter_stripe`](@ref) for the composed-observable recipes.
+
+Requires a single-site basis and a strictly two-dimensional supercell
+(`supercell_dimensions[3] == 1`); violations throw an `ArgumentError`.
+"""
+function bragg_amplitude(lattice::MLattice{1,SquareLattice}, m::Int, n::Int)
+    if length(lattice.basis) != 1
+        throw(ArgumentError("bragg_amplitude requires a single-site " *
+            "basis, got $(length(lattice.basis)) basis sites"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("bragg_amplitude requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    # Phase tables over mod-reduced cispi arguments: half-turn phases are
+    # exactly ±1.0 and quarter-turn phases exactly ±1.0/±1.0im, so the c2x2
+    # identity and the period-4 values hold to full precision
+    col = [cispi(2 * mod(m * x, d1) / d1) for x in 0:d1-1]
+    row = [cispi(2 * mod(n * y, d2) / d2) for y in 0:d2-1]
+    occ = lattice.components[1]
+    z = 0.0 + 0.0im
+    for s in eachindex(occ)
+        if occ[s]
+            # lattice_positions ordering: basis innermost, dimension 1 fastest
+            i0 = (s - 1) % d1
+            j0 = ((s - 1) ÷ d1) % d2
+            z += col[i0+1] * row[j0+1]
+        end
+    end
+    return abs(z) / (d1 * d2)
+end
+
+"""
+    order_parameter_stripe(lattice::MLattice{1,SquareLattice}; period::Int = 2) -> Float64
+
+Orientation-degenerate axial stripe order parameter on a single-component
+square lattice: the quadrature sum of the two axial Bragg amplitudes at
+wavevector 2π/P, with P = `period` in lattice constants,
+
+    Ψ = √(|ρ(2π/P, 0)|² + |ρ(0, 2π/P)|²),
+
+i.e. `sqrt(bragg_amplitude(lat, d1 ÷ period, 0)^2 +
+bragg_amplitude(lat, 0, d2 ÷ period)^2)` with the normalized amplitudes of
+[`bragg_amplitude`](@ref). A perfect single-orientation period-P stripe
+with the half-period filled attains `1/(P·sin(π/P))`: each of the `d₂` rows
+contributes `d₁/P` copies of the geometric phasor sum
+`Σ_{x=0}^{P/2−1} e^{2πix/P}`, of modulus `1/sin(π/P)`, and dividing by
+`M = d₁·d₂` leaves `1/(P·sin(π/P))`. That gives `1/2` at P = 2 (matching
+the c(2×2) = 1/2 convention at half filling) and `√2/4` at P = 4; the
+perpendicular component vanishes on a perfect stripe, so the quadrature
+maximum equals the single-orientation value. `period = 2` detects the (2×1)
+row and column stripes — the superantiferromagnetic phase of the square
+lattice with nearest- and next-nearest-neighbor couplings [Binder & Landau,
+PRB **21**, 1941 (1980)] — `period = 4` the axial period-4 phases that
+appear with third-neighbor couplings [Landau & Binder, PRB **31**, 5946
+(1985)], and `period = 2h` the width-h stripes of dipolar-frustrated
+ferromagnets [MacIsaac, Whitehead, Robinson & De'Bell, PRB **51**, 16033
+(1995)]. The perfect checkerboard and the empty and the full lattice
+give `0`.
+
+Ψ is not a function of `(E, N)` — degenerate energy levels contain ordered
+and disordered configurations alike — so it must be evaluated on
+configurations (e.g. per culled walker, via the `observables` keyword of
+the nested-sampling loops). Higher moments for Binder-cumulant analysis are
+composed caller-side, with no library change:
+
+    observables = [:stripe  => order_parameter_stripe,
+                   :stripe2 => cfg -> order_parameter_stripe(cfg)^2,
+                   :stripe4 => cfg -> order_parameter_stripe(cfg)^4]
+
+Diagonal period-4 order is composed the same way, from the k = (π/2, ±π/2)
+quadrature
+
+    cfg -> sqrt(bragg_amplitude(cfg, d1 ÷ 4, d2 ÷ 4)^2 +
+                bragg_amplitude(cfg, d1 ÷ 4, -(d2 ÷ 4))^2)
+
+which equals `√2/4` on every member of the k = (π/2, ±π/2) ground manifold
+of the nearest-neighbor-attraction plus isotropic third-neighbor-repulsion
+model — p(2×2) blocks and diagonal period-4 stripes alike — while
+`order_parameter_stripe(period=4)` is exactly `0` there; the two
+observables separate the axial and diagonal period-4 phases.
+
+Requires a single-site basis, a strictly two-dimensional supercell
+(`supercell_dimensions[3] == 1`), `period >= 2`, and `period` dividing both
+in-plane dimensions (both orientations are evaluated, and an incommensurate
+orientation leaks a spurious amplitude); violations throw an
+`ArgumentError`.
+"""
+function order_parameter_stripe(lattice::MLattice{1,SquareLattice}; period::Int=2)
+    if length(lattice.basis) != 1
+        throw(ArgumentError("order_parameter_stripe requires a single-site " *
+            "basis, got $(length(lattice.basis)) basis sites"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("order_parameter_stripe requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    if period < 2
+        throw(ArgumentError("order_parameter_stripe requires period >= 2, " *
+            "got $period"))
+    end
+    if d1 % period != 0 || d2 % period != 0
+        bad = d1 % period != 0 ? d1 : d2
+        throw(ArgumentError("order_parameter_stripe requires the period to " *
+            "divide both in-plane supercell dimensions, since both stripe " *
+            "orientations are evaluated and an incommensurate orientation " *
+            "leaks a spurious amplitude; period $period does not divide $bad"))
+    end
+    return sqrt(bragg_amplitude(lattice, d1 ÷ period, 0)^2 +
+                bragg_amplitude(lattice, 0, d2 ÷ period)^2)
+end
+
+"""
     motif_distances(coords::AbstractVector{<:Tuple}) -> Vector{Float64}
 
 Sorted multiset of the pairwise Euclidean distances of a coordinate

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -420,6 +420,59 @@ function occupied_site_count(MLattice::MLattice{C}) where C
 end
 
 """
+    order_parameter_c2x2(lattice::MLattice{1,SquareLattice}) -> Float64
+
+Sublattice order parameter for c(2×2) checkerboard ordering on a
+single-component square lattice:
+
+    Ψ = |Σ_{occupied sites} (−1)^(i+j)| / M,
+
+where `(i, j)` are the integer lattice coordinates of each site and `M` is
+the number of sites. Equivalent to the four-sublattice
+`Ψ_c(2×2) = |N_a + N_d − N_b − N_c| / M` of Zhang, Blum & Reuter
+[PRB **75**, 235406 (2007), Eq. (8)]: sublattices (a, d) share one
+checkerboard parity and (b, c) the other. A perfect c(2×2) arrangement at
+half filling gives `1/2`; the empty and the full lattice give `0`.
+
+Ψ is not a function of `(E, N)` — degenerate energy levels contain ordered
+and disordered configurations alike — so it must be evaluated on
+configurations (e.g. per culled walker, via the `observables` keyword of the
+nested-sampling loops) rather than reconstructed from an energy ledger.
+
+Requires a single-site basis, a strictly two-dimensional supercell
+(`supercell_dimensions[3] == 1`), and even in-plane dimensions (the two
+checkerboard sublattices must tile the periodic cell evenly); violations
+throw an `ArgumentError`.
+"""
+function order_parameter_c2x2(lattice::MLattice{1,SquareLattice})
+    if length(lattice.basis) != 1
+        throw(ArgumentError("order_parameter_c2x2 requires a single-site " *
+            "basis, got $(length(lattice.basis)) basis sites"))
+    end
+    d1, d2, d3 = lattice.supercell_dimensions
+    if d3 != 1
+        throw(ArgumentError("order_parameter_c2x2 requires a two-dimensional " *
+            "supercell (supercell_dimensions[3] == 1), got $d3 layers"))
+    end
+    if isodd(d1) || isodd(d2)
+        throw(ArgumentError("order_parameter_c2x2 requires even in-plane " *
+            "supercell dimensions so the checkerboard sublattices tile the " *
+            "periodic cell evenly, got ($d1, $d2)"))
+    end
+    occ = lattice.components[1]
+    acc = 0
+    for s in eachindex(occ)
+        if occ[s]
+            # lattice_positions ordering: basis innermost, dimension 1 fastest
+            i0 = (s - 1) % d1
+            j0 = ((s - 1) ÷ d1) % d2
+            acc += iseven(i0 + j0) ? 1 : -1
+        end
+    end
+    return abs(acc) / (d1 * d2)
+end
+
+"""
     mutable struct LatticeWalker
 
 The `LatticeWalker` struct represents a walker on a 3D lattice.

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -17,15 +17,38 @@ Compute the nearest and next-nearest neighbors for each atom in a 3D lattice.
 
 """
 
-function compute_neighbors(supercell_lattice_vectors::Matrix{Float64}, 
-                           positions::Matrix{Float64}, 
-                           periodicity::Tuple{Bool, Bool, Bool}, 
+"""
+    _minimum_image_distance(supercell_lattice_vectors, reciprocal_lattice_vectors,
+                            periodicity, pos_i, pos_j)
+
+Minimum-image distance between two Cartesian positions under the given
+supercell and periodicity — the single distance kernel shared by
+`compute_neighbors` and `enumerate_motif_embeddings`, so pair shells and
+cluster embeddings follow the identical torus convention.
+"""
+@inline function _minimum_image_distance(supercell_lattice_vectors::AbstractMatrix{Float64},
+                                         reciprocal_lattice_vectors::AbstractMatrix{Float64},
+                                         periodicity::Tuple{Bool,Bool,Bool},
+                                         pos_i, pos_j)
+    dr = [pos_j[1] - pos_i[1], pos_j[2] - pos_i[2], pos_j[3] - pos_i[3]]
+    fractional_dr = reciprocal_lattice_vectors * dr
+    for k in 1:3
+        if periodicity[k]
+            fractional_dr[k] -= round(fractional_dr[k])
+        end
+    end
+    return norm(supercell_lattice_vectors * fractional_dr)
+end
+
+function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
+                           positions::Matrix{Float64},
+                           periodicity::Tuple{Bool, Bool, Bool},
                            cutoff_radii::Vector{Float64}
                            )
-                           
+
     neighbors = Vector{Vector{Vector{Int}}}(undef, size(positions, 1))
     num_atoms = size(positions, 1)
-    
+
     # Compute reciprocal lattice vectors for minimum image convention
     a1 = supercell_lattice_vectors[:, 1]
     a2 = supercell_lattice_vectors[:, 2]
@@ -39,40 +62,22 @@ function compute_neighbors(supercell_lattice_vectors::Matrix{Float64},
         for _ in 1:layers_of_neighbors
             push!(nth_neighbors, Int[])
         end
-        pos_i = positions[i, :]
-        
+
         for j in 1:num_atoms
             if i != j
-                pos_j = positions[j, :]
-                dx = pos_j[1] - pos_i[1]
-                dy = pos_j[2] - pos_i[2]
-                dz = pos_j[3] - pos_i[3]
+                distance = _minimum_image_distance(
+                    supercell_lattice_vectors, reciprocal_lattice_vectors,
+                    periodicity, view(positions, i, :), view(positions, j, :))
 
-                # Apply minimum image convention using reciprocal lattice vectors
-                dr = [dx, dy, dz]
-                fractional_dr = reciprocal_lattice_vectors * dr
-                
-                for k in 1:3
-                    if periodicity[k]
-                        fractional_dr[k] -= round(fractional_dr[k])
+                for k in 1:layers_of_neighbors
+                    if distance <= cutoff_radii[k]
+                        push!(nth_neighbors[k], j)
+                        break
                     end
                 end
-                
-                dr = supercell_lattice_vectors * fractional_dr
-
-                distance = norm(dr)
-
-                for i in 1:layers_of_neighbors
-                    if distance <= cutoff_radii[i]
-                        push!(nth_neighbors[i], j)
-                        break
-                    end 
-                end
-
-
             end
         end
-        
+
         neighbors[i] = nth_neighbors
     end
 
@@ -470,6 +475,178 @@ function order_parameter_c2x2(lattice::MLattice{1,SquareLattice})
         end
     end
     return abs(acc) / (d1 * d2)
+end
+
+"""
+    motif_distances(coords::AbstractVector{<:Tuple}) -> Vector{Float64}
+
+Sorted multiset of the pairwise Euclidean distances of a coordinate
+template, for transcribing a cluster-interaction figure straight from a
+paper's geometry (e.g. the trio `[(0, 0), (1, 0), (0, 1)]` gives
+`[1, 1, √2]`). Two-component tuples are treated as in-plane coordinates
+with `z = 0`. The result is the `distances` argument of
+[`enumerate_motif_embeddings`](@ref).
+"""
+function motif_distances(coords::AbstractVector{<:Tuple})
+    n = length(coords)
+    n >= 2 || throw(ArgumentError("a motif needs at least two sites"))
+    to3(t) = (Float64(t[1]), Float64(t[2]), length(t) >= 3 ? Float64(t[3]) : 0.0)
+    pts = [to3(t) for t in coords]
+    ds = Float64[]
+    for a in 1:n, b in (a+1):n
+        push!(ds, sqrt((pts[a][1] - pts[b][1])^2 +
+                       (pts[a][2] - pts[b][2])^2 +
+                       (pts[a][3] - pts[b][3])^2))
+    end
+    return sort(ds)
+end
+
+"""
+    enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector{<:Real};
+                               tol::Float64=1e-6,
+                               expected_count::Union{Int,Nothing}=nothing)
+        -> Vector{NTuple{K,Int}}
+
+Enumerate every embedding of a cluster motif on a periodic lattice. The
+motif is declared by the sorted multiset of its pairwise minimum-image
+distances (`K` is inferred from the multiset length: 1 → pair, 3 → trio,
+6 → quattro, 10 → quinto); [`motif_distances`](@ref) builds the multiset
+from a coordinate template. Distances are compared with absolute tolerance
+`tol`, using the same minimum-image kernel as `compute_neighbors`, so
+embeddings follow the identical torus convention as the pair shells: one
+entry per unordered site set whose distances match, in canonical strictly
+increasing order — the form [`ClusterInteraction`](@ref) requires.
+
+Diagnostics:
+- The total embedding count and the count per site are logged (`@info`).
+- A warning is emitted when the per-site embedding membership is not
+  uniform: on a site-transitive lattice, nonuniformity indicates distance
+  aliasing or an unsuitable `tol`.
+- A warning is emitted when any periodic circumference does not exceed
+  `K · maximum(distances)`: such a cell is not a faithful quotient, and
+  winding (wrap-around) embeddings are counted under the torus convention
+  (e.g. the 18-site triangular cell carries 42 nearest-neighbor-triangle
+  embeddings: 36 faces plus 6 winding three-cycles).
+- When `expected_count` is given (e.g. a hand-derived per-cell
+  multiplicity), a mismatch throws an `ArgumentError` — the recommended
+  guard against silent transcription errors.
+
+Note: for a pair signature (`K = 2`) this reproduces the sites of a
+neighbor shell as unordered pairs — useful as a counting diagnostic; pair
+couplings themselves belong in `GenericLatticeHamiltonian`.
+"""
+function enumerate_motif_embeddings(lattice::MLattice, distances::AbstractVector{<:Real};
+                                    tol::Float64=1e-6,
+                                    expected_count::Union{Int,Nothing}=nothing)
+    npairs = length(distances)
+    K = round(Int, (1 + sqrt(1 + 8.0 * npairs)) / 2)
+    if K * (K - 1) ÷ 2 != npairs || !(2 <= K <= 5)
+        throw(ArgumentError(
+            "distances must be the full pairwise multiset of a K-site motif " *
+            "— 1 (K = 2), 3 (K = 3), 6 (K = 4), or 10 (K = 5) entries — got $npairs"))
+    end
+    sig = sort(collect(Float64, distances))
+    all(>(0.0), sig) || throw(ArgumentError("motif distances must be positive"))
+    tol > 0 || throw(ArgumentError("tol must be positive"))
+
+    M = num_sites(lattice)
+    dims = lattice.supercell_dimensions
+    scv = lattice.lattice_vectors * Diagonal([dims[1], dims[2], dims[3]])
+    rec = inv(scv)
+    pos = lattice.positions
+    per = lattice.periodicity
+
+    # Wrap-around guard: a periodic circumference not exceeding K·d_max
+    # admits winding embeddings; counts then follow the torus convention
+    d_max = sig[end]
+    for k in 1:3
+        per[k] || continue
+        C = norm(scv[:, k])
+        if C <= K * d_max + tol
+            @warn "periodic circumference $(round(C, digits=4)) along axis $k " *
+                  "does not exceed K·d_max = $(K * d_max); the cell is not a " *
+                  "faithful quotient and embeddings follow the torus " *
+                  "(minimum-image) convention"
+            break
+        end
+    end
+
+    uniq = Float64[]
+    for d in sig
+        any(u -> abs(u - d) <= tol, uniq) || push!(uniq, d)
+    end
+
+    dist(i, j) = _minimum_image_distance(scv, rec, per,
+                                         view(pos, i, :), view(pos, j, :))
+
+    # Per-site candidates at any signature distance, restricted to j > i:
+    # anchored strictly increasing enumeration makes each unordered set
+    # appear exactly once, with the anchor as its minimum index
+    cand = [Int[] for _ in 1:M]
+    for i in 1:M, j in (i+1):M
+        d = dist(i, j)
+        if any(u -> abs(u - d) <= tol, uniq)
+            push!(cand[i], j)
+        end
+    end
+
+    embeddings = Vector{NTuple{K,Int}}()
+    partial = Int[]
+    function extend!()
+        if length(partial) == K
+            ds = Float64[]
+            for a in 1:K, b in (a+1):K
+                push!(ds, dist(partial[a], partial[b]))
+            end
+            sort!(ds)
+            if all(abs(ds[t] - sig[t]) <= tol for t in 1:npairs)
+                push!(embeddings, NTuple{K,Int}(partial))
+            end
+            return nothing
+        end
+        for j in cand[partial[1]]
+            j > partial[end] || continue
+            ok = true
+            for s in partial
+                dj = dist(s, j)
+                if !any(u -> abs(u - dj) <= tol, uniq)
+                    ok = false
+                    break
+                end
+            end
+            ok || continue
+            push!(partial, j)
+            extend!()
+            pop!(partial)
+        end
+        return nothing
+    end
+    for i in 1:M
+        empty!(partial)
+        push!(partial, i)
+        extend!()
+    end
+
+    counts = zeros(Int, M)
+    for e in embeddings, s in e
+        counts[s] += 1
+    end
+    total = length(embeddings)
+    @info "enumerate_motif_embeddings: $total embeddings of a $K-site motif " *
+          "($(round(total / M, digits=4)) per site)"
+    if !isempty(embeddings) && !all(==(counts[1]), counts)
+        @warn "per-site embedding membership is not uniform " *
+              "(min $(minimum(counts)), max $(maximum(counts))); on a " *
+              "site-transitive lattice this indicates distance aliasing or " *
+              "an unsuitable tol"
+    end
+    if expected_count !== nothing && total != expected_count
+        throw(ArgumentError(
+            "enumerated $total embeddings but expected_count = " *
+            "$expected_count; check the motif signature, tol, and the cell " *
+            "size (wrap-around)"))
+    end
+    return embeddings
 end
 
 """

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -314,6 +314,7 @@ Throws an `ArgumentError` if the number of components does not match `C`.
 # Outer Constructors
 
     MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
+                               interlayer_spacing::Union{Nothing,Float64}=nothing,
                                basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0)],
                                supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 4, 1),
                                periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
@@ -323,6 +324,7 @@ Throws an `ArgumentError` if the number of components does not match `C`.
                                image_multiplicity::Bool=false)
 
     MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
+                                  interlayer_spacing::Union{Nothing,Float64}=nothing,
                                   basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
                                   supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 2, 1),
                                   periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
@@ -347,6 +349,29 @@ doubled bond reaches the full bond energy and a self-image entry passes the
 occupation test exactly when the site is occupied; geometric-cluster growth
 reads only the first shell, and growth across a duplicated bond remains a
 configuration-independent symmetric proposal.
+
+The `interlayer_spacing` keyword sets the out-of-plane (third-axis) lattice
+spacing. The default `nothing` means isotropic spacing: the third lattice
+vector is `[0, 0, lattice_constant]`. Note this is a behavior change on one
+previously broken path: 3D cells built with `lattice_constant ≠ 1` used to
+mix scales (the out-of-plane spacing was fixed at 1.0, so a "nearest-neighbor"
+cutoff could select only interlayer bonds without warning); such cells now
+default to isotropic spacing. Pass `interlayer_spacing = 1.0` to reproduce
+the old geometry. An explicit value `c` gives a tetragonal cell whose
+square-lattice distance ladder is a, c, √2·a, √(a² + c²), 2a, …, so a
+suitable cutoff ladder separates in-plane from interlayer nearest neighbors
+into distinct shells: with a = 1.0, c = 1.25 and `cutoff_radii = [1.1, 1.35]`,
+shell 1 is in-plane only and shell 2 interlayer only (the next distance
+√2 ≈ 1.414 is excluded), so a `GenericLatticeHamiltonian` with couplings
+`[J∥, J⊥]` expresses direction-resolved nearest-neighbor interactions with no
+other library changes. Avoid degenerate spacings that alias the two bond
+classes into one shell (c = √2·a puts interlayer bonds at the in-plane
+second-neighbor distance, c = 2a at the third); the strictly-increasing
+cutoff-ladder validation and the empty-shell warning of
+[`compute_neighbors`](@ref) are the runtime backstops. The keyword composes
+with `image_multiplicity`; the third axis is non-periodic by default, so
+slabs gain no z-wrap images. Must be finite and strictly positive when given;
+violations throw an `ArgumentError`.
 
 ## Returns
 - `MLattice{C,G}`: A square/triangular lattice object with `C` components.
@@ -491,7 +516,26 @@ function mlattice_setup(C::Int,
     return lattice_comp, lattice_adsorptions
 end
 
+"""
+    _out_of_plane_spacing(lattice_constant, interlayer_spacing)
+
+Resolve the third-axis lattice spacing for the keyword constructors:
+`nothing` means isotropic spacing (the in-plane `lattice_constant`); an
+explicit value must be finite and strictly positive, the cutoff-ladder
+idiom of `compute_neighbors`, and violations throw an `ArgumentError`.
+"""
+function _out_of_plane_spacing(lattice_constant::Float64, interlayer_spacing::Union{Nothing,Float64})
+    interlayer_spacing === nothing && return lattice_constant
+    if !(isfinite(interlayer_spacing) && interlayer_spacing > 0.0)
+        throw(ArgumentError(
+            "interlayer_spacing must be finite and strictly positive, " *
+            "got $interlayer_spacing"))
+    end
+    return interlayer_spacing
+end
+
 function MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
+                                    interlayer_spacing::Union{Nothing,Float64}=nothing,
                                     basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0)],
                                     supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 4, 1),
                                     periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
@@ -501,7 +545,8 @@ function MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
                                     image_multiplicity::Bool=false,
                                 ) where C
 
-    lattice_vectors = [lattice_constant 0.0 0.0; 0.0 lattice_constant 0.0; 0.0 0.0 1.0]
+    c = _out_of_plane_spacing(lattice_constant, interlayer_spacing)
+    lattice_vectors = [lattice_constant 0.0 0.0; 0.0 lattice_constant 0.0; 0.0 0.0 c]
     lattice_comp, lattice_adsorptions = mlattice_setup(C, basis, supercell_dimensions, components, adsorptions)
 
     return MLattice{C,SquareLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions;
@@ -509,6 +554,7 @@ function MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
 end
 
 function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
+                                        interlayer_spacing::Union{Nothing,Float64}=nothing,
                                         basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0),(1/2, sqrt(3)/2, 0.0)],
                                         supercell_dimensions::Tuple{Int64,Int64,Int64}=(4, 2, 1),
                                         periodicity::Tuple{Bool,Bool,Bool}=(true, true, false),
@@ -520,7 +566,8 @@ function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
                                         image_multiplicity::Bool=false,
                                     ) where C
 
-    lattice_vectors = [lattice_constant 0.0 0.0; 0.0 sqrt(3)*lattice_constant 0.0; 0.0 0.0 1.0]
+    c = _out_of_plane_spacing(lattice_constant, interlayer_spacing)
+    lattice_vectors = [lattice_constant 0.0 0.0; 0.0 sqrt(3)*lattice_constant 0.0; 0.0 0.0 c]
     lattice_comp, lattice_adsorptions = mlattice_setup(C, basis, supercell_dimensions, components, adsorptions)
 
     return MLattice{C,TriangularLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions;

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -736,14 +736,16 @@ end
 """
     gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
                                    n_walkers=120, n_cull=1, ω0=1.0,
-                                   live_emax=nothing, empty_energy=0.0,
-                                   kb=8.617333262e-5)
+                                   live_emax=nothing,
+                                   observable_cols=Symbol[], live_observables=nothing,
+                                   empty_energy=0.0, kb=8.617333262e-5)
 
 Atomistic method: compute grand-canonical thermodynamic averages from a stack
 of canonical nested-sampling outputs, one per fixed particle number `N`, using
-the simulation-box volume `V` and the thermal wavelength. Returns `Xi` in
-linear space (contrast the lattice-gas method of this function, which takes
-`n_sites` and returns `logXi`).
+the simulation-box volume `V` and the thermal wavelength. Returns the same
+field set as the lattice-gas method of this function (which takes `n_sites`),
+with the linear-space `Xi` retained in the leading position alongside its
+log-space companion `logXi`.
 
 For each `N`, the canonical NS evidence at inverse temperature `β` is
 
@@ -819,21 +821,54 @@ does not cancel.
 - `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
   when supplied, one vector of `K = n_walkers` live walker energies (in eV) per
   `N`. The entry for `N=0` is ignored. See "Live-set tail correction" above.
+- `observable_cols::AbstractVector{Symbol}=Symbol[]`: names of extra ledger
+  columns to average grand-canonically; each `N ≥ 1` DataFrame must carry
+  them. Requires `live_emax` and `live_observables`.
+- `live_observables=nothing`: one `Dict{Symbol,<:AbstractVector{<:Real}}` per
+  `N` sector, holding each observable's values on the surviving live walkers.
+  The `N = 0` entry supplies the observable value of the empty configuration
+  directly (averaged over the given values), unlike its ignored `live_emax`
+  entry.
 - `empty_energy::Float64=0.0`: total energy (in eV) of the `N=0` configuration on
   the same energy scale as the ledger energies. Leave at `0` when the empty
   simulation box has zero energy (free clusters and fluids); for adsorption on a
   frozen substrate pass the substrate self-energy. Must be finite. At very large
   offsets (`β·|empty_energy|` beyond about `709`) the linear-space `Xi` return
   over- or underflows while the ratio observables (`mean_N`, `var_N`, `mean_U`)
-  remain valid; when the absolute `Ξ` is needed in that regime, shift all ledger
-  and live energies to the empty-configuration reference externally instead.
+  remain valid — as does `logXi`; when the absolute `Ξ` is needed in that
+  regime, read `logXi`.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
-A `NamedTuple` `(Xi, mean_N, var_N, mean_U)`. Each field is a `Matrix{Float64}`
-of size `(length(μ_grid), length(T_grid))` indexed `[i_μ, i_T]`. `Xi` is the
-absolute grand partition function, `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
-and `mean_U` is `⟨E⟩` (grand-canonical, in eV).
+A `NamedTuple` `(Xi, mean_N, var_N, mean_U, logXi, var_U, cov_UN, log_Z_N,
+N_values, observables)`; the first four fields keep their historical leading
+positions. `Xi`, `mean_N`, `var_N`, `mean_U`, `logXi`, `var_U`, and `cov_UN`
+are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))` indexed
+`[i_μ, i_T]`. `Xi` is the absolute grand partition function in linear space —
+`Inf` once `ln Ξ` exceeds ≈ 709; `logXi`, its log-space companion, stays
+finite there. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`, and `mean_U` is
+`⟨E⟩` (grand-canonical, in eV). `var_U` is the grand-canonical energy variance
+`⟨E²⟩ − ⟨E⟩²` and `cov_UN` the covariance `⟨EN⟩ − ⟨E⟩⟨N⟩`, both assembled by
+the law of total expectation over the `N` sectors. At fixed `μ` the
+configurational heat capacity follows as
+`C_config = k_B β² (var_U − μ · cov_UN) + (3/2) k_B β · cov_UN`: the extra
+term carries the `Λ(T)^{3N}` temperature dependence of the atomistic
+activity and is absent from the lattice-gas method's identity; kinetic
+contributions must be added separately for the total-energy heat capacity.
+Both fields are accurate to roughly machine epsilon times their natural
+scales, which near their zero crossings is absolute rather than relative
+precision. `log_Z_N` is the
+`(length(N_values), length(T_grid))` matrix of per-`N` log canonical partition
+functions `log Z_N(T) = log Z_NS^{(N)}(β) + N·log(V/Λ³) − log N!` — the
+μ-independent evidence the assembly is built from — and `N_values` echoes the
+particle counts (as `Vector{Int}`) indexing its rows; the particle-number
+distribution follows as `P(N | μ, T) ∝ exp.(log_Z_N[:, j] .+ β .* μ .* N_values)`,
+normalized over the supplied sectors. `observables` is a
+`Dict{Symbol,Matrix{Float64}}` mapping each requested column to ⟨A⟩(μ, T);
+empty when no columns are requested. No Kish effective sample size is
+returned: the fixed-`N` route introduces no importance reweighting (`μ`
+enters the assembly exactly), so there is no sampling fidelity for it to
+diagnose.
 """
 function gc_thermodynamic_stats_fixed_N(
     ns_outputs::AbstractVector{<:DataFrame},
@@ -846,6 +881,8 @@ function gc_thermodynamic_stats_fixed_N(
     n_cull::Int=1,
     ω0::Float64=1.0,
     live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
+    observable_cols::AbstractVector{Symbol}=Symbol[],
+    live_observables::Union{Nothing,AbstractVector{<:AbstractDict{Symbol}}}=nothing,
     empty_energy::Float64=0.0,
     kb::Float64=8.617333262e-5,
 )
@@ -874,8 +911,72 @@ function gc_thermodynamic_stats_fixed_N(
     n_T = length(T_grid)
     V_val = ustrip(u"Å^3", V)
 
+    allunique(observable_cols) || throw(ArgumentError(
+        "observable_cols must not contain duplicate entries"))
+    if !isempty(observable_cols)
+        if live_emax === nothing || live_observables === nothing
+            throw(ArgumentError(
+                "observable recording requires both live_emax and " *
+                "live_observables: the N = 0 and single-configuration sectors " *
+                "have no dead points, so their per-sector observable averages " *
+                "come from the live entries"))
+        end
+        if length(live_observables) != length(N_values)
+            throw(DimensionMismatch(
+                "live_observables must have one Dict per N sector " *
+                "(length(N_values) = $(length(N_values)))"))
+        end
+        for (i, d) in enumerate(live_observables)
+            Set(keys(d)) == Set(observable_cols) || throw(ArgumentError(
+                "live_observables[$i] keys must match observable_cols exactly"))
+            for col in observable_cols
+                v = d[col]
+                (v isa AbstractVector && all(x -> x isa Real, v)) || throw(ArgumentError(
+                    "live_observables[$i][:$col] must be a vector of Real values"))
+                isempty(v) && throw(ArgumentError(
+                    "live_observables[$i][:$col] is empty"))
+                if N_int[i] != 0 && length(v) != length(live_emax[i])
+                    throw(DimensionMismatch(
+                        "live_observables[$i][:$col] must have one entry per " *
+                        "live walker (length(live_emax[$i]) = " *
+                        "$(length(live_emax[i])))"))
+                end
+            end
+        end
+        for (i, dfi) in enumerate(ns_outputs)
+            (N_int[i] == 0 || nrow(dfi) == 0) && continue
+            for col in observable_cols
+                hasproperty(dfi, col) || throw(ArgumentError(
+                    "ns_outputs[$i] (N = $(N_int[i])) has no observable " *
+                    "column :$col"))
+                any(ismissing, dfi[!, col]) && throw(ArgumentError(
+                    "ns_outputs[$i] column :$col contains missing values"))
+            end
+        end
+    elseif live_observables !== nothing
+        throw(ArgumentError(
+            "live_observables was given but observable_cols is empty"))
+    end
+
+    # One global energy shift for all sector second moments (the cv()
+    # convention): variances and covariances are shift-invariant, and forming
+    # them on E - E_shift avoids the ~eps*E^2 one-pass cancellation floor.
+    # The N = 0 sector pins E = empty_energy into the spectrum, hence the min
+    # with empty_energy.
+    E_shift = empty_energy
+    for (i, dfi) in enumerate(ns_outputs)
+        N_int[i] == 0 && continue
+        nrow(dfi) > 0 && (E_shift = min(E_shift, minimum(dfi.emax)))
+        if live_emax !== nothing && !isempty(live_emax[i])
+            E_shift = min(E_shift, minimum(live_emax[i]))
+        end
+    end
+
     log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
+    mean_E2_N = Matrix{Float64}(undef, n_N, n_T)   # shifted: <(E - E_shift)^2>
+    obs_N = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_N, n_T) for col in observable_cols)
 
     for (i, df) in enumerate(ns_outputs)
         # The N = 0 sector is the empty configuration: no spatial integral, so
@@ -887,14 +988,30 @@ function gc_thermodynamic_stats_fixed_N(
                 log_Z_NS[i, j] = -empty_energy / (kb * ustrip(u"K", T))
             end
             mean_E_N[i, :] .= empty_energy
+            mean_E2_N[i, :] .= (empty_energy - E_shift)^2
+            for col in observable_cols
+                # Unlike its ignored live_emax entry, the N = 0 sector's
+                # live_observables entry is used: it supplies the observable
+                # value of the single empty configuration directly (averaged
+                # over the given values)
+                vals = live_observables[i][col]
+                obs_N[col][i, :] .= sum(Float64, vals) / length(vals)
+            end
             continue
         end
 
         live = live_emax === nothing ? nothing : live_emax[i]
-        log_Z_NS[i, :], mean_E_N[i, :] = _fixed_N_log_evidence(
+        live_obs = isempty(observable_cols) ? nothing : live_observables[i]
+        log_Z_NS[i, :], mean_E_N[i, :], sector_E2, sector_obs = _fixed_N_log_evidence(
             df, T_grid;
             n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
-            live_energies=live, kb=kb)
+            live_energies=live, kb=kb,
+            observable_cols=observable_cols, live_observables=live_obs,
+            energy_shift=E_shift)
+        mean_E2_N[i, :] = sector_E2
+        for col in observable_cols
+            obs_N[col][i, :] = sector_obs[col]
+        end
     end
 
     log_fact = [_log_factorial(N) for N in N_int]
@@ -903,11 +1020,20 @@ function gc_thermodynamic_stats_fixed_N(
     mean_N = Matrix{Float64}(undef, n_mu, n_T)
     var_N = Matrix{Float64}(undef, n_mu, n_T)
     mean_U = Matrix{Float64}(undef, n_mu, n_T)
+    logXi = Matrix{Float64}(undef, n_mu, n_T)
+    var_U = Matrix{Float64}(undef, n_mu, n_T)
+    cov_UN = Matrix{Float64}(undef, n_mu, n_T)
+    log_Z_N = Matrix{Float64}(undef, n_N, n_T)
+    obs_out = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
         Λ_val = ustrip(u"Å", _thermal_wavelength(atomic_mass, T))
         log_V_over_Λ3 = log(V_val) - 3 * log(Λ_val)
+        # Per-N log canonical partition functions at this temperature:
+        # log Z_N(T) = log Z_NS^{(N)}(β) + N·log(V/Λ³) − log N!, μ-independent
+        log_Z_N[:, j] = log_Z_NS[:, j] .+ N_int .* log_V_over_Λ3 .- log_fact
         for (k, μ) in enumerate(μ_grid)
             μ_val = ustrip(u"eV", μ)
             log_zV = β * μ_val + log_V_over_Λ3
@@ -918,14 +1044,28 @@ function gc_thermodynamic_stats_fixed_N(
             sum_w = sum(ws)
 
             Xi[k, j] = exp(max_log) * sum_w
+            logXi[k, j] = max_log + log(sum_w)
             mean_N[k, j] = sum(ws .* N_int) / sum_w
             mean_N2 = sum(ws .* (N_int .^ 2)) / sum_w
             var_N[k, j] = mean_N2 - mean_N[k, j]^2
-            mean_U[k, j] = sum(ws .* view(mean_E_N, :, j)) / sum_w
+            u_avg = sum(ws .* view(mean_E_N, :, j)) / sum_w
+            mean_U[k, j] = u_avg
+            # Law of total expectation over the N sectors, formed on shifted
+            # energies (mean_E2_N holds <(E - E_shift)^2>_N; variances and
+            # covariances are shift-invariant)
+            u_c = u_avg - E_shift
+            var_U[k, j] = sum(ws .* view(mean_E2_N, :, j)) / sum_w - u_c^2
+            cov_UN[k, j] = sum(ws .* N_int .* (view(mean_E_N, :, j) .- E_shift)) / sum_w -
+                           u_c * mean_N[k, j]
+            for col in observable_cols
+                obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
+            end
         end
     end
 
-    return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
+    return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
+            logXi=logXi, var_U=var_U, cov_UN=cov_UN,
+            log_Z_N=log_Z_N, N_values=N_int, observables=obs_out)
 end
 
 """
@@ -1024,9 +1164,9 @@ A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values, var_U,
 cov_UN, observables)`. The first
 four fields are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))`
 indexed `[i_μ, i_T]`. `logXi` is the natural log of the absolute grand
-partition function — returned in log space (unlike the atomistic method's
-`Xi`) because the binomial prior mass grows like `2^M` and `Ξ` overflows
-`Float64` for modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
+partition function — returned in log space (the atomistic method returns
+linear-space `Xi` alongside the same `logXi`) because the binomial prior mass
+grows like `2^M` and `Ξ` overflows `Float64` for modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
 and `mean_U` is `⟨E⟩` (grand-canonical, in eV). `log_Z_N` is the
 `(length(N_values), length(T_grid))` matrix of log canonical
 partition-function slices `log[C(M,N) · Z_NS^{(N)}(β)]` — the per-`N`

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -13,6 +13,7 @@ export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
 export microcanonical_entropy, caloric_derivatives, inflection_transitions
 export transition_convergence
+export gc_thermodynamic_stats_ideal_ref
 
 """
     read_output(filename::String)
@@ -336,6 +337,153 @@ function gc_thermodynamic_stats(df::DataFrame,
     end
 
     return mean_Es, Cvs, mean_Ns
+end
+
+"""
+    gc_thermodynamic_stats_ideal_ref(df::DataFrame, n_sites::Int, z0::Float64,
+                                     μs::Vector{Float64}, Ts::Vector{Float64},
+                                     n_walkers::Int;
+                                     n_cull::Int=1, ω0::Float64=1.0,
+                                     live_emax::Union{Nothing,Vector{Float64}}=nothing,
+                                     live_numbers::Union{Nothing,Vector{Int}}=nothing,
+                                     kb::Float64=8.617333262e-5)
+
+Assemble grand-canonical thermodynamics on a (μ, T) grid from a single
+ideal-gas-referenced nested sampling run (`ideal_gas_referenced_nested_sampling`
+in `SamplingSchemes`).
+
+The run samples the ideal-lattice-gas prior at reference fugacity `z0`
+(configuration weight `z0^N`, total prior mass `(1 + z0)^M` on `M = n_sites`
+sites) and culls by energy alone. The absolute grand partition function at any
+target chemical potential μ and temperature T is then
+
+```math
+\\Xi(\\mu, T) = (1 + z_0)^M \\sum_j \\omega_j \\left(\\frac{z}{z_0}\\right)^{N_j}
+               e^{-\\beta E_j}, \\qquad z = e^{\\beta\\mu},
+```
+
+where the sum runs over culled walkers (plus, when `live_emax`/`live_numbers`
+are given, the surviving live walkers, each with residual weight
+`(K/(K+n_cull))^{n_iters} / K` — no `ω0` factor, since `ω0` corrects the
+dead-sample shell weights only). There is no thermal-wavelength factor: a
+lattice gas has no momentum degrees of freedom, so `z = exp(βμ)` directly.
+All sums are evaluated with the log-sum-exp trick, and Ξ is returned as
+`log Ξ` to avoid overflow at low temperature.
+
+For a fully normalized absolute Ξ, pass `ω0 = (n_walkers + n_cull)/n_walkers`
+(Skilling weights) together with the live-walker tail — the dead weights then
+sum to `1 − (K/(K+n_cull))^{n_iters}` and the tail supplies the remainder, so
+`Σω = 1` exactly. The default `ω0 = 1.0` underestimates Ξ by a factor
+`K/(K+n_cull)` and neglects the tail (see the `ωᵢ` conventions). Ratio
+observables (`mean_N`, `var_N`, `mean_U`) are insensitive to `ω0`.
+
+The reweighting factor `(z/z0)^{N_j}` is pure importance sampling in μ: its
+reliability at each grid point is reported by the Kish effective sample size
+`N_eff = (Σ w)² / Σ w²`, which collapses as `|βμ − ln z0|` grows beyond
+roughly `1/√Var(N)`. Treat grid points with small `N_eff` (≲ 100) as
+unreliable and re-run with z0 closer to the target fugacity.
+
+# Arguments
+- `df::DataFrame`: NS output with columns `[:iter, :emax, :num_particles]`.
+- `n_sites::Int`: Number of lattice sites M.
+- `z0::Float64`: Reference fugacity of the prior used in the run (must match!).
+- `μs::Vector{Float64}`: Chemical potential grid (same energy units as `df.emax`, e.g. eV).
+- `Ts::Vector{Float64}`: Temperature grid in K.
+- `n_walkers::Int`: Number of walkers K used in the NS run.
+- `n_cull::Int=1`: Number of walkers culled per iteration.
+- `ω0::Float64=1.0`: Initial phase-space volume factor.
+- `live_emax::Union{Nothing,Vector{Float64}}=nothing`: Energies of the surviving live walkers.
+- `live_numbers::Union{Nothing,Vector{Int}}=nothing`: Particle counts of the surviving live walkers.
+- `kb::Float64`: Boltzmann constant (default: eV/K).
+
+# Returns
+A `NamedTuple` of `Matrix{Float64}` of size `(length(μs), length(Ts))`,
+indexed `[i_μ, i_T]`:
+- `logXi`: Natural log of the absolute grand partition function.
+- `mean_N`: Mean particle number ⟨N⟩.
+- `var_N`: Particle-number variance ⟨N²⟩ − ⟨N⟩².
+- `mean_U`: Mean configurational energy ⟨E⟩.
+- `N_eff`: Kish effective sample size of the reweighted estimate.
+"""
+function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
+                                          n_sites::Int,
+                                          z0::Float64,
+                                          μs::Vector{Float64},
+                                          Ts::Vector{Float64},
+                                          n_walkers::Int;
+                                          n_cull::Int=1,
+                                          ω0::Float64=1.0,
+                                          live_emax::Union{Nothing,Vector{Float64}}=nothing,
+                                          live_numbers::Union{Nothing,Vector{Int}}=nothing,
+                                          kb::Float64=8.617333262e-5)
+    if z0 <= 0.0
+        throw(ArgumentError("z0 must be positive"))
+    end
+    if n_sites <= 0
+        throw(ArgumentError("n_sites must be positive"))
+    end
+    if (live_emax === nothing) != (live_numbers === nothing)
+        throw(ArgumentError("live_emax and live_numbers must be provided together"))
+    end
+    if live_emax !== nothing && length(live_emax) != length(live_numbers)
+        throw(DimensionMismatch("live_emax and live_numbers must have the same length"))
+    end
+    n_dead = nrow(df)
+    if n_dead == 0 && (live_emax === nothing || isempty(live_emax))
+        throw(ArgumentError("df is empty and no live walkers were provided"))
+    end
+
+    # β- and μ-independent per-sample log prior-volume weights, built directly
+    # in log space: the linear ωᵢ underflows to 0.0 once iter ≳ 745·K/n_cull,
+    # which silently zeroes the deepest (lowest-energy) samples on large lattices
+    log_w0 = n_dead > 0 ?
+        (log(ω0) + log(n_cull / (n_walkers + n_cull))) .+
+        Vector{Float64}(df.iter) .* log(n_walkers / (n_walkers + n_cull)) : Float64[]
+    Es = n_dead > 0 ? Vector{Float64}(df.emax) : Float64[]
+    Ns = n_dead > 0 ? Vector{Float64}(df.num_particles) : Float64[]
+
+    if live_emax !== nothing && !isempty(live_emax)
+        # Residual prior volume after the last recorded iteration, split
+        # uniformly over the K surviving walkers. No ω0 factor here: ω0
+        # corrects the dead-sample shell weights, not the residual volume
+        # X_n = (K/(K+n_cull))^n — with ω0 = (K+n_cull)/K the dead weights sum
+        # to 1 − X_n and the tail closes the identity Σw = 1 exactly
+        n_iters = n_dead > 0 ? maximum(df.iter) : 0
+        log_tail = n_iters * log(n_walkers / (n_walkers + n_cull)) - log(n_walkers)
+        log_w0 = vcat(log_w0, fill(log_tail, length(live_emax)))
+        Es = vcat(Es, live_emax)
+        Ns = vcat(Ns, Float64.(live_numbers))
+    end
+
+    log_prior_mass = n_sites * log1p(z0)
+    log_z0 = log(z0)
+
+    n_mu = length(μs)
+    n_T = length(Ts)
+    logXi = Matrix{Float64}(undef, n_mu, n_T)
+    mean_N = Matrix{Float64}(undef, n_mu, n_T)
+    var_N = Matrix{Float64}(undef, n_mu, n_T)
+    mean_U = Matrix{Float64}(undef, n_mu, n_T)
+    N_eff = Matrix{Float64}(undef, n_mu, n_T)
+
+    Threads.@threads for j in 1:n_T
+        β = 1.0 / (kb * Ts[j])
+        for i in 1:n_mu
+            s = β * μs[i] - log_z0
+            log_w = log_w0 .+ s .* Ns .- β .* Es
+            max_log = maximum(log_w)
+            ws = exp.(log_w .- max_log)
+            sum_w = sum(ws)
+            logXi[i, j] = log_prior_mass + max_log + log(sum_w)
+            n_avg = sum(ws .* Ns) / sum_w
+            mean_N[i, j] = n_avg
+            var_N[i, j] = sum(ws .* Ns .^ 2) / sum_w - n_avg^2
+            mean_U[i, j] = sum(ws .* Es) / sum_w
+            N_eff[i, j] = sum_w^2 / sum(abs2, ws)
+        end
+    end
+
+    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -10,6 +10,7 @@ using CSV, Arrow
 
 export read_output
 export ωᵢ, partition_function, internal_energy, cv
+export gc_thermodynamic_stats
 
 """
     read_output(filename::String)
@@ -206,6 +207,133 @@ function cv(Ts::Vector{Float64}, dof::Int, energy_bins::Vector{Float64}, entropy
         Cv[i] = (E2_avg[i] .- E_avg[i].^2) ./ (kb * temp.^2) .+ dof*kb/2
     end
     return Cv
+end
+
+
+"""
+    gc_thermodynamic_stats(β::Float64, ωi::Vector{Float64},
+                           grand_energies::Vector{Float64},
+                           energies::Vector{Float64},
+                           numbers::Vector{Int},
+                           μ::Float64;
+                           kb::Float64=8.617333262e-5)
+
+Compute grand-canonical thermodynamic averages from nested sampling output.
+
+The log-sum-exp trick is used for numerical stability. The grand-canonical
+heat capacity at constant μ is:
+
+    C_{V,μ} = k_B β² [Var(E) − μ Cov(E, N)]
+
+# Arguments
+- `β::Float64`: Inverse temperature 1/(k_B T).
+- `ωi::Vector{Float64}`: Phase-space volume weights from NS.
+- `grand_energies::Vector{Float64}`: Ω_i = E_i − μ N_i values.
+- `energies::Vector{Float64}`: E_i values.
+- `numbers::Vector{Int}`: N_i values.
+- `μ::Float64`: Chemical potential.
+- `kb::Float64`: Boltzmann constant (default: eV/K).
+
+# Returns
+- `(⟨E⟩, C_{V,μ}, ⟨N⟩)`: Mean energy, GC heat capacity, mean particle number.
+"""
+function gc_thermodynamic_stats(β::Float64,
+                                 ωi::Vector{Float64},
+                                 grand_energies::Vector{Float64},
+                                 energies::Vector{Float64},
+                                 numbers::Vector{Int},
+                                 μ::Float64;
+                                 kb::Float64=8.617333262e-5)
+    n = length(ωi)
+    if n != length(grand_energies) || n != length(energies) || n != length(numbers)
+        throw(DimensionMismatch("All input vectors must have the same length"))
+    end
+    if n == 0
+        return NaN, NaN, NaN
+    end
+
+    # Log-sum-exp for numerical stability
+    log_terms = [log(ωi[i]) - β * grand_energies[i] for i in 1:n]
+    max_log = maximum(log_terms)
+
+    z = 0.0
+    u = 0.0   # ⟨E⟩
+    u2 = 0.0  # ⟨E²⟩
+    n_sum = 0.0  # ⟨N⟩
+    en_sum = 0.0 # ⟨EN⟩
+
+    for i in 1:n
+        w = exp(log_terms[i] - max_log)
+        z += w
+        u += w * energies[i]
+        u2 += w * energies[i]^2
+        n_sum += w * numbers[i]
+        en_sum += w * energies[i] * numbers[i]
+    end
+
+    if z == 0.0
+        return NaN, NaN, NaN
+    end
+
+    u /= z
+    u2 /= z
+    n_avg = n_sum / z
+    en_avg = en_sum / z
+
+    var_e = u2 - u^2
+    cov_en = en_avg - u * n_avg
+
+    cv = kb * β^2 * (var_e - μ * cov_en)
+
+    return u, cv, n_avg
+end
+
+"""
+    gc_thermodynamic_stats(df::DataFrame, βs::Vector{Float64},
+                           n_walkers::Int, μ::Float64;
+                           n_cull::Int=1, ω0::Float64=1.0,
+                           kb::Float64=8.617333262e-5)
+
+Compute grand-canonical thermodynamic stats from a GC-NS output DataFrame.
+
+The DataFrame must have columns `:iter`, `:omega`, `:energy`, `:num_particles`.
+Adds the live-walker contribution to the end of the recorded samples for correct
+normalization.
+
+# Arguments
+- `df::DataFrame`: GC-NS output with columns `[:iter, :omega, :energy, :num_particles]`.
+- `βs::Vector{Float64}`: Inverse temperatures at which to evaluate.
+- `n_walkers::Int`: Number of walkers used in the NS run.
+- `μ::Float64`: Chemical potential.
+- `n_cull::Int=1`: Number of walkers culled per iteration.
+- `ω0::Float64=1.0`: Initial phase-space volume.
+- `kb::Float64`: Boltzmann constant (default: eV/K).
+
+# Returns
+- `(mean_E, Cv, mean_N)`: Vectors of ⟨E⟩, C_{V,μ}, and ⟨N⟩ at each β.
+"""
+function gc_thermodynamic_stats(df::DataFrame,
+                                 βs::Vector{Float64},
+                                 n_walkers::Int,
+                                 μ::Float64;
+                                 n_cull::Int=1,
+                                 ω0::Float64=1.0,
+                                 kb::Float64=8.617333262e-5)
+    ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
+    grand_es = df.omega
+    Es = df.energy
+    Ns = df.num_particles
+
+    mean_Es = Vector{Float64}(undef, length(βs))
+    Cvs = Vector{Float64}(undef, length(βs))
+    mean_Ns = Vector{Float64}(undef, length(βs))
+
+    Threads.@threads for (i, b) in collect(enumerate(βs))
+        mean_Es[i], Cvs[i], mean_Ns[i] = gc_thermodynamic_stats(
+            b, ωi, grand_es, Es, Ns, μ; kb=kb)
+    end
+
+    return mean_Es, Cvs, mean_Ns
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -362,6 +362,75 @@ function _log_factorial(n::Integer)
 end
 
 """
+    _log_binomial(M::Integer, N::Integer) -> Float64
+
+Return `log(binomial(M, N))` in floating point, computed from `_log_factorial`
+so that it does not overflow for lattice sizes where `binomial(M, N)` exceeds
+`typemax(Int64)`.
+"""
+function _log_binomial(M::Integer, N::Integer)
+    0 <= N <= M || throw(ArgumentError("require 0 ≤ N ≤ M, got N=$N, M=$M"))
+    return _log_factorial(M) - _log_factorial(N) - _log_factorial(M - N)
+end
+
+"""
+    _fixed_N_log_evidence(df, T_grid; n_walkers, n_cull, ω0, live_energies, kb)
+        -> (log_Z_NS::Vector{Float64}, mean_E::Vector{Float64})
+
+Canonical NS evidence `log Z_NS(β) = log Σᵢ ωᵢ exp(−βEᵢ)` and canonical mean
+energy at each temperature in `T_grid`, evaluated by log-sum-exp. When
+`live_energies` is supplied, each of the `n_walkers` live walkers contributes
+the residual prior weight `ω0 · (K/(K+n_cull))^{n_iters} / K` at its energy
+(the live-set tail correction). Internal helper shared by the
+`gc_thermodynamic_stats_fixed_N` methods.
+"""
+function _fixed_N_log_evidence(
+    df::DataFrame,
+    T_grid::AbstractVector{<:Unitful.Temperature};
+    n_walkers::Int,
+    n_cull::Int,
+    ω0::Float64,
+    live_energies::Union{Nothing,AbstractVector{<:Real}},
+    kb::Float64,
+)
+    Es = collect(Float64, df.emax)
+    n_iters = length(Es)
+    if isempty(Es) && (live_energies === nothing || isempty(live_energies))
+        throw(ArgumentError(
+            "a sector has no discarded samples and no live-set tail; for " *
+            "single-configuration sectors supply an empty DataFrame plus a " *
+            "live_emax entry carrying the sector energy"))
+    end
+    ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
+    # Each live walker carries weight ω0 · (K/(K+n_cull))^n_iters / K,
+    # accounting for the prior volume that finite termination leaves in
+    # the live set.
+    log_tail = log(ω0) + n_iters * log(n_walkers / (n_walkers + n_cull)) -
+               log(n_walkers)
+    if live_energies === nothing
+        Es_all = Es
+        log_ws = log.(ωi)
+    else
+        Es_live = collect(Float64, live_energies)
+        Es_all = vcat(Es, Es_live)
+        log_ws = vcat(log.(ωi), fill(log_tail, length(Es_live)))
+    end
+
+    log_Z_NS = Vector{Float64}(undef, length(T_grid))
+    mean_E = Vector{Float64}(undef, length(T_grid))
+    for (j, T) in enumerate(T_grid)
+        β = 1.0 / (kb * ustrip(u"K", T))
+        log_terms = log_ws .- β .* Es_all
+        max_log = maximum(log_terms)
+        ws = exp.(log_terms .- max_log)
+        sum_w = sum(ws)
+        log_Z_NS[j] = max_log + log(sum_w)
+        mean_E[j] = sum(ws .* Es_all) / sum_w
+    end
+    return log_Z_NS, mean_E
+end
+
+"""
     gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
                                    n_walkers=120, n_cull=1, ω0=1.0,
                                    live_emax=nothing, kb=8.617333262e-5)
@@ -479,31 +548,11 @@ function gc_thermodynamic_stats_fixed_N(
             continue
         end
 
-        ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
-        Es = collect(Float64, df.emax)
-        n_iters = length(df.iter)
-        # Each live walker carries weight ω0 · (K/(K+n_cull))^n_iters / K,
-        # accounting for the prior volume that finite termination leaves in
-        # the live set.
-        log_tail = log(ω0) + n_iters * log(n_walkers / (n_walkers + n_cull)) -
-                   log(n_walkers)
-        for (j, T) in enumerate(T_grid)
-            β = 1.0 / (kb * ustrip(u"K", T))
-            if live_emax === nothing
-                log_terms = log.(ωi) .- β .* Es
-                Es_all = Es
-            else
-                Es_live = collect(Float64, live_emax[i])
-                log_terms = vcat(log.(ωi) .- β .* Es,
-                                 log_tail .- β .* Es_live)
-                Es_all = vcat(Es, Es_live)
-            end
-            max_log = maximum(log_terms)
-            ws = exp.(log_terms .- max_log)
-            sum_w = sum(ws)
-            log_Z_NS[i, j] = max_log + log(sum_w)
-            mean_E_N[i, j] = sum(ws .* Es_all) / sum_w
-        end
+        live = live_emax === nothing ? nothing : live_emax[i]
+        log_Z_NS[i, :], mean_E_N[i, :] = _fixed_N_log_evidence(
+            df, T_grid;
+            n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
+            live_energies=live, kb=kb)
     end
 
     log_fact = [_log_factorial(N) for N in N_int]
@@ -535,6 +584,159 @@ function gc_thermodynamic_stats_fixed_N(
     end
 
     return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
+end
+
+"""
+    gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, n_sites, μ_grid, T_grid;
+                                   n_walkers=120, n_cull=1, ω0=1.0,
+                                   live_emax=nothing, kb=8.617333262e-5)
+
+Lattice-gas method: compute grand-canonical thermodynamic averages from a
+stack of canonical (fixed-`N`) lattice nested-sampling outputs, one per
+particle count `N`, on a lattice with `n_sites` sites.
+
+Fixed-`N` lattice NS samples the uniform prior over the `binomial(n_sites, N)`
+occupation patterns, so the absolute canonical partition function is
+`Z_N(β) = binomial(M, N) · Z_NS^{(N)}(β)` with `M = n_sites` and
+
+```math
+\\Xi(\\mu, T) = \\sum_N z^N \\binom{M}{N} Z_{\\mathrm{NS}}^{(N)}(\\beta),
+\\qquad z = \\exp(\\beta\\mu).
+```
+
+A lattice gas has no momentum integral, so `z = exp(βμ)` directly — no volume
+argument and no thermal wavelength enter (contrast the atomistic method of
+this function). The sum runs over the supplied `N_values`, which must include
+`0`; truncating `N_values` below `n_sites` truncates Ξ accordingly, which is
+safe only when `⟨N⟩` at the requested `(μ, T)` sits well below the largest
+supplied `N`.
+
+## Special sectors
+
+- `N = 0`: the empty lattice is a single configuration with `E = 0`, so
+  `Z_NS^{(0)} = 1`; the corresponding DataFrame contents are ignored.
+- `N = n_sites` (and any other single-configuration sector): NS cannot make
+  progress because every walker holds the same configuration. Supply an empty
+  DataFrame (`DataFrame(iter=Int[], emax=Float64[])`) together with a
+  `live_emax` entry holding `n_walkers` copies of the sector energy — the
+  live-set tail then carries the sector's entire prior mass (exactly `ω0`,
+  so pair this with `ω0 = 1.0` semantics in mind; see below).
+
+## Live-set tail and normalization
+
+As for the atomistic method, the recorded weights `ωᵢ` carry only part of the
+prior volume after finite NS termination. Supplying `live_emax` (one vector of
+`n_walkers` live-walker energies per `N`) adds the residual
+`ω0 · (K/(K+n_cull))^{n_iters} / K` per live walker to each sector evidence.
+For fully-normalized absolute `Ξ`, pass `ω0 = (n_walkers + n_cull)/n_walkers`
+(Skilling weights) together with `live_emax`; with the defaults, `logXi` is
+biased low by a uniform-in-`N` factor that cancels in the ratio observables
+`mean_N`, `var_N`, and `mean_U`.
+
+# Arguments
+- `ns_outputs::AbstractVector{<:DataFrame}`: one canonical lattice-NS output
+  per `N`, each with columns `[:iter, :emax]` (energies in eV, as produced by
+  `nested_sampling` on a `LatticeGasWalkers` liveset).
+- `N_values::AbstractVector{<:Integer}`: particle counts corresponding to each
+  DataFrame. Must include `0`, and every entry must lie in `0:n_sites`.
+- `n_sites::Integer`: number of lattice sites `M`.
+- `μ_grid::AbstractVector{<:typeof(1.0u"eV")}`: chemical potentials.
+- `T_grid::AbstractVector{<:Unitful.Temperature}`: temperatures.
+
+# Keyword arguments
+- `n_walkers::Int=120`: number of NS walkers used to produce each DataFrame.
+  Must be uniform across `ns_outputs`.
+- `n_cull::Int=1`: NS culls per iteration.
+- `ω0::Float64=1.0`: initial prior weight, passed to `ωᵢ`.
+- `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
+  when supplied, one vector of `n_walkers` live-walker energies (in eV) per
+  `N`. The entry for `N=0` is ignored.
+- `kb::Float64`: Boltzmann constant in eV/K.
+
+# Returns
+A `NamedTuple` `(logXi, mean_N, var_N, mean_U)`. Each field is a
+`Matrix{Float64}` of size `(length(μ_grid), length(T_grid))` indexed
+`[i_μ, i_T]`. `logXi` is the natural log of the absolute grand partition
+function — returned in log space (unlike the atomistic method's `Xi`) because
+the binomial prior mass grows like `2^M` and `Ξ` overflows `Float64` for
+modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`, and `mean_U`
+is `⟨E⟩` (grand-canonical, in eV).
+"""
+function gc_thermodynamic_stats_fixed_N(
+    ns_outputs::AbstractVector{<:DataFrame},
+    N_values::AbstractVector{<:Integer},
+    n_sites::Integer,
+    μ_grid::AbstractVector{<:typeof(1.0u"eV")},
+    T_grid::AbstractVector{<:Unitful.Temperature};
+    n_walkers::Int=120,
+    n_cull::Int=1,
+    ω0::Float64=1.0,
+    live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
+    kb::Float64=8.617333262e-5,
+)
+    if length(ns_outputs) != length(N_values)
+        throw(DimensionMismatch("ns_outputs and N_values must have the same length"))
+    end
+    if !(0 in N_values)
+        throw(ArgumentError("N_values must include 0 (the empty lattice)"))
+    end
+    if !all(0 .<= N_values .<= n_sites)
+        throw(ArgumentError("every entry of N_values must lie in 0:n_sites"))
+    end
+    if live_emax !== nothing && length(live_emax) != length(N_values)
+        throw(DimensionMismatch("live_emax and N_values must have the same length"))
+    end
+
+    N_int = collect(Int, N_values)
+    n_N = length(N_int)
+    n_mu = length(μ_grid)
+    n_T = length(T_grid)
+
+    log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
+    mean_E_N = Matrix{Float64}(undef, n_N, n_T)
+
+    for (i, df) in enumerate(ns_outputs)
+        # The N = 0 sector is the empty lattice: a single configuration with
+        # E = 0, so Z_NS^{(0)} = 1. The corresponding DataFrame is ignored.
+        if N_int[i] == 0
+            log_Z_NS[i, :] .= 0.0
+            mean_E_N[i, :] .= 0.0
+            continue
+        end
+
+        live = live_emax === nothing ? nothing : live_emax[i]
+        log_Z_NS[i, :], mean_E_N[i, :] = _fixed_N_log_evidence(
+            df, T_grid;
+            n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
+            live_energies=live, kb=kb)
+    end
+
+    log_binom = [_log_binomial(n_sites, N) for N in N_int]
+
+    logXi = Matrix{Float64}(undef, n_mu, n_T)
+    mean_N = Matrix{Float64}(undef, n_mu, n_T)
+    var_N = Matrix{Float64}(undef, n_mu, n_T)
+    mean_U = Matrix{Float64}(undef, n_mu, n_T)
+
+    for (j, T) in enumerate(T_grid)
+        β = 1.0 / (kb * ustrip(u"K", T))
+        for (k, μ) in enumerate(μ_grid)
+            μ_val = ustrip(u"eV", μ)
+
+            log_w = log_Z_NS[:, j] .+ N_int .* (β * μ_val) .+ log_binom
+            max_log = maximum(log_w)
+            ws = exp.(log_w .- max_log)
+            sum_w = sum(ws)
+
+            logXi[k, j] = max_log + log(sum_w)
+            mean_N[k, j] = sum(ws .* N_int) / sum_w
+            mean_N2 = sum(ws .* (N_int .^ 2)) / sum_w
+            var_N[k, j] = mean_N2 - mean_N[k, j]^2
+            mean_U[k, j] = sum(ws .* view(mean_E_N, :, j)) / sum_w
+        end
+    end
+
+    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -11,6 +11,7 @@ using CSV, Arrow
 export read_output
 export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
+export microcanonical_entropy, caloric_derivatives
 
 """
     read_output(filename::String)
@@ -336,5 +337,7 @@ function gc_thermodynamic_stats(df::DataFrame,
     return mean_Es, Cvs, mean_Ns
 end
 
+
+include("microcanonical_inflection.jl")
 
 end # module AnalysisTools

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -412,8 +412,12 @@ the resulting bias is small but visible at low T or shallow NS; for the absolute
   any DataFrame (e.g., `DataFrame(iter=Int[], emax=Float64[])`).
 - `N_values::AbstractVector{<:Integer}`: particle counts corresponding to each
   DataFrame. Must include `0`; `length(N_values) == length(ns_outputs)`.
-- `V::typeof(1.0u"Å^3")`: accessible configurational volume (explicit; for
-  surface systems this is *not* the simulation-box volume).
+- `V::typeof(1.0u"Å^3")`: the simulation-box volume, i.e. the NS prior volume
+  per particle (NS samples positions uniformly over the box). This is what
+  closes `Z_N^{config} = V^N · Z_{NS}^{(N)}`, so it must *not* be reduced to an
+  accessible or adsorption-region sub-volume. For surface systems the
+  substrate's volume exclusion is captured by the Boltzmann factor inside
+  `Z_{NS}^{(N)}`, not by shrinking `V`.
 - `atomic_mass::typeof(1.0u"u")`: per-atom mass for `Λ(T)`.
 - `μ_grid::AbstractVector{<:typeof(1.0u"eV")}`: chemical potentials.
 - `T_grid::AbstractVector{<:Unitful.Temperature}`: temperatures.

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -7,10 +7,12 @@ module AnalysisTools
 
 using DataFrames
 using CSV, Arrow
+using Unitful
 
 export read_output
 export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
+export gc_thermodynamic_stats_fixed_N
 
 """
     read_output(filename::String)
@@ -334,6 +336,158 @@ function gc_thermodynamic_stats(df::DataFrame,
     end
 
     return mean_Es, Cvs, mean_Ns
+end
+
+
+"""
+    _thermal_wavelength(atomic_mass::typeof(1.0u"u"), T::Unitful.Temperature) -> typeof(1.0u"Å")
+
+Compute the thermal de Broglie wavelength `Λ = h / sqrt(2π m k_B T)` in Å.
+Internal helper for `gc_thermodynamic_stats_fixed_N`.
+"""
+function _thermal_wavelength(atomic_mass::typeof(1.0u"u"), T::Unitful.Temperature)
+    return uconvert(u"Å", Unitful.h / sqrt(2π * atomic_mass * Unitful.k * T))
+end
+
+"""
+    _log_factorial(n::Integer) -> Float64
+
+Return `log(n!)` for small non-negative `n`, computed by summing `log(k)` to
+keep the result exact in floating point for `n` up to several dozen.
+"""
+function _log_factorial(n::Integer)
+    n < 0 && throw(ArgumentError("n must be non-negative"))
+    n == 0 && return 0.0
+    return sum(log, 1:n)
+end
+
+"""
+    gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
+                                   n_walkers=120, n_cull=1, ω0=1.0,
+                                   kb=8.617333262e-5)
+
+Compute grand-canonical thermodynamic averages from a stack of canonical
+nested-sampling outputs, one per fixed particle number `N`.
+
+For each `N`, the canonical NS evidence at inverse temperature `β` is
+
+```math
+Z_{\\mathrm{NS}}^{(N)}(\\beta) = \\sum_i \\omega_i \\exp(-\\beta E_i)
+```
+
+— the prior-volume-normalized configurational integral. The absolute
+configurational partition function is `Z_N^{config}(\\beta) = V^N \\cdot Z_{NS}^{(N)}(\\beta)`.
+The grand partition function is assembled as
+
+```math
+\\Xi(\\mu, T) = \\sum_N \\frac{(zV)^N}{N!}\\, Z_{\\mathrm{NS}}^{(N)}(\\beta),
+\\qquad z = \\frac{\\exp(\\beta\\mu)}{\\Lambda(T)^3}
+```
+
+with the thermal wavelength `Λ(T) = h / sqrt(2π m k_B T)` computed from `atomic_mass`.
+The sum runs over the supplied `N_values`, which must include `0` (the empty
+configuration, `Z_{NS}^{(0)} = 1`). Truncation error at the upper end of `N_values`
+is bounded by the tail of `(zV)^N / N!` for the largest `⟨N⟩` requested.
+
+A log-sum-exp pass is used both inside each per-N evidence and across the
+grand sum for numerical stability.
+
+# Arguments
+- `ns_outputs::AbstractVector{<:DataFrame}`: one canonical-NS output per `N`,
+  each with columns `[:iter, :emax]` (matching the schema produced by
+  `nested_sampling`).
+- `N_values::AbstractVector{<:Integer}`: particle counts corresponding to each
+  DataFrame. Must include `0`; `length(N_values) == length(ns_outputs)`.
+- `V::typeof(1.0u"Å^3")`: accessible configurational volume (explicit; for
+  surface systems this is *not* the simulation-box volume).
+- `atomic_mass::typeof(1.0u"u")`: per-atom mass for `Λ(T)`.
+- `μ_grid::AbstractVector{<:typeof(1.0u"eV")}`: chemical potentials.
+- `T_grid::AbstractVector{<:Unitful.Temperature}`: temperatures.
+
+# Keyword arguments
+- `n_walkers::Int=120`: number of NS walkers used to produce each DataFrame.
+  Must be uniform across `ns_outputs`.
+- `n_cull::Int=1`: NS culls per iteration.
+- `ω0::Float64=1.0`: initial prior weight, passed to `ωᵢ`.
+- `kb::Float64`: Boltzmann constant in eV/K.
+
+# Returns
+A `NamedTuple` `(Xi, mean_N, var_N, mean_U)`. Each field is a `Matrix{Float64}`
+of size `(length(μ_grid), length(T_grid))` indexed `[i_μ, i_T]`. `Xi` is the
+absolute grand partition function, `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
+and `mean_U` is `⟨E⟩` (grand-canonical, in eV).
+"""
+function gc_thermodynamic_stats_fixed_N(
+    ns_outputs::AbstractVector{<:DataFrame},
+    N_values::AbstractVector{<:Integer},
+    V::typeof(1.0u"Å^3"),
+    atomic_mass::typeof(1.0u"u"),
+    μ_grid::AbstractVector{<:typeof(1.0u"eV")},
+    T_grid::AbstractVector{<:Unitful.Temperature};
+    n_walkers::Int=120,
+    n_cull::Int=1,
+    ω0::Float64=1.0,
+    kb::Float64=8.617333262e-5,
+)
+    if length(ns_outputs) != length(N_values)
+        throw(DimensionMismatch("ns_outputs and N_values must have the same length"))
+    end
+    if !(0 in N_values)
+        throw(ArgumentError("N_values must include 0 (the empty configuration)"))
+    end
+
+    N_int = collect(Int, N_values)
+    n_N = length(N_int)
+    n_mu = length(μ_grid)
+    n_T = length(T_grid)
+    V_val = ustrip(u"Å^3", V)
+
+    log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
+    mean_E_N = Matrix{Float64}(undef, n_N, n_T)
+
+    for (i, df) in enumerate(ns_outputs)
+        ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
+        Es = df.emax
+        for (j, T) in enumerate(T_grid)
+            β = 1.0 / (kb * ustrip(u"K", T))
+            log_terms = log.(ωi) .- β .* Es
+            max_log = maximum(log_terms)
+            ws = exp.(log_terms .- max_log)
+            sum_w = sum(ws)
+            log_Z_NS[i, j] = max_log + log(sum_w)
+            mean_E_N[i, j] = sum(ws .* Es) / sum_w
+        end
+    end
+
+    log_fact = [_log_factorial(N) for N in N_int]
+
+    Xi = Matrix{Float64}(undef, n_mu, n_T)
+    mean_N = Matrix{Float64}(undef, n_mu, n_T)
+    var_N = Matrix{Float64}(undef, n_mu, n_T)
+    mean_U = Matrix{Float64}(undef, n_mu, n_T)
+
+    for (j, T) in enumerate(T_grid)
+        β = 1.0 / (kb * ustrip(u"K", T))
+        Λ_val = ustrip(u"Å", _thermal_wavelength(atomic_mass, T))
+        log_V_over_Λ3 = log(V_val) - 3 * log(Λ_val)
+        for (k, μ) in enumerate(μ_grid)
+            μ_val = ustrip(u"eV", μ)
+            log_zV = β * μ_val + log_V_over_Λ3
+
+            log_w = log_Z_NS[:, j] .+ N_int .* log_zV .- log_fact
+            max_log = maximum(log_w)
+            ws = exp.(log_w .- max_log)
+            sum_w = sum(ws)
+
+            Xi[k, j] = exp(max_log) * sum_w
+            mean_N[k, j] = sum(ws .* N_int) / sum_w
+            mean_N2 = sum(ws .* (N_int .^ 2)) / sum_w
+            var_N[k, j] = mean_N2 - mean_N[k, j]^2
+            mean_U[k, j] = sum(ws .* view(mean_E_N, :, j)) / sum_w
+        end
+    end
+
+    return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -385,6 +385,14 @@ reliability at each grid point is reported by the Kish effective sample size
 roughly `1/√Var(N)`. Treat grid points with small `N_eff` (≲ 100) as
 unreliable and re-run with z0 closer to the target fugacity.
 
+Athermal (hard-core) models sampled with the finite-J recipe (see the
+`GenericLatticeHamiltonian` docstring) are evaluated here at a temperature low
+enough that `β·J` exceeds the ladder depth in nats by ~40 while `β·δ ≪ 1`
+(δ = the run's `energy_perturbation`): the violating shells' `e^{-βE_j}` are
+then exact zeros, the retained shells' deviate from 1 only by `O(β·δ)`, and
+every observable is a function of `z = exp(βμ)` alone (`mean_U` reports the
+residual tie-breaking noise, ~δ).
+
 # Arguments
 - `df::DataFrame`: NS output with columns `[:iter, :emax, :num_particles]`.
 - `n_sites::Int`: Number of lattice sites M.
@@ -785,7 +793,11 @@ argument and no thermal wavelength enter (contrast the atomistic method of
 this function). The sum runs over the supplied `N_values`, which must include
 `0`; truncating `N_values` below `n_sites` truncates Ξ accordingly, which is
 safe only when `⟨N⟩` at the requested `(μ, T)` sits well below the largest
-supplied `N`.
+supplied `N`. (For an athermal hard-core model the truncation at the
+close-packing `N` is exact — every higher sector has no allowed
+configuration; see the hard-core recipe in the `GenericLatticeHamiltonian`
+docstring for the per-`N` sampling setup and the evaluation-temperature
+criterion.)
 
 ## Special sectors
 
@@ -837,13 +849,20 @@ in length or convergence.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
-A `NamedTuple` `(logXi, mean_N, var_N, mean_U)`. Each field is a
-`Matrix{Float64}` of size `(length(μ_grid), length(T_grid))` indexed
-`[i_μ, i_T]`. `logXi` is the natural log of the absolute grand partition
-function — returned in log space (unlike the atomistic method's `Xi`) because
-the binomial prior mass grows like `2^M` and `Ξ` overflows `Float64` for
-modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`, and `mean_U`
-is `⟨E⟩` (grand-canonical, in eV).
+A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values)`. The first
+four fields are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))`
+indexed `[i_μ, i_T]`. `logXi` is the natural log of the absolute grand
+partition function — returned in log space (unlike the atomistic method's
+`Xi`) because the binomial prior mass grows like `2^M` and `Ξ` overflows
+`Float64` for modest lattices. `mean_N` is `⟨N⟩`, `var_N` is `⟨N²⟩ − ⟨N⟩²`,
+and `mean_U` is `⟨E⟩` (grand-canonical, in eV). `log_Z_N` is the
+`(length(N_values), length(T_grid))` matrix of log canonical
+partition-function slices `log[C(M,N) · Z_NS^{(N)}(β)]` — the per-`N`
+evidence the assembly is built from — and `N_values` echoes the particle
+counts (as `Vector{Int}`) indexing its rows. For an athermal (hard-core)
+model evaluated at a sufficiently low `T` (see the hard-core recipe in the
+`GenericLatticeHamiltonian` docstring), `log_Z_N` is `log g_N`, the log count
+of allowed `N`-particle configurations.
 """
 function gc_thermodynamic_stats_fixed_N(
     ns_outputs::AbstractVector{<:DataFrame},
@@ -925,7 +944,8 @@ function gc_thermodynamic_stats_fixed_N(
         end
     end
 
-    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U)
+    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
+            log_Z_N=log_Z_NS .+ log_binom, N_values=N_int)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -736,7 +736,8 @@ end
 """
     gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
                                    n_walkers=120, n_cull=1, ω0=1.0,
-                                   live_emax=nothing, kb=8.617333262e-5)
+                                   live_emax=nothing, empty_energy=0.0,
+                                   kb=8.617333262e-5)
 
 Atomistic method: compute grand-canonical thermodynamic averages from a stack
 of canonical nested-sampling outputs, one per fixed particle number `N`, using
@@ -761,10 +762,20 @@ The grand partition function is assembled as
 
 with the thermal wavelength `Λ(T) = h / sqrt(2π m k_B T)` computed from `atomic_mass`.
 The sum runs over the supplied `N_values`, which must include `0`. The `N=0` sector
-is treated specially: `Z_{NS}^{(0)} = 1` by definition (the empty configuration has no
-spatial integral), so the corresponding DataFrame contents are ignored. Truncation
+is treated specially: the empty configuration has no spatial integral, so
+`Z_{NS}^{(0)} = exp(-β·empty_energy)` — exactly `1` at the default
+`empty_energy = 0` — and the corresponding DataFrame contents are ignored. Truncation
 error at the upper end of `N_values` is bounded by the tail of `(zV)^N / N!` for the
 largest `⟨N⟩` requested.
+
+All sectors must share one zero of energy. When the recorded energies carry a
+configuration-independent offset — for surface systems, the frozen substrate's
+self-energy, which every `N ≥ 1` walker records via `energy_frozen_part` — pass that
+offset as `empty_energy` so the `N = 0` sector sits on the same scale. Otherwise the
+empty sector's weight in the grand sum is misstated by the factor `exp(+β·offset)`,
+and for an attractive substrate the assembly silently returns `N ≥ 1`-conditional
+statistics wherever the empty sector carries weight (dilute coverage, strong binding,
+low temperature).
 
 A log-sum-exp pass is used both inside each per-N evidence and across the
 grand sum for numerical stability.
@@ -808,6 +819,14 @@ does not cancel.
 - `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
   when supplied, one vector of `K = n_walkers` live walker energies (in eV) per
   `N`. The entry for `N=0` is ignored. See "Live-set tail correction" above.
+- `empty_energy::Float64=0.0`: total energy (in eV) of the `N=0` configuration on
+  the same energy scale as the ledger energies. Leave at `0` when the empty
+  simulation box has zero energy (free clusters and fluids); for adsorption on a
+  frozen substrate pass the substrate self-energy. Must be finite. At very large
+  offsets (`β·|empty_energy|` beyond about `709`) the linear-space `Xi` return
+  over- or underflows while the ratio observables (`mean_N`, `var_N`, `mean_U`)
+  remain valid; when the absolute `Ξ` is needed in that regime, shift all ledger
+  and live energies to the empty-configuration reference externally instead.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
@@ -827,6 +846,7 @@ function gc_thermodynamic_stats_fixed_N(
     n_cull::Int=1,
     ω0::Float64=1.0,
     live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
+    empty_energy::Float64=0.0,
     kb::Float64=8.617333262e-5,
 )
     if length(ns_outputs) != length(N_values)
@@ -840,6 +860,9 @@ function gc_thermodynamic_stats_fixed_N(
     end
     if live_emax !== nothing && length(live_emax) != length(N_values)
         throw(DimensionMismatch("live_emax and N_values must have the same length"))
+    end
+    if !isfinite(empty_energy)
+        throw(ArgumentError("empty_energy must be finite"))
     end
     if !all(T -> ustrip(u"K", T) > 0, T_grid)
         throw(ArgumentError("every temperature in T_grid must be positive"))
@@ -855,11 +878,15 @@ function gc_thermodynamic_stats_fixed_N(
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
 
     for (i, df) in enumerate(ns_outputs)
-        # The N = 0 sector is the empty configuration: Z_NS^{(0)} = 1 by
-        # definition. The corresponding DataFrame contents are ignored.
+        # The N = 0 sector is the empty configuration: no spatial integral, so
+        # Z_NS^{(0)} = exp(-β·empty_energy), the Boltzmann weight of its total
+        # energy on the ledgers' energy scale (exactly 1 at the default
+        # empty_energy = 0). The corresponding DataFrame contents are ignored.
         if N_int[i] == 0
-            log_Z_NS[i, :] .= 0.0
-            mean_E_N[i, :] .= 0.0
+            for (j, T) in enumerate(T_grid)
+                log_Z_NS[i, j] = -empty_energy / (kb * ustrip(u"K", T))
+            end
+            mean_E_N[i, :] .= empty_energy
             continue
         end
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -404,16 +404,36 @@ residual tie-breaking noise, ~δ).
 - `ω0::Float64=1.0`: Initial phase-space volume factor.
 - `live_emax::Union{Nothing,Vector{Float64}}=nothing`: Energies of the surviving live walkers.
 - `live_numbers::Union{Nothing,Vector{Int}}=nothing`: Particle counts of the surviving live walkers.
+- `observable_cols::AbstractVector{Symbol}=Symbol[]`: Names of extra `df`
+  columns (recorded per dead point, e.g. via the `observables` keyword of
+  `ideal_gas_referenced_nested_sampling`) whose reweighted averages
+  ⟨A⟩(μ, T) are returned in `observables`. Requesting `:num_particles` or
+  `:emax` legitimately reproduces `mean_N`/`mean_U` (a self-consistency
+  check).
+- `live_observables=nothing`: Required whenever `observable_cols` is
+  non-empty and a live-set tail is supplied — a
+  `Dict{Symbol,<:AbstractVector{<:Real}}` with exactly the
+  `observable_cols` keys, holding each observable's values on the surviving
+  live walkers (one entry per `live_emax` entry, same order). Omitting the
+  tail values would silently deflate every ⟨A⟩, so this is an error rather
+  than a default.
 - `kb::Float64`: Boltzmann constant (default: eV/K).
 
 # Returns
-A `NamedTuple` of `Matrix{Float64}` of size `(length(μs), length(Ts))`,
-indexed `[i_μ, i_T]`:
+A `NamedTuple`; every field except `observables` is a `Matrix{Float64}` of
+size `(length(μs), length(Ts))`, indexed `[i_μ, i_T]`:
 - `logXi`: Natural log of the absolute grand partition function.
 - `mean_N`: Mean particle number ⟨N⟩.
 - `var_N`: Particle-number variance ⟨N²⟩ − ⟨N⟩².
 - `mean_U`: Mean configurational energy ⟨E⟩.
 - `N_eff`: Kish effective sample size of the reweighted estimate.
+- `var_U`: Energy variance ⟨E²⟩ − ⟨E⟩². The grand-canonical heat capacity
+  follows as `C = k_B β² (var_U − μ · cov_UN)`, matching the Ω-sorted
+  `gc_thermodynamic_stats` formula.
+- `cov_UN`: Energy–particle-number covariance ⟨EN⟩ − ⟨E⟩⟨N⟩.
+- `observables`: `Dict{Symbol,Matrix{Float64}}` mapping each requested
+  column to its reweighted average ⟨A⟩(μ, T); empty when no columns are
+  requested.
 """
 function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                                           n_sites::Int,
@@ -425,6 +445,8 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                                           ω0::Float64=1.0,
                                           live_emax::Union{Nothing,Vector{Float64}}=nothing,
                                           live_numbers::Union{Nothing,Vector{Int}}=nothing,
+                                          observable_cols::AbstractVector{Symbol}=Symbol[],
+                                          live_observables::Union{Nothing,AbstractDict{Symbol,<:AbstractVector{<:Real}}}=nothing,
                                           kb::Float64=8.617333262e-5)
     if z0 <= 0.0
         throw(ArgumentError("z0 must be positive"))
@@ -441,6 +463,42 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     n_dead = nrow(df)
     if n_dead == 0 && (live_emax === nothing || isempty(live_emax))
         throw(ArgumentError("df is empty and no live walkers were provided"))
+    end
+    allunique(observable_cols) || throw(ArgumentError(
+        "observable_cols must not contain duplicate entries"))
+    for col in observable_cols
+        hasproperty(df, col) || throw(ArgumentError(
+            "observable_cols: df has no column :$col"))
+        any(ismissing, df[!, col]) && throw(ArgumentError(
+            "observable_cols: df column :$col contains missing values"))
+    end
+    if live_observables !== nothing && live_emax === nothing
+        throw(ArgumentError(
+            "live_observables requires live_emax/live_numbers (the live-set tail)"))
+    end
+    if live_observables !== nothing && isempty(observable_cols)
+        throw(ArgumentError(
+            "live_observables was given but observable_cols is empty"))
+    end
+    if !isempty(observable_cols) && live_emax !== nothing
+        if live_observables === nothing
+            throw(ArgumentError(
+                "observable_cols with a live-set tail requires live_observables " *
+                "(the per-column values of the surviving live walkers); omitting " *
+                "them would silently deflate the tail's contribution to every " *
+                "observable average"))
+        end
+        if Set(keys(live_observables)) != Set(observable_cols)
+            throw(ArgumentError(
+                "live_observables keys must match observable_cols exactly"))
+        end
+        for col in observable_cols
+            if length(live_observables[col]) != length(live_emax)
+                throw(DimensionMismatch(
+                    "live_observables[:$col] must have one entry per live " *
+                    "walker (length(live_emax) = $(length(live_emax)))"))
+            end
+        end
     end
 
     # β- and μ-independent per-sample log prior-volume weights, built directly
@@ -465,6 +523,17 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
         Ns = vcat(Ns, Float64.(live_numbers))
     end
 
+    # Per-column observable values aligned with (Es, Ns): dead points first,
+    # then the live-set tail in the same order as live_emax
+    As = Dict{Symbol,Vector{Float64}}()
+    for col in observable_cols
+        A = n_dead > 0 ? Vector{Float64}(df[!, col]) : Float64[]
+        if live_emax !== nothing && !isempty(live_emax)
+            A = vcat(A, Vector{Float64}(live_observables[col]))
+        end
+        As[col] = A
+    end
+
     log_prior_mass = n_sites * log1p(z0)
     log_z0 = log(z0)
 
@@ -475,6 +544,10 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     var_N = Matrix{Float64}(undef, n_mu, n_T)
     mean_U = Matrix{Float64}(undef, n_mu, n_T)
     N_eff = Matrix{Float64}(undef, n_mu, n_T)
+    var_U = Matrix{Float64}(undef, n_mu, n_T)
+    cov_UN = Matrix{Float64}(undef, n_mu, n_T)
+    obs_out = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
     Threads.@threads for j in 1:n_T
         β = 1.0 / (kb * Ts[j])
@@ -488,12 +561,19 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
             n_avg = sum(ws .* Ns) / sum_w
             mean_N[i, j] = n_avg
             var_N[i, j] = sum(ws .* Ns .^ 2) / sum_w - n_avg^2
-            mean_U[i, j] = sum(ws .* Es) / sum_w
+            u_avg = sum(ws .* Es) / sum_w
+            mean_U[i, j] = u_avg
+            var_U[i, j] = sum(ws .* Es .^ 2) / sum_w - u_avg^2
+            cov_UN[i, j] = sum(ws .* Es .* Ns) / sum_w - u_avg * n_avg
+            for col in observable_cols
+                obs_out[col][i, j] = sum(ws .* As[col]) / sum_w
+            end
             N_eff[i, j] = sum_w^2 / sum(abs2, ws)
         end
     end
 
-    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff)
+    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff,
+            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -613,8 +613,10 @@ function _log_binomial(M::Integer, N::Integer)
 end
 
 """
-    _fixed_N_log_evidence(df, T_grid; n_walkers, n_cull, ω0, live_energies, kb)
-        -> (log_Z_NS::Vector{Float64}, mean_E::Vector{Float64})
+    _fixed_N_log_evidence(df, T_grid; n_walkers, n_cull, ω0, live_energies, kb,
+                          observable_cols=Symbol[], live_observables=nothing)
+        -> (log_Z_NS::Vector{Float64}, mean_E::Vector{Float64},
+            mean_E2::Vector{Float64}, mean_obs::Dict{Symbol,Vector{Float64}})
 
 Canonical NS evidence `log Z_NS(β) = log Σᵢ ωᵢ exp(−βEᵢ)` and canonical mean
 energy at each temperature in `T_grid`, evaluated by log-sum-exp. The discarded
@@ -625,8 +627,12 @@ low-energy samples. When `live_energies` is supplied, the residual prior mass
 evenly among the supplied energies — the live-set tail correction. An empty
 ladder records no compression, so its tail carries the sector's entire prior
 mass, exactly 1 and independent of `ω0` (matching the internally-handled
-`N = 0` sector). Internal helper shared by the `gc_thermodynamic_stats_fixed_N`
-methods.
+`N = 0` sector). `mean_E2` is the canonical ⟨E²⟩(β), and `mean_obs` carries
+the canonical average of each requested per-dead-point observable column
+(dead values from `df[!, col]`, live-tail values from `live_observables[col]`,
+aligned with `live_energies`). Internal helper shared by the
+`gc_thermodynamic_stats_fixed_N` methods; the caller validates the
+observable inputs.
 """
 function _fixed_N_log_evidence(
     df::DataFrame,
@@ -636,6 +642,8 @@ function _fixed_N_log_evidence(
     ω0::Float64,
     live_energies::Union{Nothing,AbstractVector{<:Real}},
     kb::Float64,
+    observable_cols::AbstractVector{Symbol}=Symbol[],
+    live_observables::Union{Nothing,AbstractDict{Symbol,<:AbstractVector{<:Real}}}=nothing,
 )
     Es = collect(Float64, df.emax)
     if isempty(Es) && (live_energies === nothing || isempty(live_energies))
@@ -668,8 +676,22 @@ function _fixed_N_log_evidence(
         log_ws = vcat(log_ωi, fill(log_tail, length(Es_live)))
     end
 
+    # Per-column observable values aligned with Es_all: dead points first,
+    # then the live-set tail in the same order as live_energies
+    As_all = Dict{Symbol,Vector{Float64}}()
+    for col in observable_cols
+        A = nrow(df) > 0 ? collect(Float64, df[!, col]) : Float64[]
+        if live_energies !== nothing
+            A = vcat(A, collect(Float64, live_observables[col]))
+        end
+        As_all[col] = A
+    end
+
     log_Z_NS = Vector{Float64}(undef, length(T_grid))
     mean_E = Vector{Float64}(undef, length(T_grid))
+    mean_E2 = Vector{Float64}(undef, length(T_grid))
+    mean_obs = Dict{Symbol,Vector{Float64}}(
+        col => Vector{Float64}(undef, length(T_grid)) for col in observable_cols)
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
         log_terms = log_ws .- β .* Es_all
@@ -678,8 +700,12 @@ function _fixed_N_log_evidence(
         sum_w = sum(ws)
         log_Z_NS[j] = max_log + log(sum_w)
         mean_E[j] = sum(ws .* Es_all) / sum_w
+        mean_E2[j] = sum(ws .* (Es_all .^ 2)) / sum_w
+        for col in observable_cols
+            mean_obs[col][j] = sum(ws .* As_all[col]) / sum_w
+        end
     end
-    return log_Z_NS, mean_E
+    return log_Z_NS, mean_E, mean_E2, mean_obs
 end
 
 """
@@ -926,10 +952,24 @@ in length or convergence.
   when supplied, one vector of live-walker energies (in eV) per `N` —
   normally the `n_walkers` live energies; the sector's residual prior mass is
   split evenly among the supplied entries. The entry for `N=0` is ignored.
+- `observable_cols::AbstractVector{Symbol}=Symbol[]`: names of extra ledger
+  columns (recorded per dead point in each sector's canonical run, e.g. via
+  the `observables` keyword of `nested_sampling`) whose grand-canonical
+  averages ⟨A⟩(μ, T) are returned in `observables`. Requesting observables
+  requires `live_emax` and `live_observables`.
+- `live_observables=nothing`: one `Dict{Symbol,<:AbstractVector{<:Real}}` per
+  `N` sector (aligned with `N_values`), holding each observable's values on
+  that sector's surviving live walkers (same order and length as the
+  sector's `live_emax` entry). The `N = 0` entry is **used**, unlike its
+  ignored `live_emax` counterpart: it supplies the observable value of the
+  single empty-lattice configuration (e.g. `[0.0]` for a sublattice order
+  parameter). Single-configuration sectors follow the empty-DataFrame
+  convention, with their observable value in the live entry.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
-A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values)`. The first
+A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values, var_U,
+cov_UN, observables)`. The first
 four fields are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))`
 indexed `[i_μ, i_T]`. `logXi` is the natural log of the absolute grand
 partition function — returned in log space (unlike the atomistic method's
@@ -942,7 +982,12 @@ evidence the assembly is built from — and `N_values` echoes the particle
 counts (as `Vector{Int}`) indexing its rows. For an athermal (hard-core)
 model evaluated at a sufficiently low `T` (see the hard-core recipe in the
 `GenericLatticeHamiltonian` docstring), `log_Z_N` is `log g_N`, the log count
-of allowed `N`-particle configurations.
+of allowed `N`-particle configurations. `var_U` is the grand-canonical energy
+variance ⟨E²⟩ − ⟨E⟩² and `cov_UN` the covariance ⟨EN⟩ − ⟨E⟩⟨N⟩, both
+assembled by the law of total expectation over the `N` sectors (the
+grand-canonical heat capacity follows as `C = k_B β² (var_U − μ · cov_UN)`).
+`observables` is a `Dict{Symbol,Matrix{Float64}}` mapping each requested
+column to ⟨A⟩(μ, T); empty when no columns are requested.
 """
 function gc_thermodynamic_stats_fixed_N(
     ns_outputs::AbstractVector{<:DataFrame},
@@ -954,6 +999,8 @@ function gc_thermodynamic_stats_fixed_N(
     n_cull::Int=1,
     ω0::Float64=1.0,
     live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
+    observable_cols::AbstractVector{Symbol}=Symbol[],
+    live_observables::Union{Nothing,AbstractVector{<:AbstractDict{Symbol,<:AbstractVector{<:Real}}}}=nothing,
     kb::Float64=8.617333262e-5,
 )
     if length(ns_outputs) != length(N_values)
@@ -980,8 +1027,55 @@ function gc_thermodynamic_stats_fixed_N(
     n_mu = length(μ_grid)
     n_T = length(T_grid)
 
+    allunique(observable_cols) || throw(ArgumentError(
+        "observable_cols must not contain duplicate entries"))
+    if !isempty(observable_cols)
+        if live_emax === nothing || live_observables === nothing
+            throw(ArgumentError(
+                "observable recording requires both live_emax and " *
+                "live_observables: the N = 0 and single-configuration sectors " *
+                "have no dead points, so their per-sector observable averages " *
+                "come from the live entries"))
+        end
+        if length(live_observables) != length(N_values)
+            throw(DimensionMismatch(
+                "live_observables must have one Dict per N sector " *
+                "(length(N_values) = $(length(N_values)))"))
+        end
+        for (i, d) in enumerate(live_observables)
+            Set(keys(d)) == Set(observable_cols) || throw(ArgumentError(
+                "live_observables[$i] keys must match observable_cols exactly"))
+            for col in observable_cols
+                isempty(d[col]) && throw(ArgumentError(
+                    "live_observables[$i][:$col] is empty"))
+                if N_int[i] != 0 && length(d[col]) != length(live_emax[i])
+                    throw(DimensionMismatch(
+                        "live_observables[$i][:$col] must have one entry per " *
+                        "live walker (length(live_emax[$i]) = " *
+                        "$(length(live_emax[i])))"))
+                end
+            end
+        end
+        for (i, dfi) in enumerate(ns_outputs)
+            (N_int[i] == 0 || nrow(dfi) == 0) && continue
+            for col in observable_cols
+                hasproperty(dfi, col) || throw(ArgumentError(
+                    "ns_outputs[$i] (N = $(N_int[i])) has no observable " *
+                    "column :$col"))
+                any(ismissing, dfi[!, col]) && throw(ArgumentError(
+                    "ns_outputs[$i] column :$col contains missing values"))
+            end
+        end
+    elseif live_observables !== nothing
+        throw(ArgumentError(
+            "live_observables was given but observable_cols is empty"))
+    end
+
     log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
+    mean_E2_N = Matrix{Float64}(undef, n_N, n_T)
+    obs_N = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_N, n_T) for col in observable_cols)
 
     for (i, df) in enumerate(ns_outputs)
         # The N = 0 sector is the empty lattice: a single configuration with
@@ -989,14 +1083,29 @@ function gc_thermodynamic_stats_fixed_N(
         if N_int[i] == 0
             log_Z_NS[i, :] .= 0.0
             mean_E_N[i, :] .= 0.0
+            mean_E2_N[i, :] .= 0.0
+            for col in observable_cols
+                # Unlike its ignored live_emax entry, the N = 0 sector's
+                # live_observables entry is used: it supplies the observable
+                # value of the single empty-lattice configuration directly
+                # (averaged over the given values)
+                vals = live_observables[i][col]
+                obs_N[col][i, :] .= sum(Float64, vals) / length(vals)
+            end
             continue
         end
 
         live = live_emax === nothing ? nothing : live_emax[i]
-        log_Z_NS[i, :], mean_E_N[i, :] = _fixed_N_log_evidence(
+        live_obs = isempty(observable_cols) ? nothing : live_observables[i]
+        log_Z_NS[i, :], mean_E_N[i, :], sector_E2, sector_obs = _fixed_N_log_evidence(
             df, T_grid;
             n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
-            live_energies=live, kb=kb)
+            live_energies=live, kb=kb,
+            observable_cols=observable_cols, live_observables=live_obs)
+        mean_E2_N[i, :] = sector_E2
+        for col in observable_cols
+            obs_N[col][i, :] = sector_obs[col]
+        end
     end
 
     log_binom = [_log_binomial(n_sites, N) for N in N_int]
@@ -1005,6 +1114,10 @@ function gc_thermodynamic_stats_fixed_N(
     mean_N = Matrix{Float64}(undef, n_mu, n_T)
     var_N = Matrix{Float64}(undef, n_mu, n_T)
     mean_U = Matrix{Float64}(undef, n_mu, n_T)
+    var_U = Matrix{Float64}(undef, n_mu, n_T)
+    cov_UN = Matrix{Float64}(undef, n_mu, n_T)
+    obs_out = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
@@ -1020,12 +1133,22 @@ function gc_thermodynamic_stats_fixed_N(
             mean_N[k, j] = sum(ws .* N_int) / sum_w
             mean_N2 = sum(ws .* (N_int .^ 2)) / sum_w
             var_N[k, j] = mean_N2 - mean_N[k, j]^2
-            mean_U[k, j] = sum(ws .* view(mean_E_N, :, j)) / sum_w
+            u_avg = sum(ws .* view(mean_E_N, :, j)) / sum_w
+            mean_U[k, j] = u_avg
+            # Law of total expectation over the N sectors: the grand-canonical
+            # <E^2> is the w_N-weighted canonical <E^2>_N, likewise <E N>
+            var_U[k, j] = sum(ws .* view(mean_E2_N, :, j)) / sum_w - u_avg^2
+            cov_UN[k, j] = sum(ws .* N_int .* view(mean_E_N, :, j)) / sum_w -
+                           u_avg * mean_N[k, j]
+            for col in observable_cols
+                obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
+            end
         end
     end
 
     return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
-            log_Z_N=log_Z_NS .+ log_binom, N_values=N_int)
+            log_Z_N=log_Z_NS .+ log_binom, N_values=N_int,
+            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
 end
 
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -446,7 +446,7 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                                           live_emax::Union{Nothing,Vector{Float64}}=nothing,
                                           live_numbers::Union{Nothing,Vector{Int}}=nothing,
                                           observable_cols::AbstractVector{Symbol}=Symbol[],
-                                          live_observables::Union{Nothing,AbstractDict{Symbol,<:AbstractVector{<:Real}}}=nothing,
+                                          live_observables::Union{Nothing,AbstractDict{Symbol}}=nothing,
                                           kb::Float64=8.617333262e-5)
     if z0 <= 0.0
         throw(ArgumentError("z0 must be positive"))
@@ -466,11 +466,16 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     end
     allunique(observable_cols) || throw(ArgumentError(
         "observable_cols must not contain duplicate entries"))
-    for col in observable_cols
-        hasproperty(df, col) || throw(ArgumentError(
-            "observable_cols: df has no column :$col"))
-        any(ismissing, df[!, col]) && throw(ArgumentError(
-            "observable_cols: df column :$col contains missing values"))
+    if n_dead > 0
+        # A zero-row df contributes no dead points, so its columns are never
+        # read: live-tail-only analyses need not carry the observable columns
+        # (mirroring the fixed-N empty-sector convention)
+        for col in observable_cols
+            hasproperty(df, col) || throw(ArgumentError(
+                "observable_cols: df has no column :$col"))
+            any(ismissing, df[!, col]) && throw(ArgumentError(
+                "observable_cols: df column :$col contains missing values"))
+        end
     end
     if live_observables !== nothing && live_emax === nothing
         throw(ArgumentError(
@@ -493,7 +498,10 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                 "live_observables keys must match observable_cols exactly"))
         end
         for col in observable_cols
-            if length(live_observables[col]) != length(live_emax)
+            v = live_observables[col]
+            (v isa AbstractVector && all(x -> x isa Real, v)) || throw(ArgumentError(
+                "live_observables[:$col] must be a vector of Real values"))
+            if length(v) != length(live_emax)
                 throw(DimensionMismatch(
                     "live_observables[:$col] must have one entry per live " *
                     "walker (length(live_emax) = $(length(live_emax)))"))
@@ -534,6 +542,13 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
         As[col] = A
     end
 
+    # Second moments are formed on shifted energies (the cv() convention):
+    # the one-pass <E^2> - <E>^2 on absolute energies carries an ~eps*E^2
+    # cancellation floor that can dominate small variances at large |E|.
+    # Variances and covariances are shift-invariant, so the shift cancels.
+    E_shift = isempty(Es) ? 0.0 : minimum(Es)
+    Es_c = Es .- E_shift
+
     log_prior_mass = n_sites * log1p(z0)
     log_z0 = log(z0)
 
@@ -561,10 +576,10 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
             n_avg = sum(ws .* Ns) / sum_w
             mean_N[i, j] = n_avg
             var_N[i, j] = sum(ws .* Ns .^ 2) / sum_w - n_avg^2
-            u_avg = sum(ws .* Es) / sum_w
-            mean_U[i, j] = u_avg
-            var_U[i, j] = sum(ws .* Es .^ 2) / sum_w - u_avg^2
-            cov_UN[i, j] = sum(ws .* Es .* Ns) / sum_w - u_avg * n_avg
+            u_c = sum(ws .* Es_c) / sum_w
+            mean_U[i, j] = u_c + E_shift
+            var_U[i, j] = sum(ws .* Es_c .^ 2) / sum_w - u_c^2
+            cov_UN[i, j] = sum(ws .* Es_c .* Ns) / sum_w - u_c * n_avg
             for col in observable_cols
                 obs_out[col][i, j] = sum(ws .* As[col]) / sum_w
             end
@@ -627,7 +642,11 @@ low-energy samples. When `live_energies` is supplied, the residual prior mass
 evenly among the supplied energies — the live-set tail correction. An empty
 ladder records no compression, so its tail carries the sector's entire prior
 mass, exactly 1 and independent of `ω0` (matching the internally-handled
-`N = 0` sector). `mean_E2` is the canonical ⟨E²⟩(β), and `mean_obs` carries
+`N = 0` sector). `mean_E2` is the canonical second moment of the shifted
+energies, ⟨(E − `energy_shift`)²⟩(β) — the caller supplies one global
+`energy_shift` so sector moments combine consistently and the one-pass
+variance avoids the ~eps·E² cancellation floor (`mean_E` stays absolute) —
+and `mean_obs` carries
 the canonical average of each requested per-dead-point observable column
 (dead values from `df[!, col]`, live-tail values from `live_observables[col]`,
 aligned with `live_energies`). Internal helper shared by the
@@ -643,7 +662,8 @@ function _fixed_N_log_evidence(
     live_energies::Union{Nothing,AbstractVector{<:Real}},
     kb::Float64,
     observable_cols::AbstractVector{Symbol}=Symbol[],
-    live_observables::Union{Nothing,AbstractDict{Symbol,<:AbstractVector{<:Real}}}=nothing,
+    live_observables::Union{Nothing,AbstractDict{Symbol}}=nothing,
+    energy_shift::Float64=0.0,
 )
     Es = collect(Float64, df.emax)
     if isempty(Es) && (live_energies === nothing || isempty(live_energies))
@@ -687,6 +707,11 @@ function _fixed_N_log_evidence(
         As_all[col] = A
     end
 
+    # Second moments are formed on shifted energies (the cv() convention);
+    # the caller supplies one global shift so the sector moments stay
+    # mutually consistent in the grand-canonical assembly
+    Es_c = Es_all .- energy_shift
+
     log_Z_NS = Vector{Float64}(undef, length(T_grid))
     mean_E = Vector{Float64}(undef, length(T_grid))
     mean_E2 = Vector{Float64}(undef, length(T_grid))
@@ -700,7 +725,7 @@ function _fixed_N_log_evidence(
         sum_w = sum(ws)
         log_Z_NS[j] = max_log + log(sum_w)
         mean_E[j] = sum(ws .* Es_all) / sum_w
-        mean_E2[j] = sum(ws .* (Es_all .^ 2)) / sum_w
+        mean_E2[j] = sum(ws .* (Es_c .^ 2)) / sum_w
         for col in observable_cols
             mean_obs[col][j] = sum(ws .* As_all[col]) / sum_w
         end
@@ -1000,7 +1025,7 @@ function gc_thermodynamic_stats_fixed_N(
     ω0::Float64=1.0,
     live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
     observable_cols::AbstractVector{Symbol}=Symbol[],
-    live_observables::Union{Nothing,AbstractVector{<:AbstractDict{Symbol,<:AbstractVector{<:Real}}}}=nothing,
+    live_observables::Union{Nothing,AbstractVector{<:AbstractDict{Symbol}}}=nothing,
     kb::Float64=8.617333262e-5,
 )
     if length(ns_outputs) != length(N_values)
@@ -1046,9 +1071,12 @@ function gc_thermodynamic_stats_fixed_N(
             Set(keys(d)) == Set(observable_cols) || throw(ArgumentError(
                 "live_observables[$i] keys must match observable_cols exactly"))
             for col in observable_cols
-                isempty(d[col]) && throw(ArgumentError(
+                v = d[col]
+                (v isa AbstractVector && all(x -> x isa Real, v)) || throw(ArgumentError(
+                    "live_observables[$i][:$col] must be a vector of Real values"))
+                isempty(v) && throw(ArgumentError(
                     "live_observables[$i][:$col] is empty"))
-                if N_int[i] != 0 && length(d[col]) != length(live_emax[i])
+                if N_int[i] != 0 && length(v) != length(live_emax[i])
                     throw(DimensionMismatch(
                         "live_observables[$i][:$col] must have one entry per " *
                         "live walker (length(live_emax[$i]) = " *
@@ -1071,9 +1099,22 @@ function gc_thermodynamic_stats_fixed_N(
             "live_observables was given but observable_cols is empty"))
     end
 
+    # One global energy shift for all sector second moments (the cv()
+    # convention): variances and covariances are shift-invariant, and forming
+    # them on E - E_shift avoids the ~eps*E^2 one-pass cancellation floor.
+    # The N = 0 sector pins E = 0 into the spectrum, hence the min with 0.
+    E_shift = 0.0
+    for (i, dfi) in enumerate(ns_outputs)
+        N_int[i] == 0 && continue
+        nrow(dfi) > 0 && (E_shift = min(E_shift, minimum(dfi.emax)))
+        if live_emax !== nothing && !isempty(live_emax[i])
+            E_shift = min(E_shift, minimum(live_emax[i]))
+        end
+    end
+
     log_Z_NS = Matrix{Float64}(undef, n_N, n_T)
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
-    mean_E2_N = Matrix{Float64}(undef, n_N, n_T)
+    mean_E2_N = Matrix{Float64}(undef, n_N, n_T)   # shifted: <(E - E_shift)^2>
     obs_N = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_N, n_T) for col in observable_cols)
 
@@ -1083,7 +1124,7 @@ function gc_thermodynamic_stats_fixed_N(
         if N_int[i] == 0
             log_Z_NS[i, :] .= 0.0
             mean_E_N[i, :] .= 0.0
-            mean_E2_N[i, :] .= 0.0
+            mean_E2_N[i, :] .= E_shift^2   # <(0 - E_shift)^2>
             for col in observable_cols
                 # Unlike its ignored live_emax entry, the N = 0 sector's
                 # live_observables entry is used: it supplies the observable
@@ -1101,7 +1142,8 @@ function gc_thermodynamic_stats_fixed_N(
             df, T_grid;
             n_walkers=n_walkers, n_cull=n_cull, ω0=ω0,
             live_energies=live, kb=kb,
-            observable_cols=observable_cols, live_observables=live_obs)
+            observable_cols=observable_cols, live_observables=live_obs,
+            energy_shift=E_shift)
         mean_E2_N[i, :] = sector_E2
         for col in observable_cols
             obs_N[col][i, :] = sector_obs[col]
@@ -1135,11 +1177,13 @@ function gc_thermodynamic_stats_fixed_N(
             var_N[k, j] = mean_N2 - mean_N[k, j]^2
             u_avg = sum(ws .* view(mean_E_N, :, j)) / sum_w
             mean_U[k, j] = u_avg
-            # Law of total expectation over the N sectors: the grand-canonical
-            # <E^2> is the w_N-weighted canonical <E^2>_N, likewise <E N>
-            var_U[k, j] = sum(ws .* view(mean_E2_N, :, j)) / sum_w - u_avg^2
-            cov_UN[k, j] = sum(ws .* N_int .* view(mean_E_N, :, j)) / sum_w -
-                           u_avg * mean_N[k, j]
+            # Law of total expectation over the N sectors, formed on shifted
+            # energies (mean_E2_N holds <(E - E_shift)^2>_N; variances and
+            # covariances are shift-invariant)
+            u_c = u_avg - E_shift
+            var_U[k, j] = sum(ws .* view(mean_E2_N, :, j)) / sum_w - u_c^2
+            cov_UN[k, j] = sum(ws .* N_int .* (view(mean_E_N, :, j) .- E_shift)) / sum_w -
+                           u_c * mean_N[k, j]
             for col in observable_cols
                 obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
             end

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -364,7 +364,7 @@ end
 """
     gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, V, atomic_mass, μ_grid, T_grid;
                                    n_walkers=120, n_cull=1, ω0=1.0,
-                                   kb=8.617333262e-5)
+                                   live_emax=nothing, kb=8.617333262e-5)
 
 Compute grand-canonical thermodynamic averages from a stack of canonical
 nested-sampling outputs, one per fixed particle number `N`.
@@ -385,17 +385,31 @@ The grand partition function is assembled as
 ```
 
 with the thermal wavelength `Λ(T) = h / sqrt(2π m k_B T)` computed from `atomic_mass`.
-The sum runs over the supplied `N_values`, which must include `0` (the empty
-configuration, `Z_{NS}^{(0)} = 1`). Truncation error at the upper end of `N_values`
-is bounded by the tail of `(zV)^N / N!` for the largest `⟨N⟩` requested.
+The sum runs over the supplied `N_values`, which must include `0`. The `N=0` sector
+is treated specially: `Z_{NS}^{(0)} = 1` by definition (the empty configuration has no
+spatial integral), so the corresponding DataFrame contents are ignored. Truncation
+error at the upper end of `N_values` is bounded by the tail of `(zV)^N / N!` for the
+largest `⟨N⟩` requested.
 
 A log-sum-exp pass is used both inside each per-N evidence and across the
 grand sum for numerical stability.
 
+## Live-set tail correction
+
+After a finite number of NS iterations `n_iters` the recorded weights `ωᵢ` carry
+only `1 − (K/(K+n_cull))^{n_iters}` of the prior volume (times `ω0`); the remainder
+sits in the `K` surviving live walkers. Supplying `live_emax` (one vector of K live
+walker energies per `N`) adds the live-set tail to each per-N evidence: each live
+walker contributes weight `ω0 · (K/(K+n_cull))^{n_iters} / K` at its current energy.
+When omitted, the live-set tail is neglected — for ratio observables (`⟨N⟩`, `⟨U⟩`)
+the resulting bias is small but visible at low T or shallow NS; for the absolute
+`Ξ` it appears as a uniform-in-N prefactor that does not cancel.
+
 # Arguments
 - `ns_outputs::AbstractVector{<:DataFrame}`: one canonical-NS output per `N`,
   each with columns `[:iter, :emax]` (matching the schema produced by
-  `nested_sampling`).
+  `nested_sampling`). The entry corresponding to `N=0` is ignored and may be
+  any DataFrame (e.g., `DataFrame(iter=Int[], emax=Float64[])`).
 - `N_values::AbstractVector{<:Integer}`: particle counts corresponding to each
   DataFrame. Must include `0`; `length(N_values) == length(ns_outputs)`.
 - `V::typeof(1.0u"Å^3")`: accessible configurational volume (explicit; for
@@ -409,6 +423,9 @@ grand sum for numerical stability.
   Must be uniform across `ns_outputs`.
 - `n_cull::Int=1`: NS culls per iteration.
 - `ω0::Float64=1.0`: initial prior weight, passed to `ωᵢ`.
+- `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
+  when supplied, one vector of `K = n_walkers` live walker energies (in eV) per
+  `N`. The entry for `N=0` is ignored. See "Live-set tail correction" above.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
@@ -427,6 +444,7 @@ function gc_thermodynamic_stats_fixed_N(
     n_walkers::Int=120,
     n_cull::Int=1,
     ω0::Float64=1.0,
+    live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing,
     kb::Float64=8.617333262e-5,
 )
     if length(ns_outputs) != length(N_values)
@@ -434,6 +452,9 @@ function gc_thermodynamic_stats_fixed_N(
     end
     if !(0 in N_values)
         throw(ArgumentError("N_values must include 0 (the empty configuration)"))
+    end
+    if live_emax !== nothing && length(live_emax) != length(N_values)
+        throw(DimensionMismatch("live_emax and N_values must have the same length"))
     end
 
     N_int = collect(Int, N_values)
@@ -446,16 +467,38 @@ function gc_thermodynamic_stats_fixed_N(
     mean_E_N = Matrix{Float64}(undef, n_N, n_T)
 
     for (i, df) in enumerate(ns_outputs)
+        # The N = 0 sector is the empty configuration: Z_NS^{(0)} = 1 by
+        # definition. The corresponding DataFrame contents are ignored.
+        if N_int[i] == 0
+            log_Z_NS[i, :] .= 0.0
+            mean_E_N[i, :] .= 0.0
+            continue
+        end
+
         ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
-        Es = df.emax
+        Es = collect(Float64, df.emax)
+        n_iters = length(df.iter)
+        # Each live walker carries weight ω0 · (K/(K+n_cull))^n_iters / K,
+        # accounting for the prior volume that finite termination leaves in
+        # the live set.
+        log_tail = log(ω0) + n_iters * log(n_walkers / (n_walkers + n_cull)) -
+                   log(n_walkers)
         for (j, T) in enumerate(T_grid)
             β = 1.0 / (kb * ustrip(u"K", T))
-            log_terms = log.(ωi) .- β .* Es
+            if live_emax === nothing
+                log_terms = log.(ωi) .- β .* Es
+                Es_all = Es
+            else
+                Es_live = collect(Float64, live_emax[i])
+                log_terms = vcat(log.(ωi) .- β .* Es,
+                                 log_tail .- β .* Es_live)
+                Es_all = vcat(Es, Es_live)
+            end
             max_log = maximum(log_terms)
             ws = exp.(log_terms .- max_log)
             sum_w = sum(ws)
             log_Z_NS[i, j] = max_log + log(sum_w)
-            mean_E_N[i, j] = sum(ws .* Es) / sum_w
+            mean_E_N[i, j] = sum(ws .* Es_all) / sum_w
         end
     end
 

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -12,6 +12,7 @@ export read_output
 export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
 export microcanonical_entropy, caloric_derivatives, inflection_transitions
+export transition_convergence
 
 """
     read_output(filename::String)

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -11,7 +11,7 @@ using CSV, Arrow
 export read_output
 export ωᵢ, partition_function, internal_energy, cv
 export gc_thermodynamic_stats
-export microcanonical_entropy, caloric_derivatives
+export microcanonical_entropy, caloric_derivatives, inflection_transitions
 
 """
     read_output(filename::String)

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -502,8 +502,9 @@ end
 """
     _log_factorial(n::Integer) -> Float64
 
-Return `log(n!)` for small non-negative `n`, computed by summing `log(k)` to
-keep the result exact in floating point for `n` up to several dozen.
+Return `log(n!)` for non-negative `n`, computed by summing `log(k)`. Accurate
+to roundoff accumulation (absolute error ~1e-11 at `n ~ 10^4`), which covers
+both the small-`n` atomistic use and the large-`M` `_log_binomial` use.
 """
 function _log_factorial(n::Integer)
     n < 0 && throw(ArgumentError("n must be non-negative"))
@@ -528,11 +529,16 @@ end
         -> (log_Z_NS::Vector{Float64}, mean_E::Vector{Float64})
 
 Canonical NS evidence `log Z_NS(β) = log Σᵢ ωᵢ exp(−βEᵢ)` and canonical mean
-energy at each temperature in `T_grid`, evaluated by log-sum-exp. When
-`live_energies` is supplied, each of the `n_walkers` live walkers contributes
-the residual prior weight `ω0 · (K/(K+n_cull))^{n_iters} / K` at its energy
-(the live-set tail correction). Internal helper shared by the
-`gc_thermodynamic_stats_fixed_N` methods.
+energy at each temperature in `T_grid`, evaluated by log-sum-exp. The discarded
+weights `ωᵢ` are built directly in log space, so deep ladders (`iter` beyond
+~`700 · n_walkers`, where the linear-space `ωᵢ` underflows Float64) keep their
+low-energy samples. When `live_energies` is supplied, the residual prior mass
+`ω0 · (K/(K+n_cull))^{n_iters}` (with `n_iters = maximum(df.iter)`) is split
+evenly among the supplied energies — the live-set tail correction. An empty
+ladder records no compression, so its tail carries the sector's entire prior
+mass, exactly 1 and independent of `ω0` (matching the internally-handled
+`N = 0` sector). Internal helper shared by the `gc_thermodynamic_stats_fixed_N`
+methods.
 """
 function _fixed_N_log_evidence(
     df::DataFrame,
@@ -544,26 +550,34 @@ function _fixed_N_log_evidence(
     kb::Float64,
 )
     Es = collect(Float64, df.emax)
-    n_iters = length(Es)
     if isempty(Es) && (live_energies === nothing || isempty(live_energies))
         throw(ArgumentError(
             "a sector has no discarded samples and no live-set tail; for " *
             "single-configuration sectors supply an empty DataFrame plus a " *
-            "live_emax entry carrying the sector energy"))
+            "live_emax entry carrying the sector energy (e.g. n_walkers " *
+            "copies of it)"))
     end
-    ωi = ωᵢ(df.iter, n_walkers; n_cull=n_cull, ω0=ω0)
-    # Each live walker carries weight ω0 · (K/(K+n_cull))^n_iters / K,
-    # accounting for the prior volume that finite termination leaves in
-    # the live set.
-    log_tail = log(ω0) + n_iters * log(n_walkers / (n_walkers + n_cull)) -
-               log(n_walkers)
+    # Log-space weights: the linear-space ωᵢ underflows Float64 for
+    # iter ≳ 700·K, silently dropping the low-energy samples that dominate
+    # at low T.
+    log_r = log(n_walkers / (n_walkers + n_cull))
+    log_ωi = (log(ω0) + log(n_cull / (n_walkers + n_cull))) .+ df.iter .* log_r
     if live_energies === nothing
         Es_all = Es
-        log_ws = log.(ωi)
+        log_ws = log_ωi
     else
         Es_live = collect(Float64, live_energies)
+        # The live set carries the residual prior mass ω0 · r^n_iters, split
+        # evenly among the supplied energies. n_iters comes from the recorded
+        # iter values (not the row count), so continuation ladders whose iter
+        # does not start at 1 stay consistent with their ωᵢ. An empty ladder
+        # records no compression: its tail is the sector's entire prior mass,
+        # exactly 1, independent of ω0.
+        n_iters = isempty(df.iter) ? 0 : maximum(df.iter)
+        log_tail_total = n_iters == 0 ? 0.0 : log(ω0) + n_iters * log_r
+        log_tail = log_tail_total - log(length(Es_live))
         Es_all = vcat(Es, Es_live)
-        log_ws = vcat(log.(ωi), fill(log_tail, length(Es_live)))
+        log_ws = vcat(log_ωi, fill(log_tail, length(Es_live)))
     end
 
     log_Z_NS = Vector{Float64}(undef, length(T_grid))
@@ -585,8 +599,11 @@ end
                                    n_walkers=120, n_cull=1, ω0=1.0,
                                    live_emax=nothing, kb=8.617333262e-5)
 
-Compute grand-canonical thermodynamic averages from a stack of canonical
-nested-sampling outputs, one per fixed particle number `N`.
+Atomistic method: compute grand-canonical thermodynamic averages from a stack
+of canonical nested-sampling outputs, one per fixed particle number `N`, using
+the simulation-box volume `V` and the thermal wavelength. Returns `Xi` in
+linear space (contrast the lattice-gas method of this function, which takes
+`n_sites` and returns `logXi`).
 
 For each `N`, the canonical NS evidence at inverse temperature `β` is
 
@@ -617,12 +634,15 @@ grand sum for numerical stability.
 
 After a finite number of NS iterations `n_iters` the recorded weights `ωᵢ` carry
 only `1 − (K/(K+n_cull))^{n_iters}` of the prior volume (times `ω0`); the remainder
-sits in the `K` surviving live walkers. Supplying `live_emax` (one vector of K live
-walker energies per `N`) adds the live-set tail to each per-N evidence: each live
-walker contributes weight `ω0 · (K/(K+n_cull))^{n_iters} / K` at its current energy.
-When omitted, the live-set tail is neglected — for ratio observables (`⟨N⟩`, `⟨U⟩`)
-the resulting bias is small but visible at low T or shallow NS; for the absolute
-`Ξ` it appears as a uniform-in-N prefactor that does not cancel.
+sits in the `K` surviving live walkers. Supplying `live_emax` (one vector of live
+walker energies per `N`, normally the K live energies) adds the live-set tail to
+each per-N evidence: the residual mass `ω0 · (K/(K+n_cull))^{n_iters}` is split
+evenly among the supplied energies. A sector supplied as an empty DataFrame plus
+live energies carries mass exactly `1`, independent of `ω0` (see the lattice-gas
+method's "Special sectors"). When omitted, the live-set tail is neglected — for
+ratio observables (`⟨N⟩`, `⟨U⟩`) the resulting bias is small but visible at low T
+or shallow NS; for the absolute `Ξ` it appears as a uniform-in-N prefactor that
+does not cancel.
 
 # Arguments
 - `ns_outputs::AbstractVector{<:DataFrame}`: one canonical-NS output per `N`,
@@ -676,8 +696,14 @@ function gc_thermodynamic_stats_fixed_N(
     if !(0 in N_values)
         throw(ArgumentError("N_values must include 0 (the empty configuration)"))
     end
+    if !allunique(N_values)
+        throw(ArgumentError("N_values must not contain duplicate entries"))
+    end
     if live_emax !== nothing && length(live_emax) != length(N_values)
         throw(DimensionMismatch("live_emax and N_values must have the same length"))
+    end
+    if !all(T -> ustrip(u"K", T) > 0, T_grid)
+        throw(ArgumentError("every temperature in T_grid must be positive"))
     end
 
     N_int = collect(Int, N_values)
@@ -768,20 +794,26 @@ supplied `N`.
 - `N = n_sites` (and any other single-configuration sector): NS cannot make
   progress because every walker holds the same configuration. Supply an empty
   DataFrame (`DataFrame(iter=Int[], emax=Float64[])`) together with a
-  `live_emax` entry holding `n_walkers` copies of the sector energy — the
-  live-set tail then carries the sector's entire prior mass (exactly `ω0`,
-  so pair this with `ω0 = 1.0` semantics in mind; see below).
+  `live_emax` entry holding the sector energy (conventionally `n_walkers`
+  copies of it; any count works) — the live-set tail then carries the
+  sector's entire prior mass, exactly `1` and independent of `ω0`, matching
+  the internally-handled `N = 0` sector. Because such sectors require a
+  `live_emax` entry, covering the full range `0:n_sites` in `N_values` is
+  only possible with `live_emax` supplied.
 
 ## Live-set tail and normalization
 
 As for the atomistic method, the recorded weights `ωᵢ` carry only part of the
 prior volume after finite NS termination. Supplying `live_emax` (one vector of
-`n_walkers` live-walker energies per `N`) adds the residual
-`ω0 · (K/(K+n_cull))^{n_iters} / K` per live walker to each sector evidence.
-For fully-normalized absolute `Ξ`, pass `ω0 = (n_walkers + n_cull)/n_walkers`
-(Skilling weights) together with `live_emax`; with the defaults, `logXi` is
-biased low by a uniform-in-`N` factor that cancels in the ratio observables
-`mean_N`, `var_N`, and `mean_U`.
+live-walker energies per `N`, normally the `n_walkers` live energies) splits
+the residual prior mass `ω0 · (K/(K+n_cull))^{n_iters}` evenly among the
+supplied entries of each sector. For fully-normalized absolute `Ξ`, pass
+`ω0 = (n_walkers + n_cull)/n_walkers` (Skilling weights) together with
+`live_emax`; with the defaults (`ω0 = 1.0`, no tail), `logXi` is biased low,
+and the omitted tail additionally leaves an `N`-dependent bias — small but
+visible at low `T` or for shallow NS runs, and not exactly cancelling in the
+ratio observables `mean_N`, `var_N`, and `mean_U` when per-`N` ladders differ
+in length or convergence.
 
 # Arguments
 - `ns_outputs::AbstractVector{<:DataFrame}`: one canonical lattice-NS output
@@ -797,10 +829,11 @@ biased low by a uniform-in-`N` factor that cancels in the ratio observables
 - `n_walkers::Int=120`: number of NS walkers used to produce each DataFrame.
   Must be uniform across `ns_outputs`.
 - `n_cull::Int=1`: NS culls per iteration.
-- `ω0::Float64=1.0`: initial prior weight, passed to `ωᵢ`.
+- `ω0::Float64=1.0`: initial prior weight for the discarded-sample ladder.
 - `live_emax::Union{Nothing,AbstractVector{<:AbstractVector{<:Real}}}=nothing`:
-  when supplied, one vector of `n_walkers` live-walker energies (in eV) per
-  `N`. The entry for `N=0` is ignored.
+  when supplied, one vector of live-walker energies (in eV) per `N` —
+  normally the `n_walkers` live energies; the sector's residual prior mass is
+  split evenly among the supplied entries. The entry for `N=0` is ignored.
 - `kb::Float64`: Boltzmann constant in eV/K.
 
 # Returns
@@ -833,8 +866,14 @@ function gc_thermodynamic_stats_fixed_N(
     if !all(0 .<= N_values .<= n_sites)
         throw(ArgumentError("every entry of N_values must lie in 0:n_sites"))
     end
+    if !allunique(N_values)
+        throw(ArgumentError("N_values must not contain duplicate entries"))
+    end
     if live_emax !== nothing && length(live_emax) != length(N_values)
         throw(DimensionMismatch("live_emax and N_values must have the same length"))
+    end
+    if !all(T -> ustrip(u"K", T) > 0, T_grid)
+        throw(ArgumentError("every temperature in T_grid must be positive"))
     end
 
     N_int = collect(Int, N_values)

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -60,6 +60,42 @@ function ωᵢ(iters::AbstractVector{Int}, n_walkers::Int; n_cull::Int=1, ω0::F
 end
 
 """
+    ωᵢ(log_compression::AbstractVector{Float64}; ω0::Float64=1.0)
+
+Calculates the \$\\omega\$ factors (per-row prior-mass shells) from a ledger's per-cull
+log-compression column, as recorded by the serial atomistic `nested_sampling_step!`
+methods. Row `i`'s shell is
+```math
+\\omega_i = X_{i-1} - X_i, \\qquad X_i = \\omega_0 \\prod_{j \\le i} t_j,
+```
+where \$t_j = \\exp(\\texttt{log\\_compression}_j)\$ is the compression factor charged
+for cull \$j\$ (`n/(n+1)` for an ordinary cull from `n` live walkers, `(n-1)/n` for a
+plateau tie evicted without replacement). For a tie-free fixed-`K` ledger the column is
+uniformly `log(K/(K+1))` and this method with the default `ω0 = 1.0` agrees with the
+iteration-based method as `ωᵢ(1:n, K; ω0=(K+1)/K)` up to floating-point evaluation
+order: here `ω0` is the total prior mass before the first cull, whereas the `(K+1)/K`
+factor conventionally passed to the iteration-based method only undoes that method's
+iteration-count offset — do not pass it here. Ledgers containing plateau tie blocks
+REQUIRE this method, since the iteration-based weights assume a constant per-cull
+compression and over-compress plateaus.
+
+# Arguments
+- `log_compression::AbstractVector{Float64}`: The ledger's per-cull log-compression
+  values, in row order.
+- `ω0::Float64`: The total prior mass before the first cull. Default is 1.0, which is
+  correct for ledgers produced by `nested_sampling`; the summed shells then equal
+  `1 - exp(sum(log_compression))`, with the remainder being the live-set tail.
+
+# Returns
+- A vector of \$\\omega\$ factors.
+"""
+function ωᵢ(log_compression::AbstractVector{Float64}; ω0::Float64=1.0)
+    X = ω0 .* exp.(cumsum(log_compression))
+    Xprev = [ω0; X[1:end-1]]
+    return Xprev .- X
+end
+
+"""
     partition_function(β::Float64, ωi::Vector{Float64}, Ei::Vector{Float64})
 
 Calculates the partition function for the given \$\\beta\$, \$\\omega\$ factors, and energies.

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -65,11 +65,11 @@ function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     W = min(W, (n - 3) ÷ 2)
     nodes = unique(round.(Int, range(W + 1, n - W; length = min(n_nodes, n - 2W))))
 
-    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]
+    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]; slope = Float64[]
     for idx in nodes
         _, ep, epp = _local_cubic(i, e, idx, W)        # dE/di, d²E/di²
         ep < 0 || continue                              # ladder must descend
-        push!(E, e[idx])
+        push!(E, e[idx]); push!(slope, ep)
         push!(Svol, cc * i[idx])                        # volume entropy ln G = ln X
         push!(Scal, cc * i[idx] - log(-ep))             # caloric entropy ln g (+const)
         push!(β, cc / ep - epp / ep^2)                  # β = dS/dE (caloric)
@@ -77,10 +77,10 @@ function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     length(E) >= 5 || throw(ArgumentError("too few usable nodes; check the ladder/halfwidth"))
 
     o = sortperm(E)                                     # ascending in energy
-    E, Svol, Scal, β = E[o], Svol[o], Scal[o], β[o]
+    E, Svol, Scal, β, slope = E[o], Svol[o], Scal[o], β[o], slope[o]
     γ = max_order >= 2 ? _derivative(E, β) : Float64[]
     δ = max_order >= 3 ? _derivative(E, γ) : Float64[]
-    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ)
+    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ, slope = slope)
 end
 
 """
@@ -148,4 +148,143 @@ function caloric_derivatives(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     max_order == 1 && return (E = r.E, β = r.β)
     max_order == 2 && return (E = r.E, β = r.β, γ = r.γ)
     return (E = r.E, β = r.β, γ = r.γ, δ = r.δ)
+end
+
+# median / linear-interpolated quantile without a Statistics dependency
+function _median(v::AbstractVector)
+    s = sort(v); m = length(s)
+    m == 0 && return zero(eltype(s))
+    iseven(m) ? (s[m÷2] + s[m÷2+1]) / 2 : s[m÷2+1]
+end
+function _quantile(v::AbstractVector, q::Real)
+    s = sort(collect(v)); m = length(s)
+    m == 1 && return float(s[1])
+    h = (m - 1) * q + 1
+    lo = floor(Int, h); hi = min(lo + 1, m)
+    return s[lo] + (h - lo) * (s[hi] - s[lo])
+end
+
+# Local extrema of the order-n entropy derivative `Sn` carrying the Qi–Bachmann
+# transition signature: odd order → positive local minimum, even order → negative
+# local maximum. Prominence-filtered (relative to the interior range) and merged by
+# a minimum energy separation. Returns node indices into `E`/`Sn`.
+function _order_extrema(E::Vector{Float64}, Sn::Vector{Float64}, order::Int;
+                        prominence::Float64, edge::Int, min_sep::Float64)
+    n = length(Sn)
+    lo, hi = 1 + edge, n - edge
+    lo < hi || return Int[]
+    interior = view(Sn, lo:hi)
+    rng = _quantile(interior, 0.9) - _quantile(interior, 0.1)   # robust to divergence outliers
+    rng > 0 || return Int[]
+    thr = prominence * rng
+    odd = isodd(order)
+    cands = Tuple{Int,Float64}[]
+    for i in lo:hi
+        if odd                                            # positive local minimum
+            (Sn[i] < Sn[i-1] && Sn[i] <= Sn[i+1] && Sn[i] > 0) || continue
+            l = i; while l > 1 && Sn[l-1] >= Sn[i]; l -= 1; end
+            r = i; while r < n && Sn[r+1] >= Sn[i]; r += 1; end
+            prom = min(maximum(view(Sn, l:i)), maximum(view(Sn, i:r))) - Sn[i]
+        else                                              # negative local maximum
+            (Sn[i] > Sn[i-1] && Sn[i] >= Sn[i+1] && Sn[i] < 0) || continue
+            l = i; while l > 1 && Sn[l-1] <= Sn[i]; l -= 1; end
+            r = i; while r < n && Sn[r+1] <= Sn[i]; r += 1; end
+            prom = Sn[i] - max(minimum(view(Sn, l:i)), minimum(view(Sn, i:r)))
+        end
+        prom >= thr && push!(cands, (i, prom))
+    end
+    sort!(cands, by = c -> -c[2])
+    chosen = Int[]
+    for (i, _) in cands
+        all(abs(E[i] - E[j]) > min_sep for j in chosen) && push!(chosen, i)
+    end
+    return sort(chosen)
+end
+
+"""
+    inflection_transitions(df::DataFrame, n_walkers::Int;
+        n_cull=1, max_order=2, n_nodes=400, halfwidth=0,
+        kb=8.617333262e-5, prominence=0.05, edge=4,
+        min_separation=nothing, energy_window=nothing, beta_max=nothing)
+
+Identify and classify phase transitions in a nested-sampling output `df` by
+microcanonical inflection-point analysis (Schnabel et al. 2011; Qi & Bachmann
+2018). Returns one entry per transition, ordered by energy.
+
+A transition of order `n` is a "least-sensitive" inflection point of the entropy,
+detected as an extremum of the `n`-th derivative `Sⁿ(E)` with the Qi–Bachmann sign:
+**odd order → a positive local minimum** of `Sⁿ` (order 1 = β backbending,
+first-order), **even order → a negative local maximum** of `Sⁿ` (order 2 = γ peak,
+second-order). Orders `1…max_order` are searched. The transition temperature is
+`T_tr = 1/(kb·β(E_tr))`.
+
+# Arguments
+- `max_order`: highest transition order to search (1–3).
+- `kb`: Boltzmann constant; default `8.617333262e-5` eV/K gives `T_tr` in Kelvin
+  when `:emax` is in eV. Pass `kb=1.0` for the microcanonical temperature in energy
+  units (`kT`).
+- `prominence`: peak prominence threshold as a fraction of the (robust 10–90
+  percentile) derivative range (default 0.20). Raise it to keep only strong
+  transitions.
+- `ground_trim`: fraction of the energy span (above the ground state) to discard
+  before differentiating, removing the `β → ∞` divergence as `dE/di → 0` (default
+  0.05). γ/δ are recomputed on the trimmed window so transitions are not
+  contaminated by the divergence.
+- `edge`, `min_separation`, `energy_window`, `beta_max`: numerical controls;
+  `min_separation` defaults to 3% of the (trimmed) energy span, and `beta_max`
+  optionally adds an explicit β ceiling.
+- `n_cull`, `n_nodes`, `halfwidth`: as in [`caloric_derivatives`].
+
+# Returns
+`Vector{NamedTuple}` with fields `E_tr`, `T_tr`, `order::Int`, `kind`
+(`:independent` or `:dependent`), and `strength` (the `Sⁿ` extremum value).
+`kind` uses the Qi–Bachmann heuristic: a transition accompanied by a lower-order
+transition at lower energy is `:dependent`, otherwise `:independent`.
+
+!!! note
+    γ and higher derivatives are sensitive to NS statistics. The ladder roughness
+    is finite-walker granularity (it does **not** average out over seeds), so use
+    enough walkers `K`; verify with [`transition_convergence`](@ref). Heavy
+    smoothing (large `halfwidth`) on under-converged ladders biases `T_tr`.
+"""
+function inflection_transitions(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
+        max_order::Int = 2, n_nodes::Int = 400, halfwidth::Int = 0,
+        kb::Float64 = 8.617333262e-5, prominence::Float64 = 0.20, edge::Int = 4,
+        ground_trim::Float64 = 0.05,
+        min_separation::Union{Nothing,Float64} = nothing,
+        energy_window::Union{Nothing,Tuple{<:Real,<:Real}} = nothing,
+        beta_max::Union{Nothing,Float64} = nothing)
+    1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
+    0 <= ground_trim < 0.5 || throw(ArgumentError("ground_trim must be in [0, 0.5)"))
+    r = _microcanonical_core(df, n_walkers; n_cull = n_cull, n_nodes = n_nodes,
+                             halfwidth = halfwidth, max_order = 1)
+    E, β = r.E, r.β
+    # Trim the ground-state β divergence (the ladder flattens, dE/di → 0, β → ∞)
+    # BEFORE differentiating, so γ/δ near the transitions are not contaminated.
+    Emin, Emax = extrema(E)
+    Elo = Emin + ground_trim * (Emax - Emin)
+    keep = (β .> 0) .& (E .>= Elo)
+    beta_max === nothing || (keep = keep .& (β .< beta_max))
+    if energy_window !== nothing
+        keep = keep .& (E .>= energy_window[1]) .& (E .<= energy_window[2])
+    end
+    idx = findall(keep)
+    length(idx) >= 2edge + 5 || return NamedTuple[]
+    Ew, βw = E[idx], β[idx]
+    # derivatives recomputed on the windowed β (free of the ground divergence)
+    γw = max_order >= 2 ? _derivative(Ew, βw) : Float64[]
+    δw = max_order >= 3 ? _derivative(Ew, γw) : Float64[]
+    derivs = (βw, γw, δw)
+    msep = min_separation === nothing ? 0.03 * (maximum(Ew) - minimum(Ew)) : min_separation
+    found = NamedTuple[]
+    for n in 1:max_order
+        Sn = derivs[n]
+        for i in _order_extrema(Ew, Sn, n; prominence = prominence, edge = edge, min_sep = msep)
+            push!(found, (E_tr = Ew[i], T_tr = 1 / (kb * βw[i]), order = n, strength = Sn[i]))
+        end
+    end
+    sort!(found, by = t -> t.E_tr)
+    return [(E_tr = t.E_tr, T_tr = t.T_tr, order = t.order,
+             kind = any(s.order < t.order && s.E_tr < t.E_tr for s in found) ? :dependent : :independent,
+             strength = t.strength) for t in found]
 end

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -53,23 +53,36 @@ function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
                               n_nodes::Int = 400, halfwidth::Int = 0, max_order::Int = 2)
     n_walkers > 0 || throw(ArgumentError("n_walkers must be positive"))
     1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
+    halfwidth == 0 || halfwidth >= 2 ||
+        throw(ArgumentError("halfwidth must be 0 (automatic) or ≥ 2 (a cubic fit needs ≥ 5 points)"))
     hasproperty(df, :iter) && hasproperty(df, :emax) ||
         throw(ArgumentError("df must have :iter and :emax columns (nested_sampling output)"))
     i = Float64.(df.iter)
     e = Float64.(df.emax)
     n = length(i)
-    n >= 9 || throw(ArgumentError("NS ladder too short (need ≥ 9 recorded iterations)"))
 
     cc = log(n_walkers / (n_walkers + n_cull))         # ln(K/(K+n_cull)) < 0
     W = halfwidth > 0 ? halfwidth : clamp(n ÷ 55, 25, 2000)
     W = min(W, (n - 3) ÷ 2)
+    n - 2W >= 5 || throw(ArgumentError(halfwidth > 0 ?
+        "NS ladder too short: halfwidth = $halfwidth needs ≥ $(2halfwidth + 5) recorded iterations (got $n)" :
+        "NS ladder too short: the automatic halfwidth needs ≥ 55 recorded iterations (got $n); pass an explicit halfwidth ≥ 2 to analyze shorter ladders"))
     nodes = unique(round.(Int, range(W + 1, n - W; length = min(n_nodes, n - 2W))))
 
-    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]; slope = Float64[]
-    for idx in nodes
-        _, ep, epp = _local_cubic(i, e, idx, W)        # dE/di, d²E/di²
-        ep < 0 || continue                              # ladder must descend
-        push!(E, e[idx]); push!(slope, ep)
+    # Fit every node first: the slope floor below needs the typical ladder slope.
+    fits = [(idx, _local_cubic(i, e, idx, W)) for idx in nodes]
+    descending = [-ep for (_, (_, ep, _)) in fits if ep < 0]
+    isempty(descending) &&
+        throw(ArgumentError("too few usable nodes; check the ladder/halfwidth"))
+    # Drop nodes whose slope is at rounding level relative to the typical slope: on
+    # emax plateaus (exactly degenerate lattice levels, or the default 1e-12 energy
+    # perturbation) the fitted slope is ~0 and β = cc/ep − epp/ep² would spike.
+    slope_floor = 1e-8 * _median(descending)
+
+    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]
+    for (idx, (_, ep, epp)) in fits
+        ep < -slope_floor || continue                   # ladder must genuinely descend
+        push!(E, e[idx])
         push!(Svol, cc * i[idx])                        # volume entropy ln G = ln X
         push!(Scal, cc * i[idx] - log(-ep))             # caloric entropy ln g (+const)
         push!(β, cc / ep - epp / ep^2)                  # β = dS/dE (caloric)
@@ -77,10 +90,10 @@ function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     length(E) >= 5 || throw(ArgumentError("too few usable nodes; check the ladder/halfwidth"))
 
     o = sortperm(E)                                     # ascending in energy
-    E, Svol, Scal, β, slope = E[o], Svol[o], Scal[o], β[o], slope[o]
+    E, Svol, Scal, β = E[o], Svol[o], Scal[o], β[o]
     γ = max_order >= 2 ? _derivative(E, β) : Float64[]
     δ = max_order >= 3 ? _derivative(E, γ) : Float64[]
-    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ, slope = slope)
+    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ)
 end
 
 """
@@ -103,7 +116,9 @@ uniform `i`-axis.
 - `n_cull`: NS culls per iteration (default 1).
 - `n_nodes`: number of smoothed output nodes (default 400).
 - `halfwidth`: half-window (in iterations) of the local cubic smoother; `0` (default)
-  picks `clamp(n÷55, 25, 2000)`.
+  picks `clamp(n÷55, 25, 2000)`, which requires a ladder of ≥ 55 recorded
+  iterations. Explicit values must be ≥ 2; pass a small one to analyze shorter
+  ladders.
 
 # Returns
 `(E, S)` — energies (ascending, same units as `:emax`) and entropy (dimensionless,
@@ -138,7 +153,11 @@ and then differentiated against energy with local cubic fits.
 A `NamedTuple` with `E` (ascending energies, same units as `:emax`) and `β` (units
 of inverse energy), plus `γ` and `δ` as requested by `max_order`. Note `γ`, `δ` are
 sensitive to NS statistics — increase the walker count `K` (not the number of seeds)
-for cleaner higher derivatives; see [`transition_convergence`](@ref).
+for cleaner higher derivatives; see [`transition_convergence`](@ref). They are also
+computed over the *full* energy range, including the near-ground region where the
+ladder flattens and the `β` estimate diverges — [`inflection_transitions`](@ref)
+trims that region (`ground_trim`) before differentiating; do the same before
+interpreting low-energy `γ`/`δ` features.
 """
 function caloric_derivatives(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
                              max_order::Int = 2, n_nodes::Int = 400, halfwidth::Int = 0)
@@ -150,7 +169,7 @@ function caloric_derivatives(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
     return (E = r.E, β = r.β, γ = r.γ, δ = r.δ)
 end
 
-# median / linear-interpolated quantile without a Statistics dependency
+# median / linear-interpolated (type-7) quantile helpers
 function _median(v::AbstractVector)
     s = sort(v); m = length(s)
     m == 0 && return zero(eltype(s))
@@ -164,58 +183,79 @@ function _quantile(v::AbstractVector, q::Real)
     return s[lo] + (h - lo) * (s[hi] - s[lo])
 end
 
-# Local extrema of the order-n entropy derivative `Sn` carrying the Qi–Bachmann
-# transition signature: odd order → positive local minimum, even order → negative
-# local maximum. Prominence-filtered (relative to the interior range) and merged by
-# a minimum energy separation. Returns node indices into `E`/`Sn`.
+# Local extrema of the order-n entropy derivative `Sn` carrying a Qi–Bachmann
+# transition signature. Independent transitions: odd order → positive local
+# minimum, even order → negative local maximum. Dependent transitions carry the
+# swapped signatures (Qi & Bachmann 2018): odd order → negative local maximum,
+# even order → positive local minimum. Prominence-filtered against the robust
+# range of the linearly detrended interior (so the threshold tracks the size of
+# the transition features, not the global cooling trend of β over however much
+# ladder is analyzed) and merged by a minimum energy separation. Returns
+# (node index, kind) pairs sorted by index.
 function _order_extrema(E::Vector{Float64}, Sn::Vector{Float64}, order::Int;
-                        prominence::Float64, edge::Int, min_sep::Float64)
+                        prominence::Float64, edge::Int, min_sep::Float64,
+                        prominence_abs::Union{Nothing,Float64} = nothing)
     n = length(Sn)
     lo, hi = 1 + edge, n - edge
-    lo < hi || return Int[]
-    interior = view(Sn, lo:hi)
-    rng = _quantile(interior, 0.9) - _quantile(interior, 0.1)   # robust to divergence outliers
-    rng > 0 || return Int[]
-    thr = prominence * rng
+    lo < hi || return Tuple{Int,Symbol}[]
+    thr = if prominence_abs === nothing
+        xs, ys = view(E, lo:hi), view(Sn, lo:hi)
+        mx = sum(xs) / length(xs); my = sum(ys) / length(ys)
+        sxx = sum(abs2, xs .- mx)
+        b = sxx > 0 ? sum((xs .- mx) .* (ys .- my)) / sxx : 0.0
+        resid = ys .- my .- b .* (xs .- mx)
+        rng = _quantile(resid, 0.9) - _quantile(resid, 0.1)     # robust to divergence outliers
+        rng > 0 || return Tuple{Int,Symbol}[]
+        prominence * rng
+    else
+        prominence_abs
+    end
     odd = isodd(order)
-    cands = Tuple{Int,Float64}[]
+    cands = Tuple{Int,Float64,Symbol}[]
     for i in lo:hi
-        if odd                                            # positive local minimum
-            (Sn[i] < Sn[i-1] && Sn[i] <= Sn[i+1] && Sn[i] > 0) || continue
+        if Sn[i] < Sn[i-1] && Sn[i] <= Sn[i+1] && Sn[i] > 0        # positive local minimum
             l = i; while l > 1 && Sn[l-1] >= Sn[i]; l -= 1; end
             r = i; while r < n && Sn[r+1] >= Sn[i]; r += 1; end
             prom = min(maximum(view(Sn, l:i)), maximum(view(Sn, i:r))) - Sn[i]
-        else                                              # negative local maximum
-            (Sn[i] > Sn[i-1] && Sn[i] >= Sn[i+1] && Sn[i] < 0) || continue
+            kind = odd ? :independent : :dependent
+        elseif Sn[i] > Sn[i-1] && Sn[i] >= Sn[i+1] && Sn[i] < 0    # negative local maximum
             l = i; while l > 1 && Sn[l-1] <= Sn[i]; l -= 1; end
             r = i; while r < n && Sn[r+1] <= Sn[i]; r += 1; end
             prom = Sn[i] - max(minimum(view(Sn, l:i)), minimum(view(Sn, i:r)))
+            kind = odd ? :dependent : :independent
+        else
+            continue
         end
-        prom >= thr && push!(cands, (i, prom))
+        prom >= thr && push!(cands, (i, prom, kind))
     end
     sort!(cands, by = c -> -c[2])
-    chosen = Int[]
-    for (i, _) in cands
-        all(abs(E[i] - E[j]) > min_sep for j in chosen) && push!(chosen, i)
+    chosen = Tuple{Int,Symbol}[]
+    for (i, _, kind) in cands
+        all(abs(E[i] - E[j]) > min_sep for (j, _) in chosen) && push!(chosen, (i, kind))
     end
-    return sort(chosen)
+    return sort!(chosen, by = first)
 end
 
 """
     inflection_transitions(df::DataFrame, n_walkers::Int;
         n_cull=1, max_order=2, n_nodes=400, halfwidth=0,
-        kb=8.617333262e-5, prominence=0.05, edge=4,
-        min_separation=nothing, energy_window=nothing, beta_max=nothing)
+        kb=8.617333262e-5, prominence=0.20, prominence_abs=nothing, edge=4,
+        ground_trim=0.05, min_separation=nothing, energy_window=nothing,
+        beta_max=nothing)
 
 Identify and classify phase transitions in a nested-sampling output `df` by
 microcanonical inflection-point analysis (Schnabel et al. 2011; Qi & Bachmann
 2018). Returns one entry per transition, ordered by energy.
 
 A transition of order `n` is a "least-sensitive" inflection point of the entropy,
-detected as an extremum of the `n`-th derivative `Sⁿ(E)` with the Qi–Bachmann sign:
-**odd order → a positive local minimum** of `Sⁿ` (order 1 = β backbending,
-first-order), **even order → a negative local maximum** of `Sⁿ` (order 2 = γ peak,
-second-order). Orders `1…max_order` are searched. The transition temperature is
+detected as an extremum of the `n`-th derivative `Sⁿ(E)` with a Qi–Bachmann sign
+signature. **Independent** transitions: odd order → a positive local minimum of
+`Sⁿ` (order 1 = β backbending, first-order), even order → a negative local
+maximum (order 2 = γ peak, second-order). **Dependent** transitions carry the
+swapped signatures (odd order → negative local maximum, even order → positive
+local minimum) and are reported only when accompanied by an independent
+transition of lower order at lower energy — Qi & Bachmann's necessary condition.
+Orders `1…max_order` are searched. The transition temperature is
 `T_tr = 1/(kb·β(E_tr))`.
 
 # Arguments
@@ -223,39 +263,51 @@ second-order). Orders `1…max_order` are searched. The transition temperature i
 - `kb`: Boltzmann constant; default `8.617333262e-5` eV/K gives `T_tr` in Kelvin
   when `:emax` is in eV. Pass `kb=1.0` for the microcanonical temperature in energy
   units (`kT`).
-- `prominence`: peak prominence threshold as a fraction of the (robust 10–90
-  percentile) derivative range (default 0.20). Raise it to keep only strong
-  transitions.
+- `prominence`: peak prominence threshold as a fraction of the robust (10–90
+  percentile) range of the **linearly detrended** derivative over the analysis
+  window (default 0.20). Detrending ties the threshold to the size of the
+  transition features rather than to how much ladder is analyzed. Raise it to
+  keep only strong transitions.
+- `prominence_abs`: absolute prominence threshold in the units of `Sⁿ`; when set,
+  it replaces the relative `prominence` criterion (default `nothing`).
 - `ground_trim`: fraction of the energy span (above the ground state) to discard
   before differentiating, removing the `β → ∞` divergence as `dE/di → 0` (default
   0.05). γ/δ are recomputed on the trimmed window so transitions are not
   contaminated by the divergence.
 - `edge`, `min_separation`, `energy_window`, `beta_max`: numerical controls;
-  `min_separation` defaults to 3% of the (trimmed) energy span, and `beta_max`
-  optionally adds an explicit β ceiling.
+  `edge ≥ 1` nodes are skipped at each window boundary, `min_separation` defaults
+  to 3% of the (trimmed) energy span, and `beta_max` optionally adds an explicit
+  β ceiling. Nodes removed by `beta_max` (or the `β > 0` filter) can split the
+  window into disjoint energy segments; derivatives and extrema are then computed
+  per contiguous segment, never across a gap.
 - `n_cull`, `n_nodes`, `halfwidth`: as in [`caloric_derivatives`](@ref).
 
 # Returns
 `Vector{NamedTuple}` with fields `E_tr`, `T_tr`, `order::Int`, `kind`
-(`:independent` or `:dependent`), and `strength` (the `Sⁿ` extremum value).
-`kind` uses the Qi–Bachmann heuristic: a transition accompanied by a lower-order
-transition at lower energy is `:dependent`, otherwise `:independent`.
+(`:independent` or `:dependent`, assigned from the sign signatures above), and
+`strength` (the `Sⁿ` extremum value).
 
 !!! note
     γ and higher derivatives are sensitive to NS statistics. The ladder roughness
     is finite-walker granularity (it does **not** average out over seeds), so use
     enough walkers `K`; verify with [`transition_convergence`](@ref). Heavy
     smoothing (large `halfwidth`) on under-converged ladders biases `T_tr`.
+    On lattice ladders with exactly (or near-exactly) degenerate levels, plateau
+    stretches of `emax` are dropped by an internal slope floor before `β` is
+    formed; a plateau longer than the smoothing window leaves a gap in the
+    analyzed energy range.
 """
 function inflection_transitions(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
         max_order::Int = 2, n_nodes::Int = 400, halfwidth::Int = 0,
-        kb::Float64 = 8.617333262e-5, prominence::Float64 = 0.20, edge::Int = 4,
+        kb::Float64 = 8.617333262e-5, prominence::Float64 = 0.20,
+        prominence_abs::Union{Nothing,Float64} = nothing, edge::Int = 4,
         ground_trim::Float64 = 0.05,
         min_separation::Union{Nothing,Float64} = nothing,
         energy_window::Union{Nothing,Tuple{<:Real,<:Real}} = nothing,
         beta_max::Union{Nothing,Float64} = nothing)
     1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
     0 <= ground_trim < 0.5 || throw(ArgumentError("ground_trim must be in [0, 0.5)"))
+    edge >= 1 || throw(ArgumentError("edge must be ≥ 1"))
     r = _microcanonical_core(df, n_walkers; n_cull = n_cull, n_nodes = n_nodes,
                              halfwidth = halfwidth, max_order = 1)
     E, β = r.E, r.β
@@ -269,24 +321,42 @@ function inflection_transitions(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
         keep = keep .& (E .>= energy_window[1]) .& (E .<= energy_window[2])
     end
     idx = findall(keep)
-    length(idx) >= 2edge + 5 || return NamedTuple[]
-    Ew, βw = E[idx], β[idx]
-    # derivatives recomputed on the windowed β (free of the ground divergence)
-    γw = max_order >= 2 ? _derivative(Ew, βw) : Float64[]
-    δw = max_order >= 3 ? _derivative(Ew, γw) : Float64[]
-    derivs = (βw, γw, δw)
-    msep = min_separation === nothing ? 0.03 * (maximum(Ew) - minimum(Ew)) : min_separation
+    isempty(idx) && return NamedTuple[]
+    msep = min_separation === nothing ? 0.03 * (E[idx[end]] - E[idx[1]]) : min_separation
+    # The β-based filters can excise interior nodes (e.g. beta_max cutting the top
+    # of a backbend); differentiate and search each contiguous segment separately
+    # so no local fit ever spans a gap.
+    runs = UnitRange{Int}[]
+    s = 1
+    for k in 2:length(idx)
+        idx[k] == idx[k-1] + 1 || (push!(runs, s:(k - 1)); s = k)
+    end
+    push!(runs, s:length(idx))
     found = NamedTuple[]
-    for n in 1:max_order
-        Sn = derivs[n]
-        for i in _order_extrema(Ew, Sn, n; prominence = prominence, edge = edge, min_sep = msep)
-            push!(found, (E_tr = Ew[i], T_tr = 1 / (kb * βw[i]), order = n, strength = Sn[i]))
+    for run in runs
+        length(run) >= 2edge + 5 || continue
+        Ew, βw = E[idx[run]], β[idx[run]]
+        # derivatives recomputed on the windowed β (free of the ground divergence)
+        γw = max_order >= 2 ? _derivative(Ew, βw) : Float64[]
+        δw = max_order >= 3 ? _derivative(Ew, γw) : Float64[]
+        derivs = (βw, γw, δw)
+        for n in 1:max_order
+            Sn = derivs[n]
+            for (i, kind) in _order_extrema(Ew, Sn, n; prominence = prominence,
+                                            edge = edge, min_sep = msep,
+                                            prominence_abs = prominence_abs)
+                push!(found, (E_tr = Ew[i], T_tr = 1 / (kb * βw[i]), order = n,
+                              kind = kind, strength = Sn[i]))
+            end
         end
     end
+    # Qi–Bachmann necessary condition: a dependent transition accompanies an
+    # independent one of lower order at lower energy; drop unaccompanied ones.
+    indep = [t for t in found if t.kind === :independent]
+    filter!(t -> t.kind === :independent ||
+                 any(s.order < t.order && s.E_tr < t.E_tr for s in indep), found)
     sort!(found, by = t -> t.E_tr)
-    return [(E_tr = t.E_tr, T_tr = t.T_tr, order = t.order,
-             kind = any(s.order < t.order && s.E_tr < t.E_tr for s in found) ? :dependent : :independent,
-             strength = t.strength) for t in found]
+    return found
 end
 
 # closest same-order transition to `t` within `match_tol` (relative in T_tr); else nothing

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -127,12 +127,12 @@ Microcanonical entropy derivatives from a nested-sampling output `df`:
 ``β(E)=dS/dE`` (inverse caloric temperature; the microcanonical temperature is
 ``k_BT=1/β``), ``γ(E)=d^2S/dE^2``, and optionally ``δ(E)=d^3S/dE^3``.
 
-Derivatives are computed in iteration-index space (see [`microcanonical_entropy`])
+Derivatives are computed in iteration-index space (see [`microcanonical_entropy`](@ref))
 and then differentiated against energy with local cubic fits.
 
 # Arguments
 - `max_order`: highest derivative to return (1 → β only; 2 → β, γ; 3 → β, γ, δ).
-- `n_cull`, `n_nodes`, `halfwidth`: as in [`microcanonical_entropy`].
+- `n_cull`, `n_nodes`, `halfwidth`: as in [`microcanonical_entropy`](@ref).
 
 # Returns
 A `NamedTuple` with `E` (ascending energies, same units as `:emax`) and `β` (units
@@ -233,7 +233,7 @@ second-order). Orders `1…max_order` are searched. The transition temperature i
 - `edge`, `min_separation`, `energy_window`, `beta_max`: numerical controls;
   `min_separation` defaults to 3% of the (trimmed) energy span, and `beta_max`
   optionally adds an explicit β ceiling.
-- `n_cull`, `n_nodes`, `halfwidth`: as in [`caloric_derivatives`].
+- `n_cull`, `n_nodes`, `halfwidth`: as in [`caloric_derivatives`](@ref).
 
 # Returns
 `Vector{NamedTuple}` with fields `E_tr`, `T_tr`, `order::Int`, `kind`
@@ -321,7 +321,7 @@ and order stop drifting as `K` increases. Near-ground transitions converge last.
   is flagged `converged` (default 0.1).
 - `match_tol`: relative `T_tr` window for matching the same transition across `K`
   (default 0.25).
-- `kwargs...`: forwarded to [`inflection_transitions`] (e.g. `max_order`, `prominence`,
+- `kwargs...`: forwarded to [`inflection_transitions`](@ref) (e.g. `max_order`, `prominence`,
   `ground_trim`, `kb`).
 
 # Returns

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -1,0 +1,151 @@
+# =============================================================================
+# Microcanonical inflection-point analysis of nested-sampling output.
+#
+# Implements the microcanonical entropy and its energetic derivatives following
+# Schnabel et al., Phys. Rev. E 84, 011127 (2011) and Qi & Bachmann, Phys. Rev.
+# Lett. 120, 180601 (2018). Transitions appear as inflection points of the
+# inverse microcanonical temperature β(E)=dS/dE; the order is read from the
+# higher derivatives (see `inflection_transitions`).
+#
+# Nested sampling gives the entropy essentially exactly along the (contiguous)
+# cull index i: the enclosed prior volume is X_i = (K/(K+1))^i, so
+# ln X_i = i·ln(K/(K+1)). With the energy ladder E(i) (E = `emax`), the caloric
+# entropy is S(E) = ln g(E) = i·ln(K/(K+1)) − ln|dE/di| (+const), and derivatives
+# are taken against the dense, uniform i-axis (local cubic fits) — far more stable
+# than differentiating a binned ln g in energy space.
+#
+# NUMERICS NOTE: γ=d²S/dE² amplifies the finite-walker "staircase" granularity of
+# the NS ladder (step ~ 1/(K·g)). That roughness shrinks with the NUMBER OF
+# WALKERS K (not with more independent runs — the ladder is reproducible across
+# seeds). Smoothing here is a light, necessary differentiation aid, NOT a
+# substitute for adequate K: heavy smoothing on under-converged ladders biases the
+# transition temperatures. Use `transition_convergence` to check K-convergence.
+# =============================================================================
+
+# Local cubic least-squares fit of `y` vs `x` over the window [idx-W, idx+W];
+# returns the value, first, and second derivative at node `idx`.
+function _local_cubic(x::AbstractVector, y::AbstractVector, idx::Int, W::Int)
+    lo = max(firstindex(x), idx - W)
+    hi = min(lastindex(x), idx + W)
+    dx = x[lo:hi] .- x[idx]
+    V = [dx[k]^p for k in eachindex(dx), p in 0:3]
+    c = V \ y[lo:hi]
+    return c[1], c[2], 2 * c[3]
+end
+
+# First derivative of `y` w.r.t. `x` at every point, via local cubic fits.
+function _derivative(x::AbstractVector, y::AbstractVector; W::Int = 12)
+    d = similar(float.(y))
+    @inbounds for j in eachindex(x)
+        lo = max(firstindex(x), j - W)
+        hi = min(lastindex(x), j + W)
+        dx = x[lo:hi] .- x[j]
+        V = [dx[k]^p for k in eachindex(dx), p in 0:3]
+        d[j] = (V \ y[lo:hi])[2]
+    end
+    return d
+end
+
+# Core: build the smoothed microcanonical curves on a set of i-space nodes.
+# Returns a NamedTuple with energies `E` (ascending) and, as requested,
+# `S_vol`, `S_caloric`, `β`, `γ`, `δ`.
+function _microcanonical_core(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
+                              n_nodes::Int = 400, halfwidth::Int = 0, max_order::Int = 2)
+    n_walkers > 0 || throw(ArgumentError("n_walkers must be positive"))
+    1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
+    hasproperty(df, :iter) && hasproperty(df, :emax) ||
+        throw(ArgumentError("df must have :iter and :emax columns (nested_sampling output)"))
+    i = Float64.(df.iter)
+    e = Float64.(df.emax)
+    n = length(i)
+    n >= 9 || throw(ArgumentError("NS ladder too short (need ≥ 9 recorded iterations)"))
+
+    cc = log(n_walkers / (n_walkers + n_cull))         # ln(K/(K+n_cull)) < 0
+    W = halfwidth > 0 ? halfwidth : clamp(n ÷ 55, 25, 2000)
+    W = min(W, (n - 3) ÷ 2)
+    nodes = unique(round.(Int, range(W + 1, n - W; length = min(n_nodes, n - 2W))))
+
+    E = Float64[]; Svol = Float64[]; Scal = Float64[]; β = Float64[]
+    for idx in nodes
+        _, ep, epp = _local_cubic(i, e, idx, W)        # dE/di, d²E/di²
+        ep < 0 || continue                              # ladder must descend
+        push!(E, e[idx])
+        push!(Svol, cc * i[idx])                        # volume entropy ln G = ln X
+        push!(Scal, cc * i[idx] - log(-ep))             # caloric entropy ln g (+const)
+        push!(β, cc / ep - epp / ep^2)                  # β = dS/dE (caloric)
+    end
+    length(E) >= 5 || throw(ArgumentError("too few usable nodes; check the ladder/halfwidth"))
+
+    o = sortperm(E)                                     # ascending in energy
+    E, Svol, Scal, β = E[o], Svol[o], Scal[o], β[o]
+    γ = max_order >= 2 ? _derivative(E, β) : Float64[]
+    δ = max_order >= 3 ? _derivative(E, γ) : Float64[]
+    return (E = E, S_vol = Svol, S_caloric = Scal, β = β, γ = γ, δ = δ)
+end
+
+"""
+    microcanonical_entropy(df::DataFrame, n_walkers::Int;
+                           n_cull=1, kind=:caloric, n_nodes=400, halfwidth=0)
+
+Estimate the microcanonical entropy ``S(E)`` from a canonical nested-sampling
+output `df` (columns `:iter`, `:emax`) produced with `n_walkers` live points.
+
+Along the contiguous cull index ``i`` the enclosed prior volume is
+``X_i=(K/(K+n_{cull}))^i``, so the volume entropy is ``S_{vol}=\\ln X_i=i\\ln(K/(K+n_{cull}))``
+and the caloric entropy is ``S(E)=\\ln g(E)=i\\ln(K/(K+n_{cull}))-\\ln|dE/di|``,
+with the ladder slope ``dE/di`` obtained from local cubic fits against the dense,
+uniform `i`-axis.
+
+# Arguments
+- `kind`: `:caloric` for ``S=\\ln g`` (matches Schnabel/Qi–Bachmann; default) or
+  `:volume` for the Hertz/Gibbs volume entropy ``S_{vol}=\\ln G`` (one fewer
+  derivative, slightly cleaner).
+- `n_cull`: NS culls per iteration (default 1).
+- `n_nodes`: number of smoothed output nodes (default 400).
+- `halfwidth`: half-window (in iterations) of the local cubic smoother; `0` (default)
+  picks `clamp(n÷55, 25, 2000)`.
+
+# Returns
+`(E, S)` — energies (ascending, same units as `:emax`) and entropy (dimensionless,
+up to an additive constant).
+
+See also [`caloric_derivatives`](@ref), [`inflection_transitions`](@ref).
+"""
+function microcanonical_entropy(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
+                                kind::Symbol = :caloric, n_nodes::Int = 400, halfwidth::Int = 0)
+    kind in (:caloric, :volume) || throw(ArgumentError("kind must be :caloric or :volume"))
+    r = _microcanonical_core(df, n_walkers; n_cull = n_cull, n_nodes = n_nodes,
+                             halfwidth = halfwidth, max_order = 1)
+    return r.E, kind === :caloric ? r.S_caloric : r.S_vol
+end
+
+"""
+    caloric_derivatives(df::DataFrame, n_walkers::Int;
+                        n_cull=1, max_order=2, n_nodes=400, halfwidth=0)
+
+Microcanonical entropy derivatives from a nested-sampling output `df`:
+``β(E)=dS/dE`` (inverse caloric temperature; the microcanonical temperature is
+``k_BT=1/β``), ``γ(E)=d^2S/dE^2``, and optionally ``δ(E)=d^3S/dE^3``.
+
+Derivatives are computed in iteration-index space (see [`microcanonical_entropy`])
+and then differentiated against energy with local cubic fits.
+
+# Arguments
+- `max_order`: highest derivative to return (1 → β only; 2 → β, γ; 3 → β, γ, δ).
+- `n_cull`, `n_nodes`, `halfwidth`: as in [`microcanonical_entropy`].
+
+# Returns
+A `NamedTuple` with `E` (ascending energies, same units as `:emax`) and `β` (units
+of inverse energy), plus `γ` and `δ` as requested by `max_order`. Note `γ`, `δ` are
+sensitive to NS statistics — increase the walker count `K` (not the number of seeds)
+for cleaner higher derivatives; see [`transition_convergence`](@ref).
+"""
+function caloric_derivatives(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
+                             max_order::Int = 2, n_nodes::Int = 400, halfwidth::Int = 0)
+    1 <= max_order <= 3 || throw(ArgumentError("max_order must be 1, 2, or 3"))
+    r = _microcanonical_core(df, n_walkers; n_cull = n_cull, n_nodes = n_nodes,
+                             halfwidth = halfwidth, max_order = max_order)
+    max_order == 1 && return (E = r.E, β = r.β)
+    max_order == 2 && return (E = r.E, β = r.β, γ = r.γ)
+    return (E = r.E, β = r.β, γ = r.γ, δ = r.δ)
+end

--- a/src/AnalysisTools/microcanonical_inflection.jl
+++ b/src/AnalysisTools/microcanonical_inflection.jl
@@ -288,3 +288,69 @@ function inflection_transitions(df::DataFrame, n_walkers::Int; n_cull::Int = 1,
              kind = any(s.order < t.order && s.E_tr < t.E_tr for s in found) ? :dependent : :independent,
              strength = t.strength) for t in found]
 end
+
+# closest same-order transition to `t` within `match_tol` (relative in T_tr); else nothing
+function _closest(transitions, t, match_tol::Float64)
+    best = nothing; bestd = Inf
+    for s in transitions
+        s.order == t.order || continue
+        d = abs(s.T_tr - t.T_tr)
+        if d <= match_tol * t.T_tr && d < bestd
+            best, bestd = s, d
+        end
+    end
+    return best
+end
+
+"""
+    transition_convergence(dfs, n_walkers; tol=0.1, match_tol=0.25, kwargs...)
+
+Assess walker-count (`K`) convergence of microcanonical inflection-point
+transitions. `dfs` is a collection of nested-sampling outputs at the walker counts
+`n_walkers` (any order; they are sorted ascending internally). `inflection_transitions`
+is run at each `K` and the results from the **largest `K`** are taken as the current
+best estimate, then traced down the `K`-ladder.
+
+This is the recommended way to use the inflection analysis: the γ (and higher)
+derivatives carry finite-`K` "staircase" granularity that does **not** average out
+over independent runs, so a transition should only be trusted once its temperature
+and order stop drifting as `K` increases. Near-ground transitions converge last.
+
+# Arguments
+- `tol`: relative `T_tr` drift between the two largest `K` below which a transition
+  is flagged `converged` (default 0.1).
+- `match_tol`: relative `T_tr` window for matching the same transition across `K`
+  (default 0.25).
+- `kwargs...`: forwarded to [`inflection_transitions`] (e.g. `max_order`, `prominence`,
+  `ground_trim`, `kb`).
+
+# Returns
+`Vector{NamedTuple}`, one per transition found at the largest `K`, with fields
+`T_tr`, `order`, `kind`, `converged::Bool`, `T_drift` (relative change from the
+second-largest `K`, `Inf` if it has no match there), `T_by_K` (the matched `T_tr`
+at each `K`, `missing` where unmatched), and `n_walkers` (the sorted `K` values).
+"""
+function transition_convergence(dfs, n_walkers; tol::Float64 = 0.1,
+                                match_tol::Float64 = 0.25, kwargs...)
+    length(dfs) == length(n_walkers) ||
+        throw(DimensionMismatch("dfs and n_walkers must have the same length"))
+    length(dfs) >= 2 ||
+        throw(ArgumentError("need at least two walker counts to assess convergence"))
+    perm = sortperm(collect(n_walkers))
+    dfv = collect(dfs)[perm]
+    Ks = collect(n_walkers)[perm]
+    per_K = [inflection_transitions(dfv[k], Ks[k]; kwargs...) for k in eachindex(dfv)]
+    ref = per_K[end]
+    out = NamedTuple[]
+    for t in ref
+        T_by_K = Union{Missing,Float64}[
+            (c = _closest(per_K[k], t, match_tol); c === nothing ? missing : c.T_tr)
+            for k in eachindex(per_K)]
+        prevc = _closest(per_K[end-1], t, match_tol)
+        drift = prevc === nothing ? Inf : abs(prevc.T_tr - t.T_tr) / t.T_tr
+        push!(out, (T_tr = t.T_tr, order = t.order, kind = t.kind,
+                    converged = drift <= tol, T_drift = drift,
+                    T_by_K = T_by_K, n_walkers = Ks))
+    end
+    return out
+end

--- a/src/EnergyEval/atomistic_pairwise.jl
+++ b/src/EnergyEval/atomistic_pairwise.jl
@@ -17,13 +17,23 @@ function inter_component_energy(at1::AbstractSystem, at2::AbstractSystem, pot::S
     pairs = [(i, j) for i in 1:length(at1), j in 1:length(at2)]
     # @show pairs # DEBUG
     energy = Array{typeof(0.0u"eV"), 1}(undef, length(pairs))
-    Threads.@threads for k in eachindex(pairs)
-        # @show i,j # DEBUG
-        (i, j) = pairs[k]
-        r = pbc_dist(position(at1, i), position(at2, j), at1)
-        energy[k] = pair_energy(r, pot)
+    # Serial path when single-threaded: @threads spawns and joins a task on
+    # every call, which dominates these small per-call loops (see ROADMAP
+    # "Threading granularity"). Results are identical either way because the
+    # iterations write disjoint slots.
+    if Threads.nthreads() == 1
+        for k in eachindex(pairs)
+            (i, j) = pairs[k]
+            r = pbc_dist(position(at1, i), position(at2, j), at1)
+            energy[k] = pair_energy(r, pot)
+        end
+    else
+        Threads.@threads for k in eachindex(pairs)
+            (i, j) = pairs[k]
+            r = pbc_dist(position(at1, i), position(at2, j), at1)
+            energy[k] = pair_energy(r, pot)
+        end
     end
-    # energy = energy*u"eV"
     return sum(energy)
 end
 
@@ -50,11 +60,18 @@ function intra_component_energy(at::AbstractSystem, pot::SingleComponentPotentia
     end
     # @info "num_pairs: $num_pairs, length(pairs): $(length(pairs))"
     energies = Vector{typeof(0.0u"eV")}(undef, length(pairs))
-    Threads.@threads for k in eachindex(pairs)
-        (i, j) = pairs[k]
-        r = pbc_dist(position(at, i), position(at, j), at)
-        energies[k] = pair_energy(r, pot)
-        # @info "interacting pair: [$(i),$(j)] $(lj_energy(r,lj))"
+    if Threads.nthreads() == 1   # see comment in inter_component_energy
+        for k in eachindex(pairs)
+            (i, j) = pairs[k]
+            r = pbc_dist(position(at, i), position(at, j), at)
+            energies[k] = pair_energy(r, pot)
+        end
+    else
+        Threads.@threads for k in eachindex(pairs)
+            (i, j) = pairs[k]
+            r = pbc_dist(position(at, i), position(at, j), at)
+            energies[k] = pair_energy(r, pot)
+        end
     end
     return sum(energies)
 end

--- a/src/EnergyEval/atomistic_single_site.jl
+++ b/src/EnergyEval/atomistic_single_site.jl
@@ -27,9 +27,20 @@ function single_site_energy(index::Int,
     all_index = collect(1:length(at))
     popat!(all_index, index)
     energies = Array{typeof(0.0u"eV"), 1}(undef, length(all_index))
-    Threads.@threads for i in eachindex(all_index)
-        r = pbc_dist(position(at, index), position(at, all_index[i]), at)
-        energies[i] = pair_energy(r,pot)
+    # Serial path when single-threaded: @threads spawns and joins a task on
+    # every call; this function runs millions of times per NS run, so the task
+    # overhead dominates the small loop (see ROADMAP "Threading granularity").
+    # Results are identical: iterations write disjoint slots.
+    if Threads.nthreads() == 1
+        for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            energies[i] = pair_energy(r,pot)
+        end
+    else
+        Threads.@threads for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            energies[i] = pair_energy(r,pot)
+        end
     end
     return sum(energies)
 end
@@ -48,15 +59,25 @@ function single_site_energy(index::Int,
     all_index = collect(1:length(at))
     popat!(all_index, index)
     energies = Array{typeof(0.0u"eV"), 1}(undef, length(all_index))
-    Threads.@threads for i in eachindex(all_index)
-        r = pbc_dist(position(at, index), position(at, all_index[i]), at)
-        if all_index[i] in comp_split[from_comp]
-            energy = pair_energy(r,cps.param_sets[from_comp,from_comp])
-            energies[i] = energy
-        else
-            to_comp = findfirst(x->all_index[i] in x, comp_split)
-            energy = pair_energy(r,cps.param_sets[from_comp,to_comp])
-            energies[i] = energy
+    if Threads.nthreads() == 1   # see comment in the single-component method
+        for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            if all_index[i] in comp_split[from_comp]
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,from_comp])
+            else
+                to_comp = findfirst(x->all_index[i] in x, comp_split)
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+            end
+        end
+    else
+        Threads.@threads for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            if all_index[i] in comp_split[from_comp]
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,from_comp])
+            else
+                to_comp = findfirst(x->all_index[i] in x, comp_split)
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+            end
         end
     end
     return sum(energies)
@@ -77,23 +98,41 @@ function single_site_energy(index::Int,
     all_index = collect(1:length(at))
     popat!(all_index, index)
     energies = Array{typeof(0.0u"eV"), 1}(undef, length(all_index))
-    Threads.@threads for i in eachindex(all_index)
-        r = pbc_dist(position(at, index), position(at, all_index[i]), at)
-        if all_index[i] in comp_split[from_comp]
-            energy = pair_energy(r,cps.param_sets[from_comp,from_comp])
-            energies[i] = energy
-        else
-            to_comp = findfirst(x->all_index[i] in x, comp_split)
-            energy = pair_energy(r,cps.param_sets[from_comp,to_comp])
-            energies[i] = energy
+    if Threads.nthreads() == 1   # see comment in the single-component method
+        for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            if all_index[i] in comp_split[from_comp]
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,from_comp])
+            else
+                to_comp = findfirst(x->all_index[i] in x, comp_split)
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+            end
+        end
+    else
+        Threads.@threads for i in eachindex(all_index)
+            r = pbc_dist(position(at, index), position(at, all_index[i]), at)
+            if all_index[i] in comp_split[from_comp]
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,from_comp])
+            else
+                to_comp = findfirst(x->all_index[i] in x, comp_split)
+                energies[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+            end
         end
     end
     internal_e = sum(energies)
     energies_surface = Array{typeof(0.0u"eV"), 1}(undef, length(surface))
-    Threads.@threads for i in eachindex(surface.position)
-        r = pbc_dist(position(at, index), position(surface, i), at)
-        to_comp = C # surface is the last component
-        energies_surface[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+    if Threads.nthreads() == 1   # see comment in the single-component method
+        for i in eachindex(surface.position)
+            r = pbc_dist(position(at, index), position(surface, i), at)
+            to_comp = C # surface is the last component
+            energies_surface[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+        end
+    else
+        Threads.@threads for i in eachindex(surface.position)
+            r = pbc_dist(position(at, index), position(surface, i), at)
+            to_comp = C # surface is the last component
+            energies_surface[i] = pair_energy(r,cps.param_sets[from_comp,to_comp])
+        end
     end
     external_e = sum(energies_surface)
     return internal_e + external_e

--- a/src/EnergyEval/lattice_energies.jl
+++ b/src/EnergyEval/lattice_energies.jl
@@ -1,4 +1,22 @@
 """
+    _check_shell_counts(lattice_neighbors, n_coupled::Int)
+
+Throw an `ArgumentError` when a Hamiltonian couples more neighbor shells
+than the lattice's neighbor list provides. Called from the energy kernels,
+so it is a single integer comparison in the common case.
+"""
+@inline function _check_shell_counts(lattice_neighbors::Vector{Vector{Vector{Int64}}}, n_coupled::Int)
+    n_shells = isempty(lattice_neighbors) ? 0 : length(lattice_neighbors[1])
+    if n_coupled > n_shells
+        throw(ArgumentError(
+            "the Hamiltonian couples $n_coupled neighbor shells but the " *
+            "lattice provides only $n_shells (= length(cutoff_radii)); " *
+            "extend cutoff_radii so every coupled shell exists"))
+    end
+    return nothing
+end
+
+"""
     lattice_interaction_energy(lattice_occupations::Vector{Bool}, lattice_neighbors::Vector{Vector{Vector{Int64}}}, h::GenericLatticeHamiltonian{N,U})
 
 Compute the interaction energy of a lattice configuration using the Hamiltonian parameters.
@@ -11,8 +29,15 @@ Compute the interaction energy of a lattice configuration using the Hamiltonian 
 # Returns
 - `e_interaction::U`: The interaction energy of the lattice configuration.
 
+Throws an `ArgumentError` when the Hamiltonian couples more neighbor shells
+than the lattice's neighbor list provides (`N > length(cutoff_radii)`),
+which would otherwise surface as a raw `BoundsError` from the innermost
+loop. The converse mismatch (fewer coupled shells than the lattice carries)
+is legal — the outer shells are simply not coupled — and is flagged once,
+with a warning, at `LatticeGasWalkers` construction.
 """
 function lattice_interaction_energy(lattice_occupations::Vector{Bool}, lattice_neighbors::Vector{Vector{Vector{Int64}}}, h::GenericLatticeHamiltonian{N,U}) where {N,U}
+    _check_shell_counts(lattice_neighbors, N)
     e_interaction::U = 0.0*unit(h.on_site_interaction)
     for index in eachindex(lattice_occupations)
         if lattice_occupations[index]
@@ -42,8 +67,11 @@ Compute the interaction energy between two lattice configurations using the Hami
 # Returns
 - `e_interaction::U`: The interaction energy between the two lattice configurations.
 
+Throws an `ArgumentError` on the same shell-count mismatch as
+[`lattice_interaction_energy`](@ref).
 """
 function inter_component_energy(lattice1::Vector{Bool}, lattice2::Vector{Bool}, lattice_neighbors::Vector{Vector{Vector{Int64}}}, h::GenericLatticeHamiltonian{N,U}) where {N,U}
+    _check_shell_counts(lattice_neighbors, N)
     e_interaction::U = 0.0*unit(h.on_site_interaction)
     for index in eachindex(lattice1)
         if lattice1[index]

--- a/src/EnergyEval/lattice_energies.jl
+++ b/src/EnergyEval/lattice_energies.jl
@@ -159,6 +159,42 @@ function interacting_energy(lattice::SLattice, h::ClusterLatticeHamiltonian{N,U}
 end
 
 """
+    site_field_energy(occupations::Vector{Bool}, field::Vector{U})
+
+Energy contribution of a per-site field: the sum of `field[i]` over every
+occupied site `i`. Iteration runs over `eachindex(occupations, field)`, so
+a field whose length differs from the occupation vector (a Hamiltonian
+built for a different lattice) raises a `DimensionMismatch` rather than
+silently summing a truncated or padded range; the liveset constructor and
+the raw-lattice sampler entry points validate the length once up front,
+with a descriptive error.
+"""
+function site_field_energy(occupations::Vector{Bool}, field::Vector{U}) where U
+    e::U = zero(U)
+    for i in eachindex(occupations, field)
+        if occupations[i]
+            e += field[i]
+        end
+    end
+    return e
+end
+
+"""
+    interacting_energy(lattice::SLattice, h::SiteFieldLatticeHamiltonian{H,U})
+
+Total energy under a site-field wrapper: the wrapped base Hamiltonian's
+energy, evaluated exactly as if the base were passed directly (including
+its `on_site_interaction × occupied-adsorption-sites` term), plus the
+occupation-masked field sum of [`site_field_energy`](@ref).
+Single-component (`SLattice`) configurations only.
+"""
+function interacting_energy(lattice::SLattice, h::SiteFieldLatticeHamiltonian{H,U}) where {H,U}
+    e_base::U = interacting_energy(lattice, h.base)
+    e_field::U = site_field_energy(lattice.components[1], h.field)
+    return e_base + e_field
+end
+
+"""
     interacting_energy(lattice::MLattice{C,G}, h::MLatticeHamiltonian{C,N,U})
 
 Compute the interaction energy of a multi-component lattice configuration using the Hamiltonian parameters.

--- a/src/EnergyEval/lattice_energies.jl
+++ b/src/EnergyEval/lattice_energies.jl
@@ -116,6 +116,49 @@ function interacting_energy(lattice::SLattice, h::MLatticeHamiltonian{C,N,U}) wh
 end
 
 """
+    cluster_energy(occupations::Vector{Bool}, c::ClusterInteraction{K,U})
+
+Energy contribution of one cluster figure: the coupling times the number of
+its embeddings whose `K` sites are all occupied. The per-figure function
+barrier keeps the inner loop type-stable across the heterogeneous cluster
+orders of a `ClusterLatticeHamiltonian`. Bounds checks stay on: an
+embedding referencing a site beyond the occupation vector must raise a
+`BoundsError` rather than read memory (the liveset constructor validates
+this once up front).
+"""
+function cluster_energy(occupations::Vector{Bool}, c::ClusterInteraction{K,U}) where {K,U}
+    n = 0
+    for emb in c.embeddings
+        occupied = true
+        for s in emb
+            if !occupations[s]
+                occupied = false
+                break
+            end
+        end
+        n += occupied ? 1 : 0
+    end
+    return n * c.coupling
+end
+
+"""
+    interacting_energy(lattice::SLattice, h::ClusterLatticeHamiltonian{N,U})
+
+Total energy under a multi-body lattice Hamiltonian: the wrapped pair
+part (on-site + `N` pair shells, evaluated exactly as for a bare
+`GenericLatticeHamiltonian`) plus every cluster figure's contribution.
+Single-component (`SLattice`) configurations only.
+"""
+function interacting_energy(lattice::SLattice, h::ClusterLatticeHamiltonian{N,U}) where {N,U}
+    e = interacting_energy(lattice, h.pair_ham)
+    occ = lattice.components[1]
+    for c in h.clusters
+        e += cluster_energy(occ, c)
+    end
+    return e
+end
+
+"""
     interacting_energy(lattice::MLattice{C,G}, h::MLatticeHamiltonian{C,N,U})
 
 Compute the interaction energy of a multi-component lattice configuration using the Hamiltonian parameters.

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -23,6 +23,7 @@ export MC_new_sample!, MC_rejection_sampling!, MC_random_swap!
 export lattice_random_walk!
 export generate_random_new_lattice_sample!
 export MC_mixed_moves!
+export MC_cluster_walk!
 export geometric_cluster_swap!
 
 export free_component_index, free_par_index

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -23,6 +23,7 @@ export MC_new_sample!, MC_rejection_sampling!, MC_random_swap!
 export lattice_random_walk!
 export generate_random_new_lattice_sample!
 export MC_mixed_moves!
+export geometric_cluster_swap!
 
 export free_component_index, free_par_index
 
@@ -33,5 +34,7 @@ include("random_walks.jl")
 include("atomistic_swaps.jl")
 
 include("mixed_moves.jl")
+
+include("cluster_moves.jl")
 
 end # module MonteCarloMoves

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -25,6 +25,9 @@ export generate_random_new_lattice_sample!
 export MC_mixed_moves!
 export MC_cluster_walk!
 export geometric_cluster_swap!
+export random_microstate!
+export lattice_insert_particle!, lattice_delete_particle!
+export MC_grand_canonical_walk!
 
 export free_component_index, free_par_index
 

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -27,6 +27,7 @@ export MC_cluster_walk!
 export geometric_cluster_swap!
 export random_microstate!
 export lattice_insert_particle!, lattice_delete_particle!
+export lattice_biased_sites
 export MC_grand_canonical_walk!
 
 export free_component_index, free_par_index

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -33,12 +33,12 @@ export free_component_index, free_par_index
 
 include("helpers.jl")
 
+include("cluster_moves.jl")
+
 include("random_walks.jl")
 
 include("atomistic_swaps.jl")
 
 include("mixed_moves.jl")
-
-include("cluster_moves.jl")
 
 end # module MonteCarloMoves

--- a/src/MonteCarloMoves/cluster_moves.jl
+++ b/src/MonteCarloMoves/cluster_moves.jl
@@ -47,7 +47,8 @@ function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64)
     seed = rand(1:n_sites)
 
     # Build cluster via BFS with fixed growth probability
-    cluster = _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, Lz, p)
+    reflect = s -> _reflect_site(s, pivot_gx, pivot_gy, Lx, Ly, Lz)
+    cluster = _build_geometric_cluster(lattice, seed, reflect, p)
 
     # Swap occupation states for each (site, reflected_site) pair
     for (a, b) in cluster
@@ -103,16 +104,17 @@ is preserved (no reflection in the non-periodic z direction).
 end
 
 """
-    _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, Lz, p) -> Vector{Tuple{Int,Int}}
+    _build_geometric_cluster(lattice, seed, reflect, p) -> Vector{Tuple{Int,Int}}
 
-Grow a geometric cluster from `seed` using BFS with fixed growth probability `p`.
+Grow a geometric cluster from `seed` using BFS with fixed growth probability `p`,
+pairing each visited site with its image under the `reflect` closure (a
+self-inverse site-index map supplied by the geometry-specific caller).
 Returns a vector of (site, reflected_site) pairs.
 """
-function _build_geometric_cluster(lattice::MLattice{C,SquareLattice},
+function _build_geometric_cluster(lattice::MLattice,
                                   seed::Int,
-                                  pivot_gx::Int, pivot_gy::Int,
-                                  Lx::Int, Ly::Int, Lz::Int,
-                                  p::Float64) where C
+                                  reflect::F,
+                                  p::Float64) where {F}
     visited = Set{Int}()
     stack = Int[seed]
     cluster = Tuple{Int,Int}[]
@@ -123,7 +125,7 @@ function _build_geometric_cluster(lattice::MLattice{C,SquareLattice},
         s in visited && continue
 
         push!(visited, s)
-        r = _reflect_site(s, pivot_gx, pivot_gy, Lx, Ly, Lz)
+        r = reflect(s)
         push!(visited, r)
         push!(cluster, (s, r))
 
@@ -136,4 +138,124 @@ function _build_geometric_cluster(lattice::MLattice{C,SquareLattice},
     end
 
     return cluster
+end
+
+# --- Triangular lattice (two-site centered-rectangular basis) ---
+
+"""
+    _tri_site_to_halfgrid(site::Int, nx::Int) -> Tuple{Int,Int}
+
+Half-grid coordinates (hx, hy) = (2·ci + b, 2·cj + b) of a site on the
+two-site-basis triangular lattice, in units of a/2 and √3·a/2, where
+b = basis index and (ci, cj) the 0-indexed cell. Under the standard site
+ordering (basis innermost, dimension 1 next), the site set is exactly
+{(hx, hy) : hx ≡ hy (mod 2)} on the (2·nx, 2·ny) torus — the
+centered-rectangular condition.
+"""
+@inline function _tri_site_to_halfgrid(site::Int, nx::Int)
+    s = site - 1
+    b = s % 2
+    cell = s ÷ 2
+    ci = cell % nx
+    cj = cell ÷ nx
+    return (2 * ci + b, 2 * cj + b)
+end
+
+"""
+    _tri_halfgrid_to_site(hx::Int, hy::Int, nx::Int) -> Int
+
+Inverse of [`_tri_site_to_halfgrid`](@ref) for in-range half-grid
+coordinates with hx ≡ hy (mod 2).
+"""
+@inline function _tri_halfgrid_to_site(hx::Int, hy::Int, nx::Int)
+    b = hx & 1
+    ci = (hx - b) >> 1
+    cj = (hy - b) >> 1
+    return b + 2 * (ci + nx * cj) + 1
+end
+
+"""
+    _tri_reflect_site(site::Int, hpx::Int, hpy::Int, nx::Int, ny::Int) -> Int
+
+Point inversion of `site` through the pivot whose doubled half-grid
+position is (hpx, hpy) = h(s₁) + h(s₂) for two pivot sites s₁, s₂, with
+periodic wrapping: σ(h) = (hpx, hpy) − h mod (2·nx, 2·ny). Both pivot
+sites satisfy hx ≡ hy (mod 2), so hpx ≡ hpy (mod 2) and σ preserves the
+parity difference — the reflected point is always a site. Site pivots
+(s₁ = s₂, hpx even) preserve each site's basis index; midpoint pivots
+with hpx odd exchange the two basis sublattices. σ is an involution:
+σ(σ(h)) = h.
+"""
+@inline function _tri_reflect_site(site::Int, hpx::Int, hpy::Int, nx::Int, ny::Int)
+    hx, hy = _tri_site_to_halfgrid(site, nx)
+    rx = mod(hpx - hx, 2 * nx)
+    ry = mod(hpy - hy, 2 * ny)
+    return _tri_halfgrid_to_site(rx, ry, nx)
+end
+
+"""
+    geometric_cluster_swap!(lattice::MLattice{C,TriangularLattice}, p::Float64) where C
+
+Geometric cluster move on the two-site-basis triangular lattice by point
+inversion through a random centrosymmetry center.
+
+The pivot is the midpoint of two random sites drawn with replacement,
+which covers exactly the two families of inversion centers of the
+triangular lattice (sites and half-lattice midpoints) and can never
+produce an invalid pivot: plaquette centers, whose doubled position is
+not a lattice vector, are unreachable by construction. The reflection
+runs in integer half-grid coordinates ((hx, hy) = (2·ci + b, 2·cj + b) on
+the (2·nx, 2·ny) torus), so no floating-point rounding or lookup table is
+involved. Cluster growth and the pair swap are shared with the square
+method via [`_build_geometric_cluster`](@ref).
+
+Detailed balance holds exactly as in the square case: the reflection is
+an involution on site indices, cluster growth is
+configuration-independent, and the swap is symmetric, so the proposal
+needs no Metropolis correction and nested sampling keeps its bare
+energy-ceiling accept test (Heringa & Blöte, Phys. Rev. E 57, 4976
+(1998)).
+
+Requires the two-site basis and a strictly two-dimensional supercell
+(`supercell_dimensions[3] == 1`); violations throw an `ArgumentError`.
+"""
+function geometric_cluster_swap!(lattice::MLattice{C,TriangularLattice}, p::Float64) where C
+    if length(lattice.basis) != 2
+        throw(ArgumentError("geometric_cluster_swap! on a triangular lattice " *
+            "requires the two-site centered-rectangular basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
+    nx, ny, nz = lattice.supercell_dimensions
+    if nz != 1
+        throw(ArgumentError("geometric_cluster_swap! on a triangular lattice " *
+            "requires a two-dimensional supercell " *
+            "(supercell_dimensions[3] == 1), got $nz layers"))
+    end
+    n_sites = num_sites(lattice)
+
+    # Pivot: midpoint of two random sites (with replacement); keep its
+    # doubled half-grid position so all arithmetic stays integer
+    h1 = _tri_site_to_halfgrid(rand(1:n_sites), nx)
+    h2 = _tri_site_to_halfgrid(rand(1:n_sites), nx)
+    hpx = h1[1] + h2[1]
+    hpy = h1[2] + h2[2]
+
+    # Choose random seed site (1-indexed)
+    seed = rand(1:n_sites)
+
+    # Build cluster via BFS with fixed growth probability
+    reflect = s -> _tri_reflect_site(s, hpx, hpy, nx, ny)
+    cluster = _build_geometric_cluster(lattice, seed, reflect, p)
+
+    # Swap occupation states for each (site, reflected_site) pair
+    for (a, b) in cluster
+        if a != b
+            for comp in 1:C
+                lattice.components[comp][a], lattice.components[comp][b] =
+                    lattice.components[comp][b], lattice.components[comp][a]
+            end
+        end
+    end
+
+    return lattice
 end

--- a/src/MonteCarloMoves/cluster_moves.jl
+++ b/src/MonteCarloMoves/cluster_moves.jl
@@ -266,3 +266,18 @@ function geometric_cluster_swap!(lattice::MLattice{C,TriangularLattice}, p::Floa
 
     return lattice
 end
+
+"""
+    geometric_cluster_swap!(lattice::MLattice{C,GenericLattice}, p::Float64)
+
+Guard method: geometric cluster moves are defined only for the square and triangular
+geometries, whose reflection maps are integer grid involutions on the site indices; a
+`GenericLattice` carries no such map, so this method always throws a descriptive
+`ArgumentError` before drawing any randomness. Use swap-only decorrelation
+(`clusters_freq = 0`) for generic geometries.
+"""
+function geometric_cluster_swap!(lattice::MLattice{C,GenericLattice}, p::Float64) where C
+    throw(ArgumentError("geometric_cluster_swap! supports square and triangular " *
+        "lattices only, got a GenericLattice configuration; use swap-only " *
+        "decorrelation (clusters_freq = 0) for generic geometries"))
+end

--- a/src/MonteCarloMoves/cluster_moves.jl
+++ b/src/MonteCarloMoves/cluster_moves.jl
@@ -1,0 +1,135 @@
+"""
+    geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64) where C
+
+Perform a geometric cluster move on a square lattice by point inversion through a random pivot.
+
+A random pivot site and seed site are chosen on the periodic lattice. A cluster of sites is
+grown from the seed via BFS, adding first-shell neighbors with fixed probability `p`
+(independent of the configuration). Each site in the cluster is paired with its reflection
+through the pivot, and the occupation states of each pair are swapped across all components.
+
+Because cluster growth does not depend on the occupancy field, the proposal is symmetric:
+P(cluster | config_A) = P(cluster | config_B). This means no Metropolis correction is needed;
+in nested sampling, one simply checks E_proposed < E_max.
+
+The parameter `p` controls the average cluster size: `p ≈ 0` gives single-site moves,
+`p → 1` gives lattice-spanning clusters.
+
+# Arguments
+- `lattice::MLattice{C,SquareLattice}`: The lattice to perform the cluster move on.
+- `p::Float64`: Growth probability for BFS cluster construction (0 < p < 1).
+
+# Returns
+- `lattice::MLattice{C,SquareLattice}`: The mutated lattice after the cluster swap.
+
+# Notes
+- Preserves per-component particle counts exactly.
+- The move is self-inverse for a fixed cluster: applying the same cluster swap twice
+  restores the original configuration.
+- Currently restricted to `SquareLattice` with a single basis atom and
+  `supercell_dimensions[3] == 1`.
+
+# References
+- Heringa & Blöte, Phys. Rev. E 57, 4976 (1998) — geometric cluster MC framework.
+- Adaptation uses fixed growth probability (configuration-independent) for symmetric proposals.
+"""
+function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64) where C
+    Lx = lattice.supercell_dimensions[1]
+    Ly = lattice.supercell_dimensions[2]
+    n_sites = num_sites(lattice)
+
+    # Choose random pivot (grid coordinates, 0-indexed)
+    pivot_gx = rand(0:Lx-1)
+    pivot_gy = rand(0:Ly-1)
+
+    # Choose random seed site (1-indexed)
+    seed = rand(1:n_sites)
+
+    # Build cluster via BFS with fixed growth probability
+    cluster = _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, p)
+
+    # Swap occupation states for each (site, reflected_site) pair
+    for (a, b) in cluster
+        if a != b
+            for comp in 1:C
+                lattice.components[comp][a], lattice.components[comp][b] =
+                    lattice.components[comp][b], lattice.components[comp][a]
+            end
+        end
+    end
+
+    return lattice
+end
+
+# --- Internal helpers (not exported) ---
+
+"""
+    _site_to_grid(site::Int, Lx::Int) -> Tuple{Int,Int}
+
+Convert a 1-indexed site index to 0-indexed grid coordinates (gx, gy)
+for a single-basis square lattice with Lx sites along x.
+"""
+@inline function _site_to_grid(site::Int, Lx::Int)
+    s = site - 1
+    gx = s % Lx
+    gy = s ÷ Lx
+    return (gx, gy)
+end
+
+"""
+    _grid_to_site(gx::Int, gy::Int, Lx::Int) -> Int
+
+Convert 0-indexed grid coordinates to a 1-indexed site index.
+"""
+@inline function _grid_to_site(gx::Int, gy::Int, Lx::Int)
+    return gy * Lx + gx + 1
+end
+
+"""
+    _reflect_site(site::Int, pivot_gx::Int, pivot_gy::Int, Lx::Int, Ly::Int) -> Int
+
+Compute the point inversion of `site` through the pivot at grid coordinates
+`(pivot_gx, pivot_gy)` with periodic wrapping on an Lx × Ly lattice.
+"""
+@inline function _reflect_site(site::Int, pivot_gx::Int, pivot_gy::Int, Lx::Int, Ly::Int)
+    gx, gy = _site_to_grid(site, Lx)
+    rx = mod(2 * pivot_gx - gx, Lx)
+    ry = mod(2 * pivot_gy - gy, Ly)
+    return _grid_to_site(rx, ry, Lx)
+end
+
+"""
+    _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, p) -> Vector{Tuple{Int,Int}}
+
+Grow a geometric cluster from `seed` using BFS with fixed growth probability `p`.
+Returns a vector of (site, reflected_site) pairs.
+"""
+function _build_geometric_cluster(lattice::MLattice{C,SquareLattice},
+                                  seed::Int,
+                                  pivot_gx::Int, pivot_gy::Int,
+                                  Lx::Int, Ly::Int,
+                                  p::Float64) where C
+    visited = Set{Int}()
+    stack = Int[seed]
+    cluster = Tuple{Int,Int}[]
+
+    while !isempty(stack)
+        s = pop!(stack)
+
+        s in visited && continue
+
+        push!(visited, s)
+        r = _reflect_site(s, pivot_gx, pivot_gy, Lx, Ly)
+        push!(visited, r)
+        push!(cluster, (s, r))
+
+        # Grow to first-shell neighbors with probability p
+        for n in lattice.neighbors[s][1]
+            if n ∉ visited && rand() < p
+                push!(stack, n)
+            end
+        end
+    end
+
+    return cluster
+end

--- a/src/MonteCarloMoves/cluster_moves.jl
+++ b/src/MonteCarloMoves/cluster_moves.jl
@@ -28,12 +28,19 @@ The parameter `p` controls the average cluster size: `p ≈ 0` gives single-site
   restores the original configuration.
 - Supports 2D (`supercell_dimensions[3] == 1`) and 3D lattices. In 3D, the reflection
   operates in the periodic xy-plane; the z-coordinate is preserved.
+- Requires the single-site basis (the site-index reflection assumes single-basis,
+  x-fastest ordering); a multi-site basis throws an `ArgumentError`.
 
 # References
 - Heringa & Blöte, Phys. Rev. E 57, 4976 (1998) — geometric cluster MC framework.
 - Adaptation uses fixed growth probability (configuration-independent) for symmetric proposals.
 """
 function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64) where C
+    if length(lattice.basis) != 1
+        throw(ArgumentError("geometric_cluster_swap! on a square lattice " *
+            "requires the single-site basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
     Lx = lattice.supercell_dimensions[1]
     Ly = lattice.supercell_dimensions[2]
     Lz = lattice.supercell_dimensions[3]

--- a/src/MonteCarloMoves/cluster_moves.jl
+++ b/src/MonteCarloMoves/cluster_moves.jl
@@ -26,8 +26,8 @@ The parameter `p` controls the average cluster size: `p ≈ 0` gives single-site
 - Preserves per-component particle counts exactly.
 - The move is self-inverse for a fixed cluster: applying the same cluster swap twice
   restores the original configuration.
-- Currently restricted to `SquareLattice` with a single basis atom and
-  `supercell_dimensions[3] == 1`.
+- Supports 2D (`supercell_dimensions[3] == 1`) and 3D lattices. In 3D, the reflection
+  operates in the periodic xy-plane; the z-coordinate is preserved.
 
 # References
 - Heringa & Blöte, Phys. Rev. E 57, 4976 (1998) — geometric cluster MC framework.
@@ -36,9 +36,10 @@ The parameter `p` controls the average cluster size: `p ≈ 0` gives single-site
 function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64) where C
     Lx = lattice.supercell_dimensions[1]
     Ly = lattice.supercell_dimensions[2]
+    Lz = lattice.supercell_dimensions[3]
     n_sites = num_sites(lattice)
 
-    # Choose random pivot (grid coordinates, 0-indexed)
+    # Choose random pivot (grid coordinates, 0-indexed) in the periodic xy-plane
     pivot_gx = rand(0:Lx-1)
     pivot_gy = rand(0:Ly-1)
 
@@ -46,7 +47,7 @@ function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64)
     seed = rand(1:n_sites)
 
     # Build cluster via BFS with fixed growth probability
-    cluster = _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, p)
+    cluster = _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, Lz, p)
 
     # Swap occupation states for each (site, reflected_site) pair
     for (a, b) in cluster
@@ -64,42 +65,45 @@ end
 # --- Internal helpers (not exported) ---
 
 """
-    _site_to_grid(site::Int, Lx::Int) -> Tuple{Int,Int}
+    _site_to_grid(site::Int, Lx::Int, Ly::Int) -> Tuple{Int,Int,Int}
 
-Convert a 1-indexed site index to 0-indexed grid coordinates (gx, gy)
-for a single-basis square lattice with Lx sites along x.
+Convert a 1-indexed site index to 0-indexed 3D grid coordinates (gx, gy, gz)
+for a single-basis square lattice. Site ordering: x varies fastest, then y, then z.
 """
-@inline function _site_to_grid(site::Int, Lx::Int)
+@inline function _site_to_grid(site::Int, Lx::Int, Ly::Int)
     s = site - 1
-    gx = s % Lx
-    gy = s ÷ Lx
-    return (gx, gy)
+    gz = s ÷ (Lx * Ly)
+    rem_xy = s % (Lx * Ly)
+    gy = rem_xy ÷ Lx
+    gx = rem_xy % Lx
+    return (gx, gy, gz)
 end
 
 """
-    _grid_to_site(gx::Int, gy::Int, Lx::Int) -> Int
+    _grid_to_site(gx::Int, gy::Int, gz::Int, Lx::Int, Ly::Int) -> Int
 
-Convert 0-indexed grid coordinates to a 1-indexed site index.
+Convert 0-indexed 3D grid coordinates to a 1-indexed site index.
 """
-@inline function _grid_to_site(gx::Int, gy::Int, Lx::Int)
-    return gy * Lx + gx + 1
+@inline function _grid_to_site(gx::Int, gy::Int, gz::Int, Lx::Int, Ly::Int)
+    return gz * Lx * Ly + gy * Lx + gx + 1
 end
 
 """
-    _reflect_site(site::Int, pivot_gx::Int, pivot_gy::Int, Lx::Int, Ly::Int) -> Int
+    _reflect_site(site::Int, pivot_gx::Int, pivot_gy::Int, Lx::Int, Ly::Int, Lz::Int) -> Int
 
 Compute the point inversion of `site` through the pivot at grid coordinates
-`(pivot_gx, pivot_gy)` with periodic wrapping on an Lx × Ly lattice.
+`(pivot_gx, pivot_gy)` with periodic wrapping in x and y. The z-coordinate
+is preserved (no reflection in the non-periodic z direction).
 """
-@inline function _reflect_site(site::Int, pivot_gx::Int, pivot_gy::Int, Lx::Int, Ly::Int)
-    gx, gy = _site_to_grid(site, Lx)
+@inline function _reflect_site(site::Int, pivot_gx::Int, pivot_gy::Int, Lx::Int, Ly::Int, Lz::Int)
+    gx, gy, gz = _site_to_grid(site, Lx, Ly)
     rx = mod(2 * pivot_gx - gx, Lx)
     ry = mod(2 * pivot_gy - gy, Ly)
-    return _grid_to_site(rx, ry, Lx)
+    return _grid_to_site(rx, ry, gz, Lx, Ly)
 end
 
 """
-    _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, p) -> Vector{Tuple{Int,Int}}
+    _build_geometric_cluster(lattice, seed, pivot_gx, pivot_gy, Lx, Ly, Lz, p) -> Vector{Tuple{Int,Int}}
 
 Grow a geometric cluster from `seed` using BFS with fixed growth probability `p`.
 Returns a vector of (site, reflected_site) pairs.
@@ -107,7 +111,7 @@ Returns a vector of (site, reflected_site) pairs.
 function _build_geometric_cluster(lattice::MLattice{C,SquareLattice},
                                   seed::Int,
                                   pivot_gx::Int, pivot_gy::Int,
-                                  Lx::Int, Ly::Int,
+                                  Lx::Int, Ly::Int, Lz::Int,
                                   p::Float64) where C
     visited = Set{Int}()
     stack = Int[seed]
@@ -119,7 +123,7 @@ function _build_geometric_cluster(lattice::MLattice{C,SquareLattice},
         s in visited && continue
 
         push!(visited, s)
-        r = _reflect_site(s, pivot_gx, pivot_gy, Lx, Ly)
+        r = _reflect_site(s, pivot_gx, pivot_gy, Lx, Ly, Lz)
         push!(visited, r)
         push!(cluster, (s, r))
 

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -622,3 +622,49 @@ function swap_occupied_sites_across_components!(lattice::MLattice{C,G},
     end
     return lattice
 end
+
+
+"""
+    MC_cluster_walk!(n_steps::Int, lattice::LatticeWalker{C}, h::ClassicalHamiltonian, emax::Float64, cluster_p::Float64; energy_perturb::Float64=0.0)
+
+Perform a sequence of geometric cluster moves on the lattice system, accepting each if `E < emax`.
+
+# Arguments
+- `n_steps::Int`: The number of cluster move attempts to perform.
+- `lattice::LatticeWalker{C}`: The walker to perform cluster moves on.
+- `h::ClassicalHamiltonian`: The lattice Hamiltonian.
+- `emax::Float64`: The maximum energy allowed for accepting a move (dimensionless).
+- `cluster_p::Float64`: The growth probability for BFS cluster construction.
+- `energy_perturb::Float64=0.0`: Energy perturbation to break degeneracies.
+
+# Returns
+- `accept_this_walker::Bool`: Whether at least one move was accepted.
+- `accept_rate::Float64`: The fraction of accepted moves.
+- `lattice::LatticeWalker`: The updated walker.
+"""
+function MC_cluster_walk!(n_steps::Int,
+                          lattice::LatticeWalker{C},
+                          h::ClassicalHamiltonian,
+                          emax::Float64,
+                          cluster_p::Float64;
+                          energy_perturb::Float64=0.0) where C
+    n_accept = 0
+    accept_this_walker = false
+    emax_u = emax * unit(lattice.energy)
+
+    for _ in 1:n_steps
+        proposed_lattice = deepcopy(lattice.configuration)
+        geometric_cluster_swap!(proposed_lattice, cluster_p)
+
+        perturbation_energy = energy_perturb * (rand() - 0.5) * unit(lattice.energy)
+        proposed_energy = interacting_energy(proposed_lattice, h) + perturbation_energy
+
+        if proposed_energy < emax_u
+            lattice.configuration = proposed_lattice
+            lattice.energy = proposed_energy
+            n_accept += 1
+            accept_this_walker = true
+        end
+    end
+    return accept_this_walker, n_accept / max(n_steps, 1), lattice
+end

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -751,7 +751,7 @@ end
                              p_move::Float64=0.5, p_insert::Float64=0.25,
                              energy_perturb::Float64=0.0, n_max::Int=typemax(Int),
                              clusters_freq::Int=0, swaps_freq::Int=1,
-                             cluster_p::Float64=0.3)
+                             cluster_p::Float64=0.3, z0::Float64=1.0)
 
 Perform grand-canonical MCMC on a single-component lattice, mixing fixed-N
 moves (local swaps and/or geometric cluster moves) with single-site insertion
@@ -763,10 +763,16 @@ Each step:
 - With probability `p_insert`: propose inserting one particle.
 - With probability `1 - p_move - p_insert`: propose deleting one particle.
 
-Insert/delete proposals use a Metropolis correction to preserve the uniform
-prior over all microstates with Ω < Ω_max:
-- Insert ratio: `(p_delete / p_insert) * (M - N) / (N + 1)`
-- Delete ratio: `(p_insert / p_delete) * N / (M - N + 1)`
+Insert/delete proposals use a Metropolis correction to preserve the ideal-lattice-gas
+prior at reference fugacity `z0` — the Bernoulli product measure giving each
+configuration with N particles weight `z0^N` — over all microstates with Ω < Ω_max:
+- Insert ratio: `z0 * (p_delete / p_insert) * (M - N) / (N + 1)`
+- Delete ratio: `(1 / z0) * (p_insert / p_delete) * N / (M - N + 1)`
+
+The default `z0 = 1.0` reduces to the uniform prior over all 2^M microstates,
+matching the Ω-sorted grand-canonical nested sampling construction. `z0 ≠ 1`
+is used by the ideal-gas-referenced (E-sorted) construction, where the walk
+runs with `mu = 0` so the Ω ceiling reduces to an energy ceiling.
 
 Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 
@@ -783,6 +789,8 @@ Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 - `clusters_freq::Int=0`: Relative weight of cluster moves within fixed-N branch (0 = disabled).
 - `swaps_freq::Int=1`: Relative weight of local swaps within fixed-N branch.
 - `cluster_p::Float64=0.3`: Current cluster growth probability.
+- `z0::Float64=1.0`: Reference fugacity of the prior preserved by insert/delete
+  (1.0 = uniform prior over microstates).
 
 # Returns
 - `accept_this_walker::Bool`: Whether at least one move was accepted.
@@ -802,9 +810,13 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   n_max::Int=typemax(Int),
                                   clusters_freq::Int=0,
                                   swaps_freq::Int=1,
-                                  cluster_p::Float64=0.3)
+                                  cluster_p::Float64=0.3,
+                                  z0::Float64=1.0)
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+    end
+    if z0 <= 0.0
+        throw(ArgumentError("z0 must be positive"))
     end
 
     n_accept = 0
@@ -869,16 +881,17 @@ function MC_grand_canonical_walk!(n_steps::Int,
             continue
         end
 
-        # Metropolis correction for insert/delete detailed balance
+        # Metropolis correction for insert/delete detailed balance under the
+        # z0^N-weighted prior (z0 = 1: uniform prior)
         # Cluster and local swap moves are symmetric — no correction needed
         accept = true
         if move_type == :insert
-            ratio = (p_delete / p_insert) * (n_sites - n) / (n + 1)
+            ratio = z0 * (p_delete / p_insert) * (n_sites - n) / (n + 1)
             if ratio < 1.0 && rand() >= ratio
                 accept = false
             end
         elseif move_type == :delete
-            ratio = (p_insert / p_delete) * n / (n_sites - n + 1)
+            ratio = (p_insert / p_delete) * n / (z0 * (n_sites - n + 1))
             if ratio < 1.0 && rand() >= ratio
                 accept = false
             end

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -749,13 +749,17 @@ end
                              h::ClassicalHamiltonian, omega_max::Float64,
                              mu::Float64;
                              p_move::Float64=0.5, p_insert::Float64=0.25,
-                             energy_perturb::Float64=0.0)
+                             energy_perturb::Float64=0.0, n_max::Int=typemax(Int),
+                             clusters_freq::Int=0, swaps_freq::Int=1,
+                             cluster_p::Float64=0.3)
 
 Perform grand-canonical MCMC on a single-component lattice, mixing fixed-N
-swap moves with single-site insertion and deletion.
+moves (local swaps and/or geometric cluster moves) with single-site insertion
+and deletion.
 
 Each step:
-- With probability `p_move`: propose a fixed-N local swap.
+- With probability `p_move`: propose a fixed-N move (local swap or cluster move,
+  selected by `swaps_freq:clusters_freq` ratio).
 - With probability `p_insert`: propose inserting one particle.
 - With probability `1 - p_move - p_insert`: propose deleting one particle.
 
@@ -763,6 +767,8 @@ Insert/delete proposals use a Metropolis correction to preserve the uniform
 prior over all microstates with Ω < Ω_max:
 - Insert ratio: `(p_delete / p_insert) * (M - N) / (N + 1)`
 - Delete ratio: `(p_insert / p_delete) * N / (M - N + 1)`
+
+Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 
 # Arguments
 - `n_steps::Int`: Number of MCMC steps.
@@ -773,11 +779,17 @@ prior over all microstates with Ω < Ω_max:
 - `p_move::Float64=0.5`: Probability of a fixed-N move.
 - `p_insert::Float64=0.25`: Probability of an insertion move.
 - `energy_perturb::Float64=0.0`: Energy perturbation for degeneracy breaking.
+- `n_max::Int=typemax(Int)`: Upper bound on particle count.
+- `clusters_freq::Int=0`: Relative weight of cluster moves within fixed-N branch (0 = disabled).
+- `swaps_freq::Int=1`: Relative weight of local swaps within fixed-N branch.
+- `cluster_p::Float64=0.3`: Current cluster growth probability.
 
 # Returns
 - `accept_this_walker::Bool`: Whether at least one move was accepted.
 - `accept_rate::Float64`: Fraction of accepted moves.
 - `lattice::LatticeWalker{1}`: The updated walker.
+- `cluster_accepted_count::Int`: Number of accepted cluster moves (for adaptive tuning).
+- `cluster_total_count::Int`: Number of attempted cluster moves (for adaptive tuning).
 """
 function MC_grand_canonical_walk!(n_steps::Int,
                                   lattice::LatticeWalker{1},
@@ -787,7 +799,10 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   p_move::Float64=0.5,
                                   p_insert::Float64=0.25,
                                   energy_perturb::Float64=0.0,
-                                  n_max::Int=typemax(Int))
+                                  n_max::Int=typemax(Int),
+                                  clusters_freq::Int=0,
+                                  swaps_freq::Int=1,
+                                  cluster_p::Float64=0.3)
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
@@ -799,15 +814,30 @@ function MC_grand_canonical_walk!(n_steps::Int,
     n_cap = min(n_sites, n_max)
     omega_max_u = omega_max * unit(lattice.energy)
 
+    # Cluster move mixing: compute probability of cluster vs local swap within fixed-N branch
+    total_fixed_n_freq = clusters_freq + swaps_freq
+    p_cluster_in_move = total_fixed_n_freq > 0 ? clusters_freq / total_fixed_n_freq : 0.0
+
+    cluster_accepted_count = 0
+    cluster_total_count = 0
+
     for _ in 1:n_steps
         r = rand()
         proposed_lattice = deepcopy(lattice.configuration)
         n = sum(proposed_lattice.components[1])
 
         if r < p_move
-            # Fixed-N local swap
-            lattice_random_walk!(proposed_lattice)
-            move_type = :move
+            # Fixed-N branch: choose cluster or local swap
+            if p_cluster_in_move > 0.0 && rand() < p_cluster_in_move
+                # Geometric cluster move
+                geometric_cluster_swap!(proposed_lattice, cluster_p)
+                move_type = :cluster
+                cluster_total_count += 1
+            else
+                # Local swap
+                lattice_random_walk!(proposed_lattice)
+                move_type = :move
+            end
         elseif r < p_move + p_insert
             # Insertion
             if n >= n_cap || p_insert <= 0.0
@@ -840,6 +870,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
         end
 
         # Metropolis correction for insert/delete detailed balance
+        # Cluster and local swap moves are symmetric — no correction needed
         accept = true
         if move_type == :insert
             ratio = (p_delete / p_insert) * (n_sites - n) / (n + 1)
@@ -858,8 +889,12 @@ function MC_grand_canonical_walk!(n_steps::Int,
             lattice.energy = proposed_energy
             n_accept += 1
             accept_this_walker = true
+            if move_type == :cluster
+                cluster_accepted_count += 1
+            end
         end
     end
 
-    return accept_this_walker, n_accept / max(n_steps, 1), lattice
+    return accept_this_walker, n_accept / max(n_steps, 1), lattice,
+           cluster_accepted_count, cluster_total_count
 end

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -745,13 +745,71 @@ function lattice_delete_particle!(lattice::SLattice)
 end
 
 """
+    lattice_biased_sites(lattice::SLattice; predicate::Symbol=:contact, shells::Int=1)
+
+Return the indices of empty sites selected by an occupancy predicate over
+neighbor shells `1:shells`:
+
+- `:contact`: empty sites with at least one occupied neighbor.
+- `:cavity`: empty sites with no occupied neighbor.
+
+For fixed `shells` the two predicates partition the empty sites:
+`length(contact set) + length(cavity set) == M - N`. Neighbor lists carrying
+periodic-image multiplicity (the same neighbor listed more than once) work
+as-is: any occupied appearance marks contact.
+
+Useful as a nested-sampling observable, e.g.
+`:n_cavity => cfg -> length(lattice_biased_sites(cfg; predicate=:cavity))`.
+
+Throws `ArgumentError` for an unknown predicate, `shells < 1`, or `shells`
+exceeding the lattice's neighbor-shell count.
+"""
+function lattice_biased_sites(lattice::SLattice; predicate::Symbol=:contact, shells::Int=1)
+    if predicate !== :contact && predicate !== :cavity
+        throw(ArgumentError("unknown predicate :$predicate; expected :contact or :cavity"))
+    end
+    if shells < 1
+        throw(ArgumentError("shells must be >= 1, got $shells"))
+    end
+    neighbors = lattice.neighbors
+    n_shells = isempty(neighbors) ? 0 : length(neighbors[1])
+    if shells > n_shells
+        throw(ArgumentError(
+            "the biased-site predicate spans $shells neighbor shells but the " *
+            "lattice provides only $n_shells (= length(cutoff_radii)); " *
+            "extend cutoff_radii so every counted shell exists"))
+    end
+    occ = lattice.components[1]
+    sites = Int[]
+    for site in eachindex(occ)
+        occ[site] && continue
+        has_occupied_neighbor = false
+        for shell in 1:shells
+            for nb in neighbors[site][shell]
+                if occ[nb]
+                    has_occupied_neighbor = true
+                    break
+                end
+            end
+            has_occupied_neighbor && break
+        end
+        if predicate === :contact ? has_occupied_neighbor : !has_occupied_neighbor
+            push!(sites, site)
+        end
+    end
+    return sites
+end
+
+"""
     MC_grand_canonical_walk!(n_steps::Int, lattice::LatticeWalker{1},
                              h::ClassicalHamiltonian, omega_max::Float64,
                              mu::Float64;
                              p_move::Float64=0.5, p_insert::Float64=0.25,
                              energy_perturb::Float64=0.0, n_max::Int=typemax(Int),
                              clusters_freq::Int=0, swaps_freq::Int=1,
-                             cluster_p::Float64=0.3, z0::Float64=1.0)
+                             cluster_p::Float64=0.3, z0::Float64=1.0,
+                             p_bias::Float64=0.0, bias_predicate::Symbol=:contact,
+                             bias_shells::Int=1)
 
 Perform grand-canonical MCMC on a single-component lattice, mixing fixed-N
 moves (local swaps and/or geometric cluster moves) with single-site insertion
@@ -791,6 +849,19 @@ Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 - `cluster_p::Float64=0.3`: Current cluster growth probability.
 - `z0::Float64=1.0`: Reference fugacity of the prior preserved by insert/delete
   (1.0 = uniform prior over microstates).
+- `p_bias::Float64=0.0`: Probability that an insertion draws its site uniformly
+  from `lattice_biased_sites(x; predicate=bias_predicate, shells=bias_shells)`
+  instead of from all empty sites. The acceptance then uses the composite
+  proposal density evaluated for the actually chosen site, and the deletion
+  acceptance uses the reverse composite density evaluated on the post-deletion
+  configuration (every set quantity on the lower-N member of the pair; the
+  delete ratio's particle count `n` is the pre-delete count), so the
+  `z0`-weighted prior stays invariant. An empty biased set makes the biased
+  sub-channel a null proposal (counted as attempted, nothing changes); a zero
+  reverse density (`p_bias = 1` with the vacated site outside the biased set)
+  is an immediate reject. `0.0` reproduces the legacy sampler bit-for-bit.
+- `bias_predicate::Symbol=:contact`: Biased-set predicate, `:contact` or `:cavity`.
+- `bias_shells::Int=1`: Neighbor shells scanned by the predicate.
 
 # Returns
 - `accept_this_walker::Bool`: Whether at least one move was accepted.
@@ -798,6 +869,11 @@ Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 - `lattice::LatticeWalker{1}`: The updated walker.
 - `cluster_accepted_count::Int`: Number of accepted cluster moves (for adaptive tuning).
 - `cluster_total_count::Int`: Number of attempted cluster moves (for adaptive tuning).
+- `move_stats::NamedTuple`: Per-move-type attempt/accept counters for the walk:
+  `swap_*`, `cluster_*` (duplicating the two preceding elements),
+  `insert_uniform_*`, `insert_biased_*`, `delete_*`. Attempts are counted at
+  proposal: ceiling rejections included, guard skips excluded, and an
+  empty-biased-set null proposal counts as an attempted biased insert.
 """
 function MC_grand_canonical_walk!(n_steps::Int,
                                   lattice::LatticeWalker{1},
@@ -811,12 +887,34 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   clusters_freq::Int=0,
                                   swaps_freq::Int=1,
                                   cluster_p::Float64=0.3,
-                                  z0::Float64=1.0)
+                                  z0::Float64=1.0,
+                                  p_bias::Float64=0.0,
+                                  bias_predicate::Symbol=:contact,
+                                  bias_shells::Int=1)
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
     if z0 <= 0.0
         throw(ArgumentError("z0 must be positive"))
+    end
+    if !(0.0 <= p_bias <= 1.0)
+        throw(ArgumentError("p_bias must satisfy 0 <= p_bias <= 1"))
+    end
+    if bias_predicate !== :contact && bias_predicate !== :cavity
+        throw(ArgumentError("unknown bias_predicate :$bias_predicate; expected :contact or :cavity"))
+    end
+    if bias_shells < 1
+        throw(ArgumentError("bias_shells must be >= 1, got $bias_shells"))
+    end
+    if p_bias > 0.0
+        nbrs = lattice.configuration.neighbors
+        n_lattice_shells = isempty(nbrs) ? 0 : length(nbrs[1])
+        if bias_shells > n_lattice_shells
+            throw(ArgumentError(
+                "the biased insertion channel spans $bias_shells neighbor shells but the " *
+                "lattice provides only $n_lattice_shells (= length(cutoff_radii)); " *
+                "extend cutoff_radii so every counted shell exists"))
+        end
     end
 
     n_accept = 0
@@ -832,6 +930,21 @@ function MC_grand_canonical_walk!(n_steps::Int,
 
     cluster_accepted_count = 0
     cluster_total_count = 0
+    swap_attempted = 0
+    swap_accepted = 0
+    insert_uniform_attempted = 0
+    insert_uniform_accepted = 0
+    insert_biased_attempted = 0
+    insert_biased_accepted = 0
+    delete_attempted = 0
+    delete_accepted = 0
+
+    # Reused inside the loop only when p_bias > 0 (the default path never
+    # computes biased sets)
+    biased_set = Int[]
+    insert_site = 0
+    insert_from_biased = false
+    deleted_site = 0
 
     for _ in 1:n_steps
         r = rand()
@@ -849,26 +962,68 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 # Local swap
                 lattice_random_walk!(proposed_lattice)
                 move_type = :move
+                swap_attempted += 1
             end
         elseif r < p_move + p_insert
             # Insertion
             if n >= n_cap || p_insert <= 0.0
-                continue
+                continue                # guard skip: not counted as an attempt
             end
-            success, proposed_lattice = lattice_insert_particle!(proposed_lattice)
-            if !success
-                continue
+            if p_bias > 0.0
+                # Composite channel. S(x) is computed ONCE per attempt and
+                # reused for both the biased draw and the composite proposal
+                # density in the acceptance below.
+                biased_set = lattice_biased_sites(proposed_lattice;
+                                                  predicate=bias_predicate,
+                                                  shells=bias_shells)
+                if rand() < p_bias
+                    insert_biased_attempted += 1
+                    if isempty(biased_set)
+                        continue        # null proposal: counted, no further draws
+                    end
+                    insert_site = rand(biased_set)
+                    insert_from_biased = true
+                else
+                    # Uniform sub-channel: the same single rand(::Vector) draw
+                    # as lattice_insert_particle!, inlined to capture the site
+                    # for the composite density (keep in lockstep with it)
+                    insert_uniform_attempted += 1
+                    empty_sites = findall(.!proposed_lattice.components[1])
+                    insert_site = rand(empty_sites)
+                    insert_from_biased = false
+                end
+                proposed_lattice.components[1][insert_site] = true
+            else
+                # p_bias == 0: legacy path, bit-identical RNG stream (no
+                # channel draw; lattice_insert_particle! draws exactly once)
+                success, proposed_lattice = lattice_insert_particle!(proposed_lattice)
+                if !success
+                    continue
+                end
+                insert_uniform_attempted += 1
+                insert_from_biased = false
             end
             move_type = :insert
         else
-            # Deletion
+            # Deletion: site selection is uniform over occupied sites in both
+            # paths; only the acceptance differs
             if n == 0 || p_delete <= 0.0
-                continue
+                continue                # guard skip: not counted as an attempt
             end
-            success, proposed_lattice = lattice_delete_particle!(proposed_lattice)
-            if !success
-                continue
+            if p_bias > 0.0
+                # Inlined uniform deletion (the same single rand(::Vector)
+                # draw as lattice_delete_particle!) to capture the vacated
+                # site for the reverse composite density (keep in lockstep)
+                occupied_sites = findall(proposed_lattice.components[1])
+                deleted_site = rand(occupied_sites)
+                proposed_lattice.components[1][deleted_site] = false
+            else
+                success, proposed_lattice = lattice_delete_particle!(proposed_lattice)
+                if !success
+                    continue
+                end
             end
+            delete_attempted += 1
             move_type = :delete
         end
 
@@ -886,14 +1041,45 @@ function MC_grand_canonical_walk!(n_steps::Int,
         # Cluster and local swap moves are symmetric — no correction needed
         accept = true
         if move_type == :insert
-            ratio = z0 * (p_delete / p_insert) * (n_sites - n) / (n + 1)
+            if p_bias > 0.0
+                # Composite forward density for the ACTUAL chosen site
+                q_fwd = p_insert * ((insert_site in biased_set ?
+                                         p_bias / length(biased_set) : 0.0) +
+                                    (1.0 - p_bias) / (n_sites - n))
+                ratio = z0 * p_delete / ((n + 1) * q_fwd)
+            else
+                # Legacy expression kept literally: bit-identical arithmetic
+                ratio = z0 * (p_delete / p_insert) * (n_sites - n) / (n + 1)
+            end
             if ratio < 1.0 && rand() >= ratio
                 accept = false
             end
         elseif move_type == :delete
-            ratio = (p_insert / p_delete) * n / (z0 * (n_sites - n + 1))
-            if ratio < 1.0 && rand() >= ratio
-                accept = false
+            if p_bias > 0.0
+                # Reverse composite density on the POST-deletion configuration
+                rev_set = lattice_biased_sites(proposed_lattice;
+                                               predicate=bias_predicate,
+                                               shells=bias_shells)
+                q_rev = p_insert * ((deleted_site in rev_set ?
+                                         p_bias / length(rev_set) : 0.0) +
+                                    (1.0 - p_bias) / (n_sites - n + 1))
+                if q_rev == 0.0
+                    # Only reachable at p_bias == 1 with the vacated site
+                    # outside S(x'): reject with no MH rand draw
+                    accept = false
+                else
+                    # n is the pre-delete particle count (docstring convention)
+                    ratio = n * q_rev / (z0 * p_delete)
+                    if ratio < 1.0 && rand() >= ratio
+                        accept = false
+                    end
+                end
+            else
+                # Legacy expression kept literally: bit-identical arithmetic
+                ratio = (p_insert / p_delete) * n / (z0 * (n_sites - n + 1))
+                if ratio < 1.0 && rand() >= ratio
+                    accept = false
+                end
             end
         end
 
@@ -904,10 +1090,27 @@ function MC_grand_canonical_walk!(n_steps::Int,
             accept_this_walker = true
             if move_type == :cluster
                 cluster_accepted_count += 1
+            elseif move_type == :move
+                swap_accepted += 1
+            elseif move_type == :insert
+                if insert_from_biased
+                    insert_biased_accepted += 1
+                else
+                    insert_uniform_accepted += 1
+                end
+            else # :delete
+                delete_accepted += 1
             end
         end
     end
 
     return accept_this_walker, n_accept / max(n_steps, 1), lattice,
-           cluster_accepted_count, cluster_total_count
+           cluster_accepted_count, cluster_total_count,
+           (swap_attempted=swap_attempted, swap_accepted=swap_accepted,
+            cluster_attempted=cluster_total_count, cluster_accepted=cluster_accepted_count,
+            insert_uniform_attempted=insert_uniform_attempted,
+            insert_uniform_accepted=insert_uniform_accepted,
+            insert_biased_attempted=insert_biased_attempted,
+            insert_biased_accepted=insert_biased_accepted,
+            delete_attempted=delete_attempted, delete_accepted=delete_accepted)
 end

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -786,7 +786,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   mu::Float64;
                                   p_move::Float64=0.5,
                                   p_insert::Float64=0.25,
-                                  energy_perturb::Float64=0.0)
+                                  energy_perturb::Float64=0.0,
+                                  n_max::Int=typemax(Int))
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
@@ -795,6 +796,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
     accept_this_walker = false
     p_delete = 1.0 - p_move - p_insert
     n_sites = num_sites(lattice.configuration)
+    n_cap = min(n_sites, n_max)
     omega_max_u = omega_max * unit(lattice.energy)
 
     for _ in 1:n_steps
@@ -808,7 +810,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
             move_type = :move
         elseif r < p_move + p_insert
             # Insertion
-            if n >= n_sites || p_insert <= 0.0
+            if n >= n_cap || p_insert <= 0.0
                 continue
             end
             success, proposed_lattice = lattice_insert_particle!(proposed_lattice)

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -668,3 +668,196 @@ function MC_cluster_walk!(n_steps::Int,
     end
     return accept_this_walker, n_accept / max(n_steps, 1), lattice
 end
+
+
+# ======================================================================
+# Grand-canonical move primitives
+# ======================================================================
+
+"""
+    random_microstate!(lattice::SLattice; p::Float64=0.5)
+
+Set each site occupied independently with probability `p`, producing a
+variable-N configuration suitable for grand-canonical sampling.
+
+# Arguments
+- `lattice::SLattice`: The single-component lattice to randomize.
+- `p::Float64=0.5`: Per-site occupation probability.
+
+# Returns
+- `lattice::SLattice`: The mutated lattice with a random microstate.
+"""
+function random_microstate!(lattice::SLattice; p::Float64=0.5)
+    for i in eachindex(lattice.components[1])
+        lattice.components[1][i] = rand() < p
+    end
+    return lattice
+end
+
+"""
+    lattice_insert_particle!(lattice::SLattice)
+
+Insert a particle at a random empty site. Returns `true` if successful,
+`false` if the lattice is full.
+
+# Arguments
+- `lattice::SLattice`: The single-component lattice.
+
+# Returns
+- `success::Bool`: Whether a particle was inserted.
+- `lattice::SLattice`: The mutated lattice.
+"""
+function lattice_insert_particle!(lattice::SLattice)
+    n_sites = num_sites(lattice)
+    n_occ = sum(lattice.components[1])
+    if n_occ >= n_sites
+        return false, lattice
+    end
+    # Collect empty site indices
+    empty_sites = findall(.!lattice.components[1])
+    site = rand(empty_sites)
+    lattice.components[1][site] = true
+    return true, lattice
+end
+
+"""
+    lattice_delete_particle!(lattice::SLattice)
+
+Delete a particle from a random occupied site. Returns `true` if successful,
+`false` if the lattice is empty.
+
+# Arguments
+- `lattice::SLattice`: The single-component lattice.
+
+# Returns
+- `success::Bool`: Whether a particle was deleted.
+- `lattice::SLattice`: The mutated lattice.
+"""
+function lattice_delete_particle!(lattice::SLattice)
+    n_occ = sum(lattice.components[1])
+    if n_occ == 0
+        return false, lattice
+    end
+    occupied_sites = findall(lattice.components[1])
+    site = rand(occupied_sites)
+    lattice.components[1][site] = false
+    return true, lattice
+end
+
+"""
+    MC_grand_canonical_walk!(n_steps::Int, lattice::LatticeWalker{1},
+                             h::ClassicalHamiltonian, omega_max::Float64,
+                             mu::Float64;
+                             p_move::Float64=0.5, p_insert::Float64=0.25,
+                             energy_perturb::Float64=0.0)
+
+Perform grand-canonical MCMC on a single-component lattice, mixing fixed-N
+swap moves with single-site insertion and deletion.
+
+Each step:
+- With probability `p_move`: propose a fixed-N local swap.
+- With probability `p_insert`: propose inserting one particle.
+- With probability `1 - p_move - p_insert`: propose deleting one particle.
+
+Insert/delete proposals use a Metropolis correction to preserve the uniform
+prior over all microstates with Ω < Ω_max:
+- Insert ratio: `(p_delete / p_insert) * (M - N) / (N + 1)`
+- Delete ratio: `(p_insert / p_delete) * N / (M - N + 1)`
+
+# Arguments
+- `n_steps::Int`: Number of MCMC steps.
+- `lattice::LatticeWalker{1}`: The walker (single component).
+- `h::ClassicalHamiltonian`: The lattice Hamiltonian.
+- `omega_max::Float64`: Upper bound on grand potential Ω = E − μN (unitless).
+- `mu::Float64`: Chemical potential (unitless, in same energy units as Hamiltonian).
+- `p_move::Float64=0.5`: Probability of a fixed-N move.
+- `p_insert::Float64=0.25`: Probability of an insertion move.
+- `energy_perturb::Float64=0.0`: Energy perturbation for degeneracy breaking.
+
+# Returns
+- `accept_this_walker::Bool`: Whether at least one move was accepted.
+- `accept_rate::Float64`: Fraction of accepted moves.
+- `lattice::LatticeWalker{1}`: The updated walker.
+"""
+function MC_grand_canonical_walk!(n_steps::Int,
+                                  lattice::LatticeWalker{1},
+                                  h::ClassicalHamiltonian,
+                                  omega_max::Float64,
+                                  mu::Float64;
+                                  p_move::Float64=0.5,
+                                  p_insert::Float64=0.25,
+                                  energy_perturb::Float64=0.0)
+    if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
+        throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+    end
+
+    n_accept = 0
+    accept_this_walker = false
+    p_delete = 1.0 - p_move - p_insert
+    n_sites = num_sites(lattice.configuration)
+    omega_max_u = omega_max * unit(lattice.energy)
+
+    for _ in 1:n_steps
+        r = rand()
+        proposed_lattice = deepcopy(lattice.configuration)
+        n = sum(proposed_lattice.components[1])
+
+        if r < p_move
+            # Fixed-N local swap
+            lattice_random_walk!(proposed_lattice)
+            move_type = :move
+        elseif r < p_move + p_insert
+            # Insertion
+            if n >= n_sites || p_insert <= 0.0
+                continue
+            end
+            success, proposed_lattice = lattice_insert_particle!(proposed_lattice)
+            if !success
+                continue
+            end
+            move_type = :insert
+        else
+            # Deletion
+            if n == 0 || p_delete <= 0.0
+                continue
+            end
+            success, proposed_lattice = lattice_delete_particle!(proposed_lattice)
+            if !success
+                continue
+            end
+            move_type = :delete
+        end
+
+        perturbation_energy = energy_perturb * (rand() - 0.5) * unit(lattice.energy)
+        proposed_energy = interacting_energy(proposed_lattice, h) + perturbation_energy
+        n_new = sum(proposed_lattice.components[1])
+        proposed_omega = proposed_energy - mu * n_new * unit(lattice.energy)
+
+        if proposed_omega >= omega_max_u
+            continue
+        end
+
+        # Metropolis correction for insert/delete detailed balance
+        accept = true
+        if move_type == :insert
+            ratio = (p_delete / p_insert) * (n_sites - n) / (n + 1)
+            if ratio < 1.0 && rand() >= ratio
+                accept = false
+            end
+        elseif move_type == :delete
+            ratio = (p_insert / p_delete) * n / (n_sites - n + 1)
+            if ratio < 1.0 && rand() >= ratio
+                accept = false
+            end
+        end
+
+        if accept
+            lattice.configuration = proposed_lattice
+            lattice.energy = proposed_energy
+            n_accept += 1
+            accept_this_walker = true
+        end
+    end
+
+    return accept_this_walker, n_accept / max(n_steps, 1), lattice
+end

--- a/src/SamplingSchemes/SamplingSchemes.jl
+++ b/src/SamplingSchemes/SamplingSchemes.jl
@@ -40,6 +40,11 @@ export MCRoutine, MCRandomWalkMaxE, MCRandomWalkClone, MCNewSample, MCRejectionS
 
 export MCRandomWalkMaxEParallel, MCRandomWalkCloneParallel, MCDistributed
 
+# grand-canonical nested sampling
+export GrandCanonicalNestedSamplingParameters
+export MCGrandCanonicalMoves
+export grand_canonical_nested_sampling
+
 # other sampling schemes
 export exact_enumeration
 export wang_landau

--- a/src/SamplingSchemes/SamplingSchemes.jl
+++ b/src/SamplingSchemes/SamplingSchemes.jl
@@ -45,6 +45,10 @@ export GrandCanonicalNestedSamplingParameters
 export MCGrandCanonicalMoves
 export grand_canonical_nested_sampling
 
+# ideal-gas-referenced grand-canonical nested sampling
+export IdealGasReferencedGCNSParameters
+export ideal_gas_referenced_nested_sampling
+
 # other sampling schemes
 export exact_enumeration
 export wang_landau

--- a/src/SamplingSchemes/helpers.jl
+++ b/src/SamplingSchemes/helpers.jl
@@ -56,3 +56,31 @@ function adjust_cluster_p(params::SamplingParameters, rate::Float64, iteration::
     push!(params.cluster_adjust_iterations, iteration)
     return params
 end
+
+"""
+    _accumulate_cluster_stats!(params::SamplingParameters, mc_routine,
+                               cl_accepted::Int, cl_total::Int, ns_iteration::Int)
+
+Accumulate cluster-move acceptance statistics from one decorrelation walk onto
+`params` and call `adjust_cluster_p` when the adjustment window is full.
+`mc_routine` supplies the static tuning configuration (`cluster_adjust_interval`,
+`target_cluster_accept`, `cluster_p_floor`, `cluster_p_ceiling`). Shared by the
+grand-canonical `nested_sampling_step!` methods.
+"""
+function _accumulate_cluster_stats!(params::SamplingParameters, mc_routine,
+                                    cl_accepted::Int, cl_total::Int, ns_iteration::Int)
+    cl_total > 0 || return params
+    params.cluster_accepted += cl_accepted
+    params.cluster_total += cl_total
+    if mc_routine.cluster_adjust_interval > 0 &&
+       params.cluster_total >= mc_routine.cluster_adjust_interval
+        window_rate = params.cluster_accepted / max(params.cluster_total, 1.0)
+        adjust_cluster_p(params, window_rate, ns_iteration;
+                         target=mc_routine.target_cluster_accept,
+                         floor=mc_routine.cluster_p_floor,
+                         ceiling=mc_routine.cluster_p_ceiling)
+        params.cluster_accepted = 0.0
+        params.cluster_total = 0.0
+    end
+    return params
+end

--- a/src/SamplingSchemes/helpers.jl
+++ b/src/SamplingSchemes/helpers.jl
@@ -84,3 +84,19 @@ function _accumulate_cluster_stats!(params::SamplingParameters, mc_routine,
     end
     return params
 end
+
+"""
+    _accumulate_move_stats!(params::SamplingParameters, stats::NamedTuple)
+
+Merge one decorrelation walk's per-move-type attempt/accept counters into
+`params.move_stats` as run totals. Unlike the window-reset cluster counters
+handled by `_accumulate_cluster_stats!`, these are never reset during a run
+(the drivers clear them once at run start). Shared by the grand-canonical
+`nested_sampling_step!` methods.
+"""
+function _accumulate_move_stats!(params::SamplingParameters, stats::NamedTuple)
+    for (key, count) in pairs(stats)
+        params.move_stats[key] = get(params.move_stats, key, 0) + count
+    end
+    return params
+end

--- a/src/SamplingSchemes/helpers.jl
+++ b/src/SamplingSchemes/helpers.jl
@@ -23,26 +23,34 @@ function adjust_step_size(params::SamplingParameters, rate::Float64; range::Tupl
 end
 
 """
-    adjust_cluster_p(params::SamplingParameters, rate::Float64; target::Float64=0.3)
+    adjust_cluster_p(params::SamplingParameters, rate::Float64, iteration::Int; target::Float64=0.3)
 
 Adjusts the cluster growth probability based on the acceptance rate.
 Uses a simple multiplicative rule: `p *= 0.9` if rate is below target,
 `p *= 1.1` if rate is at or above target, clamped to `[0.01, 1.0]`.
 
+Also logs the adjusted `cluster_p`, acceptance rate, and NS iteration index
+to `params.cluster_p_history`, `params.cluster_accept_history`, and
+`params.cluster_adjust_iterations` for post-run diagnostics.
+
 # Arguments
 - `params::SamplingParameters`: The parameters containing `cluster_p`.
 - `rate::Float64`: The cluster move acceptance rate for the current window.
+- `iteration::Int`: The current NS iteration index.
 - `target::Float64`: The target acceptance rate (default 0.3).
 
 # Returns
 - `params::SamplingParameters`: The updated parameters with adjusted cluster_p.
 """
-function adjust_cluster_p(params::SamplingParameters, rate::Float64; target::Float64=0.3)
+function adjust_cluster_p(params::SamplingParameters, rate::Float64, iteration::Int; target::Float64=0.3)
     if rate < target
         params.cluster_p *= 0.9
     else
         params.cluster_p *= 1.1
     end
     params.cluster_p = clamp(params.cluster_p, 0.01, 1.0)
+    push!(params.cluster_p_history, params.cluster_p)
+    push!(params.cluster_accept_history, rate)
+    push!(params.cluster_adjust_iterations, iteration)
     return params
 end

--- a/src/SamplingSchemes/helpers.jl
+++ b/src/SamplingSchemes/helpers.jl
@@ -21,3 +21,28 @@ function adjust_step_size(params::SamplingParameters, rate::Float64; range::Tupl
     end
     return params
 end
+
+"""
+    adjust_cluster_p(params::SamplingParameters, rate::Float64; target::Float64=0.3)
+
+Adjusts the cluster growth probability based on the acceptance rate.
+Uses a simple multiplicative rule: `p *= 0.9` if rate is below target,
+`p *= 1.1` if rate is at or above target, clamped to `[0.01, 1.0]`.
+
+# Arguments
+- `params::SamplingParameters`: The parameters containing `cluster_p`.
+- `rate::Float64`: The cluster move acceptance rate for the current window.
+- `target::Float64`: The target acceptance rate (default 0.3).
+
+# Returns
+- `params::SamplingParameters`: The updated parameters with adjusted cluster_p.
+"""
+function adjust_cluster_p(params::SamplingParameters, rate::Float64; target::Float64=0.3)
+    if rate < target
+        params.cluster_p *= 0.9
+    else
+        params.cluster_p *= 1.1
+    end
+    params.cluster_p = clamp(params.cluster_p, 0.01, 1.0)
+    return params
+end

--- a/src/SamplingSchemes/helpers.jl
+++ b/src/SamplingSchemes/helpers.jl
@@ -23,11 +23,11 @@ function adjust_step_size(params::SamplingParameters, rate::Float64; range::Tupl
 end
 
 """
-    adjust_cluster_p(params::SamplingParameters, rate::Float64, iteration::Int; target::Float64=0.3)
+    adjust_cluster_p(params::SamplingParameters, rate::Float64, iteration::Int; target::Float64=0.3, floor::Float64=0.01, ceiling::Float64=1.0)
 
 Adjusts the cluster growth probability based on the acceptance rate.
 Uses a simple multiplicative rule: `p *= 0.9` if rate is below target,
-`p *= 1.1` if rate is at or above target, clamped to `[0.01, 1.0]`.
+`p *= 1.1` if rate is at or above target, clamped to `[floor, ceiling]`.
 
 Also logs the adjusted `cluster_p`, acceptance rate, and NS iteration index
 to `params.cluster_p_history`, `params.cluster_accept_history`, and
@@ -38,17 +38,19 @@ to `params.cluster_p_history`, `params.cluster_accept_history`, and
 - `rate::Float64`: The cluster move acceptance rate for the current window.
 - `iteration::Int`: The current NS iteration index.
 - `target::Float64`: The target acceptance rate (default 0.3).
+- `floor::Float64`: Lower bound for cluster_p (default 0.01).
+- `ceiling::Float64`: Upper bound for cluster_p (default 1.0).
 
 # Returns
 - `params::SamplingParameters`: The updated parameters with adjusted cluster_p.
 """
-function adjust_cluster_p(params::SamplingParameters, rate::Float64, iteration::Int; target::Float64=0.3)
+function adjust_cluster_p(params::SamplingParameters, rate::Float64, iteration::Int; target::Float64=0.3, floor::Float64=0.01, ceiling::Float64=1.0)
     if rate < target
         params.cluster_p *= 0.9
     else
         params.cluster_p *= 1.1
     end
-    params.cluster_p = clamp(params.cluster_p, 0.01, 1.0)
+    params.cluster_p = clamp(params.cluster_p, floor, ceiling)
     push!(params.cluster_p_history, params.cluster_p)
     push!(params.cluster_accept_history, rate)
     push!(params.cluster_adjust_iterations, iteration)

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1089,9 +1089,11 @@ Perform a nested sampling loop for a given number of steps.
   `name`, exactly paired with that row's `iter`-keyed prior-volume weight.
   Names must not collide with the built-in ledger columns
   (`$(join(String.(_RESERVED_LEDGER_COLUMNS), ", "))`); callbacks must be
-  pure functions of the configuration returning a `Real`. Supported for
-  single-cull MC routines — a pairing guard raises an error otherwise.
-  The default `nothing` leaves the ledger schema unchanged.
+  pure functions of the configuration returning a `Real`. Parallel and
+  multi-cull MC routines (`MCRoutineParallel` subtypes) are rejected up
+  front with an `ArgumentError`; a bit-exact pairing guard additionally
+  raises an error if a step ever culls a different walker than the one the
+  row records. The default `nothing` leaves the ledger schema unchanged.
 
 # Returns
 - `df`: A DataFrame containing the iteration number and maximum energy for each step,
@@ -1116,6 +1118,10 @@ function nested_sampling(liveset::AbstractLiveSet,
     end
     df = DataFrame(iter=Int[], emax=Float64[])
     if observables !== nothing
+        mc_routine isa MCRoutineParallel && throw(ArgumentError(
+            "observables: parallel/multi-cull MC routines are not supported " *
+            "— each accepted iteration culls multiple walkers but records a " *
+            "single ledger row, so per-dead-point pairing is undefined"))
         _validate_observables(observables, liveset)
         for (name, _) in observables
             df[!, name] = Float64[]

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -4,7 +4,7 @@
 The `NestedSamplingParameters` struct represents the parameters used in the nested sampling scheme.
 
 # Fields
-- `mc_steps::Int64`: The number of total Monte Carlo moves to perform. For a parallel MC routine, this number will be distributed among workers. 
+- `mc_steps::Int64`: The number of total Monte Carlo moves to perform. For a parallel MC routine, this number will be distributed among workers.
 If `mc_steps` is not divisible by the number of workers, the actual number of MC moves per worker will be `ceil(mc_steps / nworkers())`.
 - `initial_step_size::Float64`: The initial step size, which is the fallback step size if MC routine fails to accept a move.
 - `step_size::Float64`: The on-the-fly step size used in the sampling process.
@@ -16,6 +16,9 @@ e.g. (0.25, 0.75) means that the step size will decrease if the acceptance rate 
 - `allowed_fail_count::Int64`: The maximum number of failed MC moves allowed before resetting the step size.
 - `energy_perturbation::Float64`: The perturbation value used to adjust the energy of the walkers.
 - `random_seed::Int64`: The seed for the random number generator.
+- `cluster_p::Float64`: Current cluster growth probability for geometric cluster moves (mutable runtime state).
+- `cluster_accepted::Float64`: Accepted cluster moves in the current adjustment window.
+- `cluster_total::Float64`: Total cluster moves attempted in the current adjustment window.
 """
 mutable struct NestedSamplingParameters <: SamplingParameters
     mc_steps::Int64
@@ -28,6 +31,9 @@ mutable struct NestedSamplingParameters <: SamplingParameters
     allowed_fail_count::Int64
     energy_perturbation::Float64
     random_seed::Int64
+    cluster_p::Float64
+    cluster_accepted::Float64
+    cluster_total::Float64
 end
 
 function NestedSamplingParameters(;
@@ -41,8 +47,11 @@ function NestedSamplingParameters(;
             allowed_fail_count::Int64=100,
             energy_perturbation::Float64=1e-12,
             random_seed::Int64=1234,
+            cluster_p::Float64=0.3,
+            cluster_accepted::Float64=0.0,
+            cluster_total::Float64=0.0,
             )
-    NestedSamplingParameters(mc_steps, initial_step_size, step_size, step_size_lo, step_size_up, accept_range, fail_count, allowed_fail_count, energy_perturbation, random_seed)  
+    NestedSamplingParameters(mc_steps, initial_step_size, step_size, step_size_lo, step_size_up, accept_range, fail_count, allowed_fail_count, energy_perturbation, random_seed, cluster_p, cluster_accepted, cluster_total)
 end
 
 """
@@ -52,6 +61,7 @@ end
             fail_count::Int64=0,
             allowed_fail_count::Int64=10,
             random_seed::Int64=1234,
+            cluster_p::Float64=0.3,
             )
 A convenience constructor for `NestedSamplingParameters` with default values suitable for lattice systems.
 """
@@ -61,8 +71,9 @@ function LatticeNestedSamplingParameters(;
             fail_count::Int64=0,
             allowed_fail_count::Int64=10,
             random_seed::Int64=1234,
+            cluster_p::Float64=0.3,
             )
-    NestedSamplingParameters(mc_steps=mc_steps, fail_count=fail_count, allowed_fail_count=allowed_fail_count, energy_perturbation=energy_perturbation, random_seed=random_seed)
+    NestedSamplingParameters(mc_steps=mc_steps, fail_count=fail_count, allowed_fail_count=allowed_fail_count, energy_perturbation=energy_perturbation, random_seed=random_seed, cluster_p=cluster_p)
 end
 
 
@@ -165,19 +176,45 @@ A type for generating a new walker from a random configuration. Currently, it is
 """
 struct MCNewSample <: MCRoutine end
 
-""" 
+"""
     struct MCMixedMoves <: MCRoutine
-A type for generating a new walker by performing random walks and swapping atoms. Currently, it is intended to use this routine for
-multi-component systems. The actual number of random walks and swaps to perform is determined by the weights of the fields `walks_freq` and `swaps_freq`.
-For example, if `walks_freq=4` and `swaps_freq=1`, then the probability of performing a random walk is 4/5, and the probability of performing a swap is 1/5.
+A type for generating a new walker by performing a mix of random walks, atom swaps, and/or geometric cluster moves.
+For atomistic systems, the `walks_freq` and `swaps_freq` fields control the ratio of random walks to atom swaps.
+For lattice systems, `walks_freq` and `clusters_freq` control the ratio of local swap moves to geometric cluster moves.
 
 # Fields
-- `walks_freq::Int`: The frequency of random walks to perform.
-- `swaps_freq::Int`: The frequency of atom swaps to perform.
+- `walks_freq::Int`: The frequency of random walks (atomistic) or local swaps (lattice) to perform.
+- `swaps_freq::Int`: The frequency of atom swaps to perform (atomistic only).
+- `clusters_freq::Int`: The frequency of geometric cluster moves to perform (lattice only, default 0).
+- `initial_cluster_p::Float64`: Starting growth probability for cluster moves (default 0.3).
+- `target_cluster_accept::Float64`: Target acceptance rate for adaptive cluster p tuning (default 0.3).
+- `cluster_adjust_interval::Int`: Number of NS iterations between cluster p adjustments (default 50).
 """
 mutable struct MCMixedMoves <: MCRoutine
     walks_freq::Int
     swaps_freq::Int
+    clusters_freq::Int
+    initial_cluster_p::Float64
+    target_cluster_accept::Float64
+    cluster_adjust_interval::Int
+end
+
+# Backward-compatible constructor: MCMixedMoves(5, 1)
+function MCMixedMoves(walks_freq::Int, swaps_freq::Int)
+    MCMixedMoves(walks_freq, swaps_freq, 0, 0.3, 0.3, 50)
+end
+
+# Keyword constructor for lattice use
+function MCMixedMoves(;
+    walks_freq::Int=1,
+    swaps_freq::Int=0,
+    clusters_freq::Int=1,
+    initial_cluster_p::Float64=0.3,
+    target_cluster_accept::Float64=0.3,
+    cluster_adjust_interval::Int=50,
+)
+    MCMixedMoves(walks_freq, swaps_freq, clusters_freq,
+                 initial_cluster_p, target_cluster_accept, cluster_adjust_interval)
 end
 
 """
@@ -617,11 +654,95 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
 end
 
 """
+    nested_sampling_step!(liveset::LatticeGasWalkers, ns_params::NestedSamplingParameters, mc_routine::MCMixedMoves)
+
+Perform a single step of the nested sampling algorithm using a mix of geometric cluster moves and local swap moves.
+
+The total `mc_steps` from `ns_params` are split between cluster moves and local swaps according to `clusters_freq` and
+`walks_freq` in the `mc_routine`. Cluster moves use `geometric_cluster_swap!` with growth probability `ns_params.cluster_p`,
+which is adaptively tuned to maintain `mc_routine.target_cluster_accept`. Local swaps use the standard `lattice_random_walk!`.
+
+## Arguments
+- `liveset::LatticeGasWalkers`: The liveset of lattice gas walkers.
+- `ns_params::NestedSamplingParameters`: The parameters for nested sampling.
+- `mc_routine::MCMixedMoves`: The mixed moves routine with cluster and local swap frequencies.
+
+## Returns
+- `iter`: The iteration number of the liveset after the step.
+- `emax`: The maximum energy of the liveset after the step.
+- `liveset::LatticeGasWalkers`: The updated liveset.
+- `ns_params::NestedSamplingParameters`: The updated parameters.
+"""
+function nested_sampling_step!(liveset::LatticeGasWalkers,
+                               ns_params::NestedSamplingParameters,
+                               mc_routine::MCMixedMoves)
+    sort_by_energy!(liveset)
+    ats = liveset.walkers
+    h = liveset.hamiltonian
+    iter::Union{Missing,Int} = missing
+    emax::Union{Missing,Float64} = liveset.walkers[1].energy.val
+
+    # Clone a random non-worst walker
+    to_walk = deepcopy(rand(ats[2:end]))
+
+    # Compute move counts from frequencies
+    total_freq = mc_routine.walks_freq + mc_routine.clusters_freq
+    n_local = round(Int, ns_params.mc_steps * mc_routine.walks_freq / max(total_freq, 1))
+    n_cluster = ns_params.mc_steps - n_local
+
+    # Apply cluster moves
+    cluster_accepted = false
+    cluster_rate = 0.0
+    if n_cluster > 0
+        cluster_accepted, cluster_rate, to_walk = MC_cluster_walk!(
+            n_cluster, to_walk, h, emax, ns_params.cluster_p;
+            energy_perturb=ns_params.energy_perturbation)
+    end
+
+    # Apply local swap moves
+    local_accepted = false
+    local_rate = 0.0
+    if n_local > 0
+        local_accepted, local_rate, to_walk = MC_random_walk!(
+            n_local, to_walk, h, emax;
+            energy_perturb=ns_params.energy_perturbation)
+    end
+
+    accept = cluster_accepted || local_accepted
+    if accept
+        push!(ats, to_walk)
+        popfirst!(ats)
+        update_iter!(liveset)
+        ns_params.fail_count = 0
+        iter = liveset.walkers[1].iter
+    else
+        emax = missing
+        ns_params.fail_count += 1
+    end
+
+    # Accumulate cluster acceptance stats for adaptive tuning
+    if n_cluster > 0
+        ns_params.cluster_accepted += cluster_rate * n_cluster
+        ns_params.cluster_total += n_cluster
+        if mc_routine.cluster_adjust_interval > 0 &&
+           ns_params.cluster_total >= mc_routine.cluster_adjust_interval * n_cluster
+            window_rate = ns_params.cluster_accepted / max(ns_params.cluster_total, 1.0)
+            adjust_cluster_p(ns_params, window_rate;
+                             target=mc_routine.target_cluster_accept)
+            ns_params.cluster_accepted = 0.0
+            ns_params.cluster_total = 0.0
+        end
+    end
+
+    return iter, emax * unit(liveset.walkers[1].energy), liveset, ns_params
+end
+
+"""
     nested_sampling_step!(liveset::LatticeGasWalkers, ns_params::LatticeNestedSamplingParameters, mc_routine::MCRoutine)
 
 Perform a single step of the nested sampling algorithm.
 
-This function takes a `liveset` of lattice gas walkers, `ns_params` containing the parameters for nested sampling, and `mc_routine` representing the Monte Carlo 
+This function takes a `liveset` of lattice gas walkers, `ns_params` containing the parameters for nested sampling, and `mc_routine` representing the Monte Carlo
 routine for generating new samples. It performs a single step of the nested sampling algorithm by updating the liveset with a new walker.
 
 ## Arguments
@@ -633,8 +754,8 @@ routine for generating new samples. It performs a single step of the nested samp
 - `iter`: The iteration number of the liveset after the step.
 - `emax`: The maximum energy of the liveset after the step.
 """
-function nested_sampling_step!(liveset::LatticeGasWalkers, 
-                               ns_params::NestedSamplingParameters, 
+function nested_sampling_step!(liveset::LatticeGasWalkers,
+                               ns_params::NestedSamplingParameters,
                                mc_routine::MCRoutine)
     sort_by_energy!(liveset)
     ats = liveset.walkers
@@ -766,6 +887,12 @@ function nested_sampling(liveset::AbstractLiveSet,
                                 n_steps::Int64, 
                                 mc_routine::MCRoutine,
                                 save_strategy::DataSavingStrategy)
+    # Initialize cluster_p and reset counters from MCMixedMoves if applicable
+    if mc_routine isa MCMixedMoves && mc_routine.clusters_freq > 0
+        ns_params.cluster_p = mc_routine.initial_cluster_p
+        ns_params.cluster_accepted = 0.0
+        ns_params.cluster_total = 0.0
+    end
     df = DataFrame(iter=Int[], emax=Float64[])
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1326,7 +1326,15 @@ truncate the prior support and bias Ξ.
   Required to be nonzero on lattices (degenerate levels stall the strict `<`
   ceiling and bias the evidence — enforced by the keyword constructor); must
   remain ≪ k_B·T at the lowest temperature targeted in post-processing, since
-  perturbed energies are recorded.
+  perturbed energies are recorded. It must also stay *above* the float
+  resolution of the largest energies on the ladder — keep
+  `energy_perturbation / eps(E_max)` above ~`K²` so the `K` walkers draw
+  distinct tie-breaking values on a degenerate plateau. The default `1e-12`
+  satisfies that only for `E_max` up to `O(1) eV`; finite-J hard-core ladders
+  reach `E_max = J·M·c/2`, so use `1e-9` there (safe through
+  `E_max ≈ 10³ eV`, i.e. a few hundred sites at `J = 1 eV`) and scale it
+  proportionally beyond — see the hard-core recipe in the
+  `GenericLatticeHamiltonian` docstring.
 - `random_seed::Int64`: Kept for parity with `GrandCanonicalNestedSamplingParameters`;
   **not currently consumed** by the NS loop — call `Random.seed!` before
   `ideal_gas_referenced_nested_sampling` for reproducible runs.

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -277,11 +277,23 @@ particle insertion and deletion.
 - `cluster_adjust_interval::Int`: Number of NS iterations between cluster p adjustments (default 50).
 - `cluster_p_floor::Float64`: Lower bound for adaptive cluster p (default 0.01).
 - `cluster_p_ceiling::Float64`: Upper bound for adaptive cluster p (default 1.0).
+- `p_bias::Float64`: Probability an insertion draws from the biased site set
+  (default 0.0 = legacy uniform insertions).
+- `bias_predicate::Symbol`: Biased-set predicate, `:contact` or `:cavity`
+  (default `:contact`).
+- `bias_shells::Int`: Neighbor shells scanned by the predicate (default 1).
 
 When `clusters_freq == 0` (the default), the fixed-N branch uses only local swaps
 (`lattice_random_walk!`), preserving backward compatibility with existing scripts.
 When `clusters_freq > 0`, the fixed-N branch mixes geometric cluster moves with
 local swaps according to the `clusters_freq:swaps_freq` ratio.
+
+With `p_bias > 0` insertions mix a sub-channel restricted to
+`lattice_biased_sites(x; predicate=bias_predicate, shells=bias_shells)` into
+the uniform proposal; the walk's composite Metropolis-Hastings correction
+keeps the sampled prior unchanged. `p_bias = 1.0` constructs but warns: the
+pure biased channel freezes N whenever the biased set is empty, so the
+uniform sub-channel is what repairs ergodicity.
 """
 struct MCGrandCanonicalMoves <: MCRoutine
     p_move::Float64
@@ -293,6 +305,9 @@ struct MCGrandCanonicalMoves <: MCRoutine
     cluster_adjust_interval::Int
     cluster_p_floor::Float64
     cluster_p_ceiling::Float64
+    p_bias::Float64
+    bias_predicate::Symbol
+    bias_shells::Int
     function MCGrandCanonicalMoves(;
             p_move::Float64=0.5,
             p_insert::Float64=0.25,
@@ -302,13 +317,32 @@ struct MCGrandCanonicalMoves <: MCRoutine
             target_cluster_accept::Float64=0.3,
             cluster_adjust_interval::Int=50,
             cluster_p_floor::Float64=0.01,
-            cluster_p_ceiling::Float64=1.0)
+            cluster_p_ceiling::Float64=1.0,
+            p_bias::Float64=0.0,
+            bias_predicate::Symbol=:contact,
+            bias_shells::Int=1)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
         end
+        if !(0.0 <= p_bias <= 1.0)
+            throw(ArgumentError("p_bias must satisfy 0 <= p_bias <= 1"))
+        end
+        if bias_predicate !== :contact && bias_predicate !== :cavity
+            throw(ArgumentError("unknown bias_predicate :$bias_predicate; expected :contact or :cavity"))
+        end
+        if bias_shells < 1
+            throw(ArgumentError("bias_shells must be >= 1, got $bias_shells"))
+        end
+        if p_bias == 1.0
+            @warn "p_bias = 1.0: the pure biased insertion channel freezes N whenever " *
+                  "the biased set is empty (every insertion becomes a null proposal and " *
+                  "the matching deletions auto-reject); keep p_bias < 1 so the uniform " *
+                  "sub-channel repairs ergodicity."
+        end
         new(p_move, p_insert, clusters_freq, swaps_freq,
             initial_cluster_p, target_cluster_accept, cluster_adjust_interval,
-            cluster_p_floor, cluster_p_ceiling)
+            cluster_p_floor, cluster_p_ceiling,
+            p_bias, bias_predicate, bias_shells)
     end
 end
 
@@ -336,6 +370,9 @@ for thermodynamic reweighting.
 - `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p after each adjustment.
 - `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adjustment.
 - `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adjustment.
+- `move_stats::Dict{Symbol,Int}`: Run-total per-move-type attempt/accept counters
+  accumulated from every decorrelation walk (keys match the walk's `move_stats`
+  NamedTuple; cleared once at run start, never window-reset).
 """
 mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     mc_steps::Int64
@@ -352,6 +389,7 @@ mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     cluster_p_history::Vector{Float64}
     cluster_accept_history::Vector{Float64}
     cluster_adjust_iterations::Vector{Int}
+    move_stats::Dict{Symbol,Int}
 end
 
 """
@@ -361,7 +399,7 @@ end
         init_occupation_p=0.5, n_max=typemax(Int64),
         cluster_p=0.3, cluster_accepted=0.0, cluster_total=0.0,
         cluster_p_history=Float64[], cluster_accept_history=Float64[],
-        cluster_adjust_iterations=Int[])
+        cluster_adjust_iterations=Int[], move_stats=Dict{Symbol,Int}())
 
 Convenience constructor for `GrandCanonicalNestedSamplingParameters`.
 
@@ -371,6 +409,10 @@ Insertions are rejected when N ≥ n_max. Default is `typemax(Int64)` (no cap).
 The `cluster_*` fields are mutable runtime state for adaptive cluster move tuning.
 They are initialized from the static configuration on `MCGrandCanonicalMoves` at
 the start of `grand_canonical_nested_sampling` when `clusters_freq > 0`.
+
+`move_stats` holds run-total per-move-type attempt/accept counters accumulated
+from every decorrelation walk (keys match the walk's `move_stats` NamedTuple;
+never window-reset, cleared once at the start of each run).
 """
 function GrandCanonicalNestedSamplingParameters(;
     mc_steps::Int64=100,
@@ -387,6 +429,7 @@ function GrandCanonicalNestedSamplingParameters(;
     cluster_p_history::Vector{Float64}=Float64[],
     cluster_accept_history::Vector{Float64}=Float64[],
     cluster_adjust_iterations::Vector{Int}=Int[],
+    move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
 )
     GrandCanonicalNestedSamplingParameters(
         mc_steps, chemical_potential, energy_perturbation,
@@ -394,6 +437,7 @@ function GrandCanonicalNestedSamplingParameters(;
         init_occupation_p, n_max,
         cluster_p, cluster_accepted, cluster_total,
         cluster_p_history, cluster_accept_history, cluster_adjust_iterations,
+        move_stats,
     )
 end
 
@@ -1271,14 +1315,17 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     to_walk = deepcopy(ats[parent_idx])
 
     # Decorrelate via GC MCMC
-    accept, rate, to_walk, cl_accepted, cl_total = MC_grand_canonical_walk!(
+    accept, rate, to_walk, cl_accepted, cl_total, move_stats = MC_grand_canonical_walk!(
         gc_params.mc_steps, to_walk, h, omega_max_val, mu;
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         energy_perturb=gc_params.energy_perturbation,
         n_max=gc_params.n_max,
         clusters_freq=mc_routine.clusters_freq,
         swaps_freq=mc_routine.swaps_freq,
-        cluster_p=gc_params.cluster_p)
+        cluster_p=gc_params.cluster_p,
+        p_bias=mc_routine.p_bias,
+        bias_predicate=mc_routine.bias_predicate,
+        bias_shells=mc_routine.bias_shells)
 
     if accept
         push!(ats, to_walk)
@@ -1295,6 +1342,7 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
 
     # Accumulate cluster acceptance stats and adapt cluster_p
     _accumulate_cluster_stats!(gc_params, mc_routine, cl_accepted, cl_total, ns_iteration)
+    _accumulate_move_stats!(gc_params, move_stats)
 
     return iter, omega_worst, energy_worst, n_worst, liveset, gc_params
 end
@@ -1345,6 +1393,9 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
         empty!(gc_params.cluster_accept_history)
         empty!(gc_params.cluster_adjust_iterations)
     end
+    # Run-total per-move-type counters: always reset, independent of the
+    # cluster-move configuration above
+    empty!(gc_params.move_stats)
 
     df = DataFrame(iter=Int[], omega=Float64[], energy=Float64[], num_particles=Int[])
     if observables !== nothing
@@ -1462,6 +1513,9 @@ truncate the prior support and bias Ξ.
 - `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p after each adjustment.
 - `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adjustment.
 - `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adjustment.
+- `move_stats::Dict{Symbol,Int}`: Run-total per-move-type attempt/accept counters
+  accumulated from every decorrelation walk (keys match the walk's `move_stats`
+  NamedTuple; cleared once at run start, never window-reset).
 """
 mutable struct IdealGasReferencedGCNSParameters <: SamplingParameters
     mc_steps::Int64
@@ -1476,6 +1530,7 @@ mutable struct IdealGasReferencedGCNSParameters <: SamplingParameters
     cluster_p_history::Vector{Float64}
     cluster_accept_history::Vector{Float64}
     cluster_adjust_iterations::Vector{Int}
+    move_stats::Dict{Symbol,Int}
 end
 
 """
@@ -1484,7 +1539,7 @@ end
         random_seed=1234, fail_count=0, allowed_fail_count=10,
         cluster_p=0.3, cluster_accepted=0.0, cluster_total=0.0,
         cluster_p_history=Float64[], cluster_accept_history=Float64[],
-        cluster_adjust_iterations=Int[])
+        cluster_adjust_iterations=Int[], move_stats=Dict{Symbol,Int}())
 
 Convenience constructor for `IdealGasReferencedGCNSParameters`.
 
@@ -1496,6 +1551,10 @@ degrades as `|βμ − ln z0|` grows (roughly beyond `1/√Var(N)`).
 The `cluster_*` fields are mutable runtime state for adaptive cluster move
 tuning, initialized from the static configuration on `MCGrandCanonicalMoves`
 at the start of `ideal_gas_referenced_nested_sampling` when `clusters_freq > 0`.
+
+`move_stats` holds run-total per-move-type attempt/accept counters accumulated
+from every decorrelation walk (keys match the walk's `move_stats` NamedTuple;
+never window-reset, cleared once at the start of each run).
 """
 function IdealGasReferencedGCNSParameters(;
     mc_steps::Int64=100,
@@ -1510,6 +1569,7 @@ function IdealGasReferencedGCNSParameters(;
     cluster_p_history::Vector{Float64}=Float64[],
     cluster_accept_history::Vector{Float64}=Float64[],
     cluster_adjust_iterations::Vector{Int}=Int[],
+    move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
 )
     if reference_fugacity <= 0.0
         throw(ArgumentError("reference_fugacity must be positive"))
@@ -1523,6 +1583,7 @@ function IdealGasReferencedGCNSParameters(;
         random_seed, fail_count, allowed_fail_count,
         cluster_p, cluster_accepted, cluster_total,
         cluster_p_history, cluster_accept_history, cluster_adjust_iterations,
+        move_stats,
     )
 end
 
@@ -1597,14 +1658,17 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     # Decorrelate via GC MCMC: with mu = 0 the Ω ceiling reduces to an energy
     # ceiling, and z0 weights the insert/delete acceptance to preserve the
     # Bernoulli(z0/(1+z0)) prior
-    accept, rate, to_walk, cl_accepted, cl_total = MC_grand_canonical_walk!(
+    accept, rate, to_walk, cl_accepted, cl_total, move_stats = MC_grand_canonical_walk!(
         params.mc_steps, to_walk, h, emax_val, 0.0;
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         energy_perturb=params.energy_perturbation,
         z0=params.reference_fugacity,
         clusters_freq=mc_routine.clusters_freq,
         swaps_freq=mc_routine.swaps_freq,
-        cluster_p=params.cluster_p)
+        cluster_p=params.cluster_p,
+        p_bias=mc_routine.p_bias,
+        bias_predicate=mc_routine.bias_predicate,
+        bias_shells=mc_routine.bias_shells)
 
     if accept
         push!(ats, to_walk)
@@ -1620,6 +1684,7 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
 
     # Accumulate cluster acceptance stats and adapt cluster_p
     _accumulate_cluster_stats!(params, mc_routine, cl_accepted, cl_total, ns_iteration)
+    _accumulate_move_stats!(params, move_stats)
 
     return iter, emax_worst, n_worst, liveset, params
 end
@@ -1679,6 +1744,9 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
         empty!(params.cluster_accept_history)
         empty!(params.cluster_adjust_iterations)
     end
+    # Run-total per-move-type counters: always reset, independent of the
+    # cluster-move configuration above
+    empty!(params.move_stats)
 
     df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
     if observables !== nothing

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1138,6 +1138,23 @@ Perform a nested sampling loop for a given number of steps.
   front with an `ArgumentError`; a bit-exact pairing guard additionally
   raises an error if a step ever culls a different walker than the one the
   row records. The default `nothing` leaves the ledger schema unchanged.
+- `dead_point_callback`: Optional function called once per recorded dead
+  point as `dead_point_callback(iter, walker)`, immediately after the
+  ledger row is pushed, with the same culled walker the row describes
+  (protected by the same bit-exact pairing guard as `observables`, which is
+  engaged whenever either keyword is supplied). Iterations that record no
+  dead point invoke no callback, so the invocation count equals `nrow(df)`.
+  The walker is the loop's live object: treat it as read-only and copy
+  anything kept, e.g. `copy(walker.configuration.components[1])` or
+  `deepcopy(walker.configuration)`. Composes freely with `observables`; the
+  surviving live set needs no callback because the loop returns it.
+  Parallel and multi-cull MC routines are rejected up front. Typical uses:
+  collecting occupation vectors for batch post-processing, and re-evaluating
+  each dead point under a second Hamiltonian, whose energies substitute for
+  the ledger energy column in the grand-canonical stats functions (the
+  prior-volume weights depend only on the iteration index, so the
+  substituted column is a valid estimator over the same ladder). The
+  default `nothing` changes nothing.
 
 # Returns
 - `df`: A DataFrame containing the iteration number and maximum energy for each step,
@@ -1150,7 +1167,8 @@ function nested_sampling(liveset::AbstractLiveSet,
                                 n_steps::Int64,
                                 mc_routine::MCRoutine,
                                 save_strategy::DataSavingStrategy;
-                                observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
+                                observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
+                                dead_point_callback::Union{Nothing,Function}=nothing)
     # Initialize cluster_p and reset counters from MCMixedMoves if applicable
     if mc_routine isa MCMixedMoves && mc_routine.clusters_freq > 0
         ns_params.cluster_p = mc_routine.initial_cluster_p
@@ -1171,11 +1189,18 @@ function nested_sampling(liveset::AbstractLiveSet,
             df[!, name] = Float64[]
         end
     end
+    if dead_point_callback !== nothing
+        mc_routine isa MCRoutineParallel && throw(ArgumentError(
+            "dead_point_callback: parallel/multi-cull MC routines are not " *
+            "supported — each accepted iteration culls multiple walkers but " *
+            "invokes a single callback, so per-dead-point pairing is " *
+            "undefined"))
+    end
     culled = nothing
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
-        if observables !== nothing
+        if observables !== nothing || dead_point_callback !== nothing
             # Pre-sort with the step's own comparator and hold the walker the
             # step will cull: the step re-sorts (stable sort, so the identity
             # permutation here) and culls walkers[1] on accept. `popfirst!`
@@ -1192,17 +1217,21 @@ function nested_sampling(liveset::AbstractLiveSet,
             ns_params.step_size = ns_params.initial_step_size
         end
         if !(iter isa typeof(missing))
-            if observables === nothing
-                push!(df, (iter, emax.val))
-            else
+            if culled !== nothing
                 emax == culled.energy || error(
                     "NS observable recording: dead-point/observable pairing " *
                     "lost (step culled a walker with energy $emax, but the " *
                     "pre-sorted worst walker had $(culled.energy)); this MC " *
-                    "routine is not supported with `observables`")
+                    "routine is not supported with `observables`/" *
+                    "`dead_point_callback`")
+            end
+            if observables === nothing
+                push!(df, (iter, emax.val))
+            else
                 push!(df, (iter, emax.val,
                            (Float64(f(culled.configuration)) for (_, f) in observables)...))
             end
+            dead_point_callback === nothing || dead_point_callback(iter, culled)
         end
         print_message(i, iter, emax, ns_params.step_size, print_info, liveset)
         write_df_every_n(df, i, save_strategy)
@@ -1368,6 +1397,9 @@ highest-Ω walker, record (Ω, E, N), replace with a decorrelated clone.
 - `observables`: Optional vector of `name::Symbol => callback` pairs
   recording per-dead-point observables as extra ledger columns; see
   [`nested_sampling`](@ref).
+- `dead_point_callback`: Optional per-dead-point callback
+  `(iter, walker) -> ...` invoked with the culled walker immediately after
+  its ledger row is pushed; see [`nested_sampling`](@ref) for the contract.
 
 # Returns
 - `df::DataFrame`: Columns `[:iter, :omega, :energy, :num_particles]`,
@@ -1380,7 +1412,8 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
                                          n_steps::Int64,
                                          mc_routine::MCGrandCanonicalMoves,
                                          save_strategy::DataSavingStrategy;
-                                         observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
+                                         observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
+                                         dead_point_callback::Union{Nothing,Function}=nothing)
     # Initialize walkers with random microstates
     _init_gc_walkers!(liveset, gc_params)
 
@@ -1410,7 +1443,7 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
 
-        if observables !== nothing
+        if observables !== nothing || dead_point_callback !== nothing
             # Pre-sort with the step's own comparator (Ω = E − μN, descending)
             # and hold the walker the step will cull; see `nested_sampling`.
             sort!(liveset.walkers,
@@ -1430,17 +1463,20 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
         end
 
         if !(iter isa typeof(missing))
-            if observables === nothing
-                push!(df, (iter, omega.val, energy.val, n_par))
-            else
+            if culled !== nothing
                 omega == _grand_potential(culled, gc_params.chemical_potential) || error(
                     "GC-NS observable recording: dead-point/observable " *
                     "pairing lost (step culled a walker with Ω = $omega, but " *
                     "the pre-sorted worst walker had Ω = " *
                     "$(_grand_potential(culled, gc_params.chemical_potential)))")
+            end
+            if observables === nothing
+                push!(df, (iter, omega.val, energy.val, n_par))
+            else
                 push!(df, (iter, omega.val, energy.val, n_par,
                            (Float64(f(culled.configuration)) for (_, f) in observables)...))
             end
+            dead_point_callback === nothing || dead_point_callback(iter, culled)
         end
 
         if print_info && !(iter isa typeof(missing))
@@ -1719,6 +1755,15 @@ extract them from the returned liveset.
   extra ledger columns; see [`nested_sampling`](@ref). The recorded columns
   feed the `observable_cols` machinery of
   `gc_thermodynamic_stats_ideal_ref`.
+- `dead_point_callback`: Optional per-dead-point callback
+  `(iter, walker) -> ...` invoked with the culled walker immediately after
+  its ledger row is pushed; see [`nested_sampling`](@ref) for the contract.
+  Configurations collected here support post-run re-evaluation under a
+  second Hamiltonian, whose energies substitute for the `emax` column (and
+  the live tail) in `gc_thermodynamic_stats_ideal_ref`: the prior-volume
+  weights depend only on the iteration index, so the substituted column is
+  a valid estimator of the second Hamiltonian's grand potential over the
+  same ladder, with the returned Kish N_eff as its fidelity diagnostic.
 
 # Returns
 - `df::DataFrame`: Columns `[:iter, :emax, :num_particles]`,
@@ -1731,7 +1776,8 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
                                               n_steps::Int64,
                                               mc_routine::MCGrandCanonicalMoves,
                                               save_strategy::DataSavingStrategy;
-                                              observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
+                                              observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
+                                              dead_point_callback::Union{Nothing,Function}=nothing)
     # Initialize walkers as i.i.d. draws from the Bernoulli(z0/(1+z0)) prior
     _init_ideal_gas_ref_walkers!(liveset, params)
 
@@ -1761,7 +1807,7 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
 
-        if observables !== nothing
+        if observables !== nothing || dead_point_callback !== nothing
             # Pre-sort with the step's own comparator (energy, descending)
             # and hold the walker the step will cull; see `nested_sampling`.
             sort_by_energy!(liveset)
@@ -1779,16 +1825,19 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
         end
 
         if !(iter isa typeof(missing))
-            if observables === nothing
-                push!(df, (iter, emax.val, n_par))
-            else
+            if culled !== nothing
                 emax == culled.energy || error(
                     "IG-ref GC-NS observable recording: dead-point/observable " *
                     "pairing lost (step culled a walker with energy $emax, " *
                     "but the pre-sorted worst walker had $(culled.energy))")
+            end
+            if observables === nothing
+                push!(df, (iter, emax.val, n_par))
+            else
                 push!(df, (iter, emax.val, n_par,
                            (Float64(f(culled.configuration)) for (_, f) in observables)...))
             end
+            dead_point_callback === nothing || dead_point_callback(iter, culled)
         end
 
         if print_info && !(iter isa typeof(missing))

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -673,7 +673,7 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
         emax = missing
         ns_params.fail_count += 1
     end
-    adjust_step_size(ns_params, rate)
+    adjust_step_size(ns_params, rate; range=ns_params.accept_range)
     return iter, emax, liveset, ns_params, log_t
 end
 
@@ -750,7 +750,7 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
     ns_params.fail_count = 0
     iter = liveset.walkers[1].iter
 
-    adjust_step_size(ns_params, rate)
+    adjust_step_size(ns_params, rate; range=ns_params.accept_range)
     return iter, emax[mc_routine.n_cull], liveset, ns_params
 end
 
@@ -802,7 +802,7 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
     ns_params.fail_count = 0
     iter = liveset.walkers[1].iter
 
-    adjust_step_size(ns_params, rate)
+    adjust_step_size(ns_params, rate; range=ns_params.accept_range)
     return iter, emax[end], liveset, ns_params
 end
 
@@ -854,7 +854,7 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSampl
     ns_params.fail_count = 0
     iter = liveset.walkers[1].iter
 
-    adjust_step_size(ns_params, rate)
+    adjust_step_size(ns_params, rate; range=ns_params.accept_range)
     return iter, emax[end], liveset, ns_params
 end
 
@@ -931,7 +931,7 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSampl
         emax = missing
         ns_params.fail_count += 1
     end
-    adjust_step_size(ns_params, rate)
+    adjust_step_size(ns_params, rate; range=ns_params.accept_range)
     return iter, emax, liveset, ns_params, log_t
 end
 
@@ -978,7 +978,7 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
         emax = missing
         ns_params.fail_count += 1
     end
-    adjust_step_size(ns_params, rate)
+    adjust_step_size(ns_params, rate; range=ns_params.accept_range)
 
     return iter, emax, liveset, ns_params
 end
@@ -1031,7 +1031,7 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
     ns_params.fail_count = 0
     iter = liveset.walkers[1].iter
 
-    adjust_step_size(ns_params, rate)
+    adjust_step_size(ns_params, rate; range=ns_params.accept_range)
     return iter, emax[1], liveset, ns_params
 end
 

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -22,6 +22,11 @@ e.g. (0.25, 0.75) means that the step size will decrease if the acceptance rate 
 - `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p values after each adaptive adjustment.
 - `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adaptive adjustment.
 - `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adaptive adjustment.
+- `plateau_refill_target::Int64`: Internal bookkeeping for plateau-aware culling in the
+  serial atomistic steps: the live-set size to restore once a block of exact energy ties
+  has been fully evicted without replacement. `0` (the default) means no plateau block is
+  in progress; the field is set and cleared by `nested_sampling_step!` and should not be
+  set by callers.
 """
 mutable struct NestedSamplingParameters <: SamplingParameters
     mc_steps::Int64
@@ -40,6 +45,7 @@ mutable struct NestedSamplingParameters <: SamplingParameters
     cluster_p_history::Vector{Float64}
     cluster_accept_history::Vector{Float64}
     cluster_adjust_iterations::Vector{Int}
+    plateau_refill_target::Int64
 end
 
 function NestedSamplingParameters(;
@@ -59,8 +65,9 @@ function NestedSamplingParameters(;
             cluster_p_history::Vector{Float64}=Float64[],
             cluster_accept_history::Vector{Float64}=Float64[],
             cluster_adjust_iterations::Vector{Int}=Int[],
+            plateau_refill_target::Int64=0,
             )
-    NestedSamplingParameters(mc_steps, initial_step_size, step_size, step_size_lo, step_size_up, accept_range, fail_count, allowed_fail_count, energy_perturbation, random_seed, cluster_p, cluster_accepted, cluster_total, cluster_p_history, cluster_accept_history, cluster_adjust_iterations)
+    NestedSamplingParameters(mc_steps, initial_step_size, step_size, step_size_lo, step_size_up, accept_range, fail_count, allowed_fail_count, energy_perturbation, random_seed, cluster_p, cluster_accepted, cluster_total, cluster_p_history, cluster_accept_history, cluster_adjust_iterations, plateau_refill_target)
 end
 
 """
@@ -473,7 +480,7 @@ function update_iter!(liveset::AbstractLiveSet)
     end
 end
 
-const _RESERVED_LEDGER_COLUMNS = (:iter, :emax, :omega, :energy, :num_particles)
+const _RESERVED_LEDGER_COLUMNS = (:iter, :emax, :omega, :energy, :num_particles, :log_compression)
 
 """
     _validate_observables(observables, liveset::AbstractLiveSet)
@@ -529,9 +536,50 @@ end
 
 
 """
+    _tie_block_length(walkers)
+
+Return the number of leading walkers in an energy-sorted (descending) walker vector whose
+energies are bit-exactly equal to the worst walker's energy. A return value of `1` means
+the energy ceiling is unique; a larger value means the ceiling sits on an exact energy
+plateau (the generic outcome of truncated pair potentials over configuration spaces with
+vacuum, where the potential is exactly zero beyond every cutoff sphere).
+"""
+function _tie_block_length(walkers)
+    e1 = walkers[1].energy
+    n = 1
+    while n < length(walkers) && walkers[n+1].energy == e1
+        n += 1
+    end
+    return n
+end
+
+"""
     nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutine)
 
 Perform a single step of the nested sampling algorithm using the Monte Carlo random walk routine.
+
+Exact energy ties at the ceiling (an energy plateau) are handled with plateau-aware
+compression following Fowlie, Handley and Su, Mon. Not. R. Astron. Soc. 503, 1199 (2021):
+when two or more live walkers tie the ceiling bit-exactly, the tied walkers are evicted
+one by one without replacement, each eviction compressing the prior volume by
+`(n_live - 1)/n_live` with the shrinking live count, and the live set is refilled by
+cloning and decorrelating survivors below the plateau only once the last tied walker has
+been evicted. A normal (unique-ceiling) cull compresses by `n_live/(n_live + 1)` as
+before. The per-cull log-compression is returned as a fifth value and recorded by the
+[`nested_sampling`](@ref) driver in a `log_compression` ledger column, consumed by the
+log-compression method of `ωᵢ`; for tie-free ledgers the column is uniformly
+`log(K/(K+1))` and the legacy iteration-based weights are unchanged. One documented
+corner keeps the previous semantics: if the ENTIRE live set ties (every walker on the
+plateau), no survivor samples the sub-plateau region, so the step falls back to the
+ordinary clone-and-walk cull with replacement, charging `n_live/(n_live + 1)`; the
+plateau under-compression bias of that corner is confined to runs whose live set is
+entirely on a plateau, which for an i.i.d. initialization occurs with probability
+`f^K` for plateau prior fraction `f` (about 1% at `f = 0.91`, `K = 48`, but about 21%
+at `K = 16` — raise `K` when the vacuum fraction is large). This plateau handling
+applies to the two SERIAL `MCRoutine` step methods (`AtomWalkers` and
+`LJSurfaceWalkers`); the parallel, distributed, and mixed-moves step methods keep the
+previous fixed-compression semantics and their ledgers carry no `log_compression`
+column.
 
 # Arguments
 - `liveset::AtomWalkers`: The set of atom walkers.
@@ -543,13 +591,59 @@ Perform a single step of the nested sampling algorithm using the Monte Carlo ran
 - `emax`: The highest energy recorded during the step.
 - `liveset`: The updated set of atom walkers.
 - `ns_params`: The updated nested sampling parameters.
+- `log_t`: The log of the prior-volume compression factor charged for this cull
+  (`missing` when no walker was culled).
 """
 function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutine; ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     lj = liveset.potential
+    # Validate the routine before any walker is touched: the plateau branch below
+    # evicts without running a walk, so an unsupported routine or dimension must
+    # error here rather than silently evicting on tie steps.
+    mc_routine isa Union{MCRandomWalkMaxE, MCRandomWalkClone} || error("Unsupported MCRoutine type: $mc_routine")
+    length(mc_routine.dims) in (2, 3) || error("Unsupported dimensions: $(mc_routine.dims)")
     iter::Union{Missing,Int} = missing
     emax::Union{Missing,typeof(0.0u"eV")} = liveset.walkers[1].energy
+    log_t::Union{Missing,Float64} = missing
+    n_live = length(ats)
+    n_tied = _tie_block_length(ats)
+    if (n_tied >= 2 || ns_params.plateau_refill_target != 0) && n_tied < n_live
+        # Plateau block: evict the worst tied walker without replacement
+        # (Fowlie-Handley-Su), charging (n_live - 1)/n_live with the shrinking
+        # live count. With the refill target set and a unique ceiling, this is
+        # the last tied walker of the block: evict it, then refill.
+        if ns_params.plateau_refill_target == 0
+            ns_params.plateau_refill_target = n_live
+        end
+        popfirst!(ats)
+        update_iter!(liveset)
+        iter = liveset.walkers[1].iter
+        log_t = log((n_live - 1) / n_live)
+        if n_tied == 1
+            # The plateau is exhausted: refill by cloning survivors and
+            # decorrelating strictly below the plateau energy (volume-neutral;
+            # no ledger row), then clear the block state.
+            refill_fails = 0
+            while length(ats) < ns_params.plateau_refill_target && refill_fails < ns_params.allowed_fail_count
+                # The refill walk uses the routine's own dimension constraint so
+                # refilled clones stay on the constrained prior manifold.
+                if length(mc_routine.dims) == 3
+                    accept_r, _, at_r = MC_random_walk!(ns_params.mc_steps, deepcopy(rand(ats)), lj, ns_params.step_size, emax)
+                else
+                    accept_r, _, at_r = MC_random_walk_2D!(ns_params.mc_steps, deepcopy(rand(ats)), lj, ns_params.step_size, emax; dims=mc_routine.dims)
+                end
+                if accept_r
+                    push!(ats, at_r)
+                else
+                    refill_fails += 1
+                end
+            end
+            length(ats) < ns_params.plateau_refill_target && @warn "Plateau refill left the live set at $(length(ats)) of $(ns_params.plateau_refill_target) walkers after $(refill_fails) failed decorrelation attempts; subsequent culls are charged with the actual live count."
+            ns_params.plateau_refill_target = 0
+        end
+        return iter, emax, liveset, ns_params, log_t
+    end
     if mc_routine isa MCRandomWalkMaxE
         to_walk = deepcopy(ats[1])
     elseif mc_routine isa MCRandomWalkClone
@@ -573,13 +667,14 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
         update_iter!(liveset)
         ns_params.fail_count = 0
         iter = liveset.walkers[1].iter
+        log_t = log(n_live / (n_live + 1))
     else
         # @warn "Failed to accept MC move"
         emax = missing
         ns_params.fail_count += 1
     end
     adjust_step_size(ns_params, rate)
-    return iter, emax, liveset, ns_params
+    return iter, emax, liveset, ns_params, log_t
 end
 
 """
@@ -763,12 +858,53 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSampl
     return iter, emax[end], liveset, ns_params
 end
 
+"""
+    nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutine)
+
+Serial nested-sampling step for surface livesets. Identical to the `AtomWalkers` serial
+method — including the plateau-aware handling of exact energy ties, the fifth
+`log_t` return value, and the all-tied fallback documented there — except that every
+decorrelation and refill walk carries the frozen surface and only `dims == [1, 2, 3]`
+is supported.
+"""
 function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutine; ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     lj = liveset.potential
+    # Validate the routine before any walker is touched (the plateau branch below
+    # evicts without running a walk); this method's walks are 3D-only.
+    mc_routine isa Union{MCRandomWalkMaxE, MCRandomWalkClone} || error("Unsupported MCRoutine type: $mc_routine")
+    length(mc_routine.dims) == 3 || error("Unsupported dimensions: $(mc_routine.dims)")
     iter::Union{Missing,Int} = missing
     emax::Union{Missing,typeof(0.0u"eV")} = liveset.walkers[1].energy
+    log_t::Union{Missing,Float64} = missing
+    n_live = length(ats)
+    n_tied = _tie_block_length(ats)
+    if (n_tied >= 2 || ns_params.plateau_refill_target != 0) && n_tied < n_live
+        # Plateau block: evict the worst tied walker without replacement
+        # (Fowlie-Handley-Su); see the AtomWalkers method docstring.
+        if ns_params.plateau_refill_target == 0
+            ns_params.plateau_refill_target = n_live
+        end
+        popfirst!(ats)
+        update_iter!(liveset)
+        iter = liveset.walkers[1].iter
+        log_t = log((n_live - 1) / n_live)
+        if n_tied == 1
+            refill_fails = 0
+            while length(ats) < ns_params.plateau_refill_target && refill_fails < ns_params.allowed_fail_count
+                accept_r, _, at_r = MC_random_walk!(ns_params.mc_steps, deepcopy(rand(ats)), lj, ns_params.step_size, emax, liveset.surface)
+                if accept_r
+                    push!(ats, at_r)
+                else
+                    refill_fails += 1
+                end
+            end
+            length(ats) < ns_params.plateau_refill_target && @warn "Plateau refill left the live set at $(length(ats)) of $(ns_params.plateau_refill_target) walkers after $(refill_fails) failed decorrelation attempts; subsequent culls are charged with the actual live count."
+            ns_params.plateau_refill_target = 0
+        end
+        return iter, emax, liveset, ns_params, log_t
+    end
     if mc_routine isa MCRandomWalkMaxE
         to_walk = deepcopy(ats[1])
     elseif mc_routine isa MCRandomWalkClone
@@ -789,13 +925,14 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSampl
         update_iter!(liveset)
         ns_params.fail_count = 0
         iter = liveset.walkers[1].iter
+        log_t = log(n_live / (n_live + 1))
     else
         # @warn "Failed to accept MC move"
         emax = missing
         ns_params.fail_count += 1
     end
     adjust_step_size(ns_params, rate)
-    return iter, emax, liveset, ns_params
+    return iter, emax, liveset, ns_params, log_t
 end
 
 """
@@ -1178,6 +1315,9 @@ function nested_sampling(liveset::AbstractLiveSet,
         empty!(ns_params.cluster_accept_history)
         empty!(ns_params.cluster_adjust_iterations)
     end
+    # Defensive: a parameters object recovered from a run that ended inside a
+    # plateau block must not arm a fresh run's first cull as a tie eviction.
+    ns_params.plateau_refill_target = 0
     df = DataFrame(iter=Int[], emax=Float64[])
     if observables !== nothing
         mc_routine isa MCRoutineParallel && throw(ArgumentError(
@@ -1209,7 +1349,12 @@ function nested_sampling(liveset::AbstractLiveSet,
             sort_by_energy!(liveset)
             culled = liveset.walkers[1]
         end
-        iter, emax, liveset, ns_params = nested_sampling_step!(liveset, ns_params, mc_routine; ns_iteration=i)
+        step_ret = nested_sampling_step!(liveset, ns_params, mc_routine; ns_iteration=i)
+        iter, emax, liveset, ns_params = step_ret[1], step_ret[2], step_ret[3], step_ret[4]
+        # Serial atomistic steps additionally return the per-cull log-compression
+        # (plateau-aware culling); other step methods keep the four-value return
+        # and their ledgers gain no column.
+        log_t = length(step_ret) >= 5 ? step_ret[5] : missing
         @debug "n_step $i, iter: $iter, emax: $emax"
         if ns_params.fail_count >= ns_params.allowed_fail_count
             @warn "Failed to accept MC move $(ns_params.allowed_fail_count) times in a row. Reset step size!"
@@ -1225,12 +1370,16 @@ function nested_sampling(liveset::AbstractLiveSet,
                     "routine is not supported with `observables`/" *
                     "`dead_point_callback`")
             end
-            if observables === nothing
-                push!(df, (iter, emax.val))
-            else
-                push!(df, (iter, emax.val,
-                           (Float64(f(culled.configuration)) for (_, f) in observables)...))
+            if log_t !== missing && !hasproperty(df, :log_compression)
+                # Every accepted row of a log-compression-emitting run carries a
+                # value, and the first accepted row is the first push, so the
+                # column can be added lazily without backfilling.
+                df[!, :log_compression] = Float64[]
             end
+            row = observables === nothing ? (iter, emax.val) :
+                (iter, emax.val,
+                 (Float64(f(culled.configuration)) for (_, f) in observables)...)
+            push!(df, log_t === missing ? row : (row..., log_t))
             dead_point_callback === nothing || dead_point_callback(iter, culled)
         end
         print_message(i, iter, emax, ns_params.step_size, print_info, liveset)

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -198,6 +198,8 @@ For lattice systems, `walks_freq` and `clusters_freq` control the ratio of local
 - `initial_cluster_p::Float64`: Starting growth probability for cluster moves (default 0.3).
 - `target_cluster_accept::Float64`: Target acceptance rate for adaptive cluster p tuning (default 0.3).
 - `cluster_adjust_interval::Int`: Number of NS iterations between cluster p adjustments (default 50).
+- `cluster_p_floor::Float64`: Lower bound for adaptive cluster p (default 0.01).
+- `cluster_p_ceiling::Float64`: Upper bound for adaptive cluster p (default 1.0).
 """
 mutable struct MCMixedMoves <: MCRoutine
     walks_freq::Int
@@ -206,11 +208,13 @@ mutable struct MCMixedMoves <: MCRoutine
     initial_cluster_p::Float64
     target_cluster_accept::Float64
     cluster_adjust_interval::Int
+    cluster_p_floor::Float64
+    cluster_p_ceiling::Float64
 end
 
 # Backward-compatible constructor: MCMixedMoves(5, 1)
 function MCMixedMoves(walks_freq::Int, swaps_freq::Int)
-    MCMixedMoves(walks_freq, swaps_freq, 0, 0.3, 0.3, 50)
+    MCMixedMoves(walks_freq, swaps_freq, 0, 0.3, 0.3, 50, 0.01, 1.0)
 end
 
 # Keyword constructor for lattice use
@@ -221,9 +225,12 @@ function MCMixedMoves(;
     initial_cluster_p::Float64=0.3,
     target_cluster_accept::Float64=0.3,
     cluster_adjust_interval::Int=50,
+    cluster_p_floor::Float64=0.01,
+    cluster_p_ceiling::Float64=1.0,
 )
     MCMixedMoves(walks_freq, swaps_freq, clusters_freq,
-                 initial_cluster_p, target_cluster_accept, cluster_adjust_interval)
+                 initial_cluster_p, target_cluster_accept, cluster_adjust_interval,
+                 cluster_p_floor, cluster_p_ceiling)
 end
 
 """
@@ -738,7 +745,9 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
            ns_params.cluster_total >= mc_routine.cluster_adjust_interval * n_cluster
             window_rate = ns_params.cluster_accepted / max(ns_params.cluster_total, 1.0)
             adjust_cluster_p(ns_params, window_rate, ns_iteration;
-                             target=mc_routine.target_cluster_accept)
+                             target=mc_routine.target_cluster_accept,
+                             floor=mc_routine.cluster_p_floor,
+                             ceiling=mc_routine.cluster_p_ceiling)
             ns_params.cluster_accepted = 0.0
             ns_params.cluster_total = 0.0
         end

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -263,21 +263,52 @@ struct MCRejectionSampling <: MCRoutine end
     struct MCGrandCanonicalMoves <: MCRoutine
 
 A type for generating a new walker using grand-canonical MCMC moves that mix
-fixed-N local swaps with single-site particle insertion and deletion.
+fixed-N moves (local swaps and/or geometric cluster moves) with single-site
+particle insertion and deletion.
 
 # Fields
-- `p_move::Float64`: Probability of a fixed-N swap move per MCMC step (default 0.5).
+- `p_move::Float64`: Probability of a fixed-N move per MCMC step (default 0.5).
 - `p_insert::Float64`: Probability of a particle insertion per step (default 0.25).
   The deletion probability is `1 - p_move - p_insert`.
+- `clusters_freq::Int`: Relative weight of cluster moves within the fixed-N branch (default 0 = disabled).
+- `swaps_freq::Int`: Relative weight of local swaps within the fixed-N branch (default 1).
+- `initial_cluster_p::Float64`: Starting growth probability for geometric cluster moves (default 0.3).
+- `target_cluster_accept::Float64`: Target acceptance rate for adaptive cluster p tuning (default 0.3).
+- `cluster_adjust_interval::Int`: Number of NS iterations between cluster p adjustments (default 50).
+- `cluster_p_floor::Float64`: Lower bound for adaptive cluster p (default 0.01).
+- `cluster_p_ceiling::Float64`: Upper bound for adaptive cluster p (default 1.0).
+
+When `clusters_freq == 0` (the default), the fixed-N branch uses only local swaps
+(`lattice_random_walk!`), preserving backward compatibility with existing scripts.
+When `clusters_freq > 0`, the fixed-N branch mixes geometric cluster moves with
+local swaps according to the `clusters_freq:swaps_freq` ratio.
 """
 struct MCGrandCanonicalMoves <: MCRoutine
     p_move::Float64
     p_insert::Float64
-    function MCGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25)
+    clusters_freq::Int
+    swaps_freq::Int
+    initial_cluster_p::Float64
+    target_cluster_accept::Float64
+    cluster_adjust_interval::Int
+    cluster_p_floor::Float64
+    cluster_p_ceiling::Float64
+    function MCGrandCanonicalMoves(;
+            p_move::Float64=0.5,
+            p_insert::Float64=0.25,
+            clusters_freq::Int=0,
+            swaps_freq::Int=1,
+            initial_cluster_p::Float64=0.3,
+            target_cluster_accept::Float64=0.3,
+            cluster_adjust_interval::Int=50,
+            cluster_p_floor::Float64=0.01,
+            cluster_p_ceiling::Float64=1.0)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
         end
-        new(p_move, p_insert)
+        new(p_move, p_insert, clusters_freq, swaps_freq,
+            initial_cluster_p, target_cluster_accept, cluster_adjust_interval,
+            cluster_p_floor, cluster_p_ceiling)
     end
 end
 
@@ -298,6 +329,13 @@ for thermodynamic reweighting.
 - `fail_count::Int64`: Consecutive failed replacements.
 - `allowed_fail_count::Int64`: Maximum consecutive failures before warning.
 - `init_occupation_p::Float64`: Per-site occupation probability for initial walkers.
+- `n_max::Int64`: Upper bound on particle count per walker.
+- `cluster_p::Float64`: Current cluster growth probability (mutable runtime state).
+- `cluster_accepted::Float64`: Accepted cluster moves in current adjustment window.
+- `cluster_total::Float64`: Total cluster moves attempted in current adjustment window.
+- `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p after each adjustment.
+- `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adjustment.
+- `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adjustment.
 """
 mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     mc_steps::Int64
@@ -308,18 +346,31 @@ mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     allowed_fail_count::Int64
     init_occupation_p::Float64
     n_max::Int64
+    cluster_p::Float64
+    cluster_accepted::Float64
+    cluster_total::Float64
+    cluster_p_history::Vector{Float64}
+    cluster_accept_history::Vector{Float64}
+    cluster_adjust_iterations::Vector{Int}
 end
 
 """
     GrandCanonicalNestedSamplingParameters(;
         mc_steps=100, chemical_potential=0.0, energy_perturbation=1e-12,
         random_seed=1234, fail_count=0, allowed_fail_count=10,
-        init_occupation_p=0.5, n_max=typemax(Int64))
+        init_occupation_p=0.5, n_max=typemax(Int64),
+        cluster_p=0.3, cluster_accepted=0.0, cluster_total=0.0,
+        cluster_p_history=Float64[], cluster_accept_history=Float64[],
+        cluster_adjust_iterations=Int[])
 
 Convenience constructor for `GrandCanonicalNestedSamplingParameters`.
 
 The `n_max` parameter sets an upper bound on the number of particles per walker.
 Insertions are rejected when N ≥ n_max. Default is `typemax(Int64)` (no cap).
+
+The `cluster_*` fields are mutable runtime state for adaptive cluster move tuning.
+They are initialized from the static configuration on `MCGrandCanonicalMoves` at
+the start of `grand_canonical_nested_sampling` when `clusters_freq > 0`.
 """
 function GrandCanonicalNestedSamplingParameters(;
     mc_steps::Int64=100,
@@ -330,11 +381,19 @@ function GrandCanonicalNestedSamplingParameters(;
     allowed_fail_count::Int64=10,
     init_occupation_p::Float64=0.5,
     n_max::Int64=typemax(Int64),
+    cluster_p::Float64=0.3,
+    cluster_accepted::Float64=0.0,
+    cluster_total::Float64=0.0,
+    cluster_p_history::Vector{Float64}=Float64[],
+    cluster_accept_history::Vector{Float64}=Float64[],
+    cluster_adjust_iterations::Vector{Int}=Int[],
 )
     GrandCanonicalNestedSamplingParameters(
         mc_steps, chemical_potential, energy_perturbation,
         random_seed, fail_count, allowed_fail_count,
         init_occupation_p, n_max,
+        cluster_p, cluster_accepted, cluster_total,
+        cluster_p_history, cluster_accept_history, cluster_adjust_iterations,
     )
 end
 
@@ -1127,11 +1186,14 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     to_walk = deepcopy(ats[parent_idx])
 
     # Decorrelate via GC MCMC
-    accept, rate, to_walk = MC_grand_canonical_walk!(
+    accept, rate, to_walk, cl_accepted, cl_total = MC_grand_canonical_walk!(
         gc_params.mc_steps, to_walk, h, omega_max_val, mu;
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         energy_perturb=gc_params.energy_perturbation,
-        n_max=gc_params.n_max)
+        n_max=gc_params.n_max,
+        clusters_freq=mc_routine.clusters_freq,
+        swaps_freq=mc_routine.swaps_freq,
+        cluster_p=gc_params.cluster_p)
 
     if accept
         push!(ats, to_walk)
@@ -1144,6 +1206,22 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
         energy_worst = missing
         n_worst = missing
         gc_params.fail_count += 1
+    end
+
+    # Accumulate cluster acceptance stats and adapt cluster_p
+    if cl_total > 0
+        gc_params.cluster_accepted += cl_accepted
+        gc_params.cluster_total += cl_total
+        if mc_routine.cluster_adjust_interval > 0 &&
+           gc_params.cluster_total >= mc_routine.cluster_adjust_interval
+            window_rate = gc_params.cluster_accepted / max(gc_params.cluster_total, 1.0)
+            adjust_cluster_p(gc_params, window_rate, ns_iteration;
+                             target=mc_routine.target_cluster_accept,
+                             floor=mc_routine.cluster_p_floor,
+                             ceiling=mc_routine.cluster_p_ceiling)
+            gc_params.cluster_accepted = 0.0
+            gc_params.cluster_total = 0.0
+        end
     end
 
     return iter, omega_worst, energy_worst, n_worst, liveset, gc_params
@@ -1180,6 +1258,16 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
                                          save_strategy::DataSavingStrategy)
     # Initialize walkers with random microstates
     _init_gc_walkers!(liveset, gc_params)
+
+    # Initialize cluster_p and reset counters from MCGrandCanonicalMoves if applicable
+    if mc_routine.clusters_freq > 0
+        gc_params.cluster_p = mc_routine.initial_cluster_p
+        gc_params.cluster_accepted = 0.0
+        gc_params.cluster_total = 0.0
+        empty!(gc_params.cluster_p_history)
+        empty!(gc_params.cluster_accept_history)
+        empty!(gc_params.cluster_adjust_iterations)
+    end
 
     df = DataFrame(iter=Int[], omega=Float64[], energy=Float64[], num_particles=Int[])
 

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1209,20 +1209,7 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     end
 
     # Accumulate cluster acceptance stats and adapt cluster_p
-    if cl_total > 0
-        gc_params.cluster_accepted += cl_accepted
-        gc_params.cluster_total += cl_total
-        if mc_routine.cluster_adjust_interval > 0 &&
-           gc_params.cluster_total >= mc_routine.cluster_adjust_interval
-            window_rate = gc_params.cluster_accepted / max(gc_params.cluster_total, 1.0)
-            adjust_cluster_p(gc_params, window_rate, ns_iteration;
-                             target=mc_routine.target_cluster_accept,
-                             floor=mc_routine.cluster_p_floor,
-                             ceiling=mc_routine.cluster_p_ceiling)
-            gc_params.cluster_accepted = 0.0
-            gc_params.cluster_total = 0.0
-        end
-    end
+    _accumulate_cluster_stats!(gc_params, mc_routine, cl_accepted, cl_total, ns_iteration)
 
     return iter, omega_worst, energy_worst, n_worst, liveset, gc_params
 end
@@ -1300,4 +1287,297 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
     end
 
     return df, liveset, gc_params
+end
+
+# ======================================================================
+# Ideal-gas-referenced grand-canonical nested sampling
+# ======================================================================
+
+"""
+    mutable struct IdealGasReferencedGCNSParameters <: SamplingParameters
+
+Parameters for ideal-gas-referenced grand-canonical nested sampling on
+lattice systems.
+
+The prior is the non-interacting (ideal) lattice gas at reference fugacity
+`z0`: a Bernoulli product measure in which each site is occupied independently
+with probability `p0 = z0/(1 + z0)`, so a configuration with N particles
+carries prior weight `z0^N` and the total prior mass on M sites is
+`(1 + z0)^M`. Nested sampling culls on the energy E alone — the chemical
+potential does not enter the sampler. Both μ and T are recovered in
+post-processing (see `gc_thermodynamic_stats_ideal_ref` in `AnalysisTools`),
+so a single run yields Ξ(μ, T) over a continuous temperature range and a
+neighborhood of μ around `μ_ref(T) = k_B T ln z0`.
+
+Setting `reference_fugacity = 1` makes the prior the uniform measure over all
+2^M microstates — the same prior as the Ω-sorted construction in
+`GrandCanonicalNestedSamplingParameters`, which instead bakes a single μ into
+the sort quantity Ω = E − μN.
+
+Unlike the Ω-sorted construction there is deliberately no `n_max` field: the
+post-processing normalization `(1 + z0)^M` is the prior mass of the *full*
+occupation range N ∈ {0, …, M}, and capping insertions would silently
+truncate the prior support and bias Ξ.
+
+# Fields
+- `mc_steps::Int64`: MCMC steps per replacement walker.
+- `reference_fugacity::Float64`: Reference fugacity z0 of the ideal-lattice-gas prior.
+- `energy_perturbation::Float64`: Perturbation to break energy degeneracies.
+  Required to be nonzero on lattices (degenerate levels stall the strict `<`
+  ceiling and bias the evidence — enforced by the keyword constructor); must
+  remain ≪ k_B·T at the lowest temperature targeted in post-processing, since
+  perturbed energies are recorded.
+- `random_seed::Int64`: Kept for parity with `GrandCanonicalNestedSamplingParameters`;
+  **not currently consumed** by the NS loop — call `Random.seed!` before
+  `ideal_gas_referenced_nested_sampling` for reproducible runs.
+- `fail_count::Int64`: Consecutive failed replacements.
+- `allowed_fail_count::Int64`: Maximum consecutive failures before warning.
+- `cluster_p::Float64`: Current cluster growth probability (mutable runtime state).
+- `cluster_accepted::Float64`: Accepted cluster moves in current adjustment window.
+- `cluster_total::Float64`: Total cluster moves attempted in current adjustment window.
+- `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p after each adjustment.
+- `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adjustment.
+- `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adjustment.
+"""
+mutable struct IdealGasReferencedGCNSParameters <: SamplingParameters
+    mc_steps::Int64
+    reference_fugacity::Float64
+    energy_perturbation::Float64
+    random_seed::Int64
+    fail_count::Int64
+    allowed_fail_count::Int64
+    cluster_p::Float64
+    cluster_accepted::Float64
+    cluster_total::Float64
+    cluster_p_history::Vector{Float64}
+    cluster_accept_history::Vector{Float64}
+    cluster_adjust_iterations::Vector{Int}
+end
+
+"""
+    IdealGasReferencedGCNSParameters(;
+        mc_steps=100, reference_fugacity=1.0, energy_perturbation=1e-12,
+        random_seed=1234, fail_count=0, allowed_fail_count=10,
+        cluster_p=0.3, cluster_accepted=0.0, cluster_total=0.0,
+        cluster_p_history=Float64[], cluster_accept_history=Float64[],
+        cluster_adjust_iterations=Int[])
+
+Convenience constructor for `IdealGasReferencedGCNSParameters`.
+
+`reference_fugacity` (z0) must be positive. Choose z0 near the target
+fugacity range `exp(βμ)` of interest: post-run reweighting to a target (μ, T)
+carries a factor `(exp(βμ)/z0)^N` per sample, and its effective sample size
+degrades as `|βμ − ln z0|` grows (roughly beyond `1/√Var(N)`).
+
+The `cluster_*` fields are mutable runtime state for adaptive cluster move
+tuning, initialized from the static configuration on `MCGrandCanonicalMoves`
+at the start of `ideal_gas_referenced_nested_sampling` when `clusters_freq > 0`.
+"""
+function IdealGasReferencedGCNSParameters(;
+    mc_steps::Int64=100,
+    reference_fugacity::Float64=1.0,
+    energy_perturbation::Float64=1e-12,
+    random_seed::Int64=1234,
+    fail_count::Int64=0,
+    allowed_fail_count::Int64=10,
+    cluster_p::Float64=0.3,
+    cluster_accepted::Float64=0.0,
+    cluster_total::Float64=0.0,
+    cluster_p_history::Vector{Float64}=Float64[],
+    cluster_accept_history::Vector{Float64}=Float64[],
+    cluster_adjust_iterations::Vector{Int}=Int[],
+)
+    if reference_fugacity <= 0.0
+        throw(ArgumentError("reference_fugacity must be positive"))
+    end
+    if energy_perturbation == 0.0
+        throw(ArgumentError("energy_perturbation must be nonzero: degenerate " *
+            "lattice energy levels stall the strict < ceiling and bias the evidence"))
+    end
+    IdealGasReferencedGCNSParameters(
+        mc_steps, reference_fugacity, energy_perturbation,
+        random_seed, fail_count, allowed_fail_count,
+        cluster_p, cluster_accepted, cluster_total,
+        cluster_p_history, cluster_accept_history, cluster_adjust_iterations,
+    )
+end
+
+"""
+    _init_ideal_gas_ref_walkers!(liveset::LatticeGasWalkers,
+                                 params::IdealGasReferencedGCNSParameters)
+
+Initialize walkers as exact i.i.d. draws from the ideal-lattice-gas prior:
+each site occupied independently with probability `z0/(1 + z0)`.
+"""
+function _init_ideal_gas_ref_walkers!(liveset::LatticeGasWalkers,
+                                      params::IdealGasReferencedGCNSParameters)
+    h = liveset.hamiltonian
+    z0 = params.reference_fugacity
+    p0 = z0 / (1.0 + z0)
+    for walker in liveset.walkers
+        random_microstate!(walker.configuration; p=p0)
+        assign_energy!(walker, h; perturb_energy=params.energy_perturbation)
+        # Reset the iteration counter: df.iter feeds the ωᵢ prior-volume
+        # weights, so a stale counter from a reused liveset corrupts them
+        walker.iter = 0
+    end
+    return liveset
+end
+
+"""
+    nested_sampling_step!(liveset::LatticeGasWalkers,
+                          params::IdealGasReferencedGCNSParameters,
+                          mc_routine::MCGrandCanonicalMoves;
+                          ns_iteration::Int=0)
+
+Perform one step of ideal-gas-referenced grand-canonical nested sampling.
+
+Sorts walkers by energy E (not Ω — the chemical potential plays no role in
+the sampler), removes the worst (highest E), clones a parent with E < E_worst,
+and decorrelates the clone via grand-canonical MCMC that preserves the
+`z0^N`-weighted prior below the energy ceiling.
+
+# Returns
+- `iter`: Iteration number (or `missing` if the step failed).
+- `emax`: The E value of the removed walker (with units).
+- `num_particles`: The N value of the removed walker.
+- `liveset`: The updated liveset.
+- `params`: The updated parameters.
+"""
+function nested_sampling_step!(liveset::LatticeGasWalkers,
+                               params::IdealGasReferencedGCNSParameters,
+                               mc_routine::MCGrandCanonicalMoves;
+                               ns_iteration::Int=0)
+    ats = liveset.walkers
+    h = liveset.hamiltonian
+    n_walkers = length(ats)
+
+    # Sort by energy (descending — worst first); the z0^N prior weighting is
+    # maintained by the MC walk, not by the sort
+    sort_by_energy!(liveset)
+
+    iter::Union{Missing,Int} = missing
+    worst = ats[1]
+    emax_worst = worst.energy
+    n_worst = sum(worst.configuration.components[1])
+
+    emax_val = emax_worst.val  # unitless for the MC function
+    eligible = [k for k in 2:n_walkers if ats[k].energy < emax_worst]
+    if !isempty(eligible)
+        parent_idx = rand(eligible)
+    else
+        parent_idx = rand(2:n_walkers)
+    end
+    to_walk = deepcopy(ats[parent_idx])
+
+    # Decorrelate via GC MCMC: with mu = 0 the Ω ceiling reduces to an energy
+    # ceiling, and z0 weights the insert/delete acceptance to preserve the
+    # Bernoulli(z0/(1+z0)) prior
+    accept, rate, to_walk, cl_accepted, cl_total = MC_grand_canonical_walk!(
+        params.mc_steps, to_walk, h, emax_val, 0.0;
+        p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
+        energy_perturb=params.energy_perturbation,
+        z0=params.reference_fugacity,
+        clusters_freq=mc_routine.clusters_freq,
+        swaps_freq=mc_routine.swaps_freq,
+        cluster_p=params.cluster_p)
+
+    if accept
+        push!(ats, to_walk)
+        popfirst!(ats)
+        update_iter!(liveset)
+        params.fail_count = 0
+        iter = liveset.walkers[1].iter
+    else
+        emax_worst = missing
+        n_worst = missing
+        params.fail_count += 1
+    end
+
+    # Accumulate cluster acceptance stats and adapt cluster_p
+    _accumulate_cluster_stats!(params, mc_routine, cl_accepted, cl_total, ns_iteration)
+
+    return iter, emax_worst, n_worst, liveset, params
+end
+
+"""
+    ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
+                                         params::IdealGasReferencedGCNSParameters,
+                                         n_steps::Int64,
+                                         mc_routine::MCGrandCanonicalMoves,
+                                         save_strategy::DataSavingStrategy)
+
+Run the ideal-gas-referenced grand-canonical nested sampling loop.
+
+Walkers are initialized as exact i.i.d. draws from the ideal-lattice-gas
+prior at reference fugacity z0 (each site occupied with probability
+`z0/(1 + z0)`), then the loop iterates: remove the highest-energy walker,
+record (E, N), replace with a clone decorrelated below the energy ceiling
+under the `z0^N`-weighted prior. The chemical potential never enters the
+run; a single run is post-processed to Ξ(μ, T) on an arbitrary (μ, T) grid
+by `gc_thermodynamic_stats_ideal_ref` in `AnalysisTools`, which also needs
+the surviving live walkers' (E, N) for the live-set tail closure —
+extract them from the returned liveset.
+
+# Arguments
+- `liveset::LatticeGasWalkers`: The initial liveset (walkers will be re-initialized).
+- `params::IdealGasReferencedGCNSParameters`: Parameters including the reference fugacity z0.
+- `n_steps::Int64`: Number of NS iterations.
+- `mc_routine::MCGrandCanonicalMoves`: The GC move routine (reused from the Ω-sorted construction).
+- `save_strategy::DataSavingStrategy`: Strategy for periodic output.
+
+# Returns
+- `df::DataFrame`: Columns `[:iter, :emax, :num_particles]`.
+- `liveset::LatticeGasWalkers`: The final liveset (surviving walkers).
+- `params::IdealGasReferencedGCNSParameters`: Updated parameters.
+"""
+function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
+                                              params::IdealGasReferencedGCNSParameters,
+                                              n_steps::Int64,
+                                              mc_routine::MCGrandCanonicalMoves,
+                                              save_strategy::DataSavingStrategy)
+    # Initialize walkers as i.i.d. draws from the Bernoulli(z0/(1+z0)) prior
+    _init_ideal_gas_ref_walkers!(liveset, params)
+
+    # Initialize cluster_p and reset counters from MCGrandCanonicalMoves if applicable
+    if mc_routine.clusters_freq > 0
+        params.cluster_p = mc_routine.initial_cluster_p
+        params.cluster_accepted = 0.0
+        params.cluster_total = 0.0
+        empty!(params.cluster_p_history)
+        empty!(params.cluster_accept_history)
+        empty!(params.cluster_adjust_iterations)
+    end
+
+    df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
+
+    for i in 1:n_steps
+        print_info = i % save_strategy.n_info == 0
+        write_walker_every_n(liveset.walkers[1], i, save_strategy)
+
+        iter, emax, n_par, liveset, params = nested_sampling_step!(
+            liveset, params, mc_routine; ns_iteration=i)
+
+        @debug "IG-ref GC-NS step $i, iter: $iter, emax: $emax, N: $n_par"
+
+        if params.fail_count >= params.allowed_fail_count
+            @warn "IG-ref GC-NS: Failed $(params.allowed_fail_count) times in a row."
+            params.fail_count = 0
+        end
+
+        if !(iter isa typeof(missing))
+            push!(df, (iter, emax.val, n_par))
+        end
+
+        if print_info && !(iter isa typeof(missing))
+            @info "IG-ref GC-NS iter: $(iter), E: $(emax), N: $(n_par)"
+        elseif print_info && iter isa typeof(missing)
+            @info "IG-ref GC-NS MC move failed, step: $(i)"
+        end
+
+        write_df_every_n(df, i, save_strategy)
+        write_ls_every_n(liveset, i, save_strategy)
+    end
+
+    return df, liveset, params
 end

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -19,6 +19,9 @@ e.g. (0.25, 0.75) means that the step size will decrease if the acceptance rate 
 - `cluster_p::Float64`: Current cluster growth probability for geometric cluster moves (mutable runtime state).
 - `cluster_accepted::Float64`: Accepted cluster moves in the current adjustment window.
 - `cluster_total::Float64`: Total cluster moves attempted in the current adjustment window.
+- `cluster_p_history::Vector{Float64}`: Trajectory of cluster_p values after each adaptive adjustment.
+- `cluster_accept_history::Vector{Float64}`: Acceptance rate at each adaptive adjustment.
+- `cluster_adjust_iterations::Vector{Int}`: NS iteration index at each adaptive adjustment.
 """
 mutable struct NestedSamplingParameters <: SamplingParameters
     mc_steps::Int64
@@ -34,6 +37,9 @@ mutable struct NestedSamplingParameters <: SamplingParameters
     cluster_p::Float64
     cluster_accepted::Float64
     cluster_total::Float64
+    cluster_p_history::Vector{Float64}
+    cluster_accept_history::Vector{Float64}
+    cluster_adjust_iterations::Vector{Int}
 end
 
 function NestedSamplingParameters(;
@@ -50,8 +56,11 @@ function NestedSamplingParameters(;
             cluster_p::Float64=0.3,
             cluster_accepted::Float64=0.0,
             cluster_total::Float64=0.0,
+            cluster_p_history::Vector{Float64}=Float64[],
+            cluster_accept_history::Vector{Float64}=Float64[],
+            cluster_adjust_iterations::Vector{Int}=Int[],
             )
-    NestedSamplingParameters(mc_steps, initial_step_size, step_size, step_size_lo, step_size_up, accept_range, fail_count, allowed_fail_count, energy_perturbation, random_seed, cluster_p, cluster_accepted, cluster_total)
+    NestedSamplingParameters(mc_steps, initial_step_size, step_size, step_size_lo, step_size_up, accept_range, fail_count, allowed_fail_count, energy_perturbation, random_seed, cluster_p, cluster_accepted, cluster_total, cluster_p_history, cluster_accept_history, cluster_adjust_iterations)
 end
 
 """
@@ -299,7 +308,7 @@ Perform a single step of the nested sampling algorithm using the Monte Carlo ran
 - `liveset`: The updated set of atom walkers.
 - `ns_params`: The updated nested sampling parameters.
 """
-function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutine)
+function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutine; ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     lj = liveset.potential
@@ -350,7 +359,7 @@ Perform a single step of the nested sampling algorithm using the parallel Monte 
 - `liveset`: The updated set of atom walkers.
 - `ns_params`: The updated nested sampling parameters.
 """
-function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCDistributed)
+function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCDistributed; ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     lj = liveset.potential
@@ -414,7 +423,7 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
     return iter, emax[mc_routine.n_cull], liveset, ns_params
 end
 
-function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutineParallel)
+function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutineParallel; ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     lj = liveset.potential
@@ -466,7 +475,7 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
     return iter, emax[end], liveset, ns_params
 end
 
-function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutineParallel)
+function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutineParallel; ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     lj = liveset.potential
@@ -518,7 +527,7 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSampl
     return iter, emax[end], liveset, ns_params
 end
 
-function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutine)
+function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSamplingParameters, mc_routine::MCRoutine; ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     lj = liveset.potential
@@ -573,7 +582,7 @@ Returns
 Note
 - To invoke the parallel version of this routine, use `MCMixedMovesParallel` as the `mc_routine` argument.
 """
-function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCMixedMoves)
+function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCMixedMoves; ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     lj = liveset.potential
@@ -601,7 +610,7 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
     return iter, emax, liveset, ns_params
 end
 
-function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCMixedMovesParallel)
+function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCMixedMovesParallel; ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     lj = liveset.potential
@@ -675,7 +684,8 @@ which is adaptively tuned to maintain `mc_routine.target_cluster_accept`. Local 
 """
 function nested_sampling_step!(liveset::LatticeGasWalkers,
                                ns_params::NestedSamplingParameters,
-                               mc_routine::MCMixedMoves)
+                               mc_routine::MCMixedMoves;
+                               ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     h = liveset.hamiltonian
@@ -727,7 +737,7 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
         if mc_routine.cluster_adjust_interval > 0 &&
            ns_params.cluster_total >= mc_routine.cluster_adjust_interval * n_cluster
             window_rate = ns_params.cluster_accepted / max(ns_params.cluster_total, 1.0)
-            adjust_cluster_p(ns_params, window_rate;
+            adjust_cluster_p(ns_params, window_rate, ns_iteration;
                              target=mc_routine.target_cluster_accept)
             ns_params.cluster_accepted = 0.0
             ns_params.cluster_total = 0.0
@@ -756,7 +766,8 @@ routine for generating new samples. It performs a single step of the nested samp
 """
 function nested_sampling_step!(liveset::LatticeGasWalkers,
                                ns_params::NestedSamplingParameters,
-                               mc_routine::MCRoutine)
+                               mc_routine::MCRoutine;
+                               ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     h = liveset.hamiltonian
@@ -805,9 +816,10 @@ This function takes a `liveset` of lattice gas walkers, `ns_params` containing t
 - `liveset::LatticeGasWalkers`: The updated liveset after the step.
 - `ns_params::LatticeNestedSamplingParameters`: The updated nested sampling parameters after the step.
 """
-function nested_sampling_step!(liveset::LatticeGasWalkers, 
-                               ns_params::NestedSamplingParameters, 
-                               mc_routine::MCNewSample)
+function nested_sampling_step!(liveset::LatticeGasWalkers,
+                               ns_params::NestedSamplingParameters,
+                               mc_routine::MCNewSample;
+                               ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     h = liveset.hamiltonian
@@ -835,9 +847,10 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
 end
 
 
-function nested_sampling_step!(liveset::LatticeGasWalkers, 
-                               ns_params::NestedSamplingParameters, 
-                               mc_routine::MCRejectionSampling)
+function nested_sampling_step!(liveset::LatticeGasWalkers,
+                               ns_params::NestedSamplingParameters,
+                               mc_routine::MCRejectionSampling;
+                               ns_iteration::Int=0)
     sort_by_energy!(liveset)
     ats = liveset.walkers
     h = liveset.hamiltonian
@@ -892,12 +905,15 @@ function nested_sampling(liveset::AbstractLiveSet,
         ns_params.cluster_p = mc_routine.initial_cluster_p
         ns_params.cluster_accepted = 0.0
         ns_params.cluster_total = 0.0
+        empty!(ns_params.cluster_p_history)
+        empty!(ns_params.cluster_accept_history)
+        empty!(ns_params.cluster_adjust_iterations)
     end
     df = DataFrame(iter=Int[], emax=Float64[])
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
-        iter, emax, liveset, ns_params = nested_sampling_step!(liveset, ns_params, mc_routine)
+        iter, emax, liveset, ns_params = nested_sampling_step!(liveset, ns_params, mc_routine; ns_iteration=i)
         @debug "n_step $i, iter: $iter, emax: $emax"
         if ns_params.fail_count >= ns_params.allowed_fail_count
             @warn "Failed to accept MC move $(ns_params.allowed_fail_count) times in a row. Reset step size!"

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -704,15 +704,17 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
 
     if length(mc_routine.dims) == 3
         random_walk_function = MC_random_walk!
+        walk_kwargs = NamedTuple()
     elseif length(mc_routine.dims) == 2
         random_walk_function = MC_random_walk_2D!
+        walk_kwargs = (dims = mc_routine.dims,)
     else
         error("Unsupported dimensions: $(mc_routine.dims)")
     end
 
     mc_steps_per_worker = ceil(Int, ns_params.mc_steps / nworkers()) # distribute the total MC steps among workers
 
-    walking = [remotecall(random_walk_function, workers()[i], mc_steps_per_worker, to_walk, lj, ns_params.step_size, emax[mc_routine.n_cull]) for (i,to_walk) in enumerate(to_walks)]
+    walking = [remotecall(random_walk_function, workers()[i], mc_steps_per_worker, to_walk, lj, ns_params.step_size, emax[mc_routine.n_cull]; walk_kwargs...) for (i,to_walk) in enumerate(to_walks)]
     walked = fetch.(walking)
     finalize.(walking) # finalize the remote calls, clear the memory
 
@@ -771,14 +773,16 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
 
     if length(mc_routine.dims) == 3
         random_walk_function = MC_random_walk!
+        walk_kwargs = NamedTuple()
     elseif length(mc_routine.dims) == 2
         random_walk_function = MC_random_walk_2D!
+        walk_kwargs = (dims = mc_routine.dims,)
     else
         error("Unsupported dimensions: $(mc_routine.dims)")
     end
 
 
-    walking = [remotecall(random_walk_function, workers()[i], ns_params.mc_steps, to_walk, lj, ns_params.step_size, emax[end]) for (i,to_walk) in enumerate(to_walks)]
+    walking = [remotecall(random_walk_function, workers()[i], ns_params.mc_steps, to_walk, lj, ns_params.step_size, emax[end]; walk_kwargs...) for (i,to_walk) in enumerate(to_walks)]
     walked = fetch.(walking)
     finalize.(walking) # finalize the remote calls, clear the memory
 
@@ -823,9 +827,10 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers, ns_params::NestedSampl
 
     if length(mc_routine.dims) == 3
         random_walk_function = MC_random_walk!
-    elseif length(mc_routine.dims) == 2
-        random_walk_function = MC_random_walk_2D!
     else
+        # The surface walks are 3D-only, matching the serial surface step's
+        # restriction: a length-2 dims would select a walk method with no
+        # surface variant and fail as a MethodError on the worker.
         error("Unsupported dimensions: $(mc_routine.dims)")
     end
 

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -429,6 +429,48 @@ function update_iter!(liveset::AbstractLiveSet)
     end
 end
 
+const _RESERVED_LEDGER_COLUMNS = (:iter, :emax, :omega, :energy, :num_particles)
+
+"""
+    _validate_observables(observables, liveset::AbstractLiveSet)
+
+Validate an `observables` specification — a vector of `name::Symbol =>
+callback` pairs — for per-dead-point recording in a nested-sampling loop.
+
+Throws `ArgumentError` on an empty list, duplicate names, a name colliding
+with a reserved ledger column, or a callback whose probe evaluation on
+`liveset.walkers[1].configuration` does not return a `Real`; warns when the
+probe value is non-finite (a non-finite observable contributes NaN/Inf to
+every weighted average downstream). Callbacks must be pure functions of the
+configuration: each is evaluated once here as a probe and once per accepted
+iteration on the culled walker.
+"""
+function _validate_observables(observables::AbstractVector{<:Pair{Symbol,<:Any}},
+                               liveset::AbstractLiveSet)
+    isempty(observables) && throw(ArgumentError(
+        "observables: empty list; pass `nothing` to disable observable recording"))
+    names = first.(observables)
+    allunique(names) || throw(ArgumentError(
+        "observables: duplicate names in $(names)"))
+    for name in names
+        if name in _RESERVED_LEDGER_COLUMNS
+            throw(ArgumentError(
+                "observables: name :$name collides with a reserved ledger " *
+                "column; reserved names are $(_RESERVED_LEDGER_COLUMNS)"))
+        end
+    end
+    for (name, f) in observables
+        probe = f(liveset.walkers[1].configuration)
+        probe isa Real || throw(ArgumentError(
+            "observables: callback :$name returned a $(typeof(probe)); " *
+            "callbacks must return a Real"))
+        if !isfinite(Float64(probe))
+            @warn "observables: probe evaluation of :$name returned a non-finite value ($probe)"
+        end
+    end
+    return nothing
+end
+
 """
     estimate_temperature(n_walker::Int, n_cull::Int, ediff::Float64)
 Estimate the temperature for the nested sampling algorithm from dlog(ω)/dE.
@@ -1041,17 +1083,28 @@ Perform a nested sampling loop for a given number of steps.
 - `ns_params::NestedSamplingParameters`: The parameters for nested sampling.
 - `n_steps::Int64`: The number of steps to perform.
 - `mc_routine::MCRoutine`: The Monte Carlo routine to use.
+- `observables`: Optional vector of `name::Symbol => callback` pairs. Each
+  callback is evaluated on the culled walker's `configuration` at every
+  accepted iteration and recorded as an extra `Float64` ledger column named
+  `name`, exactly paired with that row's `iter`-keyed prior-volume weight.
+  Names must not collide with the built-in ledger columns
+  (`$(join(String.(_RESERVED_LEDGER_COLUMNS), ", "))`); callbacks must be
+  pure functions of the configuration returning a `Real`. Supported for
+  single-cull MC routines — a pairing guard raises an error otherwise.
+  The default `nothing` leaves the ledger schema unchanged.
 
 # Returns
-- `df`: A DataFrame containing the iteration number and maximum energy for each step.
+- `df`: A DataFrame containing the iteration number and maximum energy for each step,
+  plus one column per requested observable.
 - `liveset`: The updated set of walkers.
 - `ns_params`: The updated nested sampling parameters.
 """
-function nested_sampling(liveset::AbstractLiveSet, 
-                                ns_params::NestedSamplingParameters, 
-                                n_steps::Int64, 
+function nested_sampling(liveset::AbstractLiveSet,
+                                ns_params::NestedSamplingParameters,
+                                n_steps::Int64,
                                 mc_routine::MCRoutine,
-                                save_strategy::DataSavingStrategy)
+                                save_strategy::DataSavingStrategy;
+                                observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
     # Initialize cluster_p and reset counters from MCMixedMoves if applicable
     if mc_routine isa MCMixedMoves && mc_routine.clusters_freq > 0
         ns_params.cluster_p = mc_routine.initial_cluster_p
@@ -1062,9 +1115,25 @@ function nested_sampling(liveset::AbstractLiveSet,
         empty!(ns_params.cluster_adjust_iterations)
     end
     df = DataFrame(iter=Int[], emax=Float64[])
+    if observables !== nothing
+        _validate_observables(observables, liveset)
+        for (name, _) in observables
+            df[!, name] = Float64[]
+        end
+    end
+    culled = nothing
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
+        if observables !== nothing
+            # Pre-sort with the step's own comparator and hold the walker the
+            # step will cull: the step re-sorts (stable sort, so the identity
+            # permutation here) and culls walkers[1] on accept. `popfirst!`
+            # removes but never mutates the culled walker, so evaluating the
+            # callbacks on it after the step is exact.
+            sort_by_energy!(liveset)
+            culled = liveset.walkers[1]
+        end
         iter, emax, liveset, ns_params = nested_sampling_step!(liveset, ns_params, mc_routine; ns_iteration=i)
         @debug "n_step $i, iter: $iter, emax: $emax"
         if ns_params.fail_count >= ns_params.allowed_fail_count
@@ -1073,7 +1142,17 @@ function nested_sampling(liveset::AbstractLiveSet,
             ns_params.step_size = ns_params.initial_step_size
         end
         if !(iter isa typeof(missing))
-            push!(df, (iter, emax.val))
+            if observables === nothing
+                push!(df, (iter, emax.val))
+            else
+                emax == culled.energy || error(
+                    "NS observable recording: dead-point/observable pairing " *
+                    "lost (step culled a walker with energy $emax, but the " *
+                    "pre-sorted worst walker had $(culled.energy)); this MC " *
+                    "routine is not supported with `observables`")
+                push!(df, (iter, emax.val,
+                           (Float64(f(culled.configuration)) for (_, f) in observables)...))
+            end
         end
         print_message(i, iter, emax, ns_params.step_size, print_info, liveset)
         write_df_every_n(df, i, save_strategy)
@@ -1232,9 +1311,13 @@ highest-Ω walker, record (Ω, E, N), replace with a decorrelated clone.
 - `n_steps::Int64`: Number of NS iterations.
 - `mc_routine::MCGrandCanonicalMoves`: The GC move routine.
 - `save_strategy::DataSavingStrategy`: Strategy for periodic output.
+- `observables`: Optional vector of `name::Symbol => callback` pairs
+  recording per-dead-point observables as extra ledger columns; see
+  [`nested_sampling`](@ref).
 
 # Returns
-- `df::DataFrame`: Columns `[:iter, :omega, :energy, :num_particles]`.
+- `df::DataFrame`: Columns `[:iter, :omega, :energy, :num_particles]`,
+  plus one column per requested observable.
 - `liveset::LatticeGasWalkers`: The final liveset (surviving walkers).
 - `gc_params::GrandCanonicalNestedSamplingParameters`: Updated parameters.
 """
@@ -1242,7 +1325,8 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
                                          gc_params::GrandCanonicalNestedSamplingParameters,
                                          n_steps::Int64,
                                          mc_routine::MCGrandCanonicalMoves,
-                                         save_strategy::DataSavingStrategy)
+                                         save_strategy::DataSavingStrategy;
+                                         observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
     # Initialize walkers with random microstates
     _init_gc_walkers!(liveset, gc_params)
 
@@ -1257,10 +1341,26 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
     end
 
     df = DataFrame(iter=Int[], omega=Float64[], energy=Float64[], num_particles=Int[])
+    if observables !== nothing
+        _validate_observables(observables, liveset)
+        for (name, _) in observables
+            df[!, name] = Float64[]
+        end
+    end
+    culled = nothing
 
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
+
+        if observables !== nothing
+            # Pre-sort with the step's own comparator (Ω = E − μN, descending)
+            # and hold the walker the step will cull; see `nested_sampling`.
+            sort!(liveset.walkers,
+                  by = w -> _grand_potential(w, gc_params.chemical_potential),
+                  rev=true)
+            culled = liveset.walkers[1]
+        end
 
         iter, omega, energy, n_par, liveset, gc_params = nested_sampling_step!(
             liveset, gc_params, mc_routine; ns_iteration=i)
@@ -1273,7 +1373,17 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
         end
 
         if !(iter isa typeof(missing))
-            push!(df, (iter, omega.val, energy.val, n_par))
+            if observables === nothing
+                push!(df, (iter, omega.val, energy.val, n_par))
+            else
+                omega == _grand_potential(culled, gc_params.chemical_potential) || error(
+                    "GC-NS observable recording: dead-point/observable " *
+                    "pairing lost (step culled a walker with Ω = $omega, but " *
+                    "the pre-sorted worst walker had Ω = " *
+                    "$(_grand_potential(culled, gc_params.chemical_potential)))")
+                push!(df, (iter, omega.val, energy.val, n_par,
+                           (Float64(f(culled.configuration)) for (_, f) in observables)...))
+            end
         end
 
         if print_info && !(iter isa typeof(missing))
@@ -1533,9 +1643,15 @@ extract them from the returned liveset.
 - `n_steps::Int64`: Number of NS iterations.
 - `mc_routine::MCGrandCanonicalMoves`: The GC move routine (reused from the Ω-sorted construction).
 - `save_strategy::DataSavingStrategy`: Strategy for periodic output.
+- `observables`: Optional vector of `name::Symbol => callback` pairs
+  recording per-dead-point observables (e.g. `order_parameter_c2x2`) as
+  extra ledger columns; see [`nested_sampling`](@ref). The recorded columns
+  feed the `observable_cols` machinery of
+  `gc_thermodynamic_stats_ideal_ref`.
 
 # Returns
-- `df::DataFrame`: Columns `[:iter, :emax, :num_particles]`.
+- `df::DataFrame`: Columns `[:iter, :emax, :num_particles]`,
+  plus one column per requested observable.
 - `liveset::LatticeGasWalkers`: The final liveset (surviving walkers).
 - `params::IdealGasReferencedGCNSParameters`: Updated parameters.
 """
@@ -1543,7 +1659,8 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
                                               params::IdealGasReferencedGCNSParameters,
                                               n_steps::Int64,
                                               mc_routine::MCGrandCanonicalMoves,
-                                              save_strategy::DataSavingStrategy)
+                                              save_strategy::DataSavingStrategy;
+                                              observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing)
     # Initialize walkers as i.i.d. draws from the Bernoulli(z0/(1+z0)) prior
     _init_ideal_gas_ref_walkers!(liveset, params)
 
@@ -1558,10 +1675,24 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
     end
 
     df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
+    if observables !== nothing
+        _validate_observables(observables, liveset)
+        for (name, _) in observables
+            df[!, name] = Float64[]
+        end
+    end
+    culled = nothing
 
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
+
+        if observables !== nothing
+            # Pre-sort with the step's own comparator (energy, descending)
+            # and hold the walker the step will cull; see `nested_sampling`.
+            sort_by_energy!(liveset)
+            culled = liveset.walkers[1]
+        end
 
         iter, emax, n_par, liveset, params = nested_sampling_step!(
             liveset, params, mc_routine; ns_iteration=i)
@@ -1574,7 +1705,16 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
         end
 
         if !(iter isa typeof(missing))
-            push!(df, (iter, emax.val, n_par))
+            if observables === nothing
+                push!(df, (iter, emax.val, n_par))
+            else
+                emax == culled.energy || error(
+                    "IG-ref GC-NS observable recording: dead-point/observable " *
+                    "pairing lost (step culled a walker with energy $emax, " *
+                    "but the pre-sorted worst walker had $(culled.energy))")
+                push!(df, (iter, emax.val, n_par,
+                           (Float64(f(culled.configuration)) for (_, f) in observables)...))
+            end
         end
 
         if print_info && !(iter isa typeof(missing))

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -307,15 +307,19 @@ mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
     fail_count::Int64
     allowed_fail_count::Int64
     init_occupation_p::Float64
+    n_max::Int64
 end
 
 """
     GrandCanonicalNestedSamplingParameters(;
         mc_steps=100, chemical_potential=0.0, energy_perturbation=1e-12,
         random_seed=1234, fail_count=0, allowed_fail_count=10,
-        init_occupation_p=0.5)
+        init_occupation_p=0.5, n_max=typemax(Int64))
 
 Convenience constructor for `GrandCanonicalNestedSamplingParameters`.
+
+The `n_max` parameter sets an upper bound on the number of particles per walker.
+Insertions are rejected when N ≥ n_max. Default is `typemax(Int64)` (no cap).
 """
 function GrandCanonicalNestedSamplingParameters(;
     mc_steps::Int64=100,
@@ -325,11 +329,12 @@ function GrandCanonicalNestedSamplingParameters(;
     fail_count::Int64=0,
     allowed_fail_count::Int64=10,
     init_occupation_p::Float64=0.5,
+    n_max::Int64=typemax(Int64),
 )
     GrandCanonicalNestedSamplingParameters(
         mc_steps, chemical_potential, energy_perturbation,
         random_seed, fail_count, allowed_fail_count,
-        init_occupation_p,
+        init_occupation_p, n_max,
     )
 end
 
@@ -1057,8 +1062,18 @@ Each site is occupied independently with probability `gc_params.init_occupation_
 """
 function _init_gc_walkers!(liveset::LatticeGasWalkers, gc_params::GrandCanonicalNestedSamplingParameters)
     h = liveset.hamiltonian
+    n_max = gc_params.n_max
     for walker in liveset.walkers
         random_microstate!(walker.configuration; p=gc_params.init_occupation_p)
+        # Enforce n_max: if too many particles, randomly delete until N ≤ n_max
+        n_occ = sum(walker.configuration.components[1])
+        if n_occ > n_max
+            occupied = findall(walker.configuration.components[1])
+            shuffle!(occupied)
+            for i in 1:(n_occ - n_max)
+                walker.configuration.components[1][occupied[i]] = false
+            end
+        end
         assign_energy!(walker, h; perturb_energy=gc_params.energy_perturbation)
     end
     return liveset
@@ -1115,7 +1130,8 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     accept, rate, to_walk = MC_grand_canonical_walk!(
         gc_params.mc_steps, to_walk, h, omega_max_val, mu;
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
-        energy_perturb=gc_params.energy_perturbation)
+        energy_perturb=gc_params.energy_perturbation,
+        n_max=gc_params.n_max)
 
     if accept
         push!(ats, to_walk)

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -254,6 +254,85 @@ A type for generating a new walker by performing rejection sampling. Currently, 
 """
 struct MCRejectionSampling <: MCRoutine end
 
+
+# ======================================================================
+# Grand-canonical nested sampling types
+# ======================================================================
+
+"""
+    struct MCGrandCanonicalMoves <: MCRoutine
+
+A type for generating a new walker using grand-canonical MCMC moves that mix
+fixed-N local swaps with single-site particle insertion and deletion.
+
+# Fields
+- `p_move::Float64`: Probability of a fixed-N swap move per MCMC step (default 0.5).
+- `p_insert::Float64`: Probability of a particle insertion per step (default 0.25).
+  The deletion probability is `1 - p_move - p_insert`.
+"""
+struct MCGrandCanonicalMoves <: MCRoutine
+    p_move::Float64
+    p_insert::Float64
+    function MCGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25)
+        if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
+            throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+        end
+        new(p_move, p_insert)
+    end
+end
+
+"""
+    mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
+
+Parameters for grand-canonical nested sampling on lattice systems.
+
+The grand potential Ω = E − μN is used as the sorting quantity. Walkers have
+variable particle count N, and the NS loop records (Ω, E, N) per iteration
+for thermodynamic reweighting.
+
+# Fields
+- `mc_steps::Int64`: MCMC steps per replacement walker.
+- `chemical_potential::Float64`: Chemical potential μ (unitless, in energy units of the Hamiltonian).
+- `energy_perturbation::Float64`: Perturbation to break energy degeneracies.
+- `random_seed::Int64`: Seed for the random number generator.
+- `fail_count::Int64`: Consecutive failed replacements.
+- `allowed_fail_count::Int64`: Maximum consecutive failures before warning.
+- `init_occupation_p::Float64`: Per-site occupation probability for initial walkers.
+"""
+mutable struct GrandCanonicalNestedSamplingParameters <: SamplingParameters
+    mc_steps::Int64
+    chemical_potential::Float64
+    energy_perturbation::Float64
+    random_seed::Int64
+    fail_count::Int64
+    allowed_fail_count::Int64
+    init_occupation_p::Float64
+end
+
+"""
+    GrandCanonicalNestedSamplingParameters(;
+        mc_steps=100, chemical_potential=0.0, energy_perturbation=1e-12,
+        random_seed=1234, fail_count=0, allowed_fail_count=10,
+        init_occupation_p=0.5)
+
+Convenience constructor for `GrandCanonicalNestedSamplingParameters`.
+"""
+function GrandCanonicalNestedSamplingParameters(;
+    mc_steps::Int64=100,
+    chemical_potential::Float64=0.0,
+    energy_perturbation::Float64=1e-12,
+    random_seed::Int64=1234,
+    fail_count::Int64=0,
+    allowed_fail_count::Int64=10,
+    init_occupation_p::Float64=0.5,
+)
+    GrandCanonicalNestedSamplingParameters(
+        mc_steps, chemical_potential, energy_perturbation,
+        random_seed, fail_count, allowed_fail_count,
+        init_occupation_p,
+    )
+end
+
 """
     sort_by_energy!(liveset::LJAtomWalkers)
 
@@ -954,4 +1033,167 @@ function print_message(i, iter, emax, step_size, print_info, liveset::AtomWalker
         @info "MC move failed, step: $(i), emax: $(liveset.walkers[1].energy.val), step_size: $(round(step_size; sigdigits=4))"
     end
 end
-    
+
+
+# ======================================================================
+# Grand-canonical nested sampling
+# ======================================================================
+
+"""
+    _grand_potential(walker::LatticeWalker{1}, mu::Float64) -> typeof(0.0u"eV")
+
+Compute Ω = E − μN for a single-component lattice walker.
+"""
+function _grand_potential(walker::LatticeWalker{1}, mu::Float64)
+    n = sum(walker.configuration.components[1])
+    return walker.energy - mu * n * unit(walker.energy)
+end
+
+"""
+    _init_gc_walkers!(liveset::LatticeGasWalkers, gc_params::GrandCanonicalNestedSamplingParameters)
+
+Initialize walkers with random microstates for grand-canonical NS.
+Each site is occupied independently with probability `gc_params.init_occupation_p`.
+"""
+function _init_gc_walkers!(liveset::LatticeGasWalkers, gc_params::GrandCanonicalNestedSamplingParameters)
+    h = liveset.hamiltonian
+    for walker in liveset.walkers
+        random_microstate!(walker.configuration; p=gc_params.init_occupation_p)
+        assign_energy!(walker, h; perturb_energy=gc_params.energy_perturbation)
+    end
+    return liveset
+end
+
+"""
+    nested_sampling_step!(liveset::LatticeGasWalkers,
+                          gc_params::GrandCanonicalNestedSamplingParameters,
+                          mc_routine::MCGrandCanonicalMoves;
+                          ns_iteration::Int=0)
+
+Perform one step of grand-canonical nested sampling.
+
+Sorts walkers by Ω = E − μN, removes the worst (highest Ω), clones a parent
+with Ω < Ω_worst, and decorrelates the clone via grand-canonical MCMC.
+
+# Returns
+- `iter`: Iteration number (or `missing` if the step failed).
+- `omega_max`: The Ω value of the removed walker (with units).
+- `energy`: The E value of the removed walker.
+- `num_particles`: The N value of the removed walker.
+- `liveset`: The updated liveset.
+- `gc_params`: The updated parameters.
+"""
+function nested_sampling_step!(liveset::LatticeGasWalkers,
+                               gc_params::GrandCanonicalNestedSamplingParameters,
+                               mc_routine::MCGrandCanonicalMoves;
+                               ns_iteration::Int=0)
+    ats = liveset.walkers
+    h = liveset.hamiltonian
+    mu = gc_params.chemical_potential
+    n_walkers = length(ats)
+
+    # Sort by grand potential (descending — worst first)
+    sort!(ats, by = w -> _grand_potential(w, mu), rev=true)
+
+    iter::Union{Missing,Int} = missing
+    worst = ats[1]
+    omega_worst = _grand_potential(worst, mu)
+    energy_worst = worst.energy
+    n_worst = sum(worst.configuration.components[1])
+
+    # Select parent: prefer walkers strictly below omega_worst
+    omega_max_val = omega_worst.val  # unitless for the MC function
+    eligible = [k for k in 2:n_walkers if _grand_potential(ats[k], mu) < omega_worst]
+    if !isempty(eligible)
+        parent_idx = rand(eligible)
+    else
+        parent_idx = rand(2:n_walkers)
+    end
+    to_walk = deepcopy(ats[parent_idx])
+
+    # Decorrelate via GC MCMC
+    accept, rate, to_walk = MC_grand_canonical_walk!(
+        gc_params.mc_steps, to_walk, h, omega_max_val, mu;
+        p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
+        energy_perturb=gc_params.energy_perturbation)
+
+    if accept
+        push!(ats, to_walk)
+        popfirst!(ats)
+        update_iter!(liveset)
+        gc_params.fail_count = 0
+        iter = liveset.walkers[1].iter
+    else
+        omega_worst = missing
+        energy_worst = missing
+        n_worst = missing
+        gc_params.fail_count += 1
+    end
+
+    return iter, omega_worst, energy_worst, n_worst, liveset, gc_params
+end
+
+"""
+    grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
+                                    gc_params::GrandCanonicalNestedSamplingParameters,
+                                    n_steps::Int64,
+                                    mc_routine::MCGrandCanonicalMoves,
+                                    save_strategy::DataSavingStrategy)
+
+Run the grand-canonical nested sampling loop.
+
+Initializes walkers with random microstates, then iterates: remove the
+highest-Ω walker, record (Ω, E, N), replace with a decorrelated clone.
+
+# Arguments
+- `liveset::LatticeGasWalkers`: The initial liveset (walkers will be re-initialized).
+- `gc_params::GrandCanonicalNestedSamplingParameters`: GC-NS parameters including μ.
+- `n_steps::Int64`: Number of NS iterations.
+- `mc_routine::MCGrandCanonicalMoves`: The GC move routine.
+- `save_strategy::DataSavingStrategy`: Strategy for periodic output.
+
+# Returns
+- `df::DataFrame`: Columns `[:iter, :omega, :energy, :num_particles]`.
+- `liveset::LatticeGasWalkers`: The final liveset (surviving walkers).
+- `gc_params::GrandCanonicalNestedSamplingParameters`: Updated parameters.
+"""
+function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
+                                         gc_params::GrandCanonicalNestedSamplingParameters,
+                                         n_steps::Int64,
+                                         mc_routine::MCGrandCanonicalMoves,
+                                         save_strategy::DataSavingStrategy)
+    # Initialize walkers with random microstates
+    _init_gc_walkers!(liveset, gc_params)
+
+    df = DataFrame(iter=Int[], omega=Float64[], energy=Float64[], num_particles=Int[])
+
+    for i in 1:n_steps
+        print_info = i % save_strategy.n_info == 0
+        write_walker_every_n(liveset.walkers[1], i, save_strategy)
+
+        iter, omega, energy, n_par, liveset, gc_params = nested_sampling_step!(
+            liveset, gc_params, mc_routine; ns_iteration=i)
+
+        @debug "GC-NS step $i, iter: $iter, omega: $omega, energy: $energy, N: $n_par"
+
+        if gc_params.fail_count >= gc_params.allowed_fail_count
+            @warn "GC-NS: Failed $(gc_params.allowed_fail_count) times in a row."
+            gc_params.fail_count = 0
+        end
+
+        if !(iter isa typeof(missing))
+            push!(df, (iter, omega.val, energy.val, n_par))
+        end
+
+        if print_info && !(iter isa typeof(missing))
+            @info "GC-NS iter: $(iter), Ω: $(omega), E: $(energy), N: $(n_par)"
+        elseif print_info && iter isa typeof(missing)
+            @info "GC-NS MC move failed, step: $(i)"
+        end
+
+        write_df_every_n(df, i, save_strategy)
+        write_ls_every_n(liveset, i, save_strategy)
+    end
+
+    return df, liveset, gc_params
+end

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -79,7 +79,10 @@ function nvt_monte_carlo(
 )
     # Set the random seed
     Random.seed!(random_seed)
-    
+
+    # No liveset is built on this path, so run the shell-coverage check here
+    AbstractLiveSets._warn_uncoupled_shells(lattice, h)
+
     energies = Vector{Float64}(undef, num_steps)
     configurations = Vector{typeof(lattice)}(undef, num_steps)
     # df = DataFrame(energy=Float64[], config=Vector{Vector{Bool}}[])

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -449,3 +449,13 @@ function monte_carlo_sampling(
 
     return energies, ls, cvs, acceptance_rates
 end
+
+# Catch-all for common mistake of omitting MCRoutine as the first argument
+function monte_carlo_sampling(system, potential_or_hamiltonian, mc_params::MetropolisMCParameters; kwargs...)
+    throw(ArgumentError(
+        "`monte_carlo_sampling` requires an `MCRoutine` as the first argument.\n" *
+        "For atomistic systems, use e.g. `MCRandomWalkMaxE()` or `MCMixedMoves()`.\n" *
+        "For lattice systems, use `MCNewSample()`.\n" *
+        "Example: monte_carlo_sampling(MCRandomWalkMaxE(), walker, potential, params)"
+    ))
+end

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -83,6 +83,7 @@ function nvt_monte_carlo(
     # No liveset is built on this path, so run the setup checks here
     AbstractLiveSets._warn_uncoupled_shells(lattice, h)
     AbstractLiveSets._check_cluster_sites(h, lattice)
+    AbstractLiveSets._check_field_length(h, lattice)
 
     energies = Vector{Float64}(undef, num_steps)
     configurations = Vector{typeof(lattice)}(undef, num_steps)

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -80,8 +80,9 @@ function nvt_monte_carlo(
     # Set the random seed
     Random.seed!(random_seed)
 
-    # No liveset is built on this path, so run the shell-coverage check here
+    # No liveset is built on this path, so run the setup checks here
     AbstractLiveSets._warn_uncoupled_shells(lattice, h)
+    AbstractLiveSets._check_cluster_sites(h, lattice)
 
     energies = Vector{Float64}(undef, num_steps)
     configurations = Vector{typeof(lattice)}(undef, num_steps)

--- a/src/SamplingSchemes/wang_landau.jl
+++ b/src/SamplingSchemes/wang_landau.jl
@@ -112,8 +112,9 @@ function wang_landau(
     # Set the random seed
     Random.seed!(wl_params.random_seed)
 
-    # No liveset is built on this path, so run the shell-coverage check here
+    # No liveset is built on this path, so run the setup checks here
     AbstractLiveSets._warn_uncoupled_shells(lattice, h)
+    AbstractLiveSets._check_cluster_sites(h, lattice)
 
     energy_bins_count = length(wl_params.energy_bins)
     

--- a/src/SamplingSchemes/wang_landau.jl
+++ b/src/SamplingSchemes/wang_landau.jl
@@ -115,6 +115,7 @@ function wang_landau(
     # No liveset is built on this path, so run the setup checks here
     AbstractLiveSets._warn_uncoupled_shells(lattice, h)
     AbstractLiveSets._check_cluster_sites(h, lattice)
+    AbstractLiveSets._check_field_length(h, lattice)
 
     energy_bins_count = length(wl_params.energy_bins)
     

--- a/src/SamplingSchemes/wang_landau.jl
+++ b/src/SamplingSchemes/wang_landau.jl
@@ -111,7 +111,10 @@ function wang_landau(
 )
     # Set the random seed
     Random.seed!(wl_params.random_seed)
-    
+
+    # No liveset is built on this path, so run the shell-coverage check here
+    AbstractLiveSets._warn_uncoupled_shells(lattice, h)
+
     energy_bins_count = length(wl_params.energy_bins)
     
     # Set g(E) = 1 and H(E) = 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,8 @@ include("test-AnalysisTools.jl")
 
 include("test-EnergyEval.jl")
 
+include("test-EnergyEval-clusters.jl")
+
 include("test-MonteCarloMoves.jl")
 
 include("test-SamplingSchemes/test-SamplingSchemes.jl")

--- a/test/test-AbstractHamiltonians.jl
+++ b/test/test-AbstractHamiltonians.jl
@@ -170,4 +170,76 @@
         @test contains(output, "ClusterInteraction{3}")
         @test contains(output, "2 embeddings")
     end
+
+    @testset "SiteFieldLatticeHamiltonian tests" begin
+        base = GenericLatticeHamiltonian(0.0, [0.0], u"eV")
+        h = SiteFieldLatticeHamiltonian(base, [-0.27, -0.03375, -0.01], u"eV")
+        @test h isa SiteFieldLatticeHamiltonian{typeof(base),typeof(1.0u"eV")}
+        @test h.base === base
+        @test h.field == [-0.27, -0.03375, -0.01] .* u"eV"
+        @test length(h.field) == 3
+
+        # The convenience (Float64 + units) and direct (unitful vector)
+        # constructors agree
+        h2 = SiteFieldLatticeHamiltonian(base, [-0.27, -0.03375, -0.01] .* u"eV")
+        @test h2.field == h.field
+
+        # The field is copied, not aliased
+        raw = [-0.1, -0.2] .* u"eV"
+        h_copy = SiteFieldLatticeHamiltonian(base, raw)
+        raw[1] = 0.0u"eV"
+        @test h_copy.field[1] == -0.1u"eV"
+
+        # The field-type rule is "match the base's coupling type", not
+        # "must be eV": an all-meV pairing is legal
+        base_mev = GenericLatticeHamiltonian(-40.0, [-10.0], u"meV")
+        h_mev = SiteFieldLatticeHamiltonian(base_mev, [-1.0, -2.0], u"meV")
+        @test h_mev.field == [-1.0, -2.0] .* u"meV"
+
+        # A cluster Hamiltonian is a legal base (any non-nested
+        # ClassicalHamiltonian with a declared coupling type)
+        pair = GenericLatticeHamiltonian(-1.249, [0.292, 0.090], u"eV")
+        cl = ClusterLatticeHamiltonian(pair, [ClusterInteraction(0.168u"eV", [(1, 2, 3)])])
+        hcl = SiteFieldLatticeHamiltonian(cl, [-0.1, -0.1, -0.1], u"eV")
+        @test hcl.base === cl
+
+        # An MLatticeHamiltonian is a legal base too: the coupling-type
+        # trait reads its shared U parameter
+        mlh = MLatticeHamiltonian(1, [GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")])
+        hml = SiteFieldLatticeHamiltonian(mlh, [-0.1], u"eV")
+        @test hml.base === mlh
+        @test hml isa SiteFieldLatticeHamiltonian{typeof(mlh),typeof(1.0u"eV")}
+
+        # A unitless base is constructible, and the wrapper (including the
+        # delegated base print) shows without error
+        h_unitless = SiteFieldLatticeHamiltonian(
+            GenericLatticeHamiltonian(-0.04, [-0.01]), [0.1, 0.2])
+        buf_u = IOBuffer()
+        show(buf_u, h_unitless)
+        @test contains(String(take!(buf_u)), "field: 2 sites")
+
+        # Empty fields have no meaning: which sites would they cover?
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, Float64[], u"eV")
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, typeof(1.0u"eV")[])
+        # Non-finite entries stall nested sampling silently (Inf >= Inf
+        # ceiling comparisons), the coupling-guard rationale
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [0.1, Inf], u"eV")
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [NaN], u"eV")
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [0.1u"eV", Inf * u"eV"])
+        # Field element type must equal the base coupling type exactly,
+        # mirroring the cluster coupling-type check
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [0.1, 0.2])
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base, [100.0, 200.0] .* u"meV")
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(base_mev, [-1.0], u"eV")
+        # Nesting is rejected: compose site fields by adding the vectors
+        @test_throws ArgumentError SiteFieldLatticeHamiltonian(h, [-0.1, -0.2, -0.3], u"eV")
+
+        # Show method
+        buf = IOBuffer()
+        show(buf, h)
+        output = String(take!(buf))
+        @test contains(output, "SiteFieldLatticeHamiltonian")
+        @test contains(output, "field: 3 sites")
+        @test contains(output, "base: ")
+    end
 end

--- a/test/test-AbstractHamiltonians.jl
+++ b/test/test-AbstractHamiltonians.jl
@@ -5,6 +5,12 @@
         @testset "Constructor Tests" begin
             # Test error handling for mismatched lengths
             @test_throws ArgumentError GenericLatticeHamiltonian{3,typeof(1.0u"eV")}(1.0u"eV", [1.0, 2.0] .* u"eV")
+            # Non-finite couplings stall nested sampling silently (Inf >= Inf
+            # ceiling comparisons); hard-core models use a finite J instead
+            @test_throws ArgumentError GenericLatticeHamiltonian(0.0, [Inf, 0.0], u"eV")
+            @test_throws ArgumentError GenericLatticeHamiltonian(-Inf, [0.0], u"eV")
+            @test_throws ArgumentError GenericLatticeHamiltonian(0.0, [NaN], u"eV")
+            @test_throws ArgumentError GenericLatticeHamiltonian(0.0u"eV", [Inf * u"eV"])
         end
 
         @testset "Property Tests" begin

--- a/test/test-AbstractHamiltonians.jl
+++ b/test/test-AbstractHamiltonians.jl
@@ -126,4 +126,48 @@
         end
 
     end
+
+    @testset "ClusterInteraction and ClusterLatticeHamiltonian tests" begin
+        trio = ClusterInteraction(0.168u"eV", [(1, 2, 3), (2, 3, 4)])
+        @test trio.coupling == 0.168u"eV"
+        @test length(trio.embeddings) == 2
+        @test trio isa ClusterInteraction{3,typeof(1.0u"eV")}
+
+        quattro = ClusterInteraction(-0.120u"eV", [(1, 2, 5, 6)])
+        @test quattro isa ClusterInteraction{4,typeof(1.0u"eV")}
+
+        # Pair and on-site terms belong in the wrapped pair Hamiltonian
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV", [(1, 2)])
+        # Non-finite couplings
+        @test_throws ArgumentError ClusterInteraction(Inf * u"eV", [(1, 2, 3)])
+        # Canonical form: strictly increasing, positive, no duplicates
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV", [(2, 1, 3)])
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV", [(1, 1, 2)])
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV", [(0, 1, 2)])
+        @test_throws ArgumentError ClusterInteraction(0.1u"eV",
+            [(1, 2, 3), (1, 2, 3)])
+        # Empty embedding lists contribute exactly zero and warn
+        @test_logs (:warn, r"exactly zero") match_mode = :any ClusterInteraction(
+            0.1u"eV", NTuple{3,Int}[])
+
+        pair = GenericLatticeHamiltonian(-1.249, [0.292, 0.090, -0.050, -0.010], u"eV")
+        h = ClusterLatticeHamiltonian(pair, [trio, quattro])
+        @test h isa ClusterLatticeHamiltonian{4,typeof(1.0u"eV")}
+        @test h.pair_ham === pair
+        @test length(h.clusters) == 2
+
+        # Coupling value type must match the pair Hamiltonian
+        trio_mev = ClusterInteraction(168.0u"meV", [(1, 2, 3)])
+        @test_throws ArgumentError ClusterLatticeHamiltonian(pair, [trio_mev])
+        # Non-ClusterInteraction elements are rejected
+        @test_throws ArgumentError ClusterLatticeHamiltonian(pair, [1.0])
+
+        # Show methods
+        buf = IOBuffer()
+        show(buf, h)
+        output = String(take!(buf))
+        @test contains(output, "ClusterLatticeHamiltonian")
+        @test contains(output, "ClusterInteraction{3}")
+        @test contains(output, "2 embeddings")
+    end
 end

--- a/test/test-AbstractLiveSets.jl
+++ b/test/test-AbstractLiveSets.jl
@@ -135,6 +135,110 @@ FreeBird.EnergyEval.interacting_energy(lattice::SLattice, h::ExtBadHam) = 1.6
             end
         end
 
+        @testset "LJSurfaceWalkers constructor validation tests" begin
+            # These testsets build fresh fixtures rather than sharing the
+            # `surface` above: the constructors mutate the surface walker
+            # (frozen flags, and `energy_frozen_part` under
+            # `compute_frozen_energy=true`), and the keyword tests need a
+            # surface whose `energy_frozen_part` still sits at its
+            # 0.0u"eV" default.
+            ads_list = [:H => [0.5, 0.5, 0.35]]
+            # one-component adsorbate walkers
+            make_adsorbates(n) = [AtomWalker(FastSystem(periodic_system(ads_list, box, fractional=true))) for _ in 1:n]
+            make_surface() = AtomWalker(FastSystem(periodic_system(surf_list, box, fractional=true)); freeze_species=[:H])
+            ljs2 = CompositeParameterSets(2, [lj, lj, lj])  # adsorbate + surface
+
+            @testset "bare LJParameters rejected at dispatch" begin
+                # No surface energy path can evaluate a bare LJParameters
+                # (the five-argument interacting_energy and the same-surface
+                # single_site_energy methods exist only for
+                # CompositeParameterSets), so both constructor forms accept
+                # only the composite type and a bare parameter set fails at
+                # dispatch, before any energy work.
+                walkers = make_adsorbates(1)
+                surface = make_surface()
+                @test_throws MethodError LJSurfaceWalkers(walkers, lj, surface)
+                @test_throws MethodError LJSurfaceWalkers(walkers, lj, surface, :threads)
+            end
+
+            @testset "component-count validation" begin
+                # The surface energy paths append the surface as the LAST
+                # parameter-set component, so the parameter set must carry
+                # C + 1 components over C-component walkers; a mismatch
+                # raises a descriptive ArgumentError on both constructor
+                # forms. The matching layouts need no new coverage here:
+                # the LJSurfaceWalkers testsets above construct
+                # three-over-two (`ljs` over the two-component H/O
+                # walkers), and the sampling-scheme suites construct
+                # two-over-one.
+                walkers = make_adsorbates(1)
+                surface = make_surface()
+                @test_throws ArgumentError LJSurfaceWalkers(walkers, ljs, surface)
+                @test_throws ArgumentError LJSurfaceWalkers(walkers, ljs, surface, :threads)
+                err = try
+                    LJSurfaceWalkers(walkers, ljs, surface)
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa ArgumentError
+                @test occursin("3-component parameters", err.msg)
+                @test occursin("1-component walkers", err.msg)
+                @test occursin("expected 2", err.msg)
+            end
+
+            @testset "frozen-part energy bookkeeping" begin
+                # With the adsorbent self-energy assigned by hand (the
+                # documented idiom), every walker total is the
+                # walker-surface interacting energy plus the surface
+                # self-energy, carried through the copied
+                # energy_frozen_part: the self-energy enters each total
+                # exactly once.
+                surface = make_surface()
+                surface.energy_frozen_part = interacting_energy(surface.configuration, lj)
+                ls = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface)
+                for w in ls.walkers
+                    @test w.energy == interacting_energy(w.configuration, ljs2, w.list_num_par, w.frozen, surface.configuration) + surface.energy_frozen_part
+                    @test w.energy_frozen_part == surface.energy_frozen_part
+                end
+            end
+
+            @testset "compute_frozen_energy keyword" begin
+                # Reference construction: the hand-assigned idiom.
+                surface_hand = make_surface()
+                surface_hand.energy_frozen_part = interacting_energy(surface_hand.configuration, lj)
+                ls_hand = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface_hand)
+
+                # compute_frozen_energy=true starts from an unset surface
+                # and must reproduce the hand-assigned construction
+                # bit-identically, on both constructor forms.
+                surface_kw = make_surface()
+                ls_kw = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface_kw; compute_frozen_energy=true)
+                @test surface_kw.energy_frozen_part === surface_hand.energy_frozen_part
+                surface_kwp = make_surface()
+                ls_kwp = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface_kwp, :threads; compute_frozen_energy=true)
+                @test surface_kwp.energy_frozen_part === surface_hand.energy_frozen_part
+                for i in 1:3
+                    @test ls_kw.walkers[i].energy === ls_hand.walkers[i].energy
+                    @test ls_kw.walkers[i].energy_frozen_part === ls_hand.walkers[i].energy_frozen_part
+                    @test ls_kwp.walkers[i].energy === ls_hand.walkers[i].energy
+                    @test ls_kwp.walkers[i].energy_frozen_part === ls_hand.walkers[i].energy_frozen_part
+                end
+
+                # The default leaves an unset surface at 0.0u"eV" (the
+                # silent omission the docstring documents): construction
+                # succeeds, no walker carries the self-energy, and the two
+                # constructions differ by exactly the surface self-energy.
+                surface_def = make_surface()
+                ls_def = LJSurfaceWalkers(make_adsorbates(3), ljs2, surface_def)
+                @test surface_def.energy_frozen_part == 0.0u"eV"
+                for i in 1:3
+                    @test ls_def.walkers[i].energy_frozen_part == 0.0u"eV"
+                    @test ls_def.walkers[i].energy + surface_hand.energy_frozen_part === ls_hand.walkers[i].energy
+                end
+            end
+        end
+
         @testset "LJAtomWalkers struct and functions tests" begin
             
             # Create multiple walkers with different configurations

--- a/test/test-AbstractLiveSets.jl
+++ b/test/test-AbstractLiveSets.jl
@@ -1,3 +1,29 @@
+# Custom-Hamiltonian fixtures for the extension-contract testset at the
+# bottom of this file; type definitions must sit at the file's top level.
+# ExtCoordHam: a coordination-dependent global functional no shipped pair,
+# cluster, or site-field type expresses (the documentation page's example).
+struct ExtCoordHam <: ClassicalHamiltonian
+    j::Float64
+end
+function FreeBird.EnergyEval.interacting_energy(lattice::SLattice, h::ExtCoordHam)
+    occ = lattice.components[1]
+    doubly = count(s -> occ[s] &&
+                        count(n -> occ[n], lattice.neighbors[s][1]) == 2,
+                   eachindex(occ))
+    return h.j * doubly^2 * u"eV"
+end
+# ExtDelegatingHam: wraps a shipped Hamiltonian unchanged, so a same-seed
+# run must be bit-identical to the shipped type (stream neutrality of the
+# extension path, including the setup validation)
+struct ExtDelegatingHam <: ClassicalHamiltonian
+    inner
+end
+FreeBird.EnergyEval.interacting_energy(lattice::SLattice, h::ExtDelegatingHam) =
+    interacting_energy(lattice, h.inner)
+# ExtBadHam: violates the return-type contract (plain Float64)
+struct ExtBadHam <: ClassicalHamiltonian end
+FreeBird.EnergyEval.interacting_energy(lattice::SLattice, h::ExtBadHam) = 1.6
+
 @testset "AbstractLiveSets Tests" begin
     @testset "atomistic_livesets.jl tests" begin
 
@@ -400,6 +426,136 @@
                 @test occursin("$comp", output)
             end
         end
+    end
+
+    @testset "custom-Hamiltonian extension contract" begin
+        using Random
+        ext_sq = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full)
+        ext_tri = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(3, 3, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:18]],
+            adsorptions=:full)
+        ext_ham = ExtCoordHam(0.1)
+
+        # Negative path: the return-type contract violation raises the
+        # descriptive ArgumentError at walker setup, naming the method and
+        # the required dimension, both at construction and through
+        # exact_enumeration (which constructs a liveset internally)
+        bad_walkers = [LatticeWalker(deepcopy(ext_sq), energy=0.0u"eV", iter=0)]
+        @test_throws ArgumentError LatticeGasWalkers(bad_walkers, ExtBadHam())
+        err = try
+            LatticeGasWalkers(bad_walkers, ExtBadHam())
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("interacting_energy", err.msg)
+        @test occursin("energy-dimensioned", err.msg)
+        @test occursin("Float64", err.msg)
+        @test_throws ArgumentError exact_enumeration(deepcopy(ext_sq), ExtBadHam())
+
+        # Positive path: one interacting_energy method serves construction
+        # on both geometries, with energies matching an independent
+        # re-evaluation of the same rule
+        Random.seed!(4661)
+        function ext_independent(lat)
+            occ = lat.components[1]
+            c = 0
+            for s in eachindex(occ)
+                occ[s] || continue
+                nb = count(n -> occ[n], lat.neighbors[s][1])
+                c += (nb == 2) ? 1 : 0
+            end
+            return 0.1 * c^2
+        end
+        for lat in (ext_sq, ext_tri)
+            walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                       for _ in 1:6]
+            for w in walkers
+                w.configuration.components[1] .= rand(Bool, length(w.configuration.components[1]))
+            end
+            ls = LatticeGasWalkers(walkers, ext_ham)
+            for w in ls.walkers
+                @test w.energy.val == ext_independent(w.configuration)
+            end
+        end
+
+        # Positive path, sampled: a short seeded grand-canonical run drives
+        # the custom Hamiltonian through the full loop
+        Random.seed!(4662)
+        walkers = [LatticeWalker(deepcopy(ext_sq), energy=0.0u"eV", iter=0)
+                   for _ in 1:8]
+        ls = LatticeGasWalkers(walkers, ext_ham; assign_energy=false)
+        gc = GrandCanonicalNestedSamplingParameters(mc_steps=20,
+            chemical_potential=-0.05, energy_perturbation=1e-9)
+        ext_save = SaveEveryN("t_ext.csv", "t_ext.traj", "t_ext.ls",
+                              1000000, 1000000, 1000000)
+        df, _, _ = grand_canonical_nested_sampling(ls, gc, Int64(100),
+            MCGrandCanonicalMoves(), ext_save;
+            observables=[:n_occ => (cfg -> Float64(sum(cfg.components[1])))])
+        # The 10^6-step save intervals guarantee no t_ext.* file is written
+        # in these short runs; the rm calls are defensive cleanup only
+        rm.(["t_ext.csv", "t_ext.traj", "t_ext.ls"], force=true)
+        @test nrow(df) > 0
+        @test all(isfinite, df.energy)
+        @test "n_occ" in names(df)
+        @test all(isfinite, df.n_occ)
+        @test df.n_occ == Float64.(df.num_particles)
+
+        # Positive path, enumerated: the fixed-N spectra match a brute force
+        # over all occupations of the independent rule, on the square
+        # C(16, 4) and the triangular C(18, 3) sectors
+        for (lat0, M, N) in [(ext_sq, 16, 4), (ext_tri, 18, 3)]
+            latN = deepcopy(lat0)
+            latN.components[1] .= vcat(fill(true, N), fill(false, M - N))
+            dfe, _ = exact_enumeration(latN, ext_ham)
+            @test nrow(dfe) == binomial(M, N)
+            probe = deepcopy(lat0)
+            brute = Float64[]
+            for mask in 0:(2^M-1)
+                count_ones(mask) == N || continue
+                for s in 1:M
+                    probe.components[1][s] = ((mask >> (s - 1)) & 1) == 1
+                end
+                push!(brute, ext_independent(probe))
+            end
+            @test sort([ustrip(u"eV", e) for e in dfe.energy]) == sort(brute)
+        end
+
+        # Shipped types still construct through the validated path with
+        # bit-identical energies (the validation is a no-op for them), and
+        # a delegating custom Hamiltonian is a same-seed drop-in for the
+        # shipped type it wraps: identical ideal-gas-referenced ledgers
+        ext_gham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        function ext_igref(seed, h)
+            Random.seed!(seed)
+            ws = [LatticeWalker(deepcopy(ext_sq), energy=0.0u"eV", iter=0)
+                  for _ in 1:12]
+            l = LatticeGasWalkers(ws, h; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=20,
+                reference_fugacity=1.0, energy_perturbation=1e-9)
+            d, fl, _ = ideal_gas_referenced_nested_sampling(l, p, Int64(80),
+                MCGrandCanonicalMoves(), ext_save)
+            rm.(["t_ext.csv", "t_ext.traj", "t_ext.ls"], force=true)
+            return d, [w.energy.val for w in fl.walkers]
+        end
+        dfS, liveS = ext_igref(4663, ext_gham)
+        dfD, liveD = ext_igref(4663, ExtDelegatingHam(ext_gham))
+        @test dfS.iter == dfD.iter
+        @test dfS.emax == dfD.emax
+        @test dfS.num_particles == dfD.num_particles
+        @test liveS == liveD
     end
 
 end

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -635,7 +635,9 @@
                 @test lattice.basis == [(0.0, 0.0, 0.0), (1/2, sqrt(3)/2, 0.0)]
                 @test lattice.supercell_dimensions == (4, 2, 1)
                 @test lattice.periodicity == (true, true, false)
-                @test lattice.cutoff_radii == [1.1, 1.5]
+                # Triangular default is [1.1, 1.8]: the second-neighbor
+                # distance √3 ≈ 1.732 lies beyond the square-lattice 1.5
+                @test lattice.cutoff_radii == [1.1, 1.8]
                 @test length(lattice.neighbors) == 16
                 @test length(lattice.components) == 2
                 @test length(lattice.adsorptions) == 16

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -277,7 +277,13 @@
                 periodicity = (true, true, true)
                 cutoff_radii = [1.1, 1.5, 1.8]
 
-                neighbors = AbstractWalkers.compute_neighbors(lattice_vectors, positions, periodicity, cutoff_radii)
+                # Every cutoff exceeds half the cell edge on this one-cell
+                # torus, so pairs are connected through several images: the
+                # pinned per-site counts below are the documented
+                # minimum-image convention, and the collapsed-image warning
+                # fires
+                neighbors = @test_logs (:warn, r"wrap the periodic cell") match_mode=:any AbstractWalkers.compute_neighbors(
+                    lattice_vectors, positions, periodicity, cutoff_radii)
                 
                 for i in 1:5
                     if i == 1
@@ -294,6 +300,103 @@
                         @test length(neighbors[i][3]) == 0
                     end
                 end
+            end
+        end
+
+
+        @testset "image multiplicity and cutoff_radii validation" begin
+
+            # Full-occupancy single-component square builder
+            sq_lattice(dims, per, cutoffs; kwargs...) = MLattice{1,SquareLattice}(;
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=dims,
+                periodicity=per,
+                cutoff_radii=cutoffs,
+                components=[[true for _ in 1:prod(dims)]],
+                adsorptions=:full,
+                kwargs...)
+
+            @testset "wrapped 4x4 three-shell coordination pins" begin
+                # The third shell (distance 2 = L/2) wraps: the +2 and -2
+                # images of the same site collapse to one entry under the
+                # minimum-image convention ...
+                lat_def = @test_logs (:warn, r"wrap the periodic cell") match_mode=:any sq_lattice(
+                    (4, 4, 1), (true, true, false), [1.1, 1.5, 2.1])
+                @test all(length.(lat_def.neighbors[i]) == [4, 4, 2] for i in 1:16)
+                # ... while multiplicity restores the bulk-tiled coordination,
+                # with no warning
+                lat_mult = @test_logs min_level=Base.CoreLogging.Warn sq_lattice(
+                    (4, 4, 1), (true, true, false), [1.1, 1.5, 2.1], image_multiplicity=true)
+                @test all(length.(lat_mult.neighbors[i]) == [4, 4, 4] for i in 1:16)
+                # Element-pinned lists for the corner site: entries ascending
+                # in j, multiplicity entries grouped by j
+                @test lat_def.neighbors[1] == [[2, 4, 5, 13], [6, 8, 14, 16], [3, 9]]
+                @test lat_mult.neighbors[1] == [[2, 4, 5, 13], [6, 8, 14, 16], [3, 3, 9, 9]]
+            end
+
+            @testset "L = 2r degeneracy and warning content: triangular (4, 2, 1)" begin
+                # The a2 circumference 2√3 equals exactly twice the
+                # second-neighbor distance √3, so the degenerate image
+                # distances are bit-identical — no tolerance involved — and
+                # the warning names the wrapped shell with its exact
+                # collapsed-image count
+                warnpat = r"neighbor shell\(s\) \[2 \(cutoff 1\.8\): 16 collapsed image bond\(s\)\] wrap the periodic cell"
+                lat_def = @test_logs (:warn, warnpat) match_mode=:any MLattice{1,TriangularLattice}()
+                M = length(lat_def.components[1])
+                @test M == 16
+                @test all(length(lat_def.neighbors[i][1]) == 6 for i in 1:M)
+                @test all(length(lat_def.neighbors[i][2]) == 5 for i in 1:M)
+
+                lat_mult = @test_logs min_level=Base.CoreLogging.Warn MLattice{1,TriangularLattice}(
+                    image_multiplicity=true)
+                @test all(length(lat_mult.neighbors[i][1]) == 6 for i in 1:M)
+                @test all(length(lat_mult.neighbors[i][2]) == 6 for i in 1:M)
+                # Exactly one second-shell neighbor per site — the a2-wrapped
+                # one — is doubled
+                @test all(length(unique(lat_mult.neighbors[i][2])) == 5 for i in 1:M)
+                # The faithful first shell agrees between the conventions
+                @test all(lat_mult.neighbors[i][1] == lat_def.neighbors[i][1] for i in 1:M)
+            end
+
+            @testset "1D chains, periodicity (true, false, false)" begin
+                # (4,1,1): the second shell (distance 2 = L/2) wraps
+                ch_def = @test_logs (:warn, r"wrap the periodic cell") match_mode=:any sq_lattice(
+                    (4, 1, 1), (true, false, false), [1.1, 2.1])
+                @test [n[1] for n in ch_def.neighbors] == [[2, 4], [1, 3], [2, 4], [1, 3]]
+                @test [n[2] for n in ch_def.neighbors] == [[3], [4], [1], [2]]
+                ch_mult = @test_logs min_level=Base.CoreLogging.Warn sq_lattice(
+                    (4, 1, 1), (true, false, false), [1.1, 2.1], image_multiplicity=true)
+                @test [n[1] for n in ch_mult.neighbors] == [[2, 4], [1, 3], [2, 4], [1, 3]]
+                @test [n[2] for n in ch_mult.neighbors] == [[3, 3], [4, 4], [1, 1], [2, 2]]
+
+                # (2,1,1): first-shell multiplicity 2 through the ±1 images of
+                # the other site, plus two second-shell self-image entries
+                # (j == i) through the ±2 self-images
+                ch2_def = @test_logs (:warn, r"wrap the periodic cell") match_mode=:any sq_lattice(
+                    (2, 1, 1), (true, false, false), [1.1, 2.1])
+                @test ch2_def.neighbors == [[[2], Int[]], [[1], Int[]]]
+                ch2_mult = @test_logs min_level=Base.CoreLogging.Warn sq_lattice(
+                    (2, 1, 1), (true, false, false), [1.1, 2.1], image_multiplicity=true)
+                @test ch2_mult.neighbors == [[[2, 2], [1, 1]], [[1, 1], [2, 2]]]
+            end
+
+            @testset "ArgumentError on invalid cutoff_radii ladders" begin
+                lv = [4.0 0.0 0.0; 0.0 4.0 0.0; 0.0 0.0 1.0]
+                pos = [0.0 0.0 0.0; 1.0 0.0 0.0]
+                per = (true, true, false)
+                for bad in ([1.5, 1.1], [1.1, 1.1], [-1.0], Float64[], [Inf], [1.1, Inf], [NaN])
+                    @test_throws ArgumentError AbstractWalkers.compute_neighbors(lv, pos, per, bad)
+                end
+                err = try
+                    AbstractWalkers.compute_neighbors(lv, pos, per, [1.5, 1.1])
+                catch e
+                    e
+                end
+                @test occursin("nested cutoff ladder", err.msg)
+                # ... and the validation is reached through the constructors
+                @test_throws ArgumentError MLattice{1,SquareLattice}(cutoff_radii=[1.5, 1.1])
+                @test_throws ArgumentError MLattice{1,TriangularLattice}(cutoff_radii=Float64[])
             end
         end
 

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -719,7 +719,10 @@
                     adsorptions=custom_adsorptions
                 )
                 
-                @test lattice.lattice_vectors ≈ [2.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 1.0]
+                # Isotropic default: the stored third diagonal now follows
+                # lattice_constant (at d3 = 1 the z axis never enters
+                # positions, so the geometry is unchanged)
+                @test lattice.lattice_vectors ≈ [2.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 2.0]
                 @test lattice.basis == custom_basis
                 @test lattice.supercell_dimensions == custom_dims
                 @test lattice.periodicity == custom_periodicity
@@ -762,13 +765,104 @@
                     adsorptions=custom_adsorptions
                 )
             
-                @test lattice.lattice_vectors ≈ [2.0 0.0 0.0; 0.0 2.0*sqrt(3) 0.0; 0.0 0.0 1.0]
+                # Isotropic default: see the square-constructor twin above
+                @test lattice.lattice_vectors ≈ [2.0 0.0 0.0; 0.0 2.0*sqrt(3) 0.0; 0.0 0.0 2.0]
                 @test lattice.basis == custom_basis
                 @test lattice.supercell_dimensions == custom_dims
                 @test lattice.periodicity == custom_periodicity
                 @test length(lattice.neighbors) == 4
                 @test length(lattice.components) == 2
                 @test count(lattice.adsorptions) == 2
+            end
+
+            @testset "Interlayer spacing" begin
+                # Isotropic fix: with lattice_constant = 2.0 the out-of-plane
+                # spacing now follows it, so the nearest-neighbor shell mixes
+                # in-plane and interlayer bonds at the same distance 2.0
+                # (previously the interlayer bonds sat at 1.0, silently)
+                iso = MLattice{1,SquareLattice}(
+                    lattice_constant=2.0,
+                    supercell_dimensions=(3, 3, 2),
+                    cutoff_radii=[2.2],
+                    components=[[false for _ in 1:18]]
+                )
+                @test iso.lattice_vectors[3, 3] == 2.0
+                # lattice_positions ordering: dimension 3 outermost, so the
+                # second layer is the second block of 9 sites
+                @test iso.positions[:, 3] == vcat(zeros(9), fill(2.0, 9))
+                # 4 in-plane + 1 axial on the two-layer slab (z non-periodic)
+                @test all(length(iso.neighbors[s][1]) == 5 for s in 1:18)
+                @test all((s + 9) in iso.neighbors[s][1] for s in 1:9)
+
+                # Old-geometry reproduction: interlayer_spacing = 1.0 restores
+                # the pre-change mixed-scale positions exactly
+                old = MLattice{1,SquareLattice}(
+                    lattice_constant=2.0,
+                    interlayer_spacing=1.0,
+                    supercell_dimensions=(3, 3, 2),
+                    cutoff_radii=[2.2],
+                    components=[[false for _ in 1:18]]
+                )
+                @test old.lattice_vectors[3, 3] == 1.0
+                @test old.positions[:, 3] == vcat(zeros(9), ones(9))
+
+                # Tetragonal shell separation: a = 1.0, c = 1.25 with the
+                # ladder [1.1, 1.35] puts in-plane bonds alone in shell 1 and
+                # interlayer bonds alone in shell 2 (next distance sqrt(2) ≈
+                # 1.414 excluded); construction is silent (in-plane
+                # circumference 3 > 2*1.1, no collapsed images; no empty shell)
+                tet = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,SquareLattice}(
+                    lattice_constant=1.0,
+                    interlayer_spacing=1.25,
+                    supercell_dimensions=(3, 3, 2),
+                    cutoff_radii=[1.1, 1.35],
+                    components=[[false for _ in 1:18]]
+                )
+                @test all(length(tet.neighbors[s][1]) == 4 for s in 1:18)
+                @test all(length(tet.neighbors[s][2]) == 1 for s in 1:18)
+                @test all(tet.neighbors[s][2] == [s + 9] for s in 1:9)
+                # Three layers: the middle layer has axial neighbors both ways
+                tet3 = MLattice{1,SquareLattice}(
+                    lattice_constant=1.0,
+                    interlayer_spacing=1.25,
+                    supercell_dimensions=(3, 3, 3),
+                    cutoff_radii=[1.1, 1.35],
+                    components=[[false for _ in 1:27]]
+                )
+                @test all(length(tet3.neighbors[s][2]) == 1 for s in 1:9)
+                @test all(length(tet3.neighbors[s][2]) == 2 for s in 10:18)
+                @test all(length(tet3.neighbors[s][2]) == 1 for s in 19:27)
+
+                # Default-path no-change: an explicit spacing equal to
+                # lattice_constant reproduces the default element for element
+                expl = MLattice{1,SquareLattice}(
+                    lattice_constant=2.0,
+                    interlayer_spacing=2.0,
+                    supercell_dimensions=(3, 3, 2),
+                    cutoff_radii=[2.2],
+                    components=[[false for _ in 1:18]]
+                )
+                @test expl.positions == iso.positions
+                @test expl.neighbors == iso.neighbors
+
+                # Guard paths: finite and strictly positive
+                @test_throws ArgumentError MLattice{1,SquareLattice}(
+                    interlayer_spacing=0.0, components=[[false for _ in 1:16]])
+                @test_throws ArgumentError MLattice{1,SquareLattice}(
+                    interlayer_spacing=-1.0, components=[[false for _ in 1:16]])
+                @test_throws ArgumentError MLattice{1,SquareLattice}(
+                    interlayer_spacing=Inf, components=[[false for _ in 1:16]])
+                @test_throws ArgumentError MLattice{1,TriangularLattice}(
+                    interlayer_spacing=0.0, components=[[false for _ in 1:16]])
+
+                # Triangular acceptance: keyword lands in the third vector
+                tri = MLattice{1,TriangularLattice}(
+                    supercell_dimensions=(4, 2, 2),
+                    interlayer_spacing=1.25,
+                    cutoff_radii=[1.1, 1.3],
+                    components=[[false for _ in 1:32]]
+                )
+                @test tri.lattice_vectors ≈ [1.0 0.0 0.0; 0.0 sqrt(3) 0.0; 0.0 0.0 1.25]
             end
 
             @testset "Error handling" begin

--- a/test/test-AnalysisTools.jl
+++ b/test/test-AnalysisTools.jl
@@ -87,15 +87,16 @@
     @testset "microcanonical inflection-point analysis" begin
         # Synthesize an NS ladder whose density of states has a prescribed caloric
         # temperature β(E)=dS/dE: build g=exp(∫β), its normalized CDF G, and invert
-        # G at the NS prior volumes X_i=(K/(K+1))^i so emax(i)=G⁻¹(X_i).
-        function synth_ladder(βfun; Emin=0.0, Emax=10.0, K=200, n=4000, ng=20001)
+        # G at the NS prior volumes X_i=(K/(K+n_cull))^i so emax(i)=G⁻¹(X_i).
+        # Also returns the (Eg, G) grid so tests can check S_vol = ln G exactly.
+        function synth_ladder(βfun; Emin=0.0, Emax=10.0, K=200, n=4000, ng=20001, n_cull=1)
             Eg = collect(range(Emin, Emax; length=ng)); dE = Eg[2] - Eg[1]
             βg = βfun.(Eg)
             S = zeros(ng); for j in 2:ng; S[j] = S[j-1] + 0.5*(βg[j]+βg[j-1])*dE; end
             g = exp.(S .- maximum(S))
             G = zeros(ng); for j in 2:ng; G[j] = G[j-1] + 0.5*(g[j]+g[j-1])*dE; end
             G ./= G[end]
-            c = K/(K+1); Es = Float64[]
+            c = K/(K+n_cull); Es = Float64[]
             for i in 1:n
                 Xi = c^i
                 if Xi <= G[1]; push!(Es, Eg[1]); continue; end
@@ -103,16 +104,25 @@
                 jj = searchsortedfirst(G, Xi)
                 push!(Es, Eg[jj-1] + (Xi-G[jj-1])/(G[jj]-G[jj-1])*(Eg[jj]-Eg[jj-1]))
             end
-            return DataFrame(iter = collect(1:n), emax = Es), K
+            return DataFrame(iter = collect(1:n), emax = Es), K, Eg, G
+        end
+        # linear interpolation of the CDF grid at energy x
+        function cdf_at(Eg, G, x)
+            jj = clamp(searchsortedfirst(Eg, x), 2, length(Eg))
+            G[jj-1] + (x - Eg[jj-1])/(Eg[jj] - Eg[jj-1])*(G[jj] - G[jj-1])
         end
         Etr = 5.0; w = 0.8
 
         @testset "entropy/β recovery, no spurious transition" begin
             βfun(E) = 2.0 - 0.10*E - 0.005*E^2          # β>0, γ strictly monotonic
-            df, K = synth_ladder(βfun)
+            df, K, Eg, G = synth_ladder(βfun)
             E, S = microcanonical_entropy(df, K)
             @test issorted(E)
             @test all(isfinite, S)
+            # volume entropy is exact by construction: S_vol = ln X_i = ln G(E_i)
+            Ev, Sv = microcanonical_entropy(df, K; kind=:volume)
+            @test all(abs(Sv[k] - log(cdf_at(Eg, G, Ev[k]))) < 1e-6
+                      for k in eachindex(Ev) if 0.5 < Ev[k] < 9.5)
             d = caloric_derivatives(df, K; max_order=2)
             mid = findall(e -> 3.0 < e < 7.0, d.E)
             @test !isempty(mid)
@@ -121,14 +131,24 @@
             @test isempty(inflection_transitions(df, K; kb=1.0, energy_window=(2.0, 9.0)))
         end
 
+        @testset "n_cull ≠ 1 prior-volume factor" begin
+            βfun(E) = 2.0 - 0.12*E
+            df, K = synth_ladder(βfun; n_cull=4)
+            d = caloric_derivatives(df, K; n_cull=4)
+            mid = findall(e -> 3.0 < e < 7.0, d.E)
+            @test !isempty(mid)
+            @test all(abs(d.β[i] - βfun(d.E[i])) < 0.15 for i in mid)   # cc = ln(K/(K+4))
+        end
+
         @testset "second-order transition (γ negative peak)" begin
             βfun(E) = 2.0 - 0.15*E + 0.10*tanh((E-Etr)/w)   # C/w=0.125 < 0.15 (concave)
             df, K = synth_ladder(βfun)
             ts = inflection_transitions(df, K; kb=1.0, max_order=2)
-            @test !isempty(ts)
-            t = ts[argmin([abs(s.E_tr - Etr) for s in ts])]
+            @test length(ts) == 1                       # exactly one transition reported
+            t = ts[1]
             @test abs(t.E_tr - Etr) < 1.0
             @test t.order == 2
+            @test t.kind == :independent
             @test isapprox(t.T_tr, 1/βfun(Etr); rtol=0.25)              # T_tr ≈ 1/β(Etr)
         end
 
@@ -136,10 +156,11 @@
             βfun(E) = 2.0 - 0.15*E + 0.40*tanh((E-Etr)/w)   # C/w=0.50 > 0.15 → backbend
             df, K = synth_ladder(βfun)
             ts = inflection_transitions(df, K; kb=1.0, max_order=2)
-            @test !isempty(ts)
-            t = ts[argmin([abs(s.E_tr - Etr) for s in ts])]
+            @test length(ts) == 1                       # exactly one transition reported
+            t = ts[1]
             @test abs(t.E_tr - Etr) < 1.5
             @test t.order == 1
+            @test t.kind == :independent
         end
 
         @testset "transition_convergence" begin
@@ -150,6 +171,14 @@
             @test res isa Vector
             @test all(r -> haskey(r, :converged) && haskey(r, :T_by_K) && length(r.T_by_K) == 2, res)
             @test any(r -> r.converged, res)        # deterministic DOS → stable across K
+            # negative paths: zero tolerance flags any finite drift as unconverged
+            res0 = transition_convergence([df1, df2], [150, 300]; kb=1.0, tol=0.0)
+            @test !isempty(res0) && all(r -> !r.converged, res0)
+            # an impossibly tight matching window leaves the lower-K ladder unmatched
+            resm = transition_convergence([df1, df2], [150, 300]; kb=1.0, match_tol=1e-12)
+            @test !isempty(resm)
+            @test all(r -> r.T_drift == Inf && !r.converged, resm)
+            @test all(r -> ismissing(r.T_by_K[1]) && !ismissing(r.T_by_K[2]), resm)
         end
 
         @testset "argument validation" begin
@@ -161,6 +190,11 @@
             @test_throws ArgumentError transition_convergence([df], [K])
             @test_throws DimensionMismatch transition_convergence([df, df], [K])
             @test_throws ArgumentError microcanonical_entropy(DataFrame(iter=Int[], emax=Float64[]), K)
+            @test_throws ArgumentError microcanonical_entropy(df, 0)
+            @test_throws ArgumentError microcanonical_entropy(DataFrame(a=collect(1:100)), K)
+            @test_throws ArgumentError microcanonical_entropy(df, K; halfwidth=1)
+            @test_throws ArgumentError microcanonical_entropy(df, K; halfwidth=-3)
+            @test_throws ArgumentError inflection_transitions(df, K; edge=0)
         end
     end
 end

--- a/test/test-AnalysisTools.jl
+++ b/test/test-AnalysisTools.jl
@@ -83,4 +83,84 @@
         rm("test_output_df.csv")
         rm("test_output_df.arrow")
     end
+
+    @testset "microcanonical inflection-point analysis" begin
+        # Synthesize an NS ladder whose density of states has a prescribed caloric
+        # temperature β(E)=dS/dE: build g=exp(∫β), its normalized CDF G, and invert
+        # G at the NS prior volumes X_i=(K/(K+1))^i so emax(i)=G⁻¹(X_i).
+        function synth_ladder(βfun; Emin=0.0, Emax=10.0, K=200, n=4000, ng=20001)
+            Eg = collect(range(Emin, Emax; length=ng)); dE = Eg[2] - Eg[1]
+            βg = βfun.(Eg)
+            S = zeros(ng); for j in 2:ng; S[j] = S[j-1] + 0.5*(βg[j]+βg[j-1])*dE; end
+            g = exp.(S .- maximum(S))
+            G = zeros(ng); for j in 2:ng; G[j] = G[j-1] + 0.5*(g[j]+g[j-1])*dE; end
+            G ./= G[end]
+            c = K/(K+1); Es = Float64[]
+            for i in 1:n
+                Xi = c^i
+                if Xi <= G[1]; push!(Es, Eg[1]); continue; end
+                if Xi >= G[end]; push!(Es, Eg[end]); continue; end
+                jj = searchsortedfirst(G, Xi)
+                push!(Es, Eg[jj-1] + (Xi-G[jj-1])/(G[jj]-G[jj-1])*(Eg[jj]-Eg[jj-1]))
+            end
+            return DataFrame(iter = collect(1:n), emax = Es), K
+        end
+        Etr = 5.0; w = 0.8
+
+        @testset "entropy/β recovery, no spurious transition" begin
+            βfun(E) = 2.0 - 0.10*E - 0.005*E^2          # β>0, γ strictly monotonic
+            df, K = synth_ladder(βfun)
+            E, S = microcanonical_entropy(df, K)
+            @test issorted(E)
+            @test all(isfinite, S)
+            d = caloric_derivatives(df, K; max_order=2)
+            mid = findall(e -> 3.0 < e < 7.0, d.E)
+            @test !isempty(mid)
+            @test all(abs(d.β[i] - βfun(d.E[i])) < 0.15 for i in mid)   # β recovered
+            # no false positives in the resolved bulk (edges/low-T flattening excluded)
+            @test isempty(inflection_transitions(df, K; kb=1.0, energy_window=(2.0, 9.0)))
+        end
+
+        @testset "second-order transition (γ negative peak)" begin
+            βfun(E) = 2.0 - 0.15*E + 0.10*tanh((E-Etr)/w)   # C/w=0.125 < 0.15 (concave)
+            df, K = synth_ladder(βfun)
+            ts = inflection_transitions(df, K; kb=1.0, max_order=2)
+            @test !isempty(ts)
+            t = ts[argmin([abs(s.E_tr - Etr) for s in ts])]
+            @test abs(t.E_tr - Etr) < 1.0
+            @test t.order == 2
+            @test isapprox(t.T_tr, 1/βfun(Etr); rtol=0.25)              # T_tr ≈ 1/β(Etr)
+        end
+
+        @testset "first-order transition (β backbending)" begin
+            βfun(E) = 2.0 - 0.15*E + 0.40*tanh((E-Etr)/w)   # C/w=0.50 > 0.15 → backbend
+            df, K = synth_ladder(βfun)
+            ts = inflection_transitions(df, K; kb=1.0, max_order=2)
+            @test !isempty(ts)
+            t = ts[argmin([abs(s.E_tr - Etr) for s in ts])]
+            @test abs(t.E_tr - Etr) < 1.5
+            @test t.order == 1
+        end
+
+        @testset "transition_convergence" begin
+            βfun(E) = 2.0 - 0.15*E + 0.10*tanh((E-Etr)/w)
+            df1, _ = synth_ladder(βfun; K=150)
+            df2, _ = synth_ladder(βfun; K=300)
+            res = transition_convergence([df1, df2], [150, 300]; kb=1.0)
+            @test res isa Vector
+            @test all(r -> haskey(r, :converged) && haskey(r, :T_by_K) && length(r.T_by_K) == 2, res)
+            @test any(r -> r.converged, res)        # deterministic DOS → stable across K
+        end
+
+        @testset "argument validation" begin
+            df, K = synth_ladder(E -> 2.0 - 0.12*E)
+            @test_throws ArgumentError microcanonical_entropy(df, K; kind=:bogus)
+            @test_throws ArgumentError caloric_derivatives(df, K; max_order=5)
+            @test_throws ArgumentError inflection_transitions(df, K; max_order=0)
+            @test_throws ArgumentError inflection_transitions(df, K; ground_trim=0.6)
+            @test_throws ArgumentError transition_convergence([df], [K])
+            @test_throws DimensionMismatch transition_convergence([df, df], [K])
+            @test_throws ArgumentError microcanonical_entropy(DataFrame(iter=Int[], emax=Float64[]), K)
+        end
+    end
 end

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -46,10 +46,14 @@
         @test length(enumerate_motif_embeddings(sq8, [1.0, 1.0, 2.0];
                                                 expected_count=128)) == 128
 
-        # Unit-square quattro: one per plaquette
+        # Unit-square quattro via the template method: one per plaquette
         @test length(enumerate_motif_embeddings(sq8,
-            motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]);
-            expected_count=64)) == 64
+            [(0, 0), (1, 0), (0, 1), (1, 1)]; expected_count=64)) == 64
+        # The multiset method warns for K ≥ 4 (homometric figures share
+        # multisets); the unit square has no alias, so the counts agree
+        q_ms = @test_logs (:warn, r"[Hh]omometric") match_mode = :any enumerate_motif_embeddings(
+            sq8, motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]))
+        @test length(q_ms) == 64
 
         # Pair signature (K = 2) reproduces the nearest-neighbor shell as
         # unordered pairs: 2M on the square lattice
@@ -94,6 +98,40 @@
     end
 
     # ================================================================
+    @testset "homometric figures and tolerance semantics" begin
+        # A homometric pair: non-congruent quattros sharing one distance
+        # multiset. The template method separates the two families (each has
+        # a mirror stabilizer of order 2, hence 4M embeddings); the multiset
+        # method warns and enumerates both together.
+        sq10 = cluster_square(10)
+        A = [(0, 0), (1, 0), (0, 1), (2, 2)]
+        B = [(0, 0), (1, 0), (2, 1), (2, 2)]
+        @test motif_distances(A) ≈ motif_distances(B)
+        eA = enumerate_motif_embeddings(sq10, A; expected_count=400)
+        eB = enumerate_motif_embeddings(sq10, B; expected_count=400)
+        @test isempty(intersect(Set(eA), Set(eB)))
+        both = @test_logs (:warn, r"[Hh]omometric") match_mode = :any enumerate_motif_embeddings(
+            sq10, motif_distances(A))
+        @test length(both) == 800
+        @test Set(both) == union(Set(eA), Set(eB))
+
+        # Candidate pruning is a relaxation of acceptance: a distance within
+        # tol of a signature entry that was merged into a nearby uniq
+        # representative must still be found (regression: pruning at tol
+        # from the representative silently dropped it)
+        gen = MLattice{1,GenericLattice}(
+            [5.0 0.0 0.0; 0.0 5.0 0.0; 0.0 0.0 1.0],
+            [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.1, 0.0, 0.0)],
+            (1, 1, 1),
+            (false, false, false),
+            [2.2],
+            [[false, false, false]],
+            [true, true, true])
+        found = enumerate_motif_embeddings(gen, [1.0, 1.05, 2.1]; tol=0.06)
+        @test length(found) == 1   # sides (1.0, 1.1, 2.1) accepted elementwise
+    end
+
+    # ================================================================
     @testset "cluster energy evaluation" begin
         Random.seed!(139)
         L = 6
@@ -102,7 +140,7 @@
         t1_embs = enumerate_motif_embeddings(sq6,
             motif_distances([(0, 0), (1, 0), (0, 1)]); expected_count=4M)
         q_embs = enumerate_motif_embeddings(sq6,
-            motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]); expected_count=M)
+            [(0, 0), (1, 0), (0, 1), (1, 1)]; expected_count=M)
         V0, J1, J2 = -0.1, 0.05, 0.02
         Jt, Jq = 0.168, -0.120
         pair = GenericLatticeHamiltonian(V0, [J1, J2], u"eV")
@@ -190,20 +228,40 @@
             dy = min(mod(ja - jb, 4), mod(jb - ja, 4))
             return dx^2 + dy^2
         end
-        brute3 = Float64[]
+        brute3 = Dict{NTuple{3,Int},Float64}()
         for a in 1:16, b in (a+1):16, c in (b+1):16
             r2s = sort([d24(a, b), d24(a, c), d24(b, c)])
-            push!(brute3, 0.05 * count(==(1), r2s) +
-                          (r2s == [1, 1, 2] ? 0.168 : 0.0))
+            brute3[(a, b, c)] = 0.05 * count(==(1), r2s) +
+                                (r2s == [1, 1, 2] ? 0.168 : 0.0)
         end
-        lib3 = sort([ustrip(u"eV", e) for e in df_exact.energy])
-        @test length(lib3) == 560
-        @test maximum(abs.(lib3 .- sort(brute3))) < 1e-10
+        @test nrow(df_exact) == 560
+        # Configuration-resolved: each enumerated configuration's energy
+        # against the brute force keyed by its occupied sites (a multiset
+        # comparison could not detect energies permuted among configurations)
+        for row in eachrow(df_exact)
+            occ_sites = NTuple{3,Int}(findall(row.config[1]))
+            @test abs(ustrip(u"eV", row.energy) - brute3[occ_sites]) < 1e-10
+        end
 
         # A Hamiltonian built for a larger lattice fails fast at liveset
-        # construction instead of raising a BoundsError mid-run
+        # construction instead of raising a BoundsError mid-run — and at the
+        # raw-lattice sampler entry points, which never build a liveset
         w4 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
         @test_throws ArgumentError LatticeGasWalkers(w4, h)
+        wl_params = WangLandauParameters(energy_min=-8.0, energy_max=8.0,
+                                         num_energy_bins=30, num_steps=10,
+                                         max_iter=2, random_seed=7)
+        @test_throws ArgumentError wang_landau(deepcopy(lat4), h, wl_params)
+        @test_throws ArgumentError nvt_monte_carlo(MCNewSample(), deepcopy(lat4),
+                                                   h, 300.0, 5, 7)
+
+        # The converse mismatch — a Hamiltonian enumerated on a smaller
+        # lattice, all of whose indices exist on the bigger one — is
+        # undetectable from indices alone: construction succeeds and the
+        # embeddings are geometric nonsense. Documented caller
+        # responsibility: always enumerate on the lattice being sampled.
+        w6 = [LatticeWalker(deepcopy(sq6), energy=0.0u"eV", iter=0)]
+        @test LatticeGasWalkers(w6, h4) isa LatticeGasWalkers
     end
 
     # ================================================================
@@ -229,8 +287,7 @@
         function zhang_hamiltonian(L)
             lat = cluster_square(L; cutoffs=[1.1, 1.5, 2.1, 2.3])
             clusters = [ClusterInteraction(zhang_J[k] * u"eV",
-                            enumerate_motif_embeddings(lat,
-                                motif_distances(zhang_motifs[k]);
+                            enumerate_motif_embeddings(lat, zhang_motifs[k];
                                 expected_count=zhang_per_site[k] * L * L))
                         for k in keys(zhang_motifs)]
             ham = ClusterLatticeHamiltonian(
@@ -261,6 +318,13 @@
         set_phase!((i, j) -> iseven(i + j))
         @test interacting_energy(sq12, zhang).val ≈
               72 * (-1.249 + 2 * 0.090 + 2 * (-0.050) + 2 * 0.051) atol = 1e-10
+        # p(2×1) stripes (every other column), 72 adatoms: pins J1 and the
+        # linear t1 separately from t2 (per adatom: 1 vertical first-shell
+        # pair, 2 third-shell pairs, 2 fourth-shell pairs, 1 vertical t1
+        # trio; no √2 pairs, so t2, t3, t6, and q2 are all inactive)
+        set_phase!((i, j) -> i % 2 == 0)
+        @test interacting_energy(sq12, zhang).val ≈
+              72 * (-1.249 + 0.292 + 2 * (-0.050) + 2 * (-0.010) + 0.168) atol = 1e-10
         # (1×1), 144 adatoms: every figure at its per-site multiplicity
         sq12.components[1] .= true
         @test interacting_energy(sq12, zhang).val ≈

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -205,4 +205,105 @@
         w4 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
         @test_throws ArgumentError LatticeGasWalkers(w4, h)
     end
+
+    # ================================================================
+    @testset "Zhang O-Pd(100) m = 9 expansion: counts, adlayers, sampling" begin
+        # Figure geometry transcribed from Zhang, Blum & Reuter, PRB 75,
+        # 235406 (2007), Fig. 1 (arXiv:cond-mat/0701549). In the paper's own
+        # labeling, V^t_1 is the LINEAR (1, 1, 2) trio and V^t_2 the
+        # (1, 1, √2) right triangle; t3 is the scalene (1, √2, √5), t6 the
+        # diagonal linear (√2, √2, 2√2), and q2 the "hut"
+        # (0,0)-(1,0)-(2,0)+(1,1). FreeBird couplings are the negated GGA
+        # values of their Table III (positive = repulsive).
+        zhang_motifs = (
+            t1=[(0, 0), (1, 0), (2, 0)],
+            t2=[(0, 0), (1, 0), (0, 1)],
+            t3=[(0, 1), (1, 0), (2, 0)],
+            t6=[(0, 0), (1, 1), (2, 2)],
+            q2=[(0, 0), (1, 0), (2, 0), (1, 1)])
+        zhang_J = (t1=0.168, t2=-0.060, t3=0.048, t6=0.051, q2=-0.120)
+        # Embeddings per site under standard full-orbit counting: 8 divided
+        # by the order of the motif's point-group stabilizer
+        zhang_per_site = (t1=2, t2=4, t3=8, t6=2, q2=4)
+
+        function zhang_hamiltonian(L)
+            lat = cluster_square(L; cutoffs=[1.1, 1.5, 2.1, 2.3])
+            clusters = [ClusterInteraction(zhang_J[k] * u"eV",
+                            enumerate_motif_embeddings(lat,
+                                motif_distances(zhang_motifs[k]);
+                                expected_count=zhang_per_site[k] * L * L))
+                        for k in keys(zhang_motifs)]
+            ham = ClusterLatticeHamiltonian(
+                GenericLatticeHamiltonian(-1.249, [0.292, 0.090, -0.050, -0.010], u"eV"),
+                clusters)
+            return lat, ham
+        end
+
+        L12 = 12
+        M12 = L12 * L12
+        sq12, zhang = zhang_hamiltonian(L12)
+
+        # Ordered adlayers: closed forms from hand-derived per-adatom motif
+        # multiplicities (pins transcription, sign convention, and counting
+        # simultaneously)
+        set_phase!(pred) = (sq12.components[1] .=
+            [pred((s - 1) % L12, (s - 1) ÷ L12) for s in 1:M12])
+
+        # (3×3), 16 adatoms, no neighbor within √5: on-site only
+        set_phase!((i, j) -> i % 3 == 0 && j % 3 == 0)
+        @test interacting_energy(sq12, zhang).val ≈ 16 * (-1.249) atol = 1e-10
+        # p(2×2), 36 adatoms: 2 third-shell pairs per adatom, no multi-body
+        set_phase!((i, j) -> i % 2 == 0 && j % 2 == 0)
+        @test interacting_energy(sq12, zhang).val ≈
+              36 * (-1.249 + 2 * (-0.050)) atol = 1e-10
+        # c(2×2), 72 adatoms: 2 second- and 2 third-shell pairs plus 2
+        # diagonal-linear t6 trios per adatom
+        set_phase!((i, j) -> iseven(i + j))
+        @test interacting_energy(sq12, zhang).val ≈
+              72 * (-1.249 + 2 * 0.090 + 2 * (-0.050) + 2 * 0.051) atol = 1e-10
+        # (1×1), 144 adatoms: every figure at its per-site multiplicity
+        sq12.components[1] .= true
+        @test interacting_energy(sq12, zhang).val ≈
+              144 * (-1.249 +
+                     2 * 0.292 + 2 * 0.090 + 2 * (-0.050) + 4 * (-0.010) +
+                     2 * 0.168 + 4 * (-0.060) + 8 * 0.048 + 2 * 0.051 +
+                     4 * (-0.120)) atol = 1e-10
+
+        # The Θ ≤ 1/2 closed forms also match the paper's Table I DFT
+        # binding energies to ≤ 2 meV per adatom under this counting
+        # convention. The dense phases ((2×2)-3O, (1×1)) follow a different
+        # multiplicity convention in the paper and are deliberately not
+        # asserted against Table I.
+        for (pred, n_ad, Eb_table) in (
+                ((i, j) -> i % 3 == 0 && j % 3 == 0, 16, 1.249),
+                ((i, j) -> i % 2 == 0 && j % 2 == 0, 36, 1.348),
+                ((i, j) -> iseven(i + j), 72, 1.069))
+            set_phase!(pred)
+            @test isapprox(-interacting_energy(sq12, zhang).val / n_ad, Eb_table;
+                           atol=0.003)
+        end
+
+        # The full Zhang Hamiltonian runs in GC-NS unmodified: seeded igref
+        # run on 6×6, live-set energies match direct recomputation
+        Random.seed!(1390)
+        sq6z, z6 = zhang_hamiltonian(6)
+        walkers = [LatticeWalker(deepcopy(sq6z), energy=0.0u"eV", iter=0)
+                   for _ in 1:20]
+        ls = LatticeGasWalkers(walkers, z6; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=20, reference_fugacity=1.0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        save = SaveEveryN("t_zh.csv", "t_zh.traj", "t_zh.ls",
+                          1000000, 1000000, 1000000)
+        df, fls, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(150),
+            MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3), save)
+        rm.(["t_zh.csv", "t_zh.traj", "t_zh.ls"], force=true)
+        @test nrow(df) > 0
+        for w in fls.walkers
+            @test isapprox(w.energy.val,
+                           interacting_energy(w.configuration, z6).val;
+                           atol=1e-8)
+        end
+    end
 end

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -1,0 +1,95 @@
+@testset "Cluster lattice Hamiltonian tests" begin
+    using Random
+
+    cluster_square(L; cutoffs=[1.1, 1.5]) = MLattice{1,SquareLattice}(
+        lattice_constant=1.0,
+        basis=[(0.0, 0.0, 0.0)],
+        supercell_dimensions=(L, L, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=cutoffs,
+        components=[[false for _ in 1:L*L]],
+        adsorptions=:full)
+
+    cluster_triangular(nx, ny) = MLattice{1,TriangularLattice}(
+        lattice_constant=1.0,
+        supercell_dimensions=(nx, ny, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1],
+        components=:equal,
+        adsorptions=:full)
+
+    # ================================================================
+    @testset "motif_distances" begin
+        @test motif_distances([(0, 0), (1, 0), (0, 1)]) ≈ [1.0, 1.0, sqrt(2)]
+        @test motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]) ≈
+              [1.0, 1.0, 1.0, 1.0, sqrt(2), sqrt(2)]
+        @test motif_distances([(0.0, 0.0, 0.0), (0.0, 0.0, 2.0)]) ≈ [2.0]
+        @test_throws ArgumentError motif_distances([(0, 0)])
+    end
+
+    # ================================================================
+    @testset "embedding counts on faithful cells" begin
+        sq8 = cluster_square(8)
+
+        # Right isoceles trio (1, 1, √2): four per plaquette
+        t1 = enumerate_motif_embeddings(sq8, motif_distances([(0, 0), (1, 0), (0, 1)]);
+                                        expected_count=256)
+        @test length(t1) == 256
+        counts = zeros(Int, 64)
+        for e in t1, s in e
+            counts[s] += 1
+        end
+        @test all(==(12), counts)   # per-site membership is uniform
+        @test all(e -> e[1] < e[2] < e[3], t1)   # canonical form
+
+        # Linear trio (1, 1, 2): two orientations per site pair
+        @test length(enumerate_motif_embeddings(sq8, [1.0, 1.0, 2.0];
+                                                expected_count=128)) == 128
+
+        # Unit-square quattro: one per plaquette
+        @test length(enumerate_motif_embeddings(sq8,
+            motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]);
+            expected_count=64)) == 64
+
+        # Pair signature (K = 2) reproduces the nearest-neighbor shell as
+        # unordered pairs: 2M on the square lattice
+        @test length(enumerate_motif_embeddings(sq8, [1.0];
+                                                expected_count=128)) == 128
+
+        # Triangular lattice, faithful cell: faces and linear trios
+        tri44 = cluster_triangular(4, 4)   # M = 32
+        @test length(enumerate_motif_embeddings(tri44, [1.0, 1.0, 1.0];
+                                                expected_count=64)) == 64
+        # (1, 1, 2) has K·d_max = 6 > C_x = 4: the wrap warning fires, and
+        # the torus-convention count still equals 3M (ring-of-four subsets
+        # coincide with the consecutive triples)
+        tri_lin = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            tri44, [1.0, 1.0, 2.0])
+        @test length(tri_lin) == 96
+
+        # expected_count mismatches throw
+        @test_throws ArgumentError enumerate_motif_embeddings(
+            sq8, [1.0, 1.0, sqrt(2)]; expected_count=999)
+        # Signature-length and value validation
+        @test_throws ArgumentError enumerate_motif_embeddings(sq8, [1.0, 1.0])
+        @test_throws ArgumentError enumerate_motif_embeddings(sq8, [1.0, 1.0, -2.0])
+        @test_throws ArgumentError enumerate_motif_embeddings(sq8, [1.0, 1.0, 2.0]; tol=0.0)
+    end
+
+    # ================================================================
+    @testset "wrap-around pathology (torus convention)" begin
+        # The 18-site triangular cell: 36 faces plus 6 winding three-cycles,
+        # the Study V5 diagnostic number, with the wrap warning
+        tri33 = cluster_triangular(3, 3)   # M = 18
+        t = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            tri33, [1.0, 1.0, 1.0])
+        @test length(t) == 42
+
+        # Square 4×4 with the linear trio: distance 2 = C/2 ties; the count
+        # equals every 3-subset of each 4-ring, which coincides with 2M here
+        sq4 = cluster_square(4)
+        t4 = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            sq4, [1.0, 1.0, 2.0])
+        @test length(t4) == 32
+    end
+end

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -92,4 +92,117 @@
             sq4, [1.0, 1.0, 2.0])
         @test length(t4) == 32
     end
+
+    # ================================================================
+    @testset "cluster energy evaluation" begin
+        Random.seed!(139)
+        L = 6
+        M = L * L
+        sq6 = cluster_square(L)
+        t1_embs = enumerate_motif_embeddings(sq6,
+            motif_distances([(0, 0), (1, 0), (0, 1)]); expected_count=4M)
+        q_embs = enumerate_motif_embeddings(sq6,
+            motif_distances([(0, 0), (1, 0), (0, 1), (1, 1)]); expected_count=M)
+        V0, J1, J2 = -0.1, 0.05, 0.02
+        Jt, Jq = 0.168, -0.120
+        pair = GenericLatticeHamiltonian(V0, [J1, J2], u"eV")
+        h = ClusterLatticeHamiltonian(pair,
+            [ClusterInteraction(Jt * u"eV", t1_embs),
+             ClusterInteraction(Jq * u"eV", q_embs)])
+
+        # Empty lattice, single site, and full lattice (closed forms: every
+        # site has 4 first- and 4 second-shell neighbors, 4M trio and M
+        # quattro embeddings are all occupied)
+        sq6.components[1] .= false
+        @test interacting_energy(sq6, h) == 0.0u"eV"
+        sq6.components[1][1] = true
+        @test interacting_energy(sq6, h) ≈ V0 * u"eV" atol = 1e-14 * u"eV"
+        sq6.components[1] .= true
+        E_full = M * (V0 + 2J1 + 2J2) + 4M * Jt + M * Jq
+        @test interacting_energy(sq6, h) ≈ E_full * u"eV" atol = 1e-10 * u"eV"
+
+        # 50 random configurations against an independent brute force that
+        # classifies pairs, trios, and quattros by integer squared
+        # minimum-image distances; no code shared with the enumerator
+        coord(s) = ((s - 1) % L, (s - 1) ÷ L)
+        function d2(a, b)
+            (ia, ja) = coord(a)
+            (ib, jb) = coord(b)
+            dx = min(mod(ia - ib, L), mod(ib - ia, L))
+            dy = min(mod(ja - jb, L), mod(jb - ja, L))
+            return dx^2 + dy^2
+        end
+        function brute_E(occ)
+            s = findall(occ)
+            n = length(s)
+            E = V0 * n
+            for x in 1:n, y in (x+1):n
+                r2 = d2(s[x], s[y])
+                r2 == 1 && (E += J1)
+                r2 == 2 && (E += J2)
+            end
+            for x in 1:n, y in (x+1):n, z in (y+1):n
+                r2s = sort([d2(s[x], s[y]), d2(s[x], s[z]), d2(s[y], s[z])])
+                r2s == [1, 1, 2] && (E += Jt)
+            end
+            for w in 1:n, x in (w+1):n, y in (x+1):n, z in (y+1):n
+                q = (s[w], s[x], s[y], s[z])
+                r2s = sort([d2(q[a], q[b]) for a in 1:4 for b in (a+1):4])
+                r2s == [1, 1, 1, 1, 2, 2] && (E += Jq)
+            end
+            return E
+        end
+        for _ in 1:50
+            occ = rand(M) .< 0.5
+            sq6.components[1] .= occ
+            @test interacting_energy(sq6, h).val ≈ brute_E(occ) atol = 1e-10
+        end
+
+        # Translation and point-group images leave the energy unchanged
+        occ0 = rand(M) .< 0.5
+        translate(occ) = [occ[((i0 + 1) % L) + j0 * L + 1]
+                          for j0 in 0:L-1 for i0 in 0:L-1]
+        rotate(occ) = [occ[j0 + ((L - i0) % L) * L + 1]
+                       for j0 in 0:L-1 for i0 in 0:L-1]
+        sq6.components[1] .= occ0
+        E0 = interacting_energy(sq6, h).val
+        sq6.components[1] .= translate(occ0)
+        @test interacting_energy(sq6, h).val ≈ E0 atol = 1e-12
+        sq6.components[1] .= rotate(occ0)
+        @test interacting_energy(sq6, h).val ≈ E0 atol = 1e-12
+
+        # Fixed-N exact enumeration with a trio term: full N = 3 spectrum on
+        # 4×4 against a hand-rolled triple loop
+        lat4 = cluster_square(4)
+        t1_4 = enumerate_motif_embeddings(lat4,
+            motif_distances([(0, 0), (1, 0), (0, 1)]); expected_count=64)
+        h4 = ClusterLatticeHamiltonian(
+            GenericLatticeHamiltonian(0.0, [0.05, 0.0], u"eV"),
+            [ClusterInteraction(0.168u"eV", t1_4)])
+        lat4.components[1] .= false
+        lat4.components[1][1:3] .= true
+        df_exact, _ = exact_enumeration(lat4, h4)
+        coord4(s) = ((s - 1) % 4, (s - 1) ÷ 4)
+        function d24(a, b)
+            (ia, ja) = coord4(a)
+            (ib, jb) = coord4(b)
+            dx = min(mod(ia - ib, 4), mod(ib - ia, 4))
+            dy = min(mod(ja - jb, 4), mod(jb - ja, 4))
+            return dx^2 + dy^2
+        end
+        brute3 = Float64[]
+        for a in 1:16, b in (a+1):16, c in (b+1):16
+            r2s = sort([d24(a, b), d24(a, c), d24(b, c)])
+            push!(brute3, 0.05 * count(==(1), r2s) +
+                          (r2s == [1, 1, 2] ? 0.168 : 0.0))
+        end
+        lib3 = sort([ustrip(u"eV", e) for e in df_exact.energy])
+        @test length(lib3) == 560
+        @test maximum(abs.(lib3 .- sort(brute3))) < 1e-10
+
+        # A Hamiltonian built for a larger lattice fails fast at liveset
+        # construction instead of raising a BoundsError mid-run
+        w4 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+        @test_throws ArgumentError LatticeGasWalkers(w4, h)
+    end
 end

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -83,7 +83,7 @@
     # ================================================================
     @testset "wrap-around pathology (torus convention)" begin
         # The 18-site triangular cell: 36 faces plus 6 winding three-cycles,
-        # the Study V5 diagnostic number, with the wrap warning
+        # the wrap-around torus-convention count, with the wrap warning
         tri33 = cluster_triangular(3, 3)   # M = 18
         t = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
             tri33, [1.0, 1.0, 1.0])

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -416,7 +416,7 @@
     @testset "multi-shell pair couplings (shell-count validation, sign-mixed sets)" begin
         using Random
 
-        function shell_lattice(L, cutoffs)
+        function shell_lattice(L, cutoffs; image_multiplicity::Bool=false)
             MLattice{1,SquareLattice}(
                 lattice_constant=1.0,
                 basis=[(0.0, 0.0, 0.0)],
@@ -424,7 +424,8 @@
                 periodicity=(true, true, false),
                 cutoff_radii=cutoffs,
                 components=[[false for _ in 1:L*L]],
-                adsorptions=:full)
+                adsorptions=:full,
+                image_multiplicity=image_multiplicity)
         end
 
         # Square-lattice shells at distances 1, √2, 2, √5, 2√2, 3, √10, √13, 4
@@ -571,6 +572,105 @@
             @test nrow(df) > 0
             # Live-set energies match direct recomputation up to the
             # tie-breaking perturbation
+            for w in final_ls.walkers
+                @test isapprox(w.energy.val,
+                               interacting_energy(w.configuration, ham).val;
+                               atol=1e-8)
+            end
+        end
+
+        # ------------------------------------------------------------
+        @testset "image multiplicity: faithful cells unchanged" begin
+            # On cells faithful for every shell (circumference > 2 x outermost
+            # cutoff) the two conventions must agree element-for-element, and
+            # neither construction may warn
+            for (L, cutoffs) in ((4, [1.1, 1.5]), (8, cut4), (16, cut9))
+                lat_def = @test_logs min_level = Base.CoreLogging.Warn shell_lattice(L, cutoffs)
+                lat_mult = @test_logs min_level = Base.CoreLogging.Warn shell_lattice(
+                    L, cutoffs; image_multiplicity=true)
+                @test lat_mult.neighbors == lat_def.neighbors
+            end
+        end
+
+        # ------------------------------------------------------------
+        @testset "image multiplicity: closed-form energies on wrapped cells" begin
+            # 4x4 with a unit third-shell coupling: the third shell (distance
+            # 2 = L/2) is halved under the minimum-image convention (16 eV),
+            # while multiplicity recovers the bulk-tiled 32 eV
+            ham3 = GenericLatticeHamiltonian(0.0, [0.0, 0.0, 1.0], u"eV")
+            sq_def = @test_logs (:warn, r"wrap the periodic cell") match_mode = :any shell_lattice(
+                4, [1.1, 1.5, 2.1])
+            sq_def.components[1] .= true
+            @test all(length.(sq_def.neighbors[i]) == [4, 4, 2] for i in 1:16)
+            @test interacting_energy(sq_def, ham3).val ≈ 16.0 atol = 1e-10
+            sq_mult = @test_logs min_level = Base.CoreLogging.Warn shell_lattice(
+                4, [1.1, 1.5, 2.1]; image_multiplicity=true)
+            sq_mult.components[1] .= true
+            @test all(length.(sq_mult.neighbors[i]) == [4, 4, 4] for i in 1:16)
+            @test interacting_energy(sq_mult, ham3).val ≈ 32.0 atol = 1e-10
+
+            # Shipped triangular (4, 2, 1) cell with a unit second-shell
+            # coupling: the 5-bond vs 6-bond per-site closed forms
+            ham2 = GenericLatticeHamiltonian(0.0, [0.0, 1.0], u"eV")
+            tri_def = @test_logs (:warn, r"wrap the periodic cell") match_mode = :any MLattice{1,TriangularLattice}()
+            tri_def.components[1] .= true
+            @test interacting_energy(tri_def, ham2).val ≈ 40.0 atol = 1e-10
+            tri_mult = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,TriangularLattice}(
+                image_multiplicity=true)
+            tri_mult.components[1] .= true
+            @test interacting_energy(tri_mult, ham2).val ≈ 48.0 atol = 1e-10
+
+            # Bulk-tiled chain closed forms, periodicity (true, false, false)
+            chain(d1, cutoffs; kwargs...) = MLattice{1,SquareLattice}(;
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(d1, 1, 1),
+                periodicity=(true, false, false),
+                cutoff_radii=cutoffs,
+                components=[[true for _ in 1:d1]],
+                adsorptions=:full,
+                kwargs...)
+
+            # (4,1,1) with a unit second-shell coupling: one wrapped
+            # second-shell bond per site by default, two when tiled
+            hamc = GenericLatticeHamiltonian(0.0, [0.0, 1.0], u"eV")
+            c4_def = @test_logs (:warn, r"wrap the periodic cell") match_mode = :any chain(4, [1.1, 2.1])
+            @test interacting_energy(c4_def, hamc).val ≈ 2.0 atol = 1e-10
+            c4_mult = chain(4, [1.1, 2.1]; image_multiplicity=true)
+            @test interacting_energy(c4_mult, hamc).val ≈ 4.0 atol = 1e-10
+
+            # (2,1,1) with J1 = J2 = 1: multiplicity counts the doubled
+            # nearest-neighbor bond (2 eV, shell 1) plus the self-image bonds
+            # (2 eV, shell 2) — the bulk-tiled chain value; the minimum-image
+            # convention sees a single bond in total
+            hamcc = GenericLatticeHamiltonian(0.0, [1.0, 1.0], u"eV")
+            c2_def = @test_logs (:warn, r"wrap the periodic cell") match_mode = :any chain(2, [1.1, 2.1])
+            @test interacting_energy(c2_def, hamcc).val ≈ 1.0 atol = 1e-10
+            c2_mult = chain(2, [1.1, 2.1]; image_multiplicity=true)
+            @test interacting_energy(c2_mult, hamcc).val ≈ 4.0 atol = 1e-10
+        end
+
+        # ------------------------------------------------------------
+        @testset "multiplicity lattice through GC-NS end-to-end" begin
+            Random.seed!(2081)
+            ham = GenericLatticeHamiltonian(-0.05, [0.292, 0.090, -0.050], u"eV")
+            lat = shell_lattice(4, [1.1, 1.5, 2.1]; image_multiplicity=true)
+            walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                       for _ in 1:20]
+            ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+            params = IdealGasReferencedGCNSParameters(
+                mc_steps=20, reference_fugacity=1.0, energy_perturbation=1e-9)
+            save = SaveEveryN("t_mult.csv", "t_mult.traj", "t_mult.ls",
+                              1000000, 1000000, 1000000)
+            df, final_ls, _ = ideal_gas_referenced_nested_sampling(
+                ls, params, Int64(100),
+                MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3), save)
+            rm.(["t_mult.csv", "t_mult.traj", "t_mult.ls"], force=true)
+
+            @test nrow(df) > 0
+            # Live-set energies stay consistent with direct recomputation on
+            # the duplicated neighbor lists, up to the tie-breaking
+            # perturbation
             for w in final_ls.walkers
                 @test isapprox(w.energy.val,
                                interacting_energy(w.configuration, ham).val;

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -411,6 +411,172 @@
             @test length(list_num_par) == 1
             @test length(new_sys) == 1
         end
-    end    
+    end
+
+    @testset "multi-shell pair couplings (shell-count validation, sign-mixed sets)" begin
+        using Random
+
+        function shell_lattice(L, cutoffs)
+            MLattice{1,SquareLattice}(
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(L, L, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=cutoffs,
+                components=[[false for _ in 1:L*L]],
+                adsorptions=:full)
+        end
+
+        # Square-lattice shells at distances 1, √2, 2, √5, 2√2, 3, √10, √13, 4
+        cut4 = [1.1, 1.5, 2.1, 2.3]
+        cut9 = [1.1, 1.5, 2.1, 2.3, 2.9, 3.1, 3.2, 3.7, 4.1]
+
+        # ------------------------------------------------------------
+        @testset "Zhang pair part: closed-form adlayer energies (8x8, 4 shells)" begin
+            # Pair part of the Zhang, Blum & Reuter O-Pd(100) lattice-gas
+            # Hamiltonian [PRB 75, 235406 (2007)], FreeBird sign convention
+            # (positive = repulsive); four shells with mixed signs
+            V0 = -1.249
+            J = [0.292, 0.090, -0.050, -0.010]
+            ham = GenericLatticeHamiltonian(V0, J, u"eV")
+            lat = shell_lattice(8, cut4)
+
+            # c(2x2) checkerboard at half coverage: each occupied site sees 4
+            # occupied 2nd-shell (√2) and 4 occupied 3rd-shell (distance 2)
+            # neighbors; shells 1 and 4 connect opposite sublattices and
+            # contribute exactly zero
+            lat.components[1] .= [iseven(((s - 1) % 8) + ((s - 1) ÷ 8)) for s in 1:64]
+            @test interacting_energy(lat, ham).val ≈
+                  32 * (V0 + 2 * J[2] + 2 * J[3]) atol = 1e-10
+
+            # p(2x2) at quarter coverage: only the 3rd shell (distance 2)
+            # connects occupied sites
+            lat.components[1] .= [((s - 1) % 8) % 2 == 0 && ((s - 1) ÷ 8) % 2 == 0
+                                  for s in 1:64]
+            @test interacting_energy(lat, ham).val ≈
+                  16 * (V0 + 2 * J[3]) atol = 1e-10
+        end
+
+        # ------------------------------------------------------------
+        @testset "Kappus-shape nine-shell set vs independent brute force (16x16)" begin
+            # Kappus [Surf. Sci. 691, 121444 (2020)] elastic O-Pd(100) pair
+            # set: nine shells, mixed signs. The 16x16 cell is faithful for
+            # every shell (circumference 16 > 2 x 4).
+            Random.seed!(138)
+            J9 = [0.228, 0.066, -0.043, -0.015, 0.020, 0.007, -0.006, -0.009, 0.008]
+            ham9 = GenericLatticeHamiltonian(0.0, J9, u"eV")
+            L = 16
+            lat = shell_lattice(L, cut9)
+
+            # Independent reference: integer minimum-image squared distances
+            # classify the shells exactly; shares no code with
+            # compute_neighbors. (r² = 17, i.e. √17 ≈ 4.12, falls outside the
+            # 4.1 cutoff, matching the library's shell assignment.)
+            shell_of_r2 = Dict(1 => 1, 2 => 2, 4 => 3, 5 => 4, 8 => 5,
+                               9 => 6, 10 => 7, 13 => 8, 16 => 9)
+            function brute_force_E(occ)
+                E = 0.0
+                for a in 1:L*L, b in (a+1):L*L
+                    (occ[a] && occ[b]) || continue
+                    ia, ja = (a - 1) % L, (a - 1) ÷ L
+                    ib, jb = (b - 1) % L, (b - 1) ÷ L
+                    dx = min(mod(ia - ib, L), mod(ib - ia, L))
+                    dy = min(mod(ja - jb, L), mod(jb - ja, L))
+                    sh = get(shell_of_r2, dx^2 + dy^2, 0)
+                    sh == 0 || (E += J9[sh])
+                end
+                return E
+            end
+
+            # atol sized for summation-order headroom (~2000 terms, |E| up
+            # to ~28 eV: observed discrepancy ~4e-13); adjacent shell
+            # couplings differ by >= 1e-3, so 1e-9 loses no bug-catching power
+            for _ in 1:50
+                occ = rand(L * L) .< 0.4
+                lat.components[1] .= occ
+                @test interacting_energy(lat, ham9).val ≈ brute_force_E(occ) atol = 1e-9
+            end
+        end
+
+        # ------------------------------------------------------------
+        @testset "shell-count mismatch behavior" begin
+            lat4 = shell_lattice(4, cut4)
+            lat4.components[1][1:2] .= true
+
+            # More coupled shells than the lattice provides: ArgumentError,
+            # not a raw BoundsError — on every energy path and at liveset
+            # construction (where energies are assigned)
+            ham5 = GenericLatticeHamiltonian(0.0, [0.1, 0.1, 0.1, 0.1, 0.1], u"eV")
+            @test_throws ArgumentError interacting_energy(lat4, ham5)
+            @test_throws ArgumentError FreeBird.EnergyEval.lattice_interaction_energy(
+                lat4.components[1], lat4.neighbors, ham5)
+            @test_throws ArgumentError FreeBird.EnergyEval.inter_component_energy(
+                lat4.components[1], lat4.components[1], lat4.neighbors, ham5)
+            walkers5 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+            @test_throws ArgumentError LatticeGasWalkers(walkers5, ham5)
+
+            # Fewer coupled shells than the lattice carries: legal (outer
+            # shells simply uncoupled), but warned once at liveset construction
+            ham2 = GenericLatticeHamiltonian(0.0, [0.1, 0.05], u"eV")
+            E2 = interacting_energy(lat4, ham2)
+            @test unit(E2) == u"eV"
+            walkers2 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+            @test_logs (:warn, r"couples only the first 2") match_mode = :any LatticeGasWalkers(
+                walkers2, ham2)
+
+            # Matching counts: silent
+            ham4 = GenericLatticeHamiltonian(0.0, [0.1, 0.05, 0.02, 0.01], u"eV")
+            walkers4 = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+            @test_logs min_level = Base.CoreLogging.Warn LatticeGasWalkers(walkers4, ham4)
+
+            # Both guards fire through the MLatticeHamiltonian dispatch too
+            # (its shell count is the shared type parameter N, not C)
+            mham2 = MLatticeHamiltonian(2,
+                [GenericLatticeHamiltonian(0.0, [0.1, 0.05], u"eV") for _ in 1:3])
+            lat1 = shell_lattice(4, [1.1])
+            lat1.components[1][1:2] .= true
+            @test_throws ArgumentError interacting_energy(lat1, mham2)
+            walkers_m = [LatticeWalker(deepcopy(lat4), energy=0.0u"eV", iter=0)]
+            @test_logs (:warn, r"couples only the first 2") match_mode = :any LatticeGasWalkers(
+                walkers_m, mham2)
+
+            # The warn also reaches the raw-lattice sampler entry points,
+            # which never construct a liveset
+            wl_params = WangLandauParameters(energy_min=-0.5, energy_max=3.0,
+                                             num_energy_bins=30, num_steps=10,
+                                             max_iter=2, random_seed=7)
+            @test_logs (:warn, r"couples only the first 2") match_mode = :any wang_landau(
+                deepcopy(lat4), ham2, wl_params)
+            @test_logs (:warn, r"couples only the first 2") match_mode = :any nvt_monte_carlo(
+                MCNewSample(), deepcopy(lat4), ham2, 300.0, 5, 7)
+        end
+
+        # ------------------------------------------------------------
+        @testset "sign-mixed multi-shell GC-NS smoke run" begin
+            Random.seed!(1380)
+            ham = GenericLatticeHamiltonian(-0.05, [0.292, 0.090, -0.050, -0.010], u"eV")
+            lat = shell_lattice(8, cut4)
+            walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                       for _ in 1:20]
+            ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+            params = IdealGasReferencedGCNSParameters(
+                mc_steps=20, reference_fugacity=1.0, energy_perturbation=1e-9)
+            save = SaveEveryN("t_shell.csv", "t_shell.traj", "t_shell.ls",
+                              1000000, 1000000, 1000000)
+            df, final_ls, _ = ideal_gas_referenced_nested_sampling(
+                ls, params, Int64(100),
+                MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3), save)
+            rm.(["t_shell.csv", "t_shell.traj", "t_shell.ls"], force=true)
+
+            @test nrow(df) > 0
+            # Live-set energies match direct recomputation up to the
+            # tie-breaking perturbation
+            for w in final_ls.walkers
+                @test isapprox(w.energy.val,
+                               interacting_energy(w.configuration, ham).val;
+                               atol=1e-8)
+            end
+        end
+    end
 
 end

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -268,10 +268,75 @@
             adjacent_sites = deepcopy(lattice)
             adjacent_sites.components[1] .= false
             adjacent_sites.components[1][1:2] .= true
-            @test interacting_energy(adjacent_sites, ham) ≈ 
+            @test interacting_energy(adjacent_sites, ham) ≈
                   2 * ham.on_site_interaction + ham.nth_neighbor_interactions[1]
-            @test interacting_energy(adjacent_sites, mlham) ≈ 
+            @test interacting_energy(adjacent_sites, mlham) ≈
                   2 * ham.on_site_interaction + ham.nth_neighbor_interactions[1]
+        end
+
+        @testset "triangular lattice energies" begin
+            using Random
+            # First triangular coverage on the energy path: six first-shell
+            # neighbors per site under PBC, and energy = J × (occupied
+            # first-shell pairs) against an independent pair counter.
+            J = 1.0
+            ham_nn = GenericLatticeHamiltonian(0.0, [J], u"eV")
+            tri = MLattice{1,TriangularLattice}(
+                lattice_constant=1.0,
+                supercell_dimensions=(3, 3, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1],
+                components=:equal,
+                adsorptions=:full)
+            M = length(tri.components[1])
+            @test M == 18
+            @test all(length(tri.neighbors[i][1]) == 6 for i in 1:M)
+            # First-shell adjacency is symmetric
+            @test all(i in tri.neighbors[j][1] for i in 1:M for j in tri.neighbors[i][1])
+
+            pair_count(occ) = sum(
+                occ[i] && occ[j] for i in 1:M for j in tri.neighbors[i][1] if j > i)
+
+            work = deepcopy(tri)
+            work.components[1] .= false
+            @test interacting_energy(work, ham_nn) ≈ 0.0u"eV"
+            work.components[1][1] = true
+            @test interacting_energy(work, ham_nn) ≈ 0.0u"eV"
+            work.components[1][first(tri.neighbors[1][1])] = true
+            @test interacting_energy(work, ham_nn) ≈ J * u"eV"
+            work.components[1] .= true
+            @test interacting_energy(work, ham_nn) ≈ J * 6 * M / 2 * u"eV"
+
+            Random.seed!(42)
+            for _ in 1:50
+                occ = rand(Bool, M)
+                work.components[1] .= occ
+                @test interacting_energy(work, ham_nn) ≈ J * pair_count(occ) * u"eV"
+            end
+
+            # The customary two-shell cutoffs [1.1, 1.5] leave the second
+            # shell EMPTY on a triangular lattice (second-neighbor distance
+            # √3 ≈ 1.732) — the constructor warns about the silent shell.
+            tri15 = @test_logs (:warn, r"empty on every") match_mode=:any MLattice{1,TriangularLattice}(
+                lattice_constant=1.0,
+                supercell_dimensions=(4, 4, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1, 1.5],
+                components=:equal,
+                adsorptions=:full)
+            @test all(isempty(tri15.neighbors[i][2])
+                      for i in 1:length(tri15.components[1]))
+            # ... while [1.1, 1.8] captures the six √3 second neighbors.
+            tri18 = MLattice{1,TriangularLattice}(
+                lattice_constant=1.0,
+                supercell_dimensions=(4, 4, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1, 1.8],
+                components=:equal,
+                adsorptions=:full)
+            M18 = length(tri18.components[1])
+            @test all(length(tri18.neighbors[i][1]) == 6 for i in 1:M18)
+            @test all(length(tri18.neighbors[i][2]) == 6 for i in 1:M18)
         end
     end
 

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -679,4 +679,159 @@
         end
     end
 
+    @testset "site-field lattice Hamiltonian (exactness, subsumption, setup checks)" begin
+        using Random
+
+        function sf_lattice(L; cutoffs=[1.1, 1.5], ads=:full)
+            MLattice{1,SquareLattice}(
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(L, L, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=cutoffs,
+                components=[[false for _ in 1:L*L]],
+                adsorptions=ads)
+        end
+
+        # ------------------------------------------------------------
+        @testset "field-only exactness on hand configurations" begin
+            # Base contributes exactly zero (zero on-site, zero coupling),
+            # so the energy is the masked field sum and nothing else.
+            # Distinct per-site values catch any index permutation.
+            lat = sf_lattice(4; cutoffs=[1.1])
+            base0 = GenericLatticeHamiltonian(0.0, [0.0], u"eV")
+            h = SiteFieldLatticeHamiltonian(base0, collect(1:16) .* 1e-3, u"eV")
+
+            lat.components[1] .= false
+            @test isapprox(interacting_energy(lat, h), 0.0u"eV"; atol=1e-12u"eV")
+            lat.components[1][1] = true
+            @test isapprox(interacting_energy(lat, h), 0.001u"eV"; atol=1e-12u"eV")
+            lat.components[1][7] = true                       # sites {1, 7}
+            @test isapprox(interacting_energy(lat, h), 0.008u"eV"; atol=1e-12u"eV")
+            lat.components[1] .= false
+            lat.components[1][[2, 5, 16]] .= true
+            @test isapprox(interacting_energy(lat, h), 0.023u"eV"; atol=1e-12u"eV")
+            lat.components[1] .= true
+            @test isapprox(interacting_energy(lat, h), 0.136u"eV"; atol=1e-12u"eV")
+        end
+
+        # ------------------------------------------------------------
+        @testset "subsumption identity both ways (20 random 4x4 occupations)" begin
+            # "Both ways": (i) forward, the masked scalar on-site of a bare
+            # GenericLatticeHamiltonian re-expressed as field = eps .* mask
+            # gives identical energies; (ii) reverse, the wrapper with the
+            # bare Hamiltonian as base and an all-zero field is the identity
+            # on its base. Plus the additive contract: base on-site x mask
+            # and a nonuniform field coexist and add.
+            mask = Bool[1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0]  # fixed, 8 sites
+            lat_m = sf_lattice(4; ads=findall(mask))
+            ε = -0.04
+            J = [-0.01, -0.0025]
+            bare = GenericLatticeHamiltonian(ε, J, u"eV")
+            wrapF = SiteFieldLatticeHamiltonian(
+                GenericLatticeHamiltonian(0.0, J, u"eV"), ε .* mask, u"eV")
+            wrap0 = SiteFieldLatticeHamiltonian(bare, zeros(16), u"eV")
+            g = collect(1:16) .* 1e-3
+            wrapB = SiteFieldLatticeHamiltonian(bare, g, u"eV")
+
+            Random.seed!(202)
+            for _ in 1:20
+                occ = rand(Bool, 16)
+                lat_m.components[1] .= occ
+                E_bare = interacting_energy(lat_m, bare)
+                # forward direction of the identity
+                @test isapprox(interacting_energy(lat_m, wrapF), E_bare;
+                               atol=1e-12u"eV")
+                # reverse direction: zero-field wrapper == base
+                @test isapprox(interacting_energy(lat_m, wrap0), E_bare;
+                               atol=1e-12u"eV")
+                # additive contract with the base's on-site x adsorptions term
+                @test isapprox(interacting_energy(lat_m, wrapB),
+                               E_bare + sum(g[occ]) * u"eV"; atol=1e-12u"eV")
+            end
+        end
+
+        # ------------------------------------------------------------
+        @testset "setup-check matrix: field length and delegation" begin
+            lat = sf_lattice(4)   # 16 sites, 2 neighbor shells
+            base2 = GenericLatticeHamiltonian(0.0, [0.1, 0.05], u"eV")
+            h_short = SiteFieldLatticeHamiltonian(base2, fill(-0.01, 15), u"eV")
+            h_long = SiteFieldLatticeHamiltonian(base2, fill(-0.01, 17), u"eV")
+            h_ok = SiteFieldLatticeHamiltonian(base2, fill(-0.01, 16), u"eV")
+
+            # Built-for-a-different-lattice register: ArgumentError at every
+            # setup entry point, mirroring the shell-count matrix above
+            w1 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_throws ArgumentError LatticeGasWalkers(w1, h_short)
+            w2 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_throws ArgumentError LatticeGasWalkers(w2, h_long)
+            wl_params = WangLandauParameters(energy_min=-0.5, energy_max=3.0,
+                                             num_energy_bins=30, num_steps=10,
+                                             max_iter=2, random_seed=7)
+            @test_throws ArgumentError wang_landau(deepcopy(lat), h_short, wl_params)
+            @test_throws ArgumentError nvt_monte_carlo(
+                MCNewSample(), deepcopy(lat), h_short, 300.0, 5, 7)
+
+            # Matching length: silent
+            w3 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_logs min_level = Base.CoreLogging.Warn LatticeGasWalkers(w3, h_ok)
+
+            # A stale field reaching the raw energy path must crash, not
+            # sum a truncated or padded range: eachindex(occupations, field)
+            # raises DimensionMismatch in BOTH directions
+            lat16 = deepcopy(lat)
+            lat16.components[1][16] = true
+            @test_throws DimensionMismatch interacting_energy(lat16, h_short)
+            @test_throws DimensionMismatch interacting_energy(lat16, h_long)
+
+            # The uncoupled-shell warning threads through the wrapper
+            # (_n_coupled_shells delegates to base): 1-shell base, 2-shell lattice
+            h_1shell = SiteFieldLatticeHamiltonian(
+                GenericLatticeHamiltonian(0.0, [0.1], u"eV"), fill(-0.01, 16), u"eV")
+            w4 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_logs (:warn, r"couples only the first 1") match_mode = :any LatticeGasWalkers(
+                w4, h_1shell)
+            # ... and reaches the raw-lattice sampler entry points too
+            @test_logs (:warn, r"couples only the first 1") match_mode = :any wang_landau(
+                deepcopy(lat), h_1shell, wl_params)
+            @test_logs (:warn, r"couples only the first 1") match_mode = :any nvt_monte_carlo(
+                MCNewSample(), deepcopy(lat), h_1shell, 300.0, 5, 7)
+
+            # The cluster-embedding check threads through the wrapper
+            # (_check_cluster_sites delegates to base): stale embeddings
+            # throw at liveset construction
+            pair = GenericLatticeHamiltonian(0.0, [0.1, 0.05], u"eV")
+            stale = ClusterLatticeHamiltonian(
+                pair, [ClusterInteraction(0.2u"eV", [(1, 2, 17)])])
+            h_stale = SiteFieldLatticeHamiltonian(stale, fill(-0.01, 16), u"eV")
+            w5 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)]
+            @test_throws ArgumentError LatticeGasWalkers(w5, h_stale)
+
+            # A valid wrapped cluster composes additively: pair shells +
+            # trio coupling + field sum, hand closed form. Sites {1, 2, 5}:
+            # (1,2) and (1,5) are first-shell pairs, (2,5) is the sqrt(2)
+            # shell, and the trio (1,2,5) is fully occupied.
+            good = ClusterLatticeHamiltonian(
+                pair, [ClusterInteraction(0.2u"eV", [(1, 2, 5)])])
+            h_good = SiteFieldLatticeHamiltonian(good, collect(1:16) .* 1e-3, u"eV")
+            lat3 = deepcopy(lat)
+            lat3.components[1][[1, 2, 5]] .= true
+            @test isapprox(interacting_energy(lat3, h_good),
+                           (2 * 0.1 + 0.05 + 0.2 + 0.008) * u"eV"; atol=1e-10u"eV")
+
+            # An MLatticeHamiltonian{1} base evaluates through the same
+            # delegation: wrapper energy == bare energy + field sum
+            mlh = MLatticeHamiltonian(1,
+                [GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")])
+            g_m = collect(1:16) .* 1e-3
+            wrapM = SiteFieldLatticeHamiltonian(mlh, g_m, u"eV")
+            lat_m2 = deepcopy(lat)
+            lat_m2.components[1][[1, 2, 5, 11]] .= true
+            @test isapprox(interacting_energy(lat_m2, wrapM),
+                           interacting_energy(lat_m2, mlh) +
+                           sum(g_m[lat_m2.components[1]]) * u"eV";
+                           atol=1e-12u"eV")
+        end
+    end
+
 end

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -414,6 +414,88 @@
                 @test sum(full_lattice.components[1]) == 4  # Should maintain full occupancy
             end
         end
+
+        @testset "lattice_biased_sites tests" begin
+            biased_lattice() = MLattice{1,SquareLattice}(
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(4, 4, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1, 1.5],   # shell 1: 4 NN at d=1; shell 2: 4 diagonals at d=sqrt(2)
+                components=:equal,
+                adsorptions=:full)
+
+            @testset "empty and full lattices" begin
+                lat = biased_lattice()
+                lat.components[1] .= false
+                @test sort(lattice_biased_sites(lat; predicate=:cavity)) == collect(1:16)
+                @test isempty(lattice_biased_sites(lat; predicate=:contact))
+                lat.components[1] .= true
+                @test isempty(lattice_biased_sites(lat; predicate=:cavity))
+                @test isempty(lattice_biased_sites(lat; predicate=:contact))
+            end
+
+            @testset "single particle shell counts" begin
+                lat = biased_lattice()
+                lat.components[1] .= false
+                lat.components[1][6] = true   # torus: every site equivalent
+                # shells=1: contacts are exactly the 4 NN; cavities 16-1-4 = 11
+                contact1 = lattice_biased_sites(lat; predicate=:contact, shells=1)
+                cavity1 = lattice_biased_sites(lat; predicate=:cavity, shells=1)
+                @test sort(contact1) == sort(lat.neighbors[6][1])
+                @test length(contact1) == 4
+                @test length(cavity1) == 11
+                # shells=2: 4 NN + 4 diagonals; cavities 16-1-8 = 7
+                contact2 = lattice_biased_sites(lat; predicate=:contact, shells=2)
+                cavity2 = lattice_biased_sites(lat; predicate=:cavity, shells=2)
+                @test sort(contact2) == sort(vcat(lat.neighbors[6][1], lat.neighbors[6][2]))
+                @test length(contact2) == 8
+                @test length(cavity2) == 7
+            end
+
+            @testset "contact and cavity partition the empty sites" begin
+                lat = biased_lattice()
+                lat.components[1] .= false
+                lat.components[1][[1, 4, 6, 7, 10, 13, 16]] .= true  # fixed irregular config
+                for shells in (1, 2)
+                    contact = lattice_biased_sites(lat; predicate=:contact, shells=shells)
+                    cavity = lattice_biased_sites(lat; predicate=:cavity, shells=shells)
+                    @test isempty(intersect(contact, cavity))
+                    @test sort(vcat(contact, cavity)) == findall(.!lat.components[1])
+                end
+            end
+
+            @testset "image-multiplicity neighbor lists" begin
+                # Faithful 4x4 cell: multiplicity lists equal min-image lists,
+                # so the counts must be unchanged
+                lat_m = MLattice{1,SquareLattice}(
+                    lattice_constant=1.0, basis=[(0.0, 0.0, 0.0)],
+                    supercell_dimensions=(4, 4, 1), periodicity=(true, true, false),
+                    cutoff_radii=[1.1, 1.5], components=[[false for _ in 1:16]],
+                    adsorptions=:full, image_multiplicity=true)
+                lat_m.components[1][6] = true
+                @test length(lattice_biased_sites(lat_m; predicate=:contact)) == 4
+                @test length(lattice_biased_sites(lat_m; predicate=:cavity)) == 11
+                # 2x2 torus: each site's 4 NN collapse onto 2 distinct sites
+                # (double entries); the predicates read occupancy only, so
+                # duplicated neighbor entries are harmless
+                tiny = MLattice{1,SquareLattice}(
+                    lattice_constant=1.0, basis=[(0.0, 0.0, 0.0)],
+                    supercell_dimensions=(2, 2, 1), periodicity=(true, true, false),
+                    cutoff_radii=[1.1], components=[[false for _ in 1:4]],
+                    adsorptions=:full, image_multiplicity=true)
+                tiny.components[1][1] = true
+                @test sort(lattice_biased_sites(tiny; predicate=:contact)) == [2, 3]
+                @test lattice_biased_sites(tiny; predicate=:cavity) == [4]
+            end
+
+            @testset "argument validation" begin
+                lat = biased_lattice()
+                @test_throws ArgumentError lattice_biased_sites(lat; predicate=:nonsense)
+                @test_throws ArgumentError lattice_biased_sites(lat; shells=0)
+                @test_throws ArgumentError lattice_biased_sites(lat; shells=3)  # lattice has 2 shells
+            end
+        end
     end
 
     @testset "Monte Carlo swap moves tests" begin

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -10,5 +10,7 @@
     include("test-wang_landau.jl")
     # test grand-canonical nested sampling
     include("test-grand_canonical_ns.jl")
+    # test atomistic GC-NS fixed-N post-processing (ideal gas reference)
+    include("test-atomistic-gcns-fixed-n.jl")
 
 end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -8,5 +8,7 @@
     include("test-nvt_monte_carlo.jl")
     # test Wang-Landau
     include("test-wang_landau.jl")
+    # test grand-canonical nested sampling
+    include("test-grand_canonical_ns.jl")
 
 end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -10,5 +10,7 @@
     include("test-wang_landau.jl")
     # test grand-canonical nested sampling
     include("test-grand_canonical_ns.jl")
+    # test ideal-gas-referenced grand-canonical nested sampling
+    include("test-ideal-gas-ref-gcns.jl")
 
 end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -18,5 +18,7 @@
     include("test-lattice-gcns-fixed-n.jl")
     # test hard-core lattice models (finite-J athermal recipe)
     include("test-hard-core-lattices.jl")
+    # test per-dead-point observable recording and its post-processing
+    include("test-ns-observables.jl")
 
 end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -20,5 +20,7 @@
     include("test-hard-core-lattices.jl")
     # test per-dead-point observable recording and its post-processing
     include("test-ns-observables.jl")
+    # test plateau-aware tie eviction in the serial atomistic NS steps
+    include("test-ns-plateau-ties.jl")
 
 end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -12,5 +12,7 @@
     include("test-grand_canonical_ns.jl")
     # test atomistic GC-NS fixed-N post-processing (ideal gas reference)
     include("test-atomistic-gcns-fixed-n.jl")
+    # test lattice GC-NS fixed-N post-processing
+    include("test-lattice-gcns-fixed-n.jl")
 
 end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -16,5 +16,7 @@
     include("test-atomistic-gcns-fixed-n.jl")
     # test lattice GC-NS fixed-N post-processing
     include("test-lattice-gcns-fixed-n.jl")
+    # test hard-core lattice models (finite-J athermal recipe)
+    include("test-hard-core-lattices.jl")
 
 end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -179,9 +179,20 @@ end
         return positions
     end
 
+    # Uniform-prior NS initialization (i.i.d. random placement, overlaps
+    # rejected), as canonical NS requires. A fixed-site initial live set is not
+    # a prior draw and biases the NS evidence; see scripts/fixed_n_init_test.jl.
+    function _uniform_walker_N(N::Int)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            sys = FastSystem(periodic_system(coor, box, fractional=true))
+            E = ustrip(u"eV", interacting_energy(sys, lj))
+            (isfinite(E) && E < 100.0) && return AtomWalker(sys)
+        end
+    end
+
     function _build_liveset_N(N::Int)
-        walkers = [AtomWalker(FastSystem(periodic_system(_place_n_atoms(N), box, fractional=true)))
-                   for _ in 1:K]
+        walkers = [_uniform_walker_N(N) for _ in 1:K]
         return LJAtomWalkers(walkers, lj)
     end
 
@@ -296,24 +307,23 @@ end
     end
 
     @testset "NS-vs-NVT ⟨U⟩_N agreement at T = 200 K" begin
-        # The tolerance is deliberately loose. NS at small K with single-atom
-        # random walks systematically underestimates |⟨U⟩| for N ≥ 3 in this
-        # supercritical-but-cold regime (k_B T ≈ 1.7 ε): once the live set
-        # collapses near the well bottom, the empirical df.emax sequence is too
-        # coarse in the thermally relevant E band (a few k_B T above the
-        # minimum) to faithfully reproduce the canonical distribution. The
-        # observed bias is ~30–50 % at N = 3, 4, scaling with the number of
-        # interacting pairs. NVT MC at n_sample = 8000 is converged to
-        # micro-eV precision, so it is the trustworthy reference here.
+        # NS live sets are drawn from the uniform prior (i.i.d. random
+        # placement), as canonical NS requires; the earlier fixed-site init
+        # biased ⟨U⟩ low by ~40–50 %. With correct init the residual NS-vs-NVT
+        # difference is sampling noise at these deliberately cheap CI params
+        # (K = 48, n_ns = 800, one seed per N): deeper runs (K = 192,
+        # n_ns = 8000) agree with NVT and an independent importance-sampling
+        # anchor to ~0.1 % (see scripts/fixed_n_init_test.jl). NVT MC at
+        # n_sample = 8000 is the trustworthy reference here.
         #
-        # The test's purpose is to catch normalization / unit-conversion / sign
-        # bugs in the per-N evidence assembly (which would produce errors of
-        # 100 % or more), not to certify NS sampling quality.
+        # The bound below absorbs that cheap-params sampling noise (observed
+        # ≤ 26 % here) while still catching normalization / unit / sign bugs in
+        # the per-N evidence assembly (which produce > 100 % errors).
         for (idx, N) in enumerate(N_values)
             N == 0 && continue
             U_NS = _U_with_tail(ns_outputs[idx], live_emax_all[idx])
             U_NVT = U_NVT_by_N[N]
-            @test isapprox(U_NS, U_NVT; rtol=0.60, atol=3e-3)
+            @test isapprox(U_NS, U_NVT; rtol=0.40, atol=3e-3)
             # Sign check: NS and NVT must both be non-positive in the
             # attractive regime (this catches a wrong-sign error that the
             # loose isapprox would otherwise miss for U ≈ 0).
@@ -486,9 +496,20 @@ end
         return positions
     end
 
+    # Uniform-prior NS initialization over the full box (see the 3D LJ block).
+    # Adsorbates landing in/near the slab are rejected here / discarded by NS.
+    function _uniform_walker_N(N::Int)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            w = AtomWalker(FastSystem(periodic_system(coor, box, fractional=true)))
+            E_ads = ustrip(u"eV", interacting_energy(w.configuration, ljs,
+                        w.list_num_par, w.frozen, surface.configuration))
+            (isfinite(E_ads) && E_ads < 100.0) && return w
+        end
+    end
+
     function _build_liveset_N(N::Int)
-        walkers = [AtomWalker(FastSystem(periodic_system(_place_n_adsorbates(N), box, fractional=true)))
-                   for _ in 1:K]
+        walkers = [_uniform_walker_N(N) for _ in 1:K]
         return LJSurfaceWalkers(walkers, ljs, surface)
     end
 
@@ -619,18 +640,18 @@ end
     end
 
     @testset "NS-vs-NVT ⟨U⟩_N agreement at T = 200 K" begin
-        # rtol/atol inherited from the 3D LJ fluid block: loose enough to
-        # absorb the documented small-K NS sampling bias in the
-        # supercritical-but-cold regime, tight enough to catch
-        # normalization, unit-conversion, or sign bugs in the per-N
-        # evidence assembly. Comparison is on the adsorbate part of ⟨U⟩
-        # (total minus the constant substrate self-energy), because the
-        # constant offset would otherwise dwarf any disagreement.
+        # NS live sets are drawn from the uniform prior (see the 3D LJ block);
+        # with correct init the residual NS-vs-NVT difference is cheap-params
+        # sampling noise (one seed per N at K = 48, n_ns = 800), not a
+        # systematic bias. Comparison is on the adsorbate part of ⟨U⟩ (total
+        # minus the constant substrate self-energy), since the constant offset
+        # would otherwise dwarf any disagreement. The bound still catches
+        # normalization / unit / sign bugs (which produce > 100 % errors).
         for (idx, N) in enumerate(N_values)
             N == 0 && continue
             U_NS_ads = _U_with_tail(ns_outputs[idx], live_emax_all[idx]) - E_surf_self
             U_NVT_ads = U_NVT_by_N[N] - E_surf_self
-            @test isapprox(U_NS_ads, U_NVT_ads; rtol=0.60, atol=3e-3)
+            @test isapprox(U_NS_ads, U_NVT_ads; rtol=0.40, atol=3e-3)
             # Adsorbate part should be non-positive in the attractive
             # regime (single Ar binds to the substrate at ~−3ε).
             @test U_NS_ads <= 1e-4

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -369,16 +369,18 @@ end
             # unshifted-first-moment floor (u_avg accumulates ~|E|·eps of
             # absolute error before the E_shift subtraction; the lattice
             # method shares the structure): measured ≤ 1.5e-8 relative here,
-            # against ~2e-5 with the cancellation guard disabled. The offset
-            # variant therefore gates them at 1e-7; everything else holds
-            # 1e-10.
-            rtol_uu = base == 0.0 ? 1e-10 : 1e-7
+            # against ≈5e-6 with the cancellation guard disabled — the guard
+            # stays load-bearing even at the relaxed gate. The offset variant
+            # therefore gates var_U/cov_UN at 3e-7 and mean_N/var_N at 1e-9;
+            # everything else holds 1e-10.
+            rtol_uu = base == 0.0 ? 1e-10 : 3e-7
+            rtol_nn = base == 0.0 ? 1e-10 : 1e-9
             for (k, μ) in enumerate(μ_grid), (j, T) in enumerate(T_grid)
                 ref = brute_reference(ns_outputs, live_all, N_values, E0,
                                       Symbol[], nothing, μ, T)
                 @test isapprox(out.logXi[k, j], ref.logXi, rtol=1e-10)
-                @test isapprox(out.mean_N[k, j], ref.mean_N, rtol=1e-10)
-                @test isapprox(out.var_N[k, j], ref.var_N, rtol=1e-10)
+                @test isapprox(out.mean_N[k, j], ref.mean_N, rtol=rtol_nn)
+                @test isapprox(out.var_N[k, j], ref.var_N, rtol=rtol_nn)
                 @test isapprox(out.mean_U[k, j], ref.mean_U, rtol=1e-10)
                 @test isapprox(out.var_U[k, j], ref.var_U, rtol=rtol_uu)
                 @test isapprox(out.cov_UN[k, j], ref.cov_UN, rtol=rtol_uu)
@@ -439,7 +441,7 @@ end
             if N == 0
                 ns_outputs[i] = empty_df()
                 live_all[i] = Float64[]
-                live_obs[i] = Dict(:A => [7.5], :B => [0.0])
+                live_obs[i] = Dict(:A => [7.0, 8.0], :B => [0.0])
                 continue
             end
             Es = ladder(0.0, N)

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -128,6 +128,20 @@
             [-0.25u"eV"], [300.0u"K"];
             n_walkers=K,
             live_emax=[Float64[], Float64[]])
+
+        # Duplicate entries in N_values
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [0, 1, 1],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [300.0u"K"];
+            n_walkers=K)
+
+        # Non-positive temperature
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [0, 1, 2],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [0.0u"K"];
+            n_walkers=K)
     end
 
 end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -1567,3 +1567,266 @@ end
         @test isapprox(out.observables[:z_com][1, 1], z_direct, rtol=1e-10)
     end
 end
+
+# ================================================================
+@testset "Atomistic NS at all-false periodicity (13-atom cuboctahedral cluster)" begin
+    using Random
+
+    # Issue #186 (c): the first nested-sampling liveset in the suite at
+    # all-false periodicity. The library builds such systems as a matter of
+    # course (generate_random_starting_config constructs atomic_system with
+    # explicit (false, false, false) boundary conditions), and
+    # periodic_boundary_wrap! REFLECTS rather than wraps on every
+    # non-periodic axis; the surface blocks above build fully periodic
+    # walkers via periodic_system(...; fractional=true), which is correct
+    # for slabs, so the reflecting branch has no other nested-sampling
+    # coverage and no direct pins at any wall.
+    #
+    # Fixture: a frozen 13-atom cuboctahedral LJ cluster (eps = 0.01 eV,
+    # sigma = 2.5 A, cutoff 2.5 sigma shifted, nearest-neighbor spacing
+    # d = 2^(1/6) sigma; sites as in test-ns-plateau-ties.jl), centered in a
+    # cubic box of edge L = sqrt(2) d + 4 * 2.5 sigma ~ 28.97 A: the
+    # axis-aligned shell extent (the vertex coordinates sit at
+    # +- d/sqrt(2) about the center) padded by two cutoff radii of vacuum
+    # per side. Unlike the plateau-ties fixture, the adsorbates here
+    # interact (adsorbate-adsorbate LJ on), and energy_frozen_part carries
+    # the real cluster self-energy through the compute_frozen_energy path
+    # of the LJSurfaceWalkers constructors, which now REQUIRE a
+    # CompositeParameterSets with one component per walker component plus
+    # one for the surface (CP = C + 1, walker components first).
+    afp_sig = 2.5
+    afp_eps = 0.01
+    afp_rc = 2.5                       # cutoff, units of sigma
+    afp_dnn = 2.0^(1 / 6) * afp_sig
+    afp_L = sqrt(2.0) * afp_dnn + 4 * afp_rc * afp_sig
+    afp_half = afp_L / 2
+
+    afp_shell = [(1, 1, 0), (1, -1, 0), (-1, 1, 0), (-1, -1, 0),
+                 (1, 0, 1), (1, 0, -1), (-1, 0, 1), (-1, 0, -1),
+                 (0, 1, 1), (0, 1, -1), (0, -1, 1), (0, -1, -1)]
+    afp_sites = vcat([(afp_half, afp_half, afp_half)],
+                     [(afp_half + p[1] * afp_dnn / sqrt(2),
+                       afp_half + p[2] * afp_dnn / sqrt(2),
+                       afp_half + p[3] * afp_dnn / sqrt(2)) for p in afp_shell])
+
+    afp_lj = LJParameters(epsilon=afp_eps, sigma=afp_sig, cutoff=afp_rc, shift=true)
+    afp_ljs = CompositeParameterSets(2, [afp_lj, afp_lj, afp_lj])
+    afp_box = [[afp_L, 0.0, 0.0]u"Å", [0.0, afp_L, 0.0]u"Å", [0.0, 0.0, afp_L]u"Å"]
+    afp_pbc = (false, false, false)
+
+    afp_surface = AtomWalker(FastSystem(atomic_system(
+        [:Ar => [x, y, z]u"Å" for (x, y, z) in afp_sites], afp_box, afp_pbc));
+        freeze_species=[:Ar])
+
+    afp_walker(coords) = AtomWalker(FastSystem(atomic_system(
+        [:Ar => [x, y, z]u"Å" for (x, y, z) in coords], afp_box, afp_pbc)))
+
+    # in-test brute force through the library's own pair function only
+    function afp_pair(p, q)
+        r = sqrt(sum((p[k] - q[k])^2 for k in 1:3))u"Å"
+        return ustrip(u"eV", lj_energy(r, afp_lj))
+    end
+    afp_E_frozen = sum(afp_pair(afp_sites[i], afp_sites[j])
+                       for i in 1:13 for j in (i+1):13)
+
+    @testset "periodicity contract and construction trap" begin
+        @test periodicity(afp_surface.configuration) == (false, false, false)
+        # The construction trap this fixture locks out (without calling the
+        # slab idiom wrong): periodic_system(...; fractional=true) yields a
+        # FULLY periodic system, so a finite-cluster model must construct
+        # through atomic_system -- the periodicity assertion is what
+        # catches the mix-up.
+        afp_trap = FastSystem(periodic_system([:Ar => [0.5, 0.5, 0.5]],
+                                              afp_box, fractional=true))
+        @test periodicity(afp_trap) == (true, true, true)
+    end
+
+    @testset "CompositeParameterSets energy identity vs brute force" begin
+        # 30 configurations, N = 1-6 (five per N), against the in-test sum
+        # adsorbate-adsorbate + adsorbate-cluster + frozen self-energy.
+        # Calibrated: worst relative deviation 0.0, frozen self-energy
+        # deviation 0.0 (the constructor evaluates the same truncated pair
+        # sum; the gates allow accumulation-order rounding).
+        Random.seed!(7402)
+        afp_worst = 0.0
+        for N in 1:6
+            ws = [afp_walker([ntuple(_ -> rand() * afp_L, 3) for _ in 1:N])
+                  for _ in 1:5]
+            ls = LJSurfaceWalkers(ws, afp_ljs, afp_surface;
+                                  compute_frozen_energy=true)
+            @test all(w -> periodicity(w.configuration) == (false, false, false),
+                      ls.walkers)
+            for w in ls.walkers
+                coords = [Tuple(ustrip.(u"Å", position(w.configuration, i)))
+                          for i in 1:N]
+                E_aa = N < 2 ? 0.0 :
+                       sum(afp_pair(coords[i], coords[j])
+                           for i in 1:N for j in (i+1):N)
+                E_as = sum(afp_pair(c, s) for c in coords, s in afp_sites)
+                E_brute = E_aa + E_as + afp_E_frozen
+                afp_worst = max(afp_worst,
+                    abs(ustrip(u"eV", w.energy) - E_brute) /
+                    max(abs(E_brute), 1.0e-12))
+            end
+        end
+        @test afp_worst <= 1e-12
+        @test abs(ustrip(u"eV", afp_surface.energy_frozen_part) -
+                  afp_E_frozen) <= 1e-13
+        @test afp_E_frozen < 0.0    # all 78 cluster pairs sit inside the cutoff
+
+        # Beyond-cutoff references are exact zeros: two adsorbates farther
+        # than the cutoff from the cluster and from each other leave the
+        # adsorbate part bit-exactly 0.0 eV (the truncated-shifted pair
+        # energy is an exact zero beyond the cutoff), so the walker energy
+        # is bit-exactly the frozen self-energy
+        afp_far = afp_walker([(2.0, 2.0, 2.0), (2.0, 2.0, afp_L - 2.0)])
+        afp_far_ls = LJSurfaceWalkers([afp_far], afp_ljs, afp_surface;
+                                      compute_frozen_energy=true)
+        @test ustrip(u"eV", interacting_energy(afp_far.configuration, afp_ljs,
+                  afp_far.list_num_par, afp_far.frozen,
+                  afp_surface.configuration)) === 0.0
+        @test afp_far_ls.walkers[1].energy == afp_surface.energy_frozen_part
+    end
+
+    # reflection probe: wrap a single-axis excursion through the library
+    # call, returning the full wrapped vector
+    function afp_wrap(v, ax)
+        p = [10.0, 11.0, 12.0]
+        p[ax] = v
+        sv = SVector{3,typeof(1.0u"Å")}(p[1]u"Å", p[2]u"Å", p[3]u"Å")
+        out = FreeBird.MonteCarloMoves.periodic_boundary_wrap!(
+            sv, afp_surface.configuration)
+        return ustrip.(u"Å", out)
+    end
+
+    @testset "reflection pins at all six walls" begin
+        for ax in 1:3
+            others = [k for k in 1:3 if k != ax]
+            for δ in (0.75, 7.5)
+                # upper wall: mirror reflection (2L - pos arithmetic; the
+                # gate allows one rounding ulp)
+                up = afp_wrap(afp_L + δ, ax)
+                @test abs(up[ax] - (afp_L - δ)) <= 1e-9
+                # lower wall: pure negation, bit-exact
+                lo = afp_wrap(-δ, ax)
+                @test lo[ax] === δ
+                # untouched in-range axes come back bit-exact
+                @test all(up[k] === Float64(10 + k - 1) for k in others)
+                @test all(lo[k] === Float64(10 + k - 1) for k in others)
+            end
+            # interior points and both closed endpoints are identity
+            @test all(afp_wrap(v, ax)[ax] === v for v in (0.0, 3.25, afp_L))
+
+            # single-reflection overshoot characterization: the reflection
+            # is applied once, not iterated, so wrap(2L + δ) = -δ and
+            # wrap(-(L + δ)) = L + δ both land OUTSIDE [0, L]
+            ov_up = afp_wrap(2 * afp_L + 0.75, ax)
+            @test abs(ov_up[ax] - (-0.75)) <= 1e-9
+            @test ov_up[ax] < 0.0
+            ov_lo = afp_wrap(-(afp_L + 0.75), ax)
+            @test ov_lo[ax] === afp_L + 0.75
+            @test ov_lo[ax] > afp_L
+            # hence containment silently requires every per-axis proposal
+            # to stay within [-L, 2L]; inside that range one reflection
+            # maps back into the box
+            @test all(0.0 <= afp_wrap(v, ax)[ax] <= afp_L
+                      for v in range(-afp_L, 2 * afp_L; length=41))
+        end
+    end
+
+    # ===== canonical completion at N = 2 and N = 4 =====================
+    # K = 32 clone-move runs to a live span < 2e-4 eV with zero out-of-box
+    # dead points. A finite cluster in a padded box puts a macroscopic
+    # prior fraction at exactly zero adsorbate energy, so the runs traverse
+    # an initial exact-tie plateau (the eviction path of the plateau-aware
+    # accounting; its quadrature closures live in test-ns-plateau-ties.jl)
+    # and the ledgers carry the log_compression column.
+    afp_E_THRESH = 1.0e9
+    function afp_uniform_walker(N)
+        while true
+            w = afp_walker([ntuple(_ -> rand() * afp_L, 3) for _ in 1:N])
+            E = ustrip(u"eV", interacting_energy(w.configuration, afp_ljs,
+                    w.list_num_par, w.frozen, afp_surface.configuration))
+            isfinite(E) && E < afp_E_THRESH && return w
+        end
+    end
+
+    function afp_run(N, seed, n_steps)
+        Random.seed!(seed)   # the parameters' random_seed field is not consumed
+        walkers = [afp_uniform_walker(N) for _ in 1:32]
+        ls = LJSurfaceWalkers(walkers, afp_ljs, afp_surface;
+                              compute_frozen_energy=true)
+        # per-axis step bound: the adaptive step size is capped at
+        # step_size_up = 2.0 A, a 14.5x margin on the [-L, 2L] containment
+        # bound above (>= 10x asserted below)
+        p = NestedSamplingParameters(mc_steps=100, step_size=1.0,
+                                     step_size_up=2.0,
+                                     allowed_fail_count=100_000)
+        save = SaveEveryN(df_filename="_test_afp_df.csv",
+                          wk_filename="_test_afp.traj.extxyz",
+                          ls_filename="_test_afp.ls.extxyz",
+                          n_traj=10_000_000, n_snap=10_000_000,
+                          n_info=10_000_000)
+        n_dead = Ref(0)
+        n_oob = Ref(0)
+        dead_cb = (iter, w) -> begin
+            n_dead[] += 1
+            for i in 1:length(w.configuration)
+                pos = position(w.configuration, i)
+                for k in 1:3
+                    x = ustrip(u"Å", pos[k])
+                    (0.0 <= x <= afp_L) || (n_oob[] += 1)
+                end
+            end
+        end
+        df, ls_out, p_out = nested_sampling(ls, p, n_steps, MCRandomWalkClone(),
+                                            save; dead_point_callback=dead_cb)
+        rm("_test_afp_df.csv", force=true)
+        rm("_test_afp.traj.extxyz", force=true)
+        rm("_test_afp.ls.extxyz", force=true)
+        return df, ls_out, p_out, n_dead[], n_oob[]
+    end
+
+    # ---- all RNG use happens here; the asserts below evaluate afterwards ----
+    # n_steps is sized ~1.5-2x the measured span crossing so completion is
+    # seed-robust: the shipped seeds cross span < 2e-4 eV at accepted cull
+    # 987 (N = 2, seed 81) and 1864 (N = 4, seed 82); issue #186 measured
+    # 1158 and 2596 culls on its own seeds -- seed-dependent, pinned
+    # loosely via the acceptance floor below
+    afp_runs = [(2, afp_run(2, 81, 1600)...), (4, afp_run(4, 82, 3600)...)]
+
+    @testset "canonical completion at N = 2 and N = 4" begin
+        for (N, df, ls_out, p_out, n_dead, n_oob) in afp_runs
+            # ledger schema: serial atomistic steps emit the per-cull
+            # log-compression, so the ledger carries the third column
+            @test names(df) == ["iter", "emax", "log_compression"]
+            @test all(diff(df.emax) .<= 0)
+            # loose cull pin (acceptance health; culls are seed-dependent)
+            @test nrow(df) >= 0.9 * (N == 2 ? 1600 : 3600)
+            @test n_dead == nrow(df)
+            # zero out-of-box dead points, coordinate-resolved
+            @test n_oob == 0
+            # completion: live span below 2e-4 eV (calibrated final spans
+            # 3.98e-7 and 3.50e-8 eV), live set intact and in the box
+            liveE = [ustrip(u"eV", w.energy) for w in ls_out.walkers]
+            @test length(liveE) == 32
+            @test maximum(liveE) - minimum(liveE) < 2e-4
+            @test all(w -> periodicity(w.configuration) == (false, false, false),
+                      ls_out.walkers)
+            afp_live_in_box = true
+            for w in ls_out.walkers, i in 1:length(w.configuration)
+                pos = position(w.configuration, i)
+                for k in 1:3
+                    afp_live_in_box &= (0.0 <= ustrip(u"Å", pos[k]) <= afp_L)
+                end
+            end
+            @test afp_live_in_box
+            # the shipped seeds end outside any tie block
+            @test p_out.plateau_refill_target == 0
+            # the adaptive step size respected its cap, and the cap keeps
+            # >= 10x margin on the single-reflection containment bound
+            @test p_out.step_size <= 2.0
+            @test 10 * 2.0 <= afp_L
+        end
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -390,3 +390,302 @@ end
         @test out.mean_U[2, 1] <= 1e-3
     end
 end
+
+
+@testset "Atomistic GC-NS, fixed-N construction (LJ on LJ(111) surface)" begin
+    using Random
+
+    # ===== Substrate: LJ(111) slab =======================================
+    # 2x2 in-plane rectangular supercell, 3 layers ABC stacking, all frozen.
+    # In-plane NN distance a = 2^(1/6) σ (the LJ minimum). The rectangular
+    # primitive cell on a (111) plane has dimensions (a, a√3) with 2 atoms
+    # per cell; ABC stacking places adjacent layers at the up- and down-
+    # triangle centroids of the layer below. Inter-layer spacing a√(2/3)
+    # is the FCC (111) value. Box-x is technically shorter than 2·cutoff
+    # (same convention as the 3D LJ fluid block above) so PBC self-image
+    # contributions are present but appear as a constant offset that both
+    # NS and NVT see identically — the cross-check remains valid.
+    σ_val = 2.5
+    ε_val = 0.01
+    a = 2^(1/6) * σ_val
+    Δz_layer = a * sqrt(2/3)
+    Lx = 2.0 * a
+    Ly = 2.0 * a * sqrt(3.0)
+    Lz = 22.0  # vacuum above 3-layer slab > 2·cutoff = 15 Å
+
+    # Layer-internal positions, given as fractions of the primitive
+    # rectangle (Lx/2, Ly/2): A = layer with 2 atoms at primitive corners;
+    # B and C are the up- and down-triangle centroids of A.
+    layer_offsets = [
+        [(0.0, 0.0), (0.5, 0.5)],         # A
+        [(0.5, 1.0/6.0), (0.0, 2.0/3.0)], # B
+        [(0.5, 5.0/6.0), (0.0, 1.0/3.0)], # C
+    ]
+
+    function _build_substrate_positions()
+        positions = Pair{Symbol, Vector{Float64}}[]
+        for (l, layer) in enumerate(layer_offsets)
+            z_frac = (l - 1) * Δz_layer / Lz
+            for (fx_prim, fy_prim) in layer
+                for ix in 0:1, iy in 0:1
+                    fx = (ix + fx_prim) / 2.0
+                    fy = (iy + fy_prim) / 2.0
+                    push!(positions, :Ar => [fx, fy, z_frac])
+                end
+            end
+        end
+        return positions
+    end
+
+    box = [[Lx * u"Å", 0u"Å", 0u"Å"],
+           [0u"Å", Ly * u"Å", 0u"Å"],
+           [0u"Å", 0u"Å", Lz * u"Å"]]
+    V_box = (Lx * Ly * Lz) * u"Å^3"
+    mass = 40.0u"u"
+
+    lj = LJParameters(epsilon=ε_val, sigma=σ_val, cutoff=3.0, shift=true)
+    # 2-component CPS for adsorbate × surface: [aa, as, ss] all identical.
+    ljs = CompositeParameterSets(2, [lj, lj, lj])
+
+    substrate_positions = _build_substrate_positions()
+    substrate_sys = FastSystem(periodic_system(substrate_positions, box, fractional=true))
+    surface = AtomWalker(substrate_sys; freeze_species=[:Ar])
+    surface.energy_frozen_part = interacting_energy(surface.configuration, lj)
+    E_surf_self = ustrip(u"eV", surface.energy_frozen_part)
+
+    T_val = 200.0u"K"
+    T_grid = [T_val]
+    kb = 8.617333262e-5
+    β = 1.0 / (kb * ustrip(u"K", T_val))
+
+    N_values = collect(0:4)
+    K = 48
+    mc_steps = 500
+    n_ns_steps = 800
+    n_equi = 2000
+    n_sample = 8000
+
+    # ----- Adsorbate placement: above hollow-ish xy sites, well above the
+    # top substrate layer (z = 2 Δz_layer + 1.5 σ).
+    top_z_frac = 2 * Δz_layer / Lz
+    init_z_frac = top_z_frac + (1.5 * σ_val) / Lz
+    hollow_sites = [(0.25, 0.25),
+                    (0.75, 0.25),
+                    (0.25, 0.75),
+                    (0.75, 0.75)]
+
+    function _place_n_adsorbates(N::Int)
+        positions = Pair{Symbol, Vector{Float64}}[]
+        for i in 1:N
+            fx, fy = hollow_sites[i]
+            fx += 0.02 * (rand() - 0.5)
+            fy += 0.02 * (rand() - 0.5)
+            fz = init_z_frac + 0.01 * (rand() - 0.5)
+            push!(positions, :Ar => [fx, fy, fz])
+        end
+        return positions
+    end
+
+    function _build_liveset_N(N::Int)
+        walkers = [AtomWalker(FastSystem(periodic_system(_place_n_adsorbates(N), box, fractional=true)))
+                   for _ in 1:K]
+        return LJSurfaceWalkers(walkers, ljs, surface)
+    end
+
+    function _run_ns_at_N_surface(N::Int, seed::Int)
+        Random.seed!(seed)
+        liveset = _build_liveset_N(N)
+        ns_params = NestedSamplingParameters(
+            mc_steps=mc_steps,
+            initial_step_size=0.3,
+            step_size=0.3,
+            step_size_lo=0.01,
+            step_size_up=2.0,
+            accept_range=(0.25, 0.75),
+            allowed_fail_count=1000,
+            energy_perturbation=1e-12,
+        )
+        save_strategy = SaveEveryN(
+            df_filename="_test_surf_ns_$(N).csv",
+            wk_filename="_test_surf_ns_$(N).traj.extxyz",
+            ls_filename="_test_surf_ns_$(N).ls.extxyz",
+            n_traj=100_000,
+            n_snap=100_000,
+            n_info=100_000,
+        )
+        df, final_liveset, _ = nested_sampling(
+            liveset, ns_params, n_ns_steps, MCRandomWalkClone(), save_strategy)
+        live_emax_N = [ustrip(u"eV", w.energy) for w in final_liveset.walkers]
+        rm("_test_surf_ns_$(N).csv", force=true)
+        rm("_test_surf_ns_$(N).traj.extxyz", force=true)
+        rm("_test_surf_ns_$(N).ls.extxyz", force=true)
+        return df, live_emax_N
+    end
+
+    # Bespoke NVT MC loop with surface support. The production
+    # `nvt_monte_carlo` does not yet take a surface argument; this mirrors
+    # the surface-aware `MC_random_walk!` from `MonteCarloMoves` but
+    # accepts on the Metropolis-Hastings ratio at temperature T.
+    function _run_nvt_at_N_surface(N::Int, seed::Int)
+        Random.seed!(seed)
+        sys = FastSystem(periodic_system(_place_n_adsorbates(N), box, fractional=true))
+        walker = AtomWalker(sys)
+        walker.energy = interacting_energy(
+            walker.configuration, ljs, walker.list_num_par, walker.frozen,
+            surface.configuration) + surface.energy_frozen_part
+
+        step_size = 0.3
+        kbT_eV = kb * ustrip(u"K", T_val)
+
+        function inner!(n_steps)
+            energies = Vector{Float64}(undef, n_steps)
+            for i in 1:n_steps
+                config = walker.configuration
+                free_index = FreeBird.MonteCarloMoves.free_par_index(walker)
+                if isempty(free_index)
+                    energies[i] = ustrip(u"eV", walker.energy)
+                    continue
+                end
+                i_at = rand(free_index)
+                prewalk = FreeBird.EnergyEval.single_site_energy(
+                    i_at, config, ljs, walker.list_num_par, surface.configuration)
+                pos = position(config, i_at)
+                orig = pos
+                pos = FreeBird.MonteCarloMoves.single_atom_random_walk!(pos, step_size)
+                pos = FreeBird.MonteCarloMoves.periodic_boundary_wrap!(pos, config)
+                config.position[i_at] = pos
+                postwalk = FreeBird.EnergyEval.single_site_energy(
+                    i_at, config, ljs, walker.list_num_par, surface.configuration)
+                ΔE = postwalk - prewalk
+                if ΔE < 0.0u"eV" || rand() < exp(-ustrip(u"eV", ΔE) / kbT_eV)
+                    walker.energy = walker.energy + ΔE
+                else
+                    config.position[i_at] = orig
+                end
+                energies[i] = ustrip(u"eV", walker.energy)
+            end
+            return energies
+        end
+
+        inner!(n_equi)
+        energies_sample = inner!(n_sample)
+        return mean(energies_sample)
+    end
+
+    # ===== Run NS at each N >= 1 ========================================
+    # N = 0 is handled by gc_thermodynamic_stats_fixed_N's special case.
+    # N = 1 is non-trivial here (single adsorbate sees the substrate's
+    # attractive potential), unlike the 3D LJ fluid block where N = 1 has
+    # E ≡ 0 and NS cannot make progress.
+    ns_outputs = Vector{DataFrame}(undef, length(N_values))
+    live_emax_all = Vector{Vector{Float64}}(undef, length(N_values))
+    ns_outputs[1] = DataFrame(iter=Int[], emax=Float64[])
+    live_emax_all[1] = Float64[]
+
+    for (idx, N) in enumerate(N_values)
+        N == 0 && continue
+        df, live_emax_N = _run_ns_at_N_surface(N, 3000 + N)
+        ns_outputs[idx] = df
+        live_emax_all[idx] = live_emax_N
+    end
+
+    @testset "NS run schema and basic shape" begin
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            df = ns_outputs[idx]
+            @test names(df) == ["iter", "emax"]
+            @test nrow(df) >= 0.5 * n_ns_steps
+            @test length(live_emax_all[idx]) == K
+        end
+    end
+
+    # ===== Per-N ⟨U⟩: NS vs NVT cross-check =============================
+    # Compare on the adsorbate contribution ⟨U⟩ − E_surf_self, since the
+    # constant substrate self-energy dominates the absolute scale and would
+    # otherwise make rtol-based agreement trivially pass.
+    function _U_with_tail(df::DataFrame, live_emax_N::Vector{Float64})
+        ωi = ωᵢ(df.iter, K)
+        n_iters = length(df.iter)
+        tail_w = (K / (K + 1))^n_iters / K
+        ωi_full = vcat(ωi, fill(tail_w, K))
+        Es_full = vcat(collect(Float64, df.emax), live_emax_N)
+        return internal_energy(β, ωi_full, Es_full)
+    end
+
+    U_NVT_by_N = Dict{Int, Float64}()
+    for N in N_values
+        N == 0 && continue
+        U_NVT_by_N[N] = _run_nvt_at_N_surface(N, 4000 + N)
+    end
+
+    @testset "NS-vs-NVT ⟨U⟩_N agreement at T = 200 K" begin
+        # rtol/atol inherited from the 3D LJ fluid block: loose enough to
+        # absorb the documented small-K NS sampling bias in the
+        # supercritical-but-cold regime, tight enough to catch
+        # normalization, unit-conversion, or sign bugs in the per-N
+        # evidence assembly. Comparison is on the adsorbate part of ⟨U⟩
+        # (total minus the constant substrate self-energy), because the
+        # constant offset would otherwise dwarf any disagreement.
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            U_NS_ads = _U_with_tail(ns_outputs[idx], live_emax_all[idx]) - E_surf_self
+            U_NVT_ads = U_NVT_by_N[N] - E_surf_self
+            @test isapprox(U_NS_ads, U_NVT_ads; rtol=0.60, atol=3e-3)
+            # Adsorbate part should be non-positive in the attractive
+            # regime (single Ar binds to the substrate at ~−3ε).
+            @test U_NS_ads <= 1e-4
+        end
+    end
+
+    @testset "Per-N ⟨U⟩ decreases (more negative) with N" begin
+        # Each adsorbate adds attractive surface and (for N ≥ 2)
+        # attractive lateral contributions. Allow 1 meV slack per step.
+        U_N_vec = Float64[]
+        push!(U_N_vec, 0.0)  # adsorbate contribution at N = 0 is 0
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            push!(U_N_vec, _U_with_tail(ns_outputs[idx], live_emax_all[idx]) - E_surf_self)
+        end
+        for i in 2:length(U_N_vec)
+            @test U_N_vec[i] <= U_N_vec[i-1] + 1e-3
+        end
+    end
+
+    # ===== End-to-end Ξ(μ, T) via gc_thermodynamic_stats_fixed_N ========
+    # V passed is the simulation-box volume = NS prior volume per particle
+    # (NOT a slab or adsorption-region volume). The substrate's
+    # contribution to the configurational integral is fully captured by
+    # the Boltzmann factor exp(−βU) in the per-N NS evidence; no
+    # geometric V reduction is needed.
+    #
+    # μ window placed in the dilute-coverage regime. With ε = 0.01 eV
+    # and a single-adsorbate binding of roughly −3 ε at hollow sites, we
+    # expect ⟨N⟩ ~ 1–3 across the chosen μ pair.
+    μ_grid = [-0.235u"eV", -0.215u"eV"]
+
+    out = gc_thermodynamic_stats_fixed_N(
+        ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+        n_walkers=K, live_emax=live_emax_all)
+
+    @testset "End-to-end Ξ assembly: returns expected shape" begin
+        @test size(out.Xi) == (length(μ_grid), length(T_grid))
+        @test size(out.mean_N) == (length(μ_grid), length(T_grid))
+        @test size(out.var_N) == (length(μ_grid), length(T_grid))
+        @test size(out.mean_U) == (length(μ_grid), length(T_grid))
+        @test all(out.Xi .> 0)
+        @test all(out.mean_N .>= 0)
+        @test all(out.var_N .>= 0)
+    end
+
+    @testset "⟨N⟩ in sub-monolayer window for chosen μ" begin
+        # Monolayer capacity ≈ 8 hollow sites on the 2x2 (111) supercell;
+        # sub-monolayer means ⟨N⟩ well below 8.
+        @test 0.1 < out.mean_N[1, 1] < 4.5
+        @test 0.1 < out.mean_N[2, 1] < 4.5
+    end
+
+    @testset "Ξ and ⟨N⟩ monotone in μ at fixed T" begin
+        @test out.Xi[2, 1] > out.Xi[1, 1]
+        @test out.mean_N[2, 1] > out.mean_N[1, 1]
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -144,6 +144,126 @@
             n_walkers=K)
     end
 
+    @testset "empty_energy: offset invariance, empty-sector restoration, guards" begin
+        # Deterministic synthetic ladders — no NS runs. Sector N carries a
+        # linearly descending emax ladder ending at its floor, plus K live
+        # energies at the floor.
+        K = 64
+        n_iters = 400
+        ω0_test = (K + 1) / K
+        N_values = collect(0:4)
+
+        V = 1000.0u"Å^3"
+        m = 40.0u"u"
+        T = 200.0u"K"
+        T_grid = [T]
+        kb = 8.617333262e-5
+        β = 1.0 / (kb * ustrip(u"K", T))
+        Λ_val = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+        V_val = ustrip(u"Å^3", V)
+        μ_for_zV(zV_target) = (log(zV_target * Λ_val^3 / V_val) / β) * u"eV"
+
+        E_floor(N) = -0.02 * N
+        ladder(N) = E_floor(N) .+ 0.05 .* (1.0 .- collect(1:n_iters) ./ n_iters)
+        empty_df() = DataFrame(iter=Int[], emax=Float64[])
+        ns_outputs = [N == 0 ? empty_df() :
+                      DataFrame(iter=collect(1:n_iters), emax=ladder(N))
+                      for N in N_values]
+        live_all = [N == 0 ? Float64[] : fill(E_floor(N), K) for N in N_values]
+
+        μ_grid = [μ_for_zV(0.3), μ_for_zV(1.0)]
+
+        out0 = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all)
+
+        @testset "offset invariance" begin
+            # Shifting every ledger and live energy by a constant E0 while
+            # declaring the same E0 as the empty-sector energy leaves ⟨N⟩ and
+            # Var N unchanged, scales Ξ by exp(−βE0), and offsets ⟨U⟩ by
+            # exactly E0.
+            E0 = -1.5
+            ns_shift = [N == 0 ? empty_df() :
+                        DataFrame(iter=collect(1:n_iters), emax=ladder(N) .+ E0)
+                        for N in N_values]
+            live_shift = [N == 0 ? Float64[] : fill(E_floor(N) + E0, K)
+                          for N in N_values]
+
+            outE = gc_thermodynamic_stats_fixed_N(
+                ns_shift, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_shift, empty_energy=E0)
+
+            @test all(abs.(outE.mean_N .- out0.mean_N) .<= 1e-12)
+            @test all(abs.(outE.var_N .- out0.var_N) .<= 1e-12)
+            @test all(isapprox.(outE.Xi, out0.Xi .* exp(-β * E0), rtol=1e-10))
+            @test all(abs.(outE.mean_U .- (out0.mean_U .+ E0)) .<= 1e-12)
+        end
+
+        @testset "empty-sector restoration" begin
+            # Constant-energy sectors E ≡ E0 + N·u make the truncated grand sum
+            # exactly computable: Z_NS^{(N)} = M · exp(−β(E0 + N·u)) for N ≥ 1,
+            # with the prior mass M = Σᵢ ωᵢ + tail replicated analytically. The
+            # default call reproduces the biased sum in which the empty sector
+            # enters with weight 1 instead of exp(−βE0); empty_energy = E0
+            # reproduces the exact sum.
+            E0 = -1.5
+            u1 = -0.013
+            E_N(N) = E0 + N * u1
+            ns_const = [N == 0 ? empty_df() :
+                        DataFrame(iter=collect(1:n_iters), emax=fill(E_N(N), n_iters))
+                        for N in N_values]
+            live_const = [N == 0 ? Float64[] : fill(E_N(N), K) for N in N_values]
+
+            r = K / (K + 1)
+            M_dead = sum(ω0_test * (1 / (K + 1)) * r^i for i in 1:n_iters)
+            M_tail = ω0_test * r^n_iters
+            M = M_dead + M_tail
+
+            out_def = gc_thermodynamic_stats_fixed_N(
+                ns_const, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_const)
+            out_fix = gc_thermodynamic_stats_fixed_N(
+                ns_const, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_const, empty_energy=E0)
+
+            wavg(w, x) = sum(w .* x) / sum(w)
+            Ns = collect(0:4)
+
+            for (k, μ) in enumerate(μ_grid)
+                zV = exp(β * ustrip(u"eV", μ)) * V_val / Λ_val^3
+                terms = [zV^N / factorial(N) * M * exp(-β * E_N(N)) for N in 1:4]
+                w_ex = vcat(exp(-β * E0), terms)   # exact: N = 0 at exp(−βE0)
+                w_b = vcat(1.0, terms)             # biased: N = 0 at weight 1
+                Es_ex = vcat(E0, [E_N(N) for N in 1:4])
+                Es_b = vcat(0.0, [E_N(N) for N in 1:4])  # default: mean_E(0) = 0
+
+                @test isapprox(out_fix.Xi[k, 1], sum(w_ex), rtol=1e-10)
+                @test isapprox(out_fix.mean_N[k, 1], wavg(w_ex, Ns), rtol=1e-10)
+                @test isapprox(out_fix.var_N[k, 1],
+                               wavg(w_ex, Ns .^ 2) - wavg(w_ex, Ns)^2, rtol=1e-10)
+                @test isapprox(out_fix.mean_U[k, 1], wavg(w_ex, Es_ex), rtol=1e-10)
+
+                @test isapprox(out_def.Xi[k, 1], sum(w_b), rtol=1e-10)
+                @test isapprox(out_def.mean_N[k, 1], wavg(w_b, Ns), rtol=1e-10)
+                @test isapprox(out_def.var_N[k, 1],
+                               wavg(w_b, Ns .^ 2) - wavg(w_b, Ns)^2, rtol=1e-10)
+                @test isapprox(out_def.mean_U[k, 1], wavg(w_b, Es_b), rtol=1e-10)
+
+                # The bias is material at these μ: the default overstates ⟨N⟩.
+                @test out_def.mean_N[k, 1] > out_fix.mean_N[k, 1] + 0.1
+            end
+        end
+
+        @testset "guards" begin
+            @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+                ns_outputs, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=NaN)
+            @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+                ns_outputs, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=Inf)
+        end
+    end
+
 end
 
 

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -1130,3 +1130,440 @@ end
         @test out.mean_N[2, 1] > out.mean_N[1, 1]
     end
 end
+
+
+@testset "Atomistic GC-NS, fixed-N ideal-adsorbate closure (LJ fcc(100) slab)" begin
+    using Random
+
+    # ===== Substrate: fcc(100) slab, all frozen ==========================
+    # 3×3 in-plane square supercell with side 3·2^(1/6)·σ (the LJ-minimum
+    # spacing), 3 layers in ABA stacking with the fcc(100) interlayer
+    # spacing a/√2, box height 25 Å, fully periodic. Adsorbate-adsorbate
+    # interactions are switched OFF (ε_aa = 0 in the composite parameter
+    # set), so each adsorbate sees only the frozen slab field U_s(r): an
+    # ideal gas in an external field, exactly solvable by quadrature. This
+    # makes the block the one end-to-end surface fixture that closes
+    # against exact references rather than shape and monotonicity checks
+    # alone.
+    σ_val = 2.5
+    ε_val = 0.01
+    a = 2^(1/6) * σ_val
+    Lx = 3.0 * a
+    Ly = 3.0 * a
+    Lz = 25.0
+    dz_layer = a / sqrt(2.0)
+    z_base = 4.0
+
+    slab_positions = Pair{Symbol,Vector{Float64}}[]
+    for l in 0:2
+        off = (l % 2 == 0) ? 0.0 : 0.5
+        z = z_base + l * dz_layer
+        for i in 0:2, j in 0:2
+            push!(slab_positions, :Ar => [(i + off) / 3.0, (j + off) / 3.0, z / Lz])
+        end
+    end
+
+    box = [[Lx * u"Å", 0u"Å", 0u"Å"],
+           [0u"Å", Ly * u"Å", 0u"Å"],
+           [0u"Å", 0u"Å", Lz * u"Å"]]
+    V_box = (Lx * Ly * Lz) * u"Å^3"
+    mass = 40.0u"u"
+
+    lj = LJParameters(epsilon=ε_val, sigma=σ_val, cutoff=3.0, shift=true)
+    # [aa, as, ss] upper-triangle order: the aa channel gets ε = 0.
+    lj_zero = LJParameters(epsilon=0.0, sigma=σ_val, cutoff=3.0, shift=true)
+    ljs = CompositeParameterSets(2, [lj_zero, lj, lj])
+
+    substrate_sys = FastSystem(periodic_system(slab_positions, box, fractional=true))
+    surface = AtomWalker(substrate_sys; freeze_species=[:Ar])
+    surface.energy_frozen_part = interacting_energy(surface.configuration, lj)
+    E_slab = ustrip(u"eV", surface.energy_frozen_part)
+
+    T_val = 200.0u"K"
+    T_grid = [T_val]
+    kb = 8.617333262e-5
+    β = 1.0 / (kb * ustrip(u"K", T_val))
+
+    # ===== Quadrature reference ==========================================
+    # Midpoint rule over the box for the per-particle field integrals
+    # I = ∫ e^{−βU_s} d³r, I_u = ∫ U_s e^{−βU_s} d³r, I_u2 = ∫ U_s² e^{−βU_s} d³r,
+    # plus the prior-retention fraction m₁ = |{r : U_s(r) < E_thresh}| / V
+    # (see the walker-init note below). The pair kernel replicates the
+    # shifted, 3σ-truncated lj_energy exactly; U is clamped at 50 eV, where
+    # e^{−βU} is already 0, so the U²e^{−βU} accumuland stays finite inside
+    # the hard cores. Grid (32, 32, 96) is the smallest rung of the halving
+    # ladder (16, 16, 48) → (32, 32, 96) whose refinement step changes I by
+    # < 1e-3 relative (measured: 2.3×10⁻⁵ on I and < 1e-3 on both U-moments
+    # against (40, 40, 120)); the coarser rung (16, 16, 48) still moves the
+    # U-moments by several ×10⁻³.
+    slab_xyz = Matrix{Float64}(undef, 3, length(substrate_sys))
+    for i in 1:length(substrate_sys)
+        slab_xyz[:, i] .= ustrip.(u"Å", position(substrate_sys, i))
+    end
+
+    function _slab_field_moments(slab_xyz::Matrix{Float64}, Lx, Ly, Lz, σ, ε, β,
+                                 nx::Int, ny::Int, nz::Int, E_thresh::Float64)
+        rc = 3.0 * σ
+        shift_e = 4.0 * ε * ((σ / rc)^12 - (σ / rc)^6)
+        mind(d, L) = min(abs(d), L - abs(d))
+        npos = size(slab_xyz, 2)
+        hx, hy, hz = Lx / nx, Ly / ny, Lz / nz
+        dV = hx * hy * hz
+        I = 0.0; Iu = 0.0; Iu2 = 0.0; n_below = 0
+        for iz in 1:nz
+            z = (iz - 0.5) * hz
+            for ix in 1:nx
+                x = (ix - 0.5) * hx
+                for iy in 1:ny
+                    y = (iy - 0.5) * hy
+                    U = 0.0
+                    @inbounds for s in 1:npos
+                        dx = mind(x - slab_xyz[1, s], Lx)
+                        dy = mind(y - slab_xyz[2, s], Ly)
+                        dz = mind(z - slab_xyz[3, s], Lz)
+                        r = sqrt(dx * dx + dy * dy + dz * dz)
+                        if r <= rc
+                            sr6 = (σ / r)^6
+                            U += 4.0 * ε * (sr6 * sr6 - sr6) - shift_e
+                        end
+                    end
+                    U < E_thresh && (n_below += 1)
+                    Uc = U > 50.0 ? 50.0 : U
+                    e = exp(-β * Uc)
+                    I += e
+                    Iu += Uc * e
+                    Iu2 += Uc * Uc * e
+                end
+            end
+        end
+        return I * dV, Iu * dV, Iu2 * dV, n_below / (nx * ny * nz)
+    end
+
+    E_init_thresh = 1.0e9
+    I_ref, Iu, Iu2, m1 = _slab_field_moments(slab_xyz, Lx, Ly, Lz, σ_val, ε_val, β,
+                                             32, 32, 96, E_init_thresh)
+    ubar = Iu / I_ref          # per-particle ⟨U_s⟩ under e^{−βU_s}/I
+    sig_u2 = Iu2 / I_ref - ubar^2
+    Λ = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass, T_val))
+    kT = kb * ustrip(u"K", T_val)
+    # μ placed so the occupancy parameter q = e^{βμ}·I/Λ³ — the Poisson
+    # rate of the untruncated ideal-adsorbate grand ensemble — lands at
+    # 0.5 (dilute) and 1.0; both fall near −0.22 eV here.
+    μ_grid = [kT * log(0.5 * Λ^3 / I_ref), kT * log(1.0 * Λ^3 / I_ref)] .* u"eV"
+
+    # ===== Canonical NS ladders, N = 1..4 ================================
+    # Walker-init rejection threshold: 1e9 eV, deliberately NOT the 100 eV
+    # used by the LJ(111) block above. Rejecting E_ads ≥ 100 eV draws
+    # truncates the uniform prior by a per-particle fraction worth ≈ 0.153
+    # nats, so every per-N evidence would sit ≈ 0.153·N nats above the
+    # reference — the bias alone exceeds the N = 4 gate, and combined with
+    # the NS noise it erodes the others. At 1e9 eV only the hard-core
+    # region is excluded, and the retained fraction m₁ ≈ 0.9972 (measured
+    # on the quadrature grid) is folded into the reference as −N·ln m₁.
+    K = 64
+    mc_steps = 400
+    n_ns_steps = 1200
+    N_values = collect(0:4)
+    seedbase = 3000   # gates calibrated at seedbases 3000 and 4000; 3000 ships
+
+    function _uniform_walker_ideal(N::Int)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            w = AtomWalker(FastSystem(periodic_system(coor, box, fractional=true)))
+            E_ads = ustrip(u"eV", interacting_energy(w.configuration, ljs,
+                        w.list_num_par, w.frozen, surface.configuration))
+            (isfinite(E_ads) && E_ads < E_init_thresh) && return w
+        end
+    end
+
+    tmpdir = mktempdir()
+    function _run_ns_ideal(N::Int, seed::Int)
+        Random.seed!(seed)
+        walkers = [_uniform_walker_ideal(N) for _ in 1:K]
+        liveset = LJSurfaceWalkers(walkers, ljs, surface)
+        ns_params = NestedSamplingParameters(
+            mc_steps=mc_steps,
+            initial_step_size=0.3,
+            step_size=0.3,
+            step_size_lo=0.01,
+            step_size_up=2.0,
+            accept_range=(0.25, 0.75),
+            allowed_fail_count=1000,
+            energy_perturbation=1e-12,
+        )
+        save_strategy = SaveEveryN(
+            df_filename=joinpath(tmpdir, "_test_ideal_ns_$(N).csv"),
+            wk_filename=joinpath(tmpdir, "_test_ideal_ns_$(N).traj.extxyz"),
+            ls_filename=joinpath(tmpdir, "_test_ideal_ns_$(N).ls.extxyz"),
+            n_traj=100_000,
+            n_snap=100_000,
+            n_info=100_000,
+        )
+        df, final_liveset, _ = nested_sampling(
+            liveset, ns_params, n_ns_steps, MCRandomWalkClone(), save_strategy)
+        live_emax_N = [ustrip(u"eV", w.energy) for w in final_liveset.walkers]
+        return df, live_emax_N
+    end
+
+    ns_outputs = Vector{DataFrame}(undef, length(N_values))
+    live_emax_all = Vector{Vector{Float64}}(undef, length(N_values))
+    ns_outputs[1] = DataFrame(iter=Int[], emax=Float64[])
+    live_emax_all[1] = Float64[]
+    for (idx, N) in enumerate(N_values)
+        N == 0 && continue
+        df, live_emax_N = _run_ns_ideal(N, seedbase + N)
+        ns_outputs[idx] = df
+        live_emax_all[idx] = live_emax_N
+    end
+    rm(tmpdir; recursive=true, force=true)
+
+    # ===== Stitch and exact references ===================================
+    # empty_energy = E_slab: the N = 0 sector is the bare slab at its
+    # frozen self-energy, which puts all five sectors on one energy scale.
+    out_fix = gc_thermodynamic_stats_fixed_N(
+        ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+        n_walkers=K, live_emax=live_emax_all, empty_energy=E_slab)
+
+    # Truncated-Poisson reference over the SAME N = 0..4 sector set, with
+    # the corrected rate q_corr = q/m₁ (the NS prior per particle is the
+    # m₁ fraction of the box). Ideal adsorbates make the sector energy
+    # E_slab + Σᵢuᵢ with uᵢ i.i.d. (mean ubar, variance sig_u2), so
+    #   ⟨U⟩ = E_slab + ubar·⟨N⟩,
+    #   var_U = ubar²·Var N + sig_u2·⟨N⟩   (law of total variance),
+    #   cov_UN = ubar·Var N.
+    q_phys = [exp(β * ustrip(u"eV", μ)) * I_ref / Λ^3 for μ in μ_grid]
+    q_corr = q_phys ./ m1
+    function _trunc_poisson(q::Float64)
+        Ns = 0:4
+        w = [q^N / factorial(N) for N in Ns]
+        S = sum(w)
+        p = w ./ S
+        mN = sum(p .* Ns)
+        vN = sum(p .* Ns .^ 2) - mN^2
+        return (S=S, mean_N=mN, var_N=vN,
+                mean_U=E_slab + ubar * mN,
+                var_U=ubar^2 * vN + sig_u2 * mN,
+                cov_UN=ubar * vN)
+    end
+
+    @testset "per-N evidence vs quadrature reference" begin
+        # Exact: log Z_N = −βE_slab + N·ln(I/(Λ³m₁)) − ln N! (the log_Z_N
+        # return already carries the N·ln(V/Λ³) − ln N! part, so the
+        # reference is stated on the same scale). Gates: ≥ 3× the larger
+        # two-seedbase |deviation| per N — measured 0.0112/0.1030 (N = 1),
+        # 0.1928/0.1310 (N = 2), 0.2889/0.0120 (N = 3), 0.1551/0.0077
+        # (N = 4) nats at seedbases 3000/4000, consistent with the √(3N/K)
+        # NS noise scale.
+        tol_logZ = [0.35, 0.60, 0.90, 0.50]
+        for (i, N) in enumerate(N_values)
+            N == 0 && continue
+            exact = -β * E_slab + N * (log(I_ref / Λ^3) - log(m1)) -
+                    sum(log, 1:N; init=0.0)
+            @test abs(out_fix.log_Z_N[i, 1] - exact) <= tol_logZ[N]
+        end
+    end
+
+    @testset "stitched grand stats vs truncated Poisson" begin
+        # Gates: ≥ 3× the max two-seedbase |deviation| per stat across both
+        # μ — measured maxima: logXi 0.0647 nats, mean_N 0.0850 rel,
+        # var_N 0.1055 rel, mean_U 1.55e-3 eV, var_U 0.1490 rel,
+        # cov_UN 0.1390 rel. mean_U is gated absolutely: E_slab dominates
+        # its magnitude, so a relative gate on the total would be
+        # insensitive to the adsorbate part.
+        for k in eachindex(μ_grid)
+            tp = _trunc_poisson(q_corr[k])
+            @test abs(out_fix.logXi[k, 1] - (-β * E_slab + log(tp.S))) <= 0.20
+            @test abs(out_fix.mean_N[k, 1] / tp.mean_N - 1) <= 0.26
+            @test abs(out_fix.var_N[k, 1] / tp.var_N - 1) <= 0.32
+            @test abs(out_fix.mean_U[k, 1] - tp.mean_U) <= 5.0e-3
+            @test abs(out_fix.var_U[k, 1] / tp.var_U - 1) <= 0.45
+            @test abs(out_fix.cov_UN[k, 1] / tp.cov_UN - 1) <= 0.42
+        end
+    end
+
+    @testset "default empty sector overstates ⟨N⟩" begin
+        # Without empty_energy the N = 0 sector enters the grand sum at
+        # weight 1 instead of e^{−βE_slab} = e^{+85.9}: it effectively
+        # vanishes, and ⟨N⟩ collapses toward the N ≥ 1 conditional mean.
+        # Measured gaps above the corrected ⟨N⟩ at the dilute μ: +0.778 and
+        # +0.810 at seedbases 3000/4000 (the corrected values are ≈ 0.54
+        # and ≈ 0.50); the margin ships at 0.25, ≥ 3× inside the measured
+        # gaps while still asserting a ≥ +45% bias on the corrected ⟨N⟩.
+        out_def = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_emax_all)
+        @test out_def.mean_N[1, 1] > out_fix.mean_N[1, 1] + 0.25
+    end
+end
+
+
+@testset "Atomistic observables ledger and passthrough (LJ on LJ(111) surface)" begin
+    using Random
+
+    # Same LJ(111) slab geometry as the block above, at reduced cost
+    # (N = 2 free adsorbates, K = 32, 300 iterations): every assertion here
+    # is a deterministic recording or passthrough closure given the seeded
+    # run, not a sampling-quality gate. Covered: the per-dead-point
+    # `observables` hook on an atomistic canonical run, the dead-point
+    # callback's bit-exact pairing with the ledger, and `observable_cols`
+    # passthrough of the recorded column through the fixed-N assembly.
+    σ_val = 2.5
+    ε_val = 0.01
+    a = 2^(1/6) * σ_val
+    Δz_layer = a * sqrt(2/3)
+    Lx = 2.0 * a
+    Ly = 2.0 * a * sqrt(3.0)
+    Lz = 22.0
+
+    layer_offsets = [
+        [(0.0, 0.0), (0.5, 0.5)],         # A
+        [(0.5, 1.0/6.0), (0.0, 2.0/3.0)], # B
+        [(0.5, 5.0/6.0), (0.0, 1.0/3.0)], # C
+    ]
+
+    substrate_positions = Pair{Symbol,Vector{Float64}}[]
+    for (l, layer) in enumerate(layer_offsets)
+        z_frac = (l - 1) * Δz_layer / Lz
+        for (fx_prim, fy_prim) in layer
+            for ix in 0:1, iy in 0:1
+                push!(substrate_positions,
+                      :Ar => [(ix + fx_prim) / 2.0, (iy + fy_prim) / 2.0, z_frac])
+            end
+        end
+    end
+
+    box = [[Lx * u"Å", 0u"Å", 0u"Å"],
+           [0u"Å", Ly * u"Å", 0u"Å"],
+           [0u"Å", 0u"Å", Lz * u"Å"]]
+    V_box = (Lx * Ly * Lz) * u"Å^3"
+    mass = 40.0u"u"
+
+    lj = LJParameters(epsilon=ε_val, sigma=σ_val, cutoff=3.0, shift=true)
+    ljs = CompositeParameterSets(2, [lj, lj, lj])
+
+    substrate_sys = FastSystem(periodic_system(substrate_positions, box, fractional=true))
+    surface = AtomWalker(substrate_sys; freeze_species=[:Ar])
+    surface.energy_frozen_part = interacting_energy(surface.configuration, lj)
+
+    T_val = 200.0u"K"
+    kb = 8.617333262e-5
+    β = 1.0 / (kb * ustrip(u"K", T_val))
+
+    N_free = 2
+    K = 32
+    mc_steps = 500
+    n_ns_steps = 300
+
+    function _uniform_walker_obs(N::Int)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            w = AtomWalker(FastSystem(periodic_system(coor, box, fractional=true)))
+            E_ads = ustrip(u"eV", interacting_energy(w.configuration, ljs,
+                        w.list_num_par, w.frozen, surface.configuration))
+            (isfinite(E_ads) && E_ads < 100.0) && return w
+        end
+    end
+
+    # z_com: configuration-mean z of the free adsorbates in Å as a Float64 —
+    # the adsorption-height observable natural to a slab geometry.
+    z_com = function (cfg)
+        s = 0.0
+        for i in 1:length(cfg)
+            s += ustrip(u"Å", position(cfg, i)[3])
+        end
+        return s / length(cfg)
+    end
+
+    callback_log = Tuple{Int,Float64}[]
+    record_dead = (iter, w) -> push!(callback_log, (iter, ustrip(u"eV", w.energy)))
+
+    Random.seed!(42)
+    walkers = [_uniform_walker_obs(N_free) for _ in 1:K]
+    liveset = LJSurfaceWalkers(walkers, ljs, surface)
+    ns_params = NestedSamplingParameters(
+        mc_steps=mc_steps,
+        initial_step_size=0.3,
+        step_size=0.3,
+        step_size_lo=0.01,
+        step_size_up=2.0,
+        accept_range=(0.25, 0.75),
+        allowed_fail_count=1000,
+        energy_perturbation=1e-12,
+    )
+    tmpdir = mktempdir()
+    save_strategy = SaveEveryN(
+        df_filename=joinpath(tmpdir, "_test_obs_ns.csv"),
+        wk_filename=joinpath(tmpdir, "_test_obs_ns.traj.extxyz"),
+        ls_filename=joinpath(tmpdir, "_test_obs_ns.ls.extxyz"),
+        n_traj=100_000,
+        n_snap=100_000,
+        n_info=100_000,
+    )
+    df, final_liveset, _ = nested_sampling(
+        liveset, ns_params, n_ns_steps, MCRandomWalkClone(), save_strategy;
+        observables=[:z_com => z_com],
+        dead_point_callback=record_dead)
+    rm(tmpdir; recursive=true, force=true)
+
+    @testset "observables ledger column" begin
+        @test "z_com" in names(df)
+        @test eltype(df.z_com) === Float64
+        @test all(isfinite, df.z_com)
+        @test all(0.0 .< df.z_com .< Lz)
+    end
+
+    @testset "dead-point callback pairing" begin
+        # One invocation per recorded dead point, in ledger order, with the
+        # culled walker's energy matching the emax column bit-exactly.
+        @test length(callback_log) == nrow(df)
+        @test all(callback_log[i][1] == df.iter[i] for i in eachindex(callback_log))
+        @test all(callback_log[i][2] === df.emax[i] for i in eachindex(callback_log))
+    end
+
+    @testset "observable passthrough vs direct reweighting" begin
+        # Single-sector demonstration: the run's N = 2 sector plus the
+        # empty sector (whose live_observables entry declares the empty
+        # configuration's observable value, 0.0 here). The reference is a
+        # direct log-space reweighting of the same ledger column — dead
+        # points at ω_i·e^{−βE_i}, live tail at the shared tail weight —
+        # accumulated in BigFloat: a different decomposition of the same
+        # sum, so agreement is deterministic given the run.
+        live_emax_N = [ustrip(u"eV", w.energy) for w in final_liveset.walkers]
+        live_z = [z_com(w.configuration) for w in final_liveset.walkers]
+
+        N_values = [0, 2]
+        μ_grid = [-0.22u"eV"]
+        T_grid = [T_val]
+        ns_outputs = [DataFrame(iter=Int[], emax=Float64[]), df]
+        live_emax_all = [Float64[], live_emax_N]
+        live_obs = [Dict(:z_com => [0.0]), Dict(:z_com => live_z)]
+
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_emax_all,
+            observable_cols=[:z_com], live_observables=live_obs)
+
+        Λ = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass, T_val))
+        log_zV = β * ustrip(u"eV", μ_grid[1]) + log(ustrip(u"Å^3", V_box)) - 3 * log(Λ)
+        log_r = log(BigFloat(K) / (K + 1))
+        S0 = BigFloat(1)          # N = 0 sector: weight e^{−β·0}·(zV)⁰/0! = 1
+        SA = BigFloat(0)          # its declared z_com is 0.0
+        sector = 2 * BigFloat(log_zV) - log(BigFloat(2))   # N·ln zV − ln N!, N = 2
+        for row in 1:nrow(df)
+            lw = df.iter[row] * log_r - log(BigFloat(K + 1))
+            w = exp(lw - BigFloat(β) * BigFloat(df.emax[row]) + sector)
+            S0 += w
+            SA += w * df.z_com[row]
+        end
+        n_it = maximum(df.iter)
+        lw_tail = n_it * log_r - log(BigFloat(K))
+        for (s, E) in enumerate(live_emax_N)
+            w = exp(lw_tail - BigFloat(β) * BigFloat(E) + sector)
+            S0 += w
+            SA += w * live_z[s]
+        end
+        z_direct = Float64(SA / S0)
+
+        @test isapprox(out.observables[:z_com][1, 1], z_direct, rtol=1e-10)
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -120,6 +120,273 @@
             1000.0u"Å^3", 40.0u"u",
             [-0.25u"eV"], [300.0u"K"];
             n_walkers=K)
+
+        # Length mismatch between live_emax and N_values
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [0, 1, 2],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [300.0u"K"];
+            n_walkers=K,
+            live_emax=[Float64[], Float64[]])
     end
 
+end
+
+
+@testset "Atomistic GC-NS, fixed-N construction (3D LJ fluid)" begin
+    using Random
+
+    # ===== System ==========================================================
+    # 12 Å cubic periodic box with an Ar-like LJ fluid: ε = 0.01 eV (T_crit ~ 1.3ε/k_B
+    # ≈ 150 K), σ = 2.5 Å, cutoff 3σ with energy shift. At T = 200 K we have
+    # k_B T ≈ 1.72 ε — supercritical, safely away from coexistence physics.
+    L = 12.0
+    box = [[L * u"Å", 0u"Å", 0u"Å"],
+           [0u"Å", L * u"Å", 0u"Å"],
+           [0u"Å", 0u"Å", L * u"Å"]]
+    V_box = L^3 * u"Å^3"
+    mass = 40.0u"u"
+    lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=3.0, shift=true)
+
+    T_val = 200.0u"K"
+    T_grid = [T_val]
+    kb = 8.617333262e-5
+    β = 1.0 / (kb * ustrip(u"K", T_val))
+
+    N_values = collect(0:4)
+    K = 48
+    mc_steps = 500
+    n_ns_steps = 800
+    n_equi = 2000
+    n_sample = 8000
+
+    # Build N atoms on a sparse cubic-corner grid (max 5 spots used; for N ≤ 4
+    # this gives initial separations ≈ L/2 = 6 Å, well outside the LJ wall).
+    function _place_n_atoms(N::Int)
+        spots = [(0.25, 0.25, 0.25),
+                 (0.75, 0.25, 0.25),
+                 (0.25, 0.75, 0.25),
+                 (0.75, 0.75, 0.25),
+                 (0.25, 0.25, 0.75)]
+        positions = Pair{Symbol, Vector{Float64}}[]
+        for i in 1:N
+            x, y, z = spots[i]
+            x += 0.02 * (rand() - 0.5)
+            y += 0.02 * (rand() - 0.5)
+            z += 0.02 * (rand() - 0.5)
+            push!(positions, :Ar => [x, y, z])
+        end
+        return positions
+    end
+
+    function _build_liveset_N(N::Int)
+        walkers = [AtomWalker(FastSystem(periodic_system(_place_n_atoms(N), box, fractional=true)))
+                   for _ in 1:K]
+        return LJAtomWalkers(walkers, lj)
+    end
+
+    function _run_ns_at_N(N::Int, seed::Int)
+        Random.seed!(seed)
+        liveset = _build_liveset_N(N)
+        ns_params = NestedSamplingParameters(
+            mc_steps=mc_steps,
+            initial_step_size=0.3,
+            step_size=0.3,
+            step_size_lo=0.01,
+            step_size_up=2.0,
+            accept_range=(0.25, 0.75),
+            allowed_fail_count=1000,
+            energy_perturbation=1e-12,
+        )
+        save_strategy = SaveEveryN(
+            df_filename="_test_lj_ns_$(N).csv",
+            wk_filename="_test_lj_ns_$(N).traj.extxyz",
+            ls_filename="_test_lj_ns_$(N).ls.extxyz",
+            n_traj=100_000,
+            n_snap=100_000,
+            n_info=100_000,
+        )
+        df, final_liveset, _ = nested_sampling(
+            liveset, ns_params, n_ns_steps, MCRandomWalkClone(), save_strategy)
+        live_emax_N = [ustrip(u"eV", w.energy) for w in final_liveset.walkers]
+        rm("_test_lj_ns_$(N).csv", force=true)
+        rm("_test_lj_ns_$(N).traj.extxyz", force=true)
+        rm("_test_lj_ns_$(N).ls.extxyz", force=true)
+        return df, live_emax_N
+    end
+
+    function _run_nvt_at_N(N::Int, seed::Int)
+        Random.seed!(seed)
+        atoms_list = _place_n_atoms(N)
+        sys = FastSystem(periodic_system(atoms_list, box, fractional=true))
+        walker = AtomWalker(sys)
+        mc_params = MetropolisMCParameters(
+            [ustrip(u"K", T_val)];
+            equilibrium_steps=n_equi,
+            sampling_steps=n_sample,
+            step_size=0.3,
+            step_size_lo=0.05,
+            step_size_up=1.0,
+            accept_range=(0.3, 0.7),
+            random_seed=seed,
+        )
+        energies, _, _, _ = monte_carlo_sampling(MCRandomWalkMaxE(), walker, lj, mc_params)
+        return energies[1]
+    end
+
+    # ===== Run NS at each N ≥ 2 ==========================================
+    # N = 0 is handled by the function's special case.
+    # N = 1 cannot make NS progress: a single atom in a periodic box has no
+    # pair interactions, so every walker has E = 0 exactly and every MC walk
+    # is rejected by the energy-ceiling check. Z_NS^{(1)} = 1 by definition,
+    # so we synthesize the DataFrame directly. Using a long, all-zero-energy
+    # df with default ω₀ yields the same `K/(K+1)` multiplicative scaling as
+    # the real NS runs at N ≥ 2, keeping the Ξ assembly internally consistent.
+    ns_outputs = Vector{DataFrame}(undef, length(N_values))
+    live_emax_all = Vector{Vector{Float64}}(undef, length(N_values))
+    ns_outputs[1] = DataFrame(iter=Int[], emax=Float64[])
+    live_emax_all[1] = Float64[]
+
+    for (idx, N) in enumerate(N_values)
+        N == 0 && continue
+        if N == 1
+            n_synth = 5000
+            ns_outputs[idx] = DataFrame(iter=collect(1:n_synth), emax=zeros(n_synth))
+            live_emax_all[idx] = zeros(Float64, K)
+            continue
+        end
+        df, live_emax_N = _run_ns_at_N(N, 1000 + N)
+        ns_outputs[idx] = df
+        live_emax_all[idx] = live_emax_N
+    end
+
+    @testset "NS run schema and basic shape" begin
+        for (idx, N) in enumerate(N_values)
+            (N == 0 || N == 1) && continue
+            df = ns_outputs[idx]
+            @test names(df) == ["iter", "emax"]
+            @test nrow(df) >= 0.5 * n_ns_steps
+            @test length(live_emax_all[idx]) == K
+        end
+    end
+
+    # ===== Per-N ⟨U⟩: NS vs NVT cross-check =============================
+    # Construct per-N ⟨U⟩_NS with live-set tail closure, compare to NVT mean.
+    # internal_energy uses the same ω·exp(−βE) weighting as the function.
+    function _U_with_tail(df::DataFrame, live_emax_N::Vector{Float64})
+        ωi = ωᵢ(df.iter, K)
+        n_iters = length(df.iter)
+        tail_w = (K / (K + 1))^n_iters / K
+        ωi_full = vcat(ωi, fill(tail_w, K))
+        Es_full = vcat(collect(Float64, df.emax), live_emax_N)
+        return internal_energy(β, ωi_full, Es_full)
+    end
+
+    function _U_no_tail(df::DataFrame)
+        ωi = ωᵢ(df.iter, K)
+        Es = collect(Float64, df.emax)
+        return internal_energy(β, ωi, Es)
+    end
+
+    # Cache NVT cross-check results — used by two test blocks.
+    U_NVT_by_N = Dict{Int, Float64}()
+    for N in N_values
+        N == 0 && continue
+        U_NVT_by_N[N] = _run_nvt_at_N(N, 2000 + N)
+    end
+
+    @testset "NS-vs-NVT ⟨U⟩_N agreement at T = 200 K" begin
+        # The tolerance is deliberately loose. NS at small K with single-atom
+        # random walks systematically underestimates |⟨U⟩| for N ≥ 3 in this
+        # supercritical-but-cold regime (k_B T ≈ 1.7 ε): once the live set
+        # collapses near the well bottom, the empirical df.emax sequence is too
+        # coarse in the thermally relevant E band (a few k_B T above the
+        # minimum) to faithfully reproduce the canonical distribution. The
+        # observed bias is ~30–50 % at N = 3, 4, scaling with the number of
+        # interacting pairs. NVT MC at n_sample = 8000 is converged to
+        # micro-eV precision, so it is the trustworthy reference here.
+        #
+        # The test's purpose is to catch normalization / unit-conversion / sign
+        # bugs in the per-N evidence assembly (which would produce errors of
+        # 100 % or more), not to certify NS sampling quality.
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            U_NS = _U_with_tail(ns_outputs[idx], live_emax_all[idx])
+            U_NVT = U_NVT_by_N[N]
+            @test isapprox(U_NS, U_NVT; rtol=0.60, atol=3e-3)
+            # Sign check: NS and NVT must both be non-positive in the
+            # attractive regime (this catches a wrong-sign error that the
+            # loose isapprox would otherwise miss for U ≈ 0).
+            @test U_NS <= 1e-4
+        end
+    end
+
+    @testset "Live-set tail correction moves U toward NVT" begin
+        # For at least one N, the tail-corrected ⟨U⟩ should be no further from
+        # NVT than the uncorrected ⟨U⟩. Tested at N = 2 where the well is
+        # deepest in relative terms and live walkers concentrate below the
+        # latest recorded emax. Includes a small slack to absorb the case
+        # where the two estimates are essentially indistinguishable.
+        N_check = 2
+        idx_check = findfirst(==(N_check), N_values)
+        df = ns_outputs[idx_check]
+        live_emax_N = live_emax_all[idx_check]
+        U_with = _U_with_tail(df, live_emax_N)
+        U_without = _U_no_tail(df)
+        U_NVT = U_NVT_by_N[N_check]
+        @test abs(U_with - U_NVT) <= abs(U_without - U_NVT) + 1e-6
+    end
+
+    @testset "Per-N ⟨U⟩ decreases (more negative) with N" begin
+        # Attractive LJ regime → adding a particle adds (on average) negative
+        # pair contributions to ⟨U⟩_N. Allow 1 meV slack per step for noise.
+        U_N_vec = Float64[]
+        push!(U_N_vec, 0.0)  # N = 0 by definition
+        for (idx, N) in enumerate(N_values)
+            N == 0 && continue
+            push!(U_N_vec, _U_with_tail(ns_outputs[idx], live_emax_all[idx]))
+        end
+        # N=1 → N=2: pair energy appears, U drops.
+        # N=2 → N=3 → N=4: each adds more pair contributions.
+        for i in 2:length(U_N_vec)
+            @test U_N_vec[i] <= U_N_vec[i-1] + 1e-3
+        end
+    end
+
+    # ===== End-to-end Ξ(μ, T) via gc_thermodynamic_stats_fixed_N =========
+    # μ values placed in the dilute-gas window: at zV ≈ 1, μ ≈ -0.205 eV
+    # (from the ideal-gas zV relation with V = 1728 Å³, m = 40u, T = 200 K).
+    # μ_grid below brackets ⟨N⟩ values around 1 and 2.
+    μ_grid = [-0.215u"eV", -0.200u"eV"]
+
+    out = gc_thermodynamic_stats_fixed_N(
+        ns_outputs, N_values, V_box, mass, μ_grid, T_grid;
+        n_walkers=K, live_emax=live_emax_all)
+
+    @testset "End-to-end Ξ assembly: returns expected shape" begin
+        @test size(out.Xi) == (length(μ_grid), length(T_grid))
+        @test size(out.mean_N) == (length(μ_grid), length(T_grid))
+        @test size(out.var_N) == (length(μ_grid), length(T_grid))
+        @test size(out.mean_U) == (length(μ_grid), length(T_grid))
+        @test all(out.Xi .> 0)
+        @test all(out.mean_N .>= 0)
+        @test all(out.var_N .>= 0)
+    end
+
+    @testset "⟨N⟩ in expected range for chosen μ window" begin
+        @test 0.3 < out.mean_N[1, 1] < 2.5
+        @test 0.5 < out.mean_N[2, 1] < 3.5
+    end
+
+    @testset "Ξ and ⟨N⟩ monotone in μ at fixed T" begin
+        @test out.Xi[2, 1] > out.Xi[1, 1]
+        @test out.mean_N[2, 1] > out.mean_N[1, 1]
+    end
+
+    @testset "Grand ⟨U⟩ is non-positive (attractive regime, low density)" begin
+        # In the dilute attractive regime, ⟨U⟩_GC should be ≤ 0 (with slack
+        # for sampling noise at the lowest μ where ⟨N⟩ ≈ 0).
+        @test out.mean_U[1, 1] <= 1e-3
+        @test out.mean_U[2, 1] <= 1e-3
+    end
 end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -155,13 +155,14 @@
 
         V = 1000.0u"Å^3"
         m = 40.0u"u"
-        T = 200.0u"K"
-        T_grid = [T]
+        T_grid = [200.0u"K", 350.0u"K"]
         kb = 8.617333262e-5
-        β = 1.0 / (kb * ustrip(u"K", T))
-        Λ_val = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+        βs = [1.0 / (kb * ustrip(u"K", T)) for T in T_grid]
+        Λs = [ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T)) for T in T_grid]
         V_val = ustrip(u"Å^3", V)
-        μ_for_zV(zV_target) = (log(zV_target * Λ_val^3 / V_val) / β) * u"eV"
+        # μ targets are set at the first (coldest) temperature; the second
+        # temperature exercises the per-T empty-sector row at the same μ.
+        μ_for_zV(zV_target) = (log(zV_target * Λs[1]^3 / V_val) / βs[1]) * u"eV"
 
         E_floor(N) = -0.02 * N
         ladder(N) = E_floor(N) .+ 0.05 .* (1.0 .- collect(1:n_iters) ./ n_iters)
@@ -195,7 +196,10 @@
 
             @test all(abs.(outE.mean_N .- out0.mean_N) .<= 1e-12)
             @test all(abs.(outE.var_N .- out0.var_N) .<= 1e-12)
-            @test all(isapprox.(outE.Xi, out0.Xi .* exp(-β * E0), rtol=1e-10))
+            for j in eachindex(T_grid)
+                @test all(isapprox.(outE.Xi[:, j], out0.Xi[:, j] .* exp(-βs[j] * E0),
+                                    rtol=1e-10))
+            end
             @test all(abs.(outE.mean_U .- (out0.mean_U .+ E0)) .<= 1e-12)
         end
 
@@ -229,28 +233,32 @@
             wavg(w, x) = sum(w .* x) / sum(w)
             Ns = collect(0:4)
 
-            for (k, μ) in enumerate(μ_grid)
-                zV = exp(β * ustrip(u"eV", μ)) * V_val / Λ_val^3
-                terms = [zV^N / factorial(N) * M * exp(-β * E_N(N)) for N in 1:4]
-                w_ex = vcat(exp(-β * E0), terms)   # exact: N = 0 at exp(−βE0)
+            for (k, μ) in enumerate(μ_grid), j in eachindex(T_grid)
+                βj = βs[j]
+                zV = exp(βj * ustrip(u"eV", μ)) * V_val / Λs[j]^3
+                terms = [zV^N / factorial(N) * M * exp(-βj * E_N(N)) for N in 1:4]
+                w_ex = vcat(exp(-βj * E0), terms)  # exact: N = 0 at exp(−βE0)
                 w_b = vcat(1.0, terms)             # biased: N = 0 at weight 1
                 Es_ex = vcat(E0, [E_N(N) for N in 1:4])
                 Es_b = vcat(0.0, [E_N(N) for N in 1:4])  # default: mean_E(0) = 0
 
-                @test isapprox(out_fix.Xi[k, 1], sum(w_ex), rtol=1e-10)
-                @test isapprox(out_fix.mean_N[k, 1], wavg(w_ex, Ns), rtol=1e-10)
-                @test isapprox(out_fix.var_N[k, 1],
+                @test isapprox(out_fix.Xi[k, j], sum(w_ex), rtol=1e-10)
+                @test isapprox(out_fix.mean_N[k, j], wavg(w_ex, Ns), rtol=1e-10)
+                @test isapprox(out_fix.var_N[k, j],
                                wavg(w_ex, Ns .^ 2) - wavg(w_ex, Ns)^2, rtol=1e-10)
-                @test isapprox(out_fix.mean_U[k, 1], wavg(w_ex, Es_ex), rtol=1e-10)
+                @test isapprox(out_fix.mean_U[k, j], wavg(w_ex, Es_ex), rtol=1e-10)
 
-                @test isapprox(out_def.Xi[k, 1], sum(w_b), rtol=1e-10)
-                @test isapprox(out_def.mean_N[k, 1], wavg(w_b, Ns), rtol=1e-10)
-                @test isapprox(out_def.var_N[k, 1],
+                @test isapprox(out_def.Xi[k, j], sum(w_b), rtol=1e-10)
+                @test isapprox(out_def.mean_N[k, j], wavg(w_b, Ns), rtol=1e-10)
+                @test isapprox(out_def.var_N[k, j],
                                wavg(w_b, Ns .^ 2) - wavg(w_b, Ns)^2, rtol=1e-10)
-                @test isapprox(out_def.mean_U[k, 1], wavg(w_b, Es_b), rtol=1e-10)
+                @test isapprox(out_def.mean_U[k, j], wavg(w_b, Es_b), rtol=1e-10)
 
-                # The bias is material at these μ: the default overstates ⟨N⟩.
-                @test out_def.mean_N[k, 1] > out_fix.mean_N[k, 1] + 0.1
+                # The bias is material in the cold dilute column: the default
+                # overstates ⟨N⟩ (analytic gaps 0.713 and 0.277 at 200 K).
+                if j == 1
+                    @test out_def.mean_N[k, 1] > out_fix.mean_N[k, 1] + 0.05
+                end
             end
         end
 
@@ -261,6 +269,9 @@
             @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
                 ns_outputs, N_values, V, m, μ_grid, T_grid;
                 n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=Inf)
+            @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+                ns_outputs, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=-Inf)
         end
     end
 

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -1,0 +1,125 @@
+@testset "Atomistic GC-NS, fixed-N construction (ideal gas)" begin
+
+    @testset "IdealGasParameters dispatch" begin
+        pot = IdealGasParameters()
+
+        # pair_energy is identically zero
+        @test pair_energy(1.0u"Å", pot) == 0.0u"eV"
+        @test pair_energy(0.5u"Å", pot) == 0.0u"eV"
+        @test pair_energy(100.0u"Å", pot) == 0.0u"eV"
+
+        # Construct a 3-atom periodic system and verify every pairwise dispatch
+        # path returns 0.0u"eV".
+        box = [[10.0u"Å", 0u"Å", 0u"Å"],
+               [0u"Å", 10.0u"Å", 0u"Å"],
+               [0u"Å", 0u"Å", 10.0u"Å"]]
+        coor = [:Ar => [0.1, 0.2, 0.3],
+                :Ar => [0.4, 0.5, 0.6],
+                :Ar => [0.7, 0.8, 0.9]]
+        sys = FastSystem(periodic_system(coor, box, fractional=true))
+
+        @test interacting_energy(sys, pot) == 0.0u"eV"
+        @test interacting_energy(sys, pot, [3], [false]) == 0.0u"eV"
+        @test frozen_energy(sys, pot, [3], [true]) == 0.0u"eV"
+    end
+
+    @testset "_thermal_wavelength" begin
+        # Reference value for H (m=1u) at T=300K: Λ ≈ 1.008 Å.
+        Λ_H = FreeBird.AnalysisTools._thermal_wavelength(1.0u"u", 300.0u"K")
+        @test isapprox(ustrip(u"Å", Λ_H), 1.008, rtol=1e-2)
+
+        # Exact scaling: Λ ∝ 1/sqrt(m), Λ ∝ 1/sqrt(T).
+        Λ_2m = FreeBird.AnalysisTools._thermal_wavelength(2.0u"u", 300.0u"K")
+        Λ_2T = FreeBird.AnalysisTools._thermal_wavelength(1.0u"u", 600.0u"K")
+        @test isapprox(ustrip(u"Å", Λ_2m) / ustrip(u"Å", Λ_H), 1 / sqrt(2), rtol=1e-10)
+        @test isapprox(ustrip(u"Å", Λ_2T) / ustrip(u"Å", Λ_H), 1 / sqrt(2), rtol=1e-10)
+    end
+
+    @testset "ideal-gas closed form: Ξ, ⟨N⟩, Var(N), ⟨U⟩" begin
+        # Synthesize per-N canonical NS DataFrames for an ideal gas (E ≡ 0).
+        # With ω0 = (K+1)/K and many iterations, sum(ω_i) → 1 exactly,
+        # making Z_NS^{(N)} = 1 for every N (the analytical answer).
+        # N_max = 20 keeps the truncation tail (zV)^N/N! negligible for
+        # ⟨N⟩ ≤ 3 at rtol = 1e-3.
+        N_max = 20
+        N_values = collect(0:N_max)
+        K = 120
+        n_iters = 5000
+        ω0_test = (K + 1) / K
+
+        ns_outputs = [DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for _ in N_values]
+
+        V = 1000.0u"Å^3"
+        m = 40.0u"u"
+        T = 300.0u"K"
+        T_grid = [T]
+
+        kb = 8.617333262e-5
+        β = 1.0 / (kb * ustrip(u"K", T))
+        Λ_val = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+        V_val = ustrip(u"Å^3", V)
+
+        # Solve zV = (exp(βμ)/Λ³) · V for μ given a target zV.
+        μ_for_zV(zV_target) = (log(zV_target * Λ_val^3 / V_val) / β) * u"eV"
+
+        zV_targets = (0.5, 1.5, 3.0)
+        μ_grid = [μ_for_zV(z) for z in zV_targets]
+
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test)
+
+        for (k, zV) in enumerate(zV_targets)
+            @test isapprox(out.Xi[k, 1], exp(zV), rtol=1e-3)
+            @test isapprox(out.mean_N[k, 1], zV, rtol=1e-3)
+            @test isapprox(out.var_N[k, 1], zV, rtol=1e-3)
+            @test isapprox(out.mean_U[k, 1], 0.0, atol=1e-12)
+        end
+    end
+
+    @testset "Ξ monotone in μ at fixed T" begin
+        N_max = 20
+        N_values = collect(0:N_max)
+        K = 120
+        n_iters = 5000
+        ω0_test = (K + 1) / K
+
+        ns_outputs = [DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for _ in N_values]
+
+        V = 1000.0u"Å^3"
+        m = 40.0u"u"
+        T_grid = [300.0u"K", 600.0u"K"]
+
+        μ_grid = collect(range(-0.30u"eV", -0.20u"eV", length=10))
+
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test)
+
+        @test all(diff(out.Xi, dims=1) .> 0)
+    end
+
+    @testset "argument validation" begin
+        K = 120
+        n_iters = 100
+        ns_outputs = [DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for _ in 1:3]
+
+        # Missing N=0 in N_values
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [1, 2, 3],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [300.0u"K"];
+            n_walkers=K)
+
+        # Length mismatch between ns_outputs and N_values
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            ns_outputs, [0, 1, 2, 3],
+            1000.0u"Å^3", 40.0u"u",
+            [-0.25u"eV"], [300.0u"K"];
+            n_walkers=K)
+    end
+
+end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -695,7 +695,7 @@ end
         for (idx, N) in enumerate(N_values)
             (N == 0 || N == 1) && continue
             df = ns_outputs[idx]
-            @test names(df) == ["iter", "emax"]
+            @test names(df) == ["iter", "emax", "log_compression"]
             @test nrow(df) >= 0.5 * n_ns_steps
             @test length(live_emax_all[idx]) == K
         end
@@ -1034,7 +1034,7 @@ end
         for (idx, N) in enumerate(N_values)
             N == 0 && continue
             df = ns_outputs[idx]
-            @test names(df) == ["iter", "emax"]
+            @test names(df) == ["iter", "emax", "log_compression"]
             @test nrow(df) >= 0.5 * n_ns_steps
             @test length(live_emax_all[idx]) == K
         end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -278,6 +278,279 @@
 end
 
 
+@testset "Atomistic GC-NS, fixed-N parity fields" begin
+    # Deterministic synthetic ladders — no NS runs. Every closure is gated
+    # against an independent reference: direct sample-level reweighting of the
+    # raw ledger weights accumulated in BigFloat (no energy shift needed at
+    # that precision), a different decomposition than the library's
+    # law-of-total-expectation assembly.
+    K = 64
+    n_iters = 400
+    ω0_test = (K + 1) / K
+    N_values = collect(0:4)
+
+    V = 1000.0u"Å^3"
+    m = 40.0u"u"
+    T_grid = [200.0u"K", 350.0u"K"]
+    kb = 8.617333262e-5
+    βs = [1.0 / (kb * ustrip(u"K", T)) for T in T_grid]
+    Λs = [ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T)) for T in T_grid]
+    V_val = ustrip(u"Å^3", V)
+    μ_for_zV(zV_target) = (log(zV_target * Λs[1]^3 / V_val) / βs[1]) * u"eV"
+    μ_grid = [μ_for_zV(0.3), μ_for_zV(1.0)]
+    empty_df() = DataFrame(iter=Int[], emax=Float64[])
+    r = K / (K + 1)
+
+    ladder(base, N) = base + N * (-0.02) .+ 0.05 .* (1.0 .- collect(1:n_iters) ./ n_iters)
+    floor_of(base, N) = base + N * (-0.02)
+
+    function brute_reference(ns_outs, live_all, N_vals, empty_E, obs_cols,
+                             live_obs, μ, T)
+        β = 1.0 / (kb * ustrip(u"K", T))
+        Λ = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+        log_zV = β * ustrip(u"eV", μ) + log(V_val) - 3 * log(Λ)
+        S0 = BigFloat(0); SN = BigFloat(0); SN2 = BigFloat(0)
+        SE = BigFloat(0); SE2 = BigFloat(0); SEN = BigFloat(0)
+        SA = Dict(col => BigFloat(0) for col in obs_cols)
+        function add!(E, lw, N, avals)
+            w = exp(BigFloat(lw) - BigFloat(β) * BigFloat(E) +
+                    N * BigFloat(log_zV) - log(BigFloat(factorial(N))))
+            S0 += w; SN += w * N; SN2 += w * N^2
+            SE += w * E; SE2 += w * E^2; SEN += w * E * N
+            for col in obs_cols
+                SA[col] += w * avals[col]
+            end
+            return nothing
+        end
+        for (i, N) in enumerate(N_vals)
+            if N == 0
+                a0 = Dict(col => sum(Float64, live_obs[i][col]) / length(live_obs[i][col])
+                          for col in obs_cols)
+                add!(empty_E, 0.0, 0, a0)
+                continue
+            end
+            df = ns_outs[i]
+            for row in 1:nrow(df)
+                lw = log(ω0_test) + log(1 / (K + 1)) + df.iter[row] * log(r)
+                arow = Dict(col => Float64(df[row, col]) for col in obs_cols)
+                add!(df.emax[row], lw, N, arow)
+            end
+            n_it = maximum(df.iter)
+            lw_tail = log(ω0_test) + n_it * log(r) - log(K)
+            for (s, E) in enumerate(live_all[i])
+                atail = Dict(col => Float64(live_obs === nothing ? 0.0 :
+                                            live_obs[i][col][s]) for col in obs_cols)
+                add!(E, lw_tail, N, atail)
+            end
+        end
+        mN = SN / S0; mE = SE / S0
+        return (logXi=Float64(log(S0)), mean_N=Float64(mN),
+                var_N=Float64(SN2 / S0 - mN^2), mean_U=Float64(mE),
+                var_U=Float64(SE2 / S0 - mE^2),
+                cov_UN=Float64(SEN / S0 - mE * mN),
+                obs=Dict(col => Float64(SA[col] / S0) for col in obs_cols))
+    end
+
+    @testset "brute-force closure, ordinary and offset ladders" begin
+        # Variant (a): energies of ordinary magnitude, default empty_energy.
+        # Variant (b): every energy carries a -1000 eV offset with
+        # empty_energy to match — the E_shift cancellation guard is the only
+        # thing keeping var_U/cov_UN at rtol 1e-10 there.
+        for (base, E0) in ((0.0, 0.0), (-1000.0, -1000.0))
+            ns_outputs = [N == 0 ? empty_df() :
+                          DataFrame(iter=collect(1:n_iters), emax=ladder(base, N))
+                          for N in N_values]
+            live_all = [N == 0 ? Float64[] : fill(floor_of(base, N), K)
+                        for N in N_values]
+            out = gc_thermodynamic_stats_fixed_N(
+                ns_outputs, N_values, V, m, μ_grid, T_grid;
+                n_walkers=K, ω0=ω0_test, live_emax=live_all, empty_energy=E0)
+            # var_U/cov_UN at the 10³ eV offset sit on the assembly's
+            # unshifted-first-moment floor (u_avg accumulates ~|E|·eps of
+            # absolute error before the E_shift subtraction; the lattice
+            # method shares the structure): measured ≤ 1.5e-8 relative here,
+            # against ~2e-5 with the cancellation guard disabled. The offset
+            # variant therefore gates them at 1e-7; everything else holds
+            # 1e-10.
+            rtol_uu = base == 0.0 ? 1e-10 : 1e-7
+            for (k, μ) in enumerate(μ_grid), (j, T) in enumerate(T_grid)
+                ref = brute_reference(ns_outputs, live_all, N_values, E0,
+                                      Symbol[], nothing, μ, T)
+                @test isapprox(out.logXi[k, j], ref.logXi, rtol=1e-10)
+                @test isapprox(out.mean_N[k, j], ref.mean_N, rtol=1e-10)
+                @test isapprox(out.var_N[k, j], ref.var_N, rtol=1e-10)
+                @test isapprox(out.mean_U[k, j], ref.mean_U, rtol=1e-10)
+                @test isapprox(out.var_U[k, j], ref.var_U, rtol=rtol_uu)
+                @test isapprox(out.cov_UN[k, j], ref.cov_UN, rtol=rtol_uu)
+            end
+        end
+    end
+
+    @testset "overflow: logXi finite where Xi is Inf" begin
+        ns_outputs = [N == 0 ? empty_df() :
+                      DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for N in N_values]
+        live_all = [N == 0 ? Float64[] : zeros(K) for N in N_values]
+        μ_deep = [μ_for_zV(exp(180.0))]
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_deep, T_grid[1:1];
+            n_walkers=K, ω0=ω0_test, live_emax=live_all)
+        @test out.Xi[1, 1] == Inf
+        ref = brute_reference(ns_outputs, live_all, N_values, 0.0,
+                              Symbol[], nothing, μ_deep[1], T_grid[1])
+        @test isapprox(out.logXi[1, 1], ref.logXi, rtol=1e-12)
+    end
+
+    @testset "P(N | μ, T) recipe from log_Z_N" begin
+        # E ≡ 0 ladders: the truncated weights are (zV)^N/N! · M with the
+        # prior mass M = Σᵢ ωᵢ + tail, and M = 1 for the empty sector.
+        ns_outputs = [N == 0 ? empty_df() :
+                      DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))
+                      for N in N_values]
+        live_all = [N == 0 ? Float64[] : zeros(K) for N in N_values]
+        M_dead = sum(ω0_test * (1 / (K + 1)) * r^i for i in 1:n_iters)
+        M_tail = ω0_test * r^n_iters
+        M = M_dead + M_tail
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all)
+        @test out.N_values == N_values
+        @test size(out.log_Z_N) == (length(N_values), length(T_grid))
+        for (k, μ) in enumerate(μ_grid), (j, T) in enumerate(T_grid)
+            β = βs[j]
+            logP = out.log_Z_N[:, j] .+ β .* ustrip(u"eV", μ) .* out.N_values
+            P = exp.(logP .- maximum(logP))
+            P ./= sum(P)
+            zV = exp(β * ustrip(u"eV", μ)) * V_val / Λs[j]^3
+            w_ref = [N == 0 ? 1.0 : zV^N / factorial(N) * M for N in N_values]
+            @test isapprox(P, w_ref ./ sum(w_ref), rtol=1e-12)
+            @test isapprox(sum(P .* out.N_values), out.mean_N[k, j], rtol=1e-12)
+            @test isapprox(sum(P .* out.N_values .^ 2) - sum(P .* out.N_values)^2,
+                           out.var_N[k, j], rtol=1e-12)
+        end
+    end
+
+    @testset "observables passthrough" begin
+        obs_cols = [:A, :B]
+        ns_outputs = Vector{DataFrame}(undef, length(N_values))
+        live_all = Vector{Vector{Float64}}(undef, length(N_values))
+        live_obs = Vector{Dict{Symbol,Vector{Float64}}}(undef, length(N_values))
+        for (i, N) in enumerate(N_values)
+            if N == 0
+                ns_outputs[i] = empty_df()
+                live_all[i] = Float64[]
+                live_obs[i] = Dict(:A => [7.5], :B => [0.0])
+                continue
+            end
+            Es = ladder(0.0, N)
+            ns_outputs[i] = DataFrame(iter=collect(1:n_iters), emax=Es,
+                                      A=2.0 .* Es .+ 1.0, B=fill(Float64(N), n_iters))
+            live_all[i] = fill(floor_of(0.0, N), K)
+            live_obs[i] = Dict(:A => 2.0 .* live_all[i] .+ 1.0,
+                               :B => fill(Float64(N), K))
+        end
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all,
+            observable_cols=obs_cols, live_observables=live_obs)
+        for (k, μ) in enumerate(μ_grid), (j, T) in enumerate(T_grid)
+            ref = brute_reference(ns_outputs, live_all, N_values, 0.0,
+                                  obs_cols, live_obs, μ, T)
+            @test isapprox(out.observables[:A][k, j], ref.obs[:A], rtol=1e-10)
+            @test isapprox(out.observables[:B][k, j], ref.obs[:B], rtol=1e-10)
+            # B ≡ N per sector, except the empty sector's declared 0.0 — the
+            # grand average must therefore reproduce ⟨N⟩ exactly.
+            @test isapprox(out.observables[:B][k, j], out.mean_N[k, j], rtol=1e-12)
+        end
+        # Guards, mirroring the lattice method's validation.
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all, live_observables=live_obs)
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, observable_cols=obs_cols)
+        bad_obs = [Dict(:A => d[:A]) for d in live_obs]
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all,
+            observable_cols=obs_cols, live_observables=bad_obs)
+    end
+
+    @testset "cross-method pin on the coinciding two-sector ladder" begin
+        # N_values = [0, 1] with E ≡ 0 is the one ladder where the atomistic
+        # (zV/Λ³)^N/N! and lattice C(M,N)·e^{βμN} priors coincide exactly
+        # under zV = M·e^{βμ_lat}.
+        M_sites = 8
+        N2 = [0, 1]
+        ns2 = [empty_df(), DataFrame(iter=collect(1:n_iters), emax=zeros(n_iters))]
+        live2 = [Float64[], zeros(K)]
+        T1 = T_grid[1:1]
+        μ_lat = [-0.05u"eV"]
+        μ_atom = [μ_lat[1] + (log(M_sites * Λs[1]^3 / V_val) / βs[1]) * u"eV"]
+        out_lat = gc_thermodynamic_stats_fixed_N(
+            ns2, N2, M_sites, μ_lat, T1;
+            n_walkers=K, ω0=ω0_test, live_emax=live2)
+        out_atom = gc_thermodynamic_stats_fixed_N(
+            ns2, N2, V, m, μ_atom, T1;
+            n_walkers=K, ω0=ω0_test, live_emax=live2)
+        @test abs(out_atom.mean_N[1, 1] - out_lat.mean_N[1, 1]) <= 1e-12
+        @test abs(out_atom.var_N[1, 1] - out_lat.var_N[1, 1]) <= 1e-12
+        @test isapprox(out_atom.logXi[1, 1], out_lat.logXi[1, 1], rtol=1e-12)
+    end
+
+    @testset "leading positions and legacy expressions" begin
+        ns_outputs = [N == 0 ? empty_df() :
+                      DataFrame(iter=collect(1:n_iters), emax=ladder(0.0, N))
+                      for N in N_values]
+        live_all = [N == 0 ? Float64[] : fill(floor_of(0.0, N), K)
+                    for N in N_values]
+        out = gc_thermodynamic_stats_fixed_N(
+            ns_outputs, N_values, V, m, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0_test, live_emax=live_all)
+        @test propertynames(out) == (:Xi, :mean_N, :var_N, :mean_U, :logXi,
+                                     :var_U, :cov_UN, :log_Z_N, :N_values,
+                                     :observables)
+        @test out[1] === out.Xi && out[2] === out.mean_N &&
+              out[3] === out.var_N && out[4] === out.mean_U
+        @test isempty(out.observables)
+        # The four legacy fields must be bit-identical to the pre-extension
+        # assembly, replicated here expression for expression.
+        n = length(N_values)
+        log_Z_NS = Matrix{Float64}(undef, n, length(T_grid))
+        mean_E_N = Matrix{Float64}(undef, n, length(T_grid))
+        for (i, N) in enumerate(N_values)
+            if N == 0
+                log_Z_NS[i, :] .= 0.0
+                mean_E_N[i, :] .= 0.0
+                continue
+            end
+            log_Z_NS[i, :], mean_E_N[i, :] = FreeBird.AnalysisTools._fixed_N_log_evidence(
+                ns_outputs[i], T_grid;
+                n_walkers=K, n_cull=1, ω0=ω0_test,
+                live_energies=live_all[i], kb=kb)
+        end
+        log_fact = [FreeBird.AnalysisTools._log_factorial(N) for N in N_values]
+        for (j, T) in enumerate(T_grid)
+            β = 1.0 / (kb * ustrip(u"K", T))
+            Λ_val = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(m, T))
+            log_V_over_Λ3 = log(V_val) - 3 * log(Λ_val)
+            for (k, μ) in enumerate(μ_grid)
+                log_zV = β * ustrip(u"eV", μ) + log_V_over_Λ3
+                log_w = log_Z_NS[:, j] .+ N_values .* log_zV .- log_fact
+                max_log = maximum(log_w)
+                ws = exp.(log_w .- max_log)
+                sum_w = sum(ws)
+                @test out.Xi[k, j] === exp(max_log) * sum_w
+                @test out.mean_N[k, j] === sum(ws .* N_values) / sum_w
+                mean_N2 = sum(ws .* (N_values .^ 2)) / sum_w
+                @test out.var_N[k, j] === mean_N2 - (sum(ws .* N_values) / sum_w)^2
+                @test out.mean_U[k, j] === sum(ws .* view(mean_E_N, :, j)) / sum_w
+            end
+        end
+    end
+end
+
+
 @testset "Atomistic GC-NS, fixed-N construction (3D LJ fluid)" begin
     using Random
 

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -25,6 +25,7 @@
         @test gc_params.fail_count == 0
         @test gc_params.allowed_fail_count == 10
         @test gc_params.init_occupation_p == 0.5
+        @test gc_params.n_max == typemax(Int64)
  
         gc_params2 = GrandCanonicalNestedSamplingParameters(
             mc_steps=200, chemical_potential=-0.05,
@@ -32,7 +33,11 @@
         @test gc_params2.mc_steps == 200
         @test gc_params2.chemical_potential == -0.05
         @test gc_params2.init_occupation_p == 0.3
- 
+        @test gc_params2.n_max == typemax(Int64)
+
+        gc_params3 = GrandCanonicalNestedSamplingParameters(n_max=Int64(5))
+        @test gc_params3.n_max == 5
+
         # Test mutability
         gc_params.fail_count = 5
         @test gc_params.fail_count == 5
@@ -328,5 +333,35 @@
         rm("test_val.csv", force=true)
         rm("test_val.traj", force=true)
         rm("test_val.ls", force=true)
+    end
+
+    # ================================================================
+    @testset "n_max enforcement" begin
+        n_max_val = Int64(5)
+        walkers_nm = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:10]
+        liveset_nm = LatticeGasWalkers(walkers_nm, ham; assign_energy=false)
+
+        gc_params_nm = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05,
+            init_occupation_p=0.5, n_max=n_max_val)
+        mc_routine_nm = MCGrandCanonicalMoves()
+        save_nm = SaveEveryN("test_nmax_df.csv", "test_nmax.traj", "test_nmax.ls", 10000, 10000, 10000)
+
+        df_nm, updated_liveset_nm, _ = grand_canonical_nested_sampling(
+            liveset_nm, gc_params_nm, Int64(50), mc_routine_nm, save_nm)
+
+        # After initialization, all walkers must respect n_max
+        for w in updated_liveset_nm.walkers
+            @test sum(w.configuration.components[1]) <= n_max_val
+        end
+
+        # All recorded samples must respect n_max
+        if nrow(df_nm) > 0
+            @test all(df_nm.num_particles .<= n_max_val)
+        end
+
+        rm("test_nmax_df.csv", force=true)
+        rm("test_nmax.traj", force=true)
+        rm("test_nmax.ls", force=true)
     end
 end

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -41,6 +41,18 @@
         # Test mutability
         gc_params.fail_count = 5
         @test gc_params.fail_count == 5
+
+        # Cluster field defaults
+        @test gc_params.cluster_p == 0.3
+        @test gc_params.cluster_accepted == 0.0
+        @test gc_params.cluster_total == 0.0
+        @test gc_params.cluster_p_history == Float64[]
+        @test gc_params.cluster_accept_history == Float64[]
+        @test gc_params.cluster_adjust_iterations == Int[]
+
+        # Cluster field mutability
+        gc_params.cluster_p = 0.5
+        @test gc_params.cluster_p == 0.5
     end
  
     # ================================================================
@@ -53,7 +65,23 @@
         mc2 = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
         @test mc2.p_move == 0.4
         @test mc2.p_insert == 0.3
- 
+
+        # Cluster field defaults
+        @test mc.clusters_freq == 0
+        @test mc.swaps_freq == 1
+        @test mc.initial_cluster_p == 0.3
+        @test mc.target_cluster_accept == 0.3
+        @test mc.cluster_adjust_interval == 50
+        @test mc.cluster_p_floor == 0.01
+        @test mc.cluster_p_ceiling == 1.0
+
+        # Cluster-enabled construction
+        mc3 = MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25,
+            clusters_freq=3, swaps_freq=1, initial_cluster_p=0.5)
+        @test mc3.clusters_freq == 3
+        @test mc3.swaps_freq == 1
+        @test mc3.initial_cluster_p == 0.5
+
         # Invalid probabilities
         @test_throws ArgumentError MCGrandCanonicalMoves(p_move=0.8, p_insert=0.3)
         @test_throws ArgumentError MCGrandCanonicalMoves(p_move=-0.1, p_insert=0.3)
@@ -138,14 +166,17 @@
         n_init = sum(walker.configuration.components[1])
         omega_max = walker.energy.val - mu * n_init + 1.0  # generous upper bound
  
-        accept, rate, updated_walker = MC_grand_canonical_walk!(
+        accept, rate, updated_walker, cl_acc, cl_tot = MC_grand_canonical_walk!(
             100, walker, ham, omega_max, mu;
             p_move=0.5, p_insert=0.25, energy_perturb=0.0)
- 
+
         @test accept isa Bool
         @test 0.0 <= rate <= 1.0
         @test updated_walker isa LatticeWalker{1}
- 
+        # No cluster moves when clusters_freq=0 (default)
+        @test cl_acc == 0
+        @test cl_tot == 0
+
         # Energy should be consistent with the configuration
         expected_energy = interacting_energy(updated_walker.configuration, ham)
         @test updated_walker.energy ≈ expected_energy
@@ -159,7 +190,34 @@
         @test_throws ArgumentError MC_grand_canonical_walk!(
             10, walker, ham, omega_max, mu; p_move=0.8, p_insert=0.3)
     end
- 
+
+    # ================================================================
+    @testset "MC_grand_canonical_walk! with cluster moves" begin
+        walker = LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0)
+        assign_energy!(walker, ham)
+
+        mu = -0.05
+        n_init = sum(walker.configuration.components[1])
+        omega_max = walker.energy.val - mu * n_init + 1.0
+
+        accept, rate, updated_walker, cl_acc, cl_tot = MC_grand_canonical_walk!(
+            200, walker, ham, omega_max, mu;
+            p_move=0.5, p_insert=0.25, energy_perturb=0.0,
+            clusters_freq=1, swaps_freq=1, cluster_p=0.3)
+
+        @test accept isa Bool
+        @test 0.0 <= rate <= 1.0
+        @test updated_walker isa LatticeWalker{1}
+        # Should have attempted some cluster moves
+        @test cl_tot > 0
+        @test cl_acc >= 0
+        @test cl_acc <= cl_tot
+
+        # Energy should be consistent
+        expected_energy = interacting_energy(updated_walker.configuration, ham)
+        @test updated_walker.energy ≈ expected_energy
+    end
+
     # ================================================================
     @testset "nested_sampling_step! for GC" begin
         walkers = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:5]
@@ -363,5 +421,112 @@
         rm("test_nmax_df.csv", force=true)
         rm("test_nmax.traj", force=true)
         rm("test_nmax.ls", force=true)
+    end
+
+    # ================================================================
+    @testset "GC-NS with cluster moves: basic functionality" begin
+        walkers_cl = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:10]
+        liveset_cl = LatticeGasWalkers(walkers_cl, ham; assign_energy=false)
+
+        gc_params_cl = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05)
+        mc_routine_cl = MCGrandCanonicalMoves(
+            p_move=0.5, p_insert=0.25,
+            clusters_freq=1, swaps_freq=1, initial_cluster_p=0.3,
+            cluster_adjust_interval=20)
+        save_cl = SaveEveryN("test_gc_cl_df.csv", "test_gc_cl.traj", "test_gc_cl.ls", 10000, 10000, 10000)
+
+        df_cl, updated_liveset_cl, updated_params_cl = grand_canonical_nested_sampling(
+            liveset_cl, gc_params_cl, Int64(50), mc_routine_cl, save_cl)
+
+        @test df_cl isa DataFrame
+        @test names(df_cl) == ["iter", "omega", "energy", "num_particles"]
+        @test nrow(df_cl) > 0
+        @test length(updated_liveset_cl.walkers) == 10
+
+        # Cluster adaptation should have been active
+        @test length(updated_params_cl.cluster_p_history) >= 0
+        # cluster_p should be within bounds
+        @test updated_params_cl.cluster_p >= mc_routine_cl.cluster_p_floor
+        @test updated_params_cl.cluster_p <= mc_routine_cl.cluster_p_ceiling
+
+        rm("test_gc_cl_df.csv", force=true)
+        rm("test_gc_cl.traj", force=true)
+        rm("test_gc_cl.ls", force=true)
+    end
+
+    # ================================================================
+    @testset "GC-NS with cluster moves: validation against exact enumeration" begin
+        # Reuse the 4x4 lattice and Hamiltonian from Study B
+        L = 4
+        lattice_template_cl = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(L, L, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:L*L]],
+            adsorptions=:full
+        )
+        ham_cl = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        n_sites_cl = L * L
+
+        mu_cl = -0.05
+        kb = 8.617333262e-5
+        T_cl = 300.0
+        beta_cl = 1.0 / (kb * T_cl)
+
+        # Exact enumeration
+        exact_z_cl = 0.0
+        exact_N_cl = 0.0
+        for mask in 0:(2^n_sites_cl - 1)
+            lat = deepcopy(lattice_template_cl)
+            for site in 1:n_sites_cl
+                lat.components[1][site] = ((mask >> (site - 1)) & 1) == 1
+            end
+            E_v = interacting_energy(lat, ham_cl).val
+            N_v = sum(lat.components[1])
+            omega_v = E_v - mu_cl * N_v
+            boltz = exp(-beta_cl * omega_v)
+            exact_z_cl += boltz
+            exact_N_cl += boltz * N_v
+        end
+        exact_mean_N_cl = exact_N_cl / exact_z_cl
+        exact_ln_z_cl = log(exact_z_cl)
+
+        # Run GC-NS with cluster moves
+        n_walkers_cl = 100
+        n_steps_cl = Int64(3000)
+        walkers_val_cl = [LatticeWalker(deepcopy(lattice_template_cl), energy=0.0u"eV", iter=0)
+                          for _ in 1:n_walkers_cl]
+        liveset_val_cl = LatticeGasWalkers(walkers_val_cl, ham_cl; assign_energy=false)
+
+        gc_params_val_cl = GrandCanonicalNestedSamplingParameters(
+            mc_steps=100, chemical_potential=mu_cl,
+            energy_perturbation=1e-12, init_occupation_p=0.5)
+        mc_routine_val_cl = MCGrandCanonicalMoves(
+            p_move=0.5, p_insert=0.25,
+            clusters_freq=3, swaps_freq=1, initial_cluster_p=0.3,
+            cluster_adjust_interval=50)
+        save_val_cl = SaveEveryN("test_val_cl.csv", "test_val_cl.traj", "test_val_cl.ls", 10000, 10000, 10000)
+
+        df_val_cl, _, params_val_cl = grand_canonical_nested_sampling(
+            liveset_val_cl, gc_params_val_cl, n_steps_cl, mc_routine_val_cl, save_val_cl)
+
+        @test nrow(df_val_cl) > 0
+
+        # Compute NS thermodynamic stats
+        mean_E_cl, Cv_cl, mean_N_ns_cl = gc_thermodynamic_stats(
+            df_val_cl, [beta_cl], n_walkers_cl, mu_cl)
+
+        # Compare ⟨N⟩ with exact (|error| < 0.5)
+        @test abs(mean_N_ns_cl[1] - exact_mean_N_cl) < 0.5
+
+        # Cluster adaptation should have fired
+        @test length(params_val_cl.cluster_p_history) > 0
+
+        rm("test_val_cl.csv", force=true)
+        rm("test_val_cl.traj", force=true)
+        rm("test_val_cl.ls", force=true)
     end
 end

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -658,4 +658,44 @@
         rm("test_val_cl.traj", force=true)
         rm("test_val_cl.ls", force=true)
     end
+
+    @testset "dead-point callback (Ω-sorted route)" begin
+        using Random
+        dpc_save = SaveEveryN("t_dpc_gc.csv", "t_dpc_gc.traj", "t_dpc_gc.ls",
+                              1000000, 1000000, 1000000)
+        dpc_cleanup() = rm.(["t_dpc_gc.csv", "t_dpc_gc.traj", "t_dpc_gc.ls"],
+                            force=true)
+
+        function dpc_run(seed, cb)
+            Random.seed!(seed)
+            walkers = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV",
+                                     iter=0) for _ in 1:10]
+            ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+            gc = GrandCanonicalNestedSamplingParameters(mc_steps=30,
+                chemical_potential=-0.05, energy_perturbation=1e-9)
+            d, _, _ = grand_canonical_nested_sampling(ls, gc, Int64(150),
+                MCGrandCanonicalMoves(), dpc_save; dead_point_callback=cb)
+            dpc_cleanup()
+            return d
+        end
+
+        # Invocation count equals nrow(df); the (iter, energy, N) triple seen
+        # by the callback matches the ledger row bit-exactly
+        seen = Tuple{Int,Float64,Int}[]
+        df = dpc_run(4271, (iter, w) -> push!(seen,
+            (iter, w.energy.val, sum(w.configuration.components[1]))))
+        @test nrow(df) > 0
+        @test length(seen) == nrow(df)
+        @test [t[1] for t in seen] == df.iter
+        @test [t[2] for t in seen] == df.energy
+        @test [t[3] for t in seen] == df.num_particles
+
+        # Stream neutrality: same-seed A/B with and without the callback
+        dfA = dpc_run(4272, nothing)
+        dfB = dpc_run(4272, (iter, w) -> nothing)
+        @test dfA.iter == dfB.iter
+        @test dfA.omega == dfB.omega
+        @test dfA.energy == dfB.energy
+        @test dfA.num_particles == dfB.num_particles
+    end
 end

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -50,6 +50,10 @@
         @test gc_params.cluster_accept_history == Float64[]
         @test gc_params.cluster_adjust_iterations == Int[]
 
+        # move_stats defaults (issue #158)
+        @test gc_params.move_stats isa Dict{Symbol,Int}
+        @test isempty(gc_params.move_stats)
+
         # Cluster field mutability
         gc_params.cluster_p = 0.5
         @test gc_params.cluster_p == 0.5
@@ -85,6 +89,29 @@
         # Invalid probabilities
         @test_throws ArgumentError MCGrandCanonicalMoves(p_move=0.8, p_insert=0.3)
         @test_throws ArgumentError MCGrandCanonicalMoves(p_move=-0.1, p_insert=0.3)
+
+        # Bias field defaults (issue #158)
+        @test mc.p_bias == 0.0
+        @test mc.bias_predicate == :contact
+        @test mc.bias_shells == 1
+
+        # Bias-enabled construction
+        mc4 = MCGrandCanonicalMoves(p_bias=0.5, bias_predicate=:cavity, bias_shells=2)
+        @test mc4.p_bias == 0.5
+        @test mc4.bias_predicate == :cavity
+        @test mc4.bias_shells == 2
+
+        # Invalid bias parameters
+        @test_throws ArgumentError MCGrandCanonicalMoves(p_bias=-0.1)
+        @test_throws ArgumentError MCGrandCanonicalMoves(p_bias=1.5)
+        @test_throws ArgumentError MCGrandCanonicalMoves(bias_shells=0)
+        @test_throws ArgumentError MCGrandCanonicalMoves(bias_predicate=:nonsense)
+
+        # p_bias = 1.0 constructs but warns (reducible kernel; see the
+        # non-ergodicity pin in test-ideal-gas-ref-gcns.jl) ...
+        @test_logs (:warn, r"p_bias") match_mode = :any MCGrandCanonicalMoves(p_bias=1.0)
+        # ... and stays silent below 1
+        @test_logs min_level = Base.CoreLogging.Warn MCGrandCanonicalMoves(p_bias=0.99)
     end
  
     # ================================================================
@@ -189,6 +216,64 @@
         # Invalid probability should throw
         @test_throws ArgumentError MC_grand_canonical_walk!(
             10, walker, ham, omega_max, mu; p_move=0.8, p_insert=0.3)
+
+        # ---- Move counters: 6th return element (issue #158) ----
+        walker6 = LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0)
+        assign_energy!(walker6, ham)
+        _, _, walker6, _, _, counters = MC_grand_canonical_walk!(
+            100, walker6, ham, 1e3, mu;
+            p_move=0.5, p_insert=0.25, energy_perturb=0.0)
+        @test counters isa NamedTuple
+        @test keys(counters) == (
+            :swap_attempted, :swap_accepted, :cluster_attempted, :cluster_accepted,
+            :insert_uniform_attempted, :insert_uniform_accepted,
+            :insert_biased_attempted, :insert_biased_accepted,
+            :delete_attempted, :delete_accepted)
+        # Default path: the bias and cluster families never fire
+        @test counters.insert_biased_attempted == 0
+        @test counters.insert_biased_accepted == 0
+        @test counters.cluster_attempted == 0
+        # accepted <= attempted per family
+        @test counters.swap_accepted <= counters.swap_attempted
+        @test counters.insert_uniform_accepted <= counters.insert_uniform_attempted
+        @test counters.delete_accepted <= counters.delete_attempted
+    end
+
+    # ================================================================
+    @testset "MC_grand_canonical_walk! counters: exact bookkeeping" begin
+        ham0 = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        # Skip-free by construction: N starts at 8, |dN| <= 1 per step, so
+        # over 8 steps N stays in [1, 15]: insert-at-full and delete-at-empty
+        # can never fire, and with 0 < N < M on a connected lattice the
+        # :contact set is never empty, so the biased branch cannot skip.
+        # Every step assigns a move type, for any RNG stream:
+        # sum(attempted) == n_steps exactly.
+        lat_bk = deepcopy(square_lattice)
+        lat_bk.components[1] .= false
+        lat_bk.components[1][1:8] .= true
+        walker_bk = LatticeWalker(lat_bk, energy=0.0u"eV", iter=0)
+        _, _, _, _, _, c = MC_grand_canonical_walk!(
+            8, walker_bk, ham0, 1e3, 0.0;
+            p_move=0.5, p_insert=0.25, energy_perturb=0.0,
+            p_bias=0.5, bias_predicate=:contact, bias_shells=1)
+        attempted = c.swap_attempted + c.cluster_attempted +
+                    c.insert_uniform_attempted + c.insert_biased_attempted +
+                    c.delete_attempted
+        accepted = c.swap_accepted + c.cluster_accepted +
+                   c.insert_uniform_accepted + c.insert_biased_accepted +
+                   c.delete_accepted
+        @test attempted == 8
+        @test accepted <= attempted
+
+        # kwarg validation on the walk
+        w2 = LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0)
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w2, ham0, 1e3, 0.0; p_bias=-0.1)
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w2, ham0, 1e3, 0.0; p_bias=1.5)
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w2, ham0, 1e3, 0.0; bias_shells=0)
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w2, ham0, 1e3, 0.0; bias_predicate=:nonsense)
+        # bias_shells beyond the lattice fires only when the channel is active
+        @test_throws ArgumentError MC_grand_canonical_walk!(
+            1, w2, ham0, 1e3, 0.0; p_bias=0.5, bias_shells=3)
     end
 
     # ================================================================
@@ -240,6 +325,22 @@
         @test n_par isa Union{Missing,Int}
         @test length(updated_liveset.walkers) == 5
         @test updated_params.fail_count >= 0
+
+        # ---- move_stats accumulation through one NS step (issue #158) ----
+        attempted_keys = (:swap_attempted, :cluster_attempted,
+                          :insert_uniform_attempted, :insert_biased_attempted,
+                          :delete_attempted)
+        ms = updated_params.move_stats
+        @test ms isa Dict{Symbol,Int}
+        @test all(v >= 0 for v in values(ms))
+        att = sum(get(ms, k, 0) for k in attempted_keys)
+        # One NS step walks one replacement walker for mc_steps steps; skips
+        # require a boundary configuration, so at least one step attempts
+        @test 1 <= att <= gc_params.mc_steps
+        @test get(ms, :swap_accepted, 0) <= get(ms, :swap_attempted, 0)
+        @test get(ms, :insert_uniform_accepted, 0) <= get(ms, :insert_uniform_attempted, 0)
+        @test get(ms, :insert_biased_accepted, 0) <= get(ms, :insert_biased_attempted, 0)
+        @test get(ms, :delete_accepted, 0) <= get(ms, :delete_attempted, 0)
     end
  
     # ================================================================
@@ -276,7 +377,35 @@
         rm("test_gc.traj", force=true)
         rm("test_gc.ls", force=true)
     end
- 
+
+    # ================================================================
+    @testset "move_stats: accumulated per run, reset between runs" begin
+        walkers_ms = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:10]
+        liveset_ms = LatticeGasWalkers(walkers_ms, ham; assign_energy=false)
+        params_ms = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05)
+        save_ms = SaveEveryN("test_ms_df.csv", "test_ms.traj", "test_ms.ls", 1000, 1000, 1000)
+        attempted_keys = (:swap_attempted, :cluster_attempted,
+                          :insert_uniform_attempted, :insert_biased_attempted,
+                          :delete_attempted)
+
+        _, _, params1 = grand_canonical_nested_sampling(
+            liveset_ms, params_ms, Int64(20), MCGrandCanonicalMoves(), save_ms)
+        s1 = sum(get(params1.move_stats, k, 0) for k in attempted_keys)
+        @test 0 < s1 <= 20 * 50   # per-run ceiling: n_iters x mc_steps
+
+        # Re-running with the RETURNED params must reset the accumulator: a
+        # carried-over dict would exceed the single-run ceiling
+        _, _, params2 = grand_canonical_nested_sampling(
+            liveset_ms, params1, Int64(20), MCGrandCanonicalMoves(), save_ms)
+        s2 = sum(get(params2.move_stats, k, 0) for k in attempted_keys)
+        @test 0 < s2 <= 20 * 50
+
+        rm("test_ms_df.csv", force=true)
+        rm("test_ms.traj", force=true)
+        rm("test_ms.ls", force=true)
+    end
+
     # ================================================================
     @testset "gc_thermodynamic_stats basic" begin
         # Hand-crafted test: 2 microstates

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -586,7 +586,7 @@
 
     # ================================================================
     @testset "GC-NS with cluster moves: validation against exact enumeration" begin
-        # Reuse the 4x4 lattice and Hamiltonian from Study B
+        # Same 4x4 lattice and Hamiltonian as the exact-enumeration validation above
         L = 4
         lattice_template_cl = MLattice{1,SquareLattice}(
             lattice_constant=1.0,

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -1,0 +1,332 @@
+@testset "Grand-canonical nested sampling tests" begin
+ 
+    # ================================================================
+    # Shared lattice and Hamiltonian for all GC tests
+    # ================================================================
+    square_lattice = MLattice{1,SquareLattice}(
+        lattice_constant=1.0,
+        basis=[(0.0, 0.0, 0.0)],
+        supercell_dimensions=(4, 4, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1, 1.5],
+        components=:equal,
+        adsorptions=:full
+    )
+    ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+ 
+    # ================================================================
+    @testset "GrandCanonicalNestedSamplingParameters" begin
+        gc_params = GrandCanonicalNestedSamplingParameters()
+        @test gc_params isa SamplingSchemes.SamplingParameters
+        @test gc_params.mc_steps == 100
+        @test gc_params.chemical_potential == 0.0
+        @test gc_params.energy_perturbation == 1e-12
+        @test gc_params.random_seed == 1234
+        @test gc_params.fail_count == 0
+        @test gc_params.allowed_fail_count == 10
+        @test gc_params.init_occupation_p == 0.5
+ 
+        gc_params2 = GrandCanonicalNestedSamplingParameters(
+            mc_steps=200, chemical_potential=-0.05,
+            init_occupation_p=0.3)
+        @test gc_params2.mc_steps == 200
+        @test gc_params2.chemical_potential == -0.05
+        @test gc_params2.init_occupation_p == 0.3
+ 
+        # Test mutability
+        gc_params.fail_count = 5
+        @test gc_params.fail_count == 5
+    end
+ 
+    # ================================================================
+    @testset "MCGrandCanonicalMoves" begin
+        mc = MCGrandCanonicalMoves()
+        @test mc isa MCRoutine
+        @test mc.p_move == 0.5
+        @test mc.p_insert == 0.25
+ 
+        mc2 = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+        @test mc2.p_move == 0.4
+        @test mc2.p_insert == 0.3
+ 
+        # Invalid probabilities
+        @test_throws ArgumentError MCGrandCanonicalMoves(p_move=0.8, p_insert=0.3)
+        @test_throws ArgumentError MCGrandCanonicalMoves(p_move=-0.1, p_insert=0.3)
+    end
+ 
+    # ================================================================
+    @testset "random_microstate!" begin
+        lattice = deepcopy(square_lattice)
+ 
+        # p=0 gives empty lattice
+        random_microstate!(lattice; p=0.0)
+        @test sum(lattice.components[1]) == 0
+ 
+        # p=1 gives full lattice
+        random_microstate!(lattice; p=1.0)
+        @test sum(lattice.components[1]) == num_sites(lattice)
+ 
+        # p=0.5 gives variable occupancy (statistical — just check it runs)
+        counts = Int[]
+        for _ in 1:50
+            random_microstate!(lattice; p=0.5)
+            push!(counts, sum(lattice.components[1]))
+        end
+        # With 16 sites and p=0.5, we should see variation
+        @test minimum(counts) < maximum(counts)
+        # Mean should be roughly 8
+        @test 4 < mean(counts) < 12
+    end
+ 
+    # ================================================================
+    @testset "lattice_insert_particle!" begin
+        lattice = deepcopy(square_lattice)
+        lattice.components[1] .= false
+        n_sites = num_sites(lattice)
+ 
+        # Insert into empty lattice
+        success, _ = lattice_insert_particle!(lattice)
+        @test success
+        @test sum(lattice.components[1]) == 1
+ 
+        # Fill the lattice
+        for _ in 2:n_sites
+            lattice_insert_particle!(lattice)
+        end
+        @test sum(lattice.components[1]) == n_sites
+ 
+        # Insert into full lattice should fail
+        success, _ = lattice_insert_particle!(lattice)
+        @test !success
+        @test sum(lattice.components[1]) == n_sites
+    end
+ 
+    # ================================================================
+    @testset "lattice_delete_particle!" begin
+        lattice = deepcopy(square_lattice)
+        lattice.components[1] .= true
+        n_sites = num_sites(lattice)
+ 
+        # Delete from full lattice
+        success, _ = lattice_delete_particle!(lattice)
+        @test success
+        @test sum(lattice.components[1]) == n_sites - 1
+ 
+        # Empty the lattice
+        lattice.components[1] .= false
+        lattice.components[1][1] = true
+        success, _ = lattice_delete_particle!(lattice)
+        @test success
+        @test sum(lattice.components[1]) == 0
+ 
+        # Delete from empty lattice should fail
+        success, _ = lattice_delete_particle!(lattice)
+        @test !success
+    end
+ 
+    # ================================================================
+    @testset "MC_grand_canonical_walk!" begin
+        walker = LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0)
+        assign_energy!(walker, ham)
+ 
+        mu = -0.05  # in eV
+        n_init = sum(walker.configuration.components[1])
+        omega_max = walker.energy.val - mu * n_init + 1.0  # generous upper bound
+ 
+        accept, rate, updated_walker = MC_grand_canonical_walk!(
+            100, walker, ham, omega_max, mu;
+            p_move=0.5, p_insert=0.25, energy_perturb=0.0)
+ 
+        @test accept isa Bool
+        @test 0.0 <= rate <= 1.0
+        @test updated_walker isa LatticeWalker{1}
+ 
+        # Energy should be consistent with the configuration
+        expected_energy = interacting_energy(updated_walker.configuration, ham)
+        @test updated_walker.energy ≈ expected_energy
+ 
+        # Omega should be below omega_max
+        n_final = sum(updated_walker.configuration.components[1])
+        omega_final = updated_walker.energy.val - mu * n_final
+        @test omega_final < omega_max
+ 
+        # Invalid probability should throw
+        @test_throws ArgumentError MC_grand_canonical_walk!(
+            10, walker, ham, omega_max, mu; p_move=0.8, p_insert=0.3)
+    end
+ 
+    # ================================================================
+    @testset "nested_sampling_step! for GC" begin
+        walkers = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:5]
+        liveset = LatticeGasWalkers(walkers, ham)
+ 
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05)
+        mc_routine = MCGrandCanonicalMoves()
+ 
+        # Initialize walkers with random microstates
+        SamplingSchemes._init_gc_walkers!(liveset, gc_params)
+ 
+        e_type = typeof(walkers[1].energy)
+        iter, omega, energy, n_par, updated_liveset, updated_params = nested_sampling_step!(
+            liveset, gc_params, mc_routine)
+ 
+        @test iter isa Union{Missing,Int}
+        @test omega isa Union{Missing,e_type}
+        @test energy isa Union{Missing,e_type}
+        @test n_par isa Union{Missing,Int}
+        @test length(updated_liveset.walkers) == 5
+        @test updated_params.fail_count >= 0
+    end
+ 
+    # ================================================================
+    @testset "grand_canonical_nested_sampling loop" begin
+        walkers = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV", iter=0) for _ in 1:10]
+        liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
+ 
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=50, chemical_potential=-0.05)
+        mc_routine = MCGrandCanonicalMoves()
+        save_strategy = SaveEveryN("test_gc_df.csv", "test_gc.traj", "test_gc.ls", 1000, 1000, 1000)
+ 
+        df, updated_liveset, updated_params = grand_canonical_nested_sampling(
+            liveset, gc_params, Int64(20), mc_routine, save_strategy)
+ 
+        @test df isa DataFrame
+        @test names(df) == ["iter", "omega", "energy", "num_particles"]
+        @test nrow(df) <= 20
+        @test nrow(df) > 0  # At least some steps should succeed
+        @test eltype(df.iter) == Int
+        @test eltype(df.omega) == Float64
+        @test eltype(df.energy) == Float64
+        @test eltype(df.num_particles) == Int
+        @test length(updated_liveset.walkers) == 10
+ 
+        # Omega should be monotonically non-increasing (each recorded Ω <= previous)
+        if nrow(df) > 1
+            for i in 2:nrow(df)
+                @test df.omega[i] <= df.omega[1] + 1e-10
+            end
+        end
+ 
+        rm("test_gc_df.csv", force=true)
+        rm("test_gc.traj", force=true)
+        rm("test_gc.ls", force=true)
+    end
+ 
+    # ================================================================
+    @testset "gc_thermodynamic_stats basic" begin
+        # Hand-crafted test: 2 microstates
+        # Microstate 1: E=0, N=0, Ω=0
+        # Microstate 2: E=-1, N=1, Ω=-1-μ*1
+        μ = -0.5
+        ωi = [0.5, 0.5]
+        grand_es = [0.0, -1.0 - μ * 1.0]  # Ω = E - μN
+        Es = [0.0, -1.0]
+        Ns = [0, 1]
+ 
+        # At β=0 (infinite T), equal weights
+        u, cv_val, n_avg = gc_thermodynamic_stats(
+            0.001, ωi, grand_es, Es, Ns, μ; kb=1.0)
+        @test isfinite(u)
+        @test isfinite(cv_val)
+        @test isfinite(n_avg)
+        # At very low β, should be roughly equal mixture
+        @test n_avg ≈ 0.5 atol=0.1
+ 
+        # Dimension mismatch should throw
+        @test_throws DimensionMismatch gc_thermodynamic_stats(
+            1.0, [0.5], [0.0, 1.0], [0.0, 1.0], [0, 1], 0.0)
+    end
+ 
+    # ================================================================
+    @testset "Validation against exact grand-canonical enumeration" begin
+        # 4x4 lattice, NN interactions only, single component
+        # Exact: sum over all 2^16 = 65536 microstates
+        L = 4
+        lattice_template = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(L, L, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:L*L]],
+            adsorptions=:full
+        )
+        ham_val = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        n_sites = L * L
+ 
+        # Exact grand-canonical enumeration
+        mu_val = -0.05  # eV
+        kb = 8.617333262e-5  # eV/K
+        T_test = 300.0  # K
+        beta_test = 1.0 / (kb * T_test)
+ 
+        # Enumerate all 2^16 microstates
+        exact_z = 0.0
+        exact_E = 0.0
+        exact_E2 = 0.0
+        exact_N = 0.0
+        exact_EN = 0.0
+ 
+        for mask in 0:(2^n_sites - 1)
+            lattice = deepcopy(lattice_template)
+            for site in 1:n_sites
+                lattice.components[1][site] = ((mask >> (site - 1)) & 1) == 1
+            end
+            E_val = interacting_energy(lattice, ham_val).val
+            N_val = sum(lattice.components[1])
+            omega_val = E_val - mu_val * N_val
+ 
+            boltz = exp(-beta_test * omega_val)
+            exact_z += boltz
+            exact_E += boltz * E_val
+            exact_E2 += boltz * E_val^2
+            exact_N += boltz * N_val
+            exact_EN += boltz * E_val * N_val
+        end
+ 
+        exact_mean_E = exact_E / exact_z
+        exact_mean_N = exact_N / exact_z
+        exact_mean_E2 = exact_E2 / exact_z
+        exact_mean_EN = exact_EN / exact_z
+        exact_var_E = exact_mean_E2 - exact_mean_E^2
+        exact_cov_EN = exact_mean_EN - exact_mean_E * exact_mean_N
+        exact_Cv = kb * beta_test^2 * (exact_var_E - mu_val * exact_cov_EN)
+ 
+        # Run GC-NS with enough walkers and iterations
+        n_walkers = 100
+        n_steps = Int64(3000)
+ 
+        walkers = [LatticeWalker(deepcopy(lattice_template), energy=0.0u"eV", iter=0)
+                   for _ in 1:n_walkers]
+        liveset = LatticeGasWalkers(walkers, ham_val; assign_energy=false)
+ 
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=100, chemical_potential=mu_val,
+            energy_perturbation=1e-12, init_occupation_p=0.5)
+        mc_routine = MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25)
+        save_strategy = SaveEveryN("test_val.csv", "test_val.traj", "test_val.ls", 10000, 10000, 10000)
+ 
+        df, _, _ = grand_canonical_nested_sampling(
+            liveset, gc_params, n_steps, mc_routine, save_strategy)
+ 
+        @test nrow(df) > 0
+ 
+        # Compute NS thermodynamic stats
+        mean_E_ns, Cv_ns, mean_N_ns = gc_thermodynamic_stats(
+            df, [beta_test], n_walkers, mu_val)
+ 
+        # Compare with exact values (generous tolerances for stochastic algorithm)
+        @test mean_E_ns[1] ≈ exact_mean_E rtol=0.3
+        @test mean_N_ns[1] ≈ exact_mean_N rtol=0.3
+        # Cv is harder to converge; just check it's in the right ballpark
+        if isfinite(Cv_ns[1]) && isfinite(exact_Cv) && exact_Cv > 0
+            @test Cv_ns[1] > 0
+        end
+ 
+        rm("test_val.csv", force=true)
+        rm("test_val.traj", force=true)
+        rm("test_val.ls", force=true)
+    end
+end

--- a/test/test-SamplingSchemes/test-hard-core-lattices.jl
+++ b/test/test-SamplingSchemes/test-hard-core-lattices.jl
@@ -308,4 +308,79 @@
         # diagnostic every reweighted grid point must be gated on.
         @test stats.N_eff[4, 1] < stats.N_eff[2, 1]
     end
+
+    # ================================================================
+    @testset "igref route vs exact (hard hexagons, z0 = 1)" begin
+        # The 18-site cell's close-packed states are exactly the three pure
+        # √3×√3 sublattice states: zero energy and maximal order parameter.
+        # A deterministic tie between g_tr's close-packing degeneracy 3 and
+        # the sublattice geometry, independent of the sampled run below.
+        let lat = hc_tri()
+            for c in 0:2
+                lat.components[1] .= [
+                    begin
+                        b = (s - 1) % 2
+                        ci = ((s - 1) ÷ 2) % 3
+                        (b == 0 ? ci % 3 : (ci + 2) % 3) == c
+                    end for s in 1:M_tr]
+                @test interacting_energy(lat, ham_hc) ≈ 0.0u"eV" atol=1e-12u"eV"
+                @test order_parameter_sqrt3(lat) == 1 / 3
+            end
+        end
+
+        # Full-compression depth M·ln(1 + z0) = 18·ln 2 ≈ 12.5 nats at K = 100
+        # wants ≈ 1.15·K·D ≈ 1440 iterations; 1800 adds margin (the square
+        # testset's 1500 at D ≈ 11.1, scaled).
+        Random.seed!(22)
+        K = 100
+        template = hc_tri()
+        template.components[1] .= false
+        walkers = [LatticeWalker(deepcopy(template), energy=0.0u"eV", iter=0)
+                   for _ in 1:K]
+        liveset = LatticeGasWalkers(walkers, ham_hc; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=1.0,
+            energy_perturbation=1e-9, allowed_fail_count=100_000)
+        mc_routine = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+        df, final_ls, _ = ideal_gas_referenced_nested_sampling(
+            liveset, params, Int64(1800), mc_routine, save_strategy)
+        hc_cleanup()
+
+        @test nrow(df) > 0
+        @test issorted(df.emax, rev=true)
+        # The ladder reached the allowed manifold and the live set sits in it
+        @test minimum(df.emax) < J / 2
+        live_E = [w.energy.val for w in final_ls.walkers]
+        live_N = [sum(w.configuration.components[1]) for w in final_ls.walkers]
+        @test all(e -> e < J / 2, live_E)
+
+        # Any close-packed live walker must be one of the three sublattice
+        # states (the only N = 6 members of the allowed manifold). At z0 = 1
+        # their prior weight is 3/418 per walker, so this is usually
+        # vacuously true; the deterministic check above is the real tie.
+        for w in final_ls.walkers
+            sum(w.configuration.components[1]) == 6 || continue
+            @test order_parameter_sqrt3(w.configuration) == 1 / 3
+        end
+
+        T_ath = 150.0
+        zs = [0.7, 1.0, 1.5, 2.0]
+        μs = [kb * T_ath * log(z) for z in zs]
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, M_tr, 1.0, μs, [T_ath], K;
+            ω0=(K + 1) / K, live_emax=live_E, live_numbers=live_N)
+
+        # Tolerances ≥ 3σ of the evidence noise, sized from three-seed
+        # scatter at this configuration (max observed |ΔlogΞ| 0.37,
+        # |Δ⟨N⟩| 0.24); a dropped (1+z0)^M normalization would shift logΞ
+        # by 18·ln 2 ≈ 12.5 — still cleanly discriminating.
+        for (i, z) in enumerate(zs[1:3])  # z = 2.0 is the N_eff check below
+            ex = exact_hc_stats(g_tr, z)
+            @test isapprox(stats.logXi[i, 1], ex.logXi, atol=0.75)
+            @test isapprox(stats.mean_N[i, 1], ex.mean_N, atol=0.5)
+        end
+
+        # Kish N_eff degrades away from the run's z0
+        @test stats.N_eff[4, 1] < stats.N_eff[2, 1]
+    end
 end

--- a/test/test-SamplingSchemes/test-hard-core-lattices.jl
+++ b/test/test-SamplingSchemes/test-hard-core-lattices.jl
@@ -432,4 +432,62 @@
         # Kish N_eff degrades away from the run's z0
         @test stats.N_eff[4, 1] < stats.N_eff[2, 1]
     end
+
+    # ================================================================
+    @testset "biased :cavity walk samples the restricted prior (hard squares)" begin
+        # Fixed ceiling J/2 in (0, J) with mu = 0, z0 = 1: the only reachable
+        # states are independent sets (E = J x violations), and the walk's
+        # stationary law is the RESTRICTED Bernoulli prior
+        # P(N) = g_N / sum(g) = g_N / 743.
+        # A fixed-ceiling walk is used instead of an NS dead-point histogram:
+        # dead points are moving-ceiling order statistics with no closed-form
+        # N-marginal, while this chain has an exact target, and it exercises
+        # the composite kernel directly, including the isolated-particle
+        # delete branch (on an independent set every occupied site is
+        # isolated, so every deletion takes that branch).
+        Random.seed!(158)
+        template_bc = hc_square()
+        template_bc.components[1] .= false
+        walker_bc = LatticeWalker(template_bc, energy=0.0u"eV", iter=0)
+        wcap = J / 2
+        gc_walk!(n) = MC_grand_canonical_walk!(n, walker_bc, ham_hc, wcap, 0.0;
+            p_move=0.4, p_insert=0.3, z0=1.0,
+            p_bias=0.9, bias_predicate=:cavity, bias_shells=1)
+        gc_walk!(500)   # burn-in from the empty (allowed) state
+
+        n_samples = 12_000
+        counts = zeros(Int, M_sq + 1)
+        rate_sum = 0.0
+        all_independent = true
+        for _ in 1:n_samples
+            _, r, _, _, _, _ = gc_walk!(15)   # 15-step decorrelation blocks
+            occ = walker_bc.configuration.components[1]
+            all_independent &= violation_count(masks_sq, occ) == 0
+            counts[sum(occ) + 1] += 1
+            rate_sum += r
+        end
+
+        # The ceiling was never breached: every sample is an independent set
+        @test all_independent
+        @test all(counts[10:end] .== 0)   # g_N = 0 for N > 8
+
+        # Multinomial gates: p_N = g_N/743, sigma = sqrt(p(1-p)/n) at
+        # n = 12000, with mild residual autocorrelation from the 15-step
+        # blocks. Three-seed calibration (seeds 158/159/160): max |dev| =
+        # 2.3 iid-sigma, zero tail counts, acceptance rate 0.70 on every
+        # seed; the shipped k = 7 is >= 3x the maximum. Discrimination: an
+        # uncorrected biased kernel distorts P(N) at the tens-of-percent
+        # level, orders above these gates.
+        Zg = sum(g_sq)   # = 743
+        for N in 0:8
+            p = g_sq[N + 1] / Zg
+            sig = sqrt(p * (1 - p) / n_samples)
+            @test abs(counts[N + 1] / n_samples - p) < 7 * sig
+        end
+
+        # Acceptance sanity: cavity insertions never create a violation, so
+        # the ceiling never rejects the biased branch; only the MH factor
+        # can. A soft floor pins that the kernel is not ceiling-starved.
+        @test rate_sum / n_samples > 0.1
+    end
 end

--- a/test/test-SamplingSchemes/test-hard-core-lattices.jl
+++ b/test/test-SamplingSchemes/test-hard-core-lattices.jl
@@ -176,7 +176,8 @@
     # to the E = 0 manifold; gc_thermodynamic_stats_fixed_N assembles Ξ(z).
     # This is the primary route for athermal models: every z is an exact
     # polynomial evaluation in the per-N evidence (no reweighting window).
-    function fixed_N_hard_core(make, N_max; K, n_iters, mc_steps, seed)
+    function fixed_N_hard_core(make, N_max; K, n_iters, mc_steps, seed,
+                               routine=MCRandomWalkClone())
         Random.seed!(seed)
         dfs = Vector{DataFrame}(undef, N_max + 1)
         live = Vector{Vector{Float64}}(undef, N_max + 1)
@@ -195,7 +196,7 @@
                 energy_perturbation=1e-9,
                 allowed_fail_count=100_000)
             df, final_ls, _ = nested_sampling(
-                liveset, ns_params, n_iters, MCRandomWalkClone(), save_strategy)
+                liveset, ns_params, n_iters, routine, save_strategy)
             dfs[N + 1] = df
             live[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
         end
@@ -257,6 +258,54 @@
                 end
             end
         end
+    end
+
+    # ================================================================
+    # Cluster-move A/B: the triangular geometric cluster move is variance
+    # reduction only, so mixed-move ladders must reproduce the same exact
+    # per-N evidence as the local-move reference above. Unbiasedness is the
+    # assertion; a hard variance comparison over a few seeds would be
+    # F-statistics noise and is deliberately not asserted.
+    @testset "fixed-N route with cluster moves (hard hexagons)" begin
+        K = 60
+        n_iters = 900
+        T_ath = 150.0
+        routine = MCMixedMoves(walks_freq=1, clusters_freq=1)
+        dfs, live = fixed_N_hard_core(hc_tri, 6;
+            K=K, n_iters=n_iters, mc_steps=100, seed=4000, routine=routine)
+
+        # Every mixed-move ladder still descends into the E = 0 manifold
+        for N in 1:6
+            @test issorted(dfs[N + 1].emax, rev=true)
+            @test all(e -> e < J / 2, live[N + 1])
+        end
+
+        stats = gc_thermodynamic_stats_fixed_N(
+            dfs, collect(0:6), M_tr, [0.0] .* u"eV", [T_ath * u"K"];
+            n_walkers=K, n_cull=1, ω0=(K + 1) / K, live_emax=live)
+
+        # Same per-sector tolerance as the local-move reference (≥ 3σ)
+        for N in 0:6
+            @test isapprox(stats.log_Z_N[N + 1, 1], log(g_tr[N + 1]), atol=1.5)
+        end
+
+        # Wiring: the mixed step exercised cluster moves, tuned cluster_p
+        # adaptively, and conserved N through the full NS machinery
+        Random.seed!(4001)
+        walkers = [
+            begin
+                lat = lattice_at(hc_tri, 4)
+                generate_random_new_lattice_sample!(lat)
+                LatticeWalker(lat)
+            end for _ in 1:20]
+        liveset = LatticeGasWalkers(walkers, ham_hc, perturb_energy=1e-9)
+        ns_params = LatticeNestedSamplingParameters(
+            mc_steps=40, energy_perturbation=1e-9, allowed_fail_count=100_000)
+        _, ls_out, params_out = nested_sampling(
+            liveset, ns_params, 200, routine, save_strategy)
+        hc_cleanup()
+        @test !isempty(params_out.cluster_p_history)
+        @test all(sum(w.configuration.components[1]) == 4 for w in ls_out.walkers)
     end
 
     # ================================================================

--- a/test/test-SamplingSchemes/test-hard-core-lattices.jl
+++ b/test/test-SamplingSchemes/test-hard-core-lattices.jl
@@ -1,0 +1,311 @@
+@testset "Hard-core lattice models (finite-J athermal recipe)" begin
+    using Random
+
+    # Hard squares (square lattice, NN exclusion) and hard hexagons
+    # (triangular lattice, NN exclusion) via the finite-J recipe: a finite
+    # repulsive coupling J on a single-shell lattice makes the energy
+    # J × (number of excluded-neighbor pairs), an integer-leveled ladder whose
+    # E = 0 manifold is exactly the hard-core configuration space. Post-
+    # processing at β·J ≥ (ladder depth in nats) + ~40 turns the Boltzmann
+    # factor into an exact 0/1 indicator, so every observable is athermal —
+    # a function of the activity z = exp(βμ) alone. See the hard-core recipe
+    # in the GenericLatticeHamiltonian docstring.
+
+    kb = 8.617333262e-5  # eV/K
+    J = 1.0              # eV per excluded-neighbor pair
+    ham_hc = GenericLatticeHamiltonian(0.0, [J], u"eV")
+
+    hc_square() = MLattice{1,SquareLattice}(
+        lattice_constant=1.0,
+        basis=[(0.0, 0.0, 0.0)],
+        supercell_dimensions=(4, 4, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1],
+        components=:equal,
+        adsorptions=:full)
+
+    # (3, 3, 1) with the 2-site basis: M = 18, commensurate with the
+    # √3×√3 three-sublattice ordering (close packing N = M/3 = 6, g = 3).
+    hc_tri() = MLattice{1,TriangularLattice}(
+        lattice_constant=1.0,
+        supercell_dimensions=(3, 3, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1],
+        components=:equal,
+        adsorptions=:full)
+
+    function lattice_at(make, N::Int)
+        lat = make()
+        lat.components[1] .= false
+        lat.components[1][1:N] .= true
+        return lat
+    end
+
+    # Brute-force reference built from the neighbor lists alone (independent
+    # of EnergyEval): bitmask adjacency, count independent sets by N.
+    function neighbor_masks(lat)
+        M = length(lat.components[1])
+        masks = zeros(UInt64, M)
+        for i in 1:M
+            m = UInt64(0)
+            for j in lat.neighbors[i][1]
+                m |= UInt64(1) << (j - 1)
+            end
+            masks[i] = m
+        end
+        return masks
+    end
+
+    function independent_set_counts(masks, M)
+        g = zeros(Int, M + 1)
+        for cfg in UInt64(0):(UInt64(1) << M) - UInt64(1)
+            ok = true
+            c = cfg
+            while c != 0
+                i = trailing_zeros(c) + 1
+                if masks[i] & cfg != 0
+                    ok = false
+                    break
+                end
+                c &= c - UInt64(1)
+            end
+            ok && (g[count_ones(cfg) + 1] += 1)
+        end
+        return g
+    end
+
+    function violation_count(masks, occ)
+        v = 0
+        for i in eachindex(occ)
+            occ[i] || continue
+            for j in eachindex(occ)
+                if occ[j] && masks[i] & (UInt64(1) << (j - 1)) != 0
+                    v += 1
+                end
+            end
+        end
+        return v ÷ 2
+    end
+
+    function triangle_count(masks, M)
+        t = 0
+        for i in 1:M, j in (i + 1):M
+            masks[i] & (UInt64(1) << (j - 1)) == 0 && continue
+            common = masks[i] & masks[j] & ~((UInt64(1) << j) - UInt64(1))
+            t += count_ones(common)
+        end
+        return t
+    end
+
+    # Exact hard-core grand-canonical stats from the g_N table:
+    # Ξ(z) = Σ_N g_N z^N.
+    function exact_hc_stats(g, z)
+        Ns = [N for N in 0:length(g)-1 if g[N+1] > 0]
+        lt = [log(g[N+1]) + N * log(z) for N in Ns]
+        mx = maximum(lt)
+        w = exp.(lt .- mx)
+        sw = sum(w)
+        return (logXi=mx + log(sw),
+                mean_N=sum(w .* Ns) / sw,
+                var_N=sum(w .* Ns .^ 2) / sw - (sum(w .* Ns) / sw)^2)
+    end
+
+    sq = hc_square()
+    tr = hc_tri()
+    M_sq = length(sq.components[1])
+    M_tr = length(tr.components[1])
+    masks_sq = neighbor_masks(sq)
+    masks_tr = neighbor_masks(tr)
+    g_sq = independent_set_counts(masks_sq, M_sq)
+    g_tr = independent_set_counts(masks_tr, M_tr)
+
+    save_strategy = SaveEveryN(
+        df_filename="test_hc_df.csv",
+        wk_filename="test_hc.traj.extxyz",
+        ls_filename="test_hc.ls.extxyz",
+        n_traj=1_000_000, n_snap=1_000_000, n_info=1_000_000)
+    hc_cleanup() = foreach(f -> rm(f, force=true),
+        ("test_hc_df.csv", "test_hc.traj.extxyz", "test_hc.ls.extxyz"))
+
+    # ================================================================
+    @testset "exact enumeration references" begin
+        # Hard squares, 4×4 PBC: pins the square neighbor lists and the
+        # close-packed c(2×2) pair.
+        @test M_sq == 16
+        @test all(length(sq.neighbors[i][1]) == 4 for i in 1:M_sq)
+        @test g_sq[1:9] == [1, 16, 88, 208, 228, 128, 56, 16, 2]
+        @test all(g_sq[10:end] .== 0)
+
+        # Hard hexagons, 18-site commensurate torus: pins the triangular
+        # neighbor lists, the cell commensurability, and the three √3×√3
+        # sublattice states at close packing.
+        @test M_tr == 18
+        @test all(length(tr.neighbors[i][1]) == 6 for i in 1:M_tr)
+        @test g_tr[1:7] == [1, 18, 99, 180, 99, 18, 3]
+        @test all(g_tr[8:end] .== 0)
+
+        # Pin the adjacency graphs exactly. The square torus is bipartite
+        # (no triangles). The 18-site cell is a genuine quotient of the
+        # triangular lattice, but its x-circumference is 3, so besides the
+        # 2M = 36 face triangles it carries 6 wrap-around 3-cycles (one per
+        # a₁-row): 42 total. The exact reference is enumerated on this same
+        # graph, so the pipeline comparison is exact for this cell; it is a
+        # pipeline validation, not a thermodynamic-limit statement —
+        # production cells must use circumference ≥ 4.
+        @test triangle_count(masks_sq, M_sq) == 0
+        @test triangle_count(masks_tr, M_tr) == 42
+    end
+
+    # ================================================================
+    @testset "energy = J × violation count" begin
+        Random.seed!(7)
+        for (make, masks, M) in ((hc_square, masks_sq, M_sq),
+                                 (hc_tri, masks_tr, M_tr))
+            lat = make()
+            for _ in 1:50
+                occ = rand(Bool, M)
+                lat.components[1] .= occ
+                @test interacting_energy(lat, ham_hc) ≈
+                      J * violation_count(masks, occ) * u"eV"
+            end
+        end
+    end
+
+    # ================================================================
+    # Fixed-N route: per-N canonical NS ladders descend the violation count
+    # to the E = 0 manifold; gc_thermodynamic_stats_fixed_N assembles Ξ(z).
+    # This is the primary route for athermal models: every z is an exact
+    # polynomial evaluation in the per-N evidence (no reweighting window).
+    function fixed_N_hard_core(make, N_max; K, n_iters, mc_steps, seed)
+        Random.seed!(seed)
+        dfs = Vector{DataFrame}(undef, N_max + 1)
+        live = Vector{Vector{Float64}}(undef, N_max + 1)
+        dfs[1] = DataFrame(iter=Int[], emax=Float64[])
+        live[1] = Float64[]
+        for N in 1:N_max
+            walkers = [
+                begin
+                    lat = lattice_at(make, N)
+                    generate_random_new_lattice_sample!(lat)
+                    LatticeWalker(lat)
+                end for _ in 1:K]
+            liveset = LatticeGasWalkers(walkers, ham_hc, perturb_energy=1e-9)
+            ns_params = LatticeNestedSamplingParameters(
+                mc_steps=mc_steps,
+                energy_perturbation=1e-9,
+                allowed_fail_count=100_000)
+            df, final_ls, _ = nested_sampling(
+                liveset, ns_params, n_iters, MCRandomWalkClone(), save_strategy)
+            dfs[N + 1] = df
+            live[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
+        end
+        hc_cleanup()
+        return dfs, live
+    end
+
+    @testset "fixed-N route vs exact" begin
+        K = 60
+        # Ladder depth 900/60 = 15 nats; the athermal evaluation temperature
+        # must satisfy β·J ≥ depth + ~40: T = 150 K gives β·J ≈ 77.
+        n_iters = 900
+        T_ath = 150.0
+        zs = [0.5, 1.0, 2.0, 3.796, 11.09]  # numeric z_c of hard squares and
+                                            # Baxter's z_c = (11+5√5)/2 among them
+        μ_grid = [kb * T_ath * log(z) for z in zs] .* u"eV"
+
+        for (tag, make, M, N_max, g, seed) in (
+                ("hard squares", hc_square, M_sq, 8, g_sq, 1000),
+                ("hard hexagons", hc_tri, M_tr, 6, g_tr, 2000))
+            @testset "$tag" begin
+                dfs, live = fixed_N_hard_core(make, N_max;
+                    K=K, n_iters=n_iters, mc_steps=100, seed=seed)
+
+                # Every ladder descended into the allowed (E = 0) manifold:
+                # the athermal termination gate.
+                for N in 1:N_max
+                    @test issorted(dfs[N + 1].emax, rev=true)
+                    @test all(e -> e < J / 2, live[N + 1])
+                end
+
+                stats = gc_thermodynamic_stats_fixed_N(
+                    dfs, collect(0:N_max), M, μ_grid, [T_ath * u"K"];
+                    n_walkers=K, n_cull=1, ω0=(K + 1) / K, live_emax=live)
+
+                # Tolerances sized ≥ 3σ of the intrinsic NS shrinkage noise:
+                # the deepest sectors carry H_N = ln(C(M,N)/g_N) ≈ 8.8 nats,
+                # so σ(log Z_N) ≈ √(H_N/K) ≈ 0.38 per sector and
+                # σ(logΞ) ≈ 0.23 at the largest z after the sector mixture.
+                # atol = 0.75 ≈ 3.3σ; still discriminating (a dropped
+                # (1+z0)^M-style normalization shifts logΞ by ≫ 1).
+                for (k, z) in enumerate(zs)
+                    ex = exact_hc_stats(g, z)
+                    @test isapprox(stats.logXi[k, 1], ex.logXi, atol=0.75)
+                    @test isapprox(stats.mean_N[k, 1], ex.mean_N, atol=0.5)
+                    # Athermal: ⟨E⟩ is pure tie-breaking noise
+                    @test abs(stats.mean_U[k, 1]) < 1e-6
+                end
+
+                # Per-N evidence: at the athermal temperature log_Z_N is the
+                # log independent-set count log g_N. atol = 1.5 ≈ 3.9σ of the
+                # per-sector noise, ≪ the log C(M,N) ≥ 7.5 shift a dropped
+                # binomial factor would cause.
+                @test stats.N_values == collect(0:N_max)
+                @test size(stats.log_Z_N) == (N_max + 1, 1)
+                for N in 0:N_max
+                    @test isapprox(stats.log_Z_N[N + 1, 1], log(g[N + 1]),
+                                   atol=1.5)
+                end
+            end
+        end
+    end
+
+    # ================================================================
+    # igref route: one grand-canonical run against the z0-Bernoulli prior;
+    # the descent through the violating shells measures the allowed set's
+    # prior mass, and the (1+z0)^M normalization stays valid because the
+    # prior support is never restricted.
+    @testset "igref route vs exact (hard squares, z0 = 1)" begin
+        Random.seed!(7)
+        K = 100
+        template = hc_square()
+        template.components[1] .= false
+        walkers = [LatticeWalker(deepcopy(template), energy=0.0u"eV", iter=0)
+                   for _ in 1:K]
+        liveset = LatticeGasWalkers(walkers, ham_hc; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=1.0,
+            energy_perturbation=1e-9, allowed_fail_count=100_000)
+        mc_routine = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+        df, final_ls, _ = ideal_gas_referenced_nested_sampling(
+            liveset, params, Int64(1500), mc_routine, save_strategy)
+        hc_cleanup()
+
+        @test nrow(df) > 0
+        @test issorted(df.emax, rev=true)
+        # The ladder reached the allowed manifold and the live set sits in it
+        @test minimum(df.emax) < J / 2
+        live_E = [w.energy.val for w in final_ls.walkers]
+        live_N = [sum(w.configuration.components[1]) for w in final_ls.walkers]
+        @test all(e -> e < J / 2, live_E)
+
+        T_ath = 150.0
+        zs = [0.7, 1.0, 1.5, 2.0]
+        μs = [kb * T_ath * log(z) for z in zs]
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, M_sq, 1.0, μs, [T_ath], K;
+            ω0=(K + 1) / K, live_emax=live_E, live_numbers=live_N)
+
+        # Tolerances ≥ 3σ of the NS evidence noise (σ(logΞ) ≈ 0.25 at this
+        # depth/K), while a dropped (1+z0)^M normalization would shift logΞ
+        # by M·ln 2 ≈ 11 — still cleanly discriminating.
+        for (i, z) in enumerate(zs[1:3])  # z = 2.0 is the N_eff check below
+            ex = exact_hc_stats(g_sq, z)
+            @test isapprox(stats.logXi[i, 1], ex.logXi, atol=0.75)
+            @test isapprox(stats.mean_N[i, 1], ex.mean_N, atol=0.5)
+        end
+
+        # Kish N_eff degrades away from the run's z0 — the trust-window
+        # diagnostic every reweighted grid point must be gated on.
+        @test stats.N_eff[4, 1] < stats.N_eff[2, 1]
+    end
+end

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -1,0 +1,329 @@
+@testset "Ideal-gas-referenced GC-NS" begin
+    using Random
+
+    kb = 8.617333262e-5  # eV/K
+
+    # Shared 4x4 single-component square lattice template
+    igref_L = 4
+    igref_n_sites = igref_L * igref_L
+    igref_template = MLattice{1,SquareLattice}(
+        lattice_constant=1.0,
+        basis=[(0.0, 0.0, 0.0)],
+        supercell_dimensions=(igref_L, igref_L, 1),
+        periodicity=(true, true, false),
+        cutoff_radii=[1.1, 1.5],
+        components=[[false for _ in 1:igref_L*igref_L]],
+        adsorptions=:full
+    )
+
+    function igref_run(template, ham, z0, n_walkers, n_steps; seed=7, mc_steps=100)
+        Random.seed!(seed)
+        walkers = [LatticeWalker(deepcopy(template), energy=0.0u"eV", iter=0)
+                   for _ in 1:n_walkers]
+        liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(mc_steps=mc_steps, reference_fugacity=z0)
+        mc_routine = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+        save = SaveEveryN("test_igref.csv", "test_igref.traj", "test_igref.ls",
+                          100000, 100000, 100000)
+        df, final_ls, params = ideal_gas_referenced_nested_sampling(
+            liveset, params, Int64(n_steps), mc_routine, save)
+        rm("test_igref.csv", force=true)
+        rm("test_igref.traj", force=true)
+        rm("test_igref.ls", force=true)
+        live_E = [w.energy.val for w in final_ls.walkers]
+        live_N = [sum(w.configuration.components[1]) for w in final_ls.walkers]
+        return df, live_E, live_N
+    end
+
+    # ================================================================
+    @testset "IdealGasReferencedGCNSParameters constructor" begin
+        params = IdealGasReferencedGCNSParameters()
+        @test params.mc_steps == 100
+        @test params.reference_fugacity == 1.0
+        @test params.energy_perturbation == 1e-12
+        @test params.fail_count == 0
+        @test params.allowed_fail_count == 10
+        @test params.cluster_p == 0.3
+        @test isempty(params.cluster_p_history)
+
+        params2 = IdealGasReferencedGCNSParameters(reference_fugacity=0.25, mc_steps=50)
+        @test params2.reference_fugacity == 0.25
+        @test params2.mc_steps == 50
+
+        @test_throws ArgumentError IdealGasReferencedGCNSParameters(reference_fugacity=0.0)
+        @test_throws ArgumentError IdealGasReferencedGCNSParameters(reference_fugacity=-1.0)
+        # Tie-breaking is a correctness requirement on degenerate lattice spectra
+        @test_throws ArgumentError IdealGasReferencedGCNSParameters(energy_perturbation=0.0)
+    end
+
+    # ================================================================
+    @testset "nested_sampling_step! for IG-ref GC-NS" begin
+        Random.seed!(3)
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        walkers = [LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+                   for _ in 1:5]
+        liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
+
+        params = IdealGasReferencedGCNSParameters(mc_steps=50, reference_fugacity=0.5)
+        mc_routine = MCGrandCanonicalMoves()
+
+        # Initialize walkers as draws from the Bernoulli(z0/(1+z0)) prior
+        SamplingSchemes._init_ideal_gas_ref_walkers!(liveset, params)
+        @test all(w.iter == 0 for w in liveset.walkers)
+
+        e_type = typeof(walkers[1].energy)
+        iter, emax, n_par, updated_liveset, updated_params = nested_sampling_step!(
+            liveset, params, mc_routine)
+
+        @test iter isa Union{Missing,Int}
+        @test emax isa Union{Missing,e_type}
+        @test n_par isa Union{Missing,Int}
+        @test length(updated_liveset.walkers) == 5
+        @test updated_params.fail_count >= 0
+        if !(iter isa Missing)
+            # The culled walker had the highest energy: all survivors sit
+            # strictly below the recorded ceiling (perturbation breaks ties)
+            @test all(w.energy < emax for w in updated_liveset.walkers)
+        end
+    end
+
+    # ================================================================
+    @testset "MC_grand_canonical_walk! z0 prior stationarity" begin
+        # With a zero Hamiltonian (E ≡ 0) and a non-binding ceiling, the walk
+        # must sample the Bernoulli(z0/(1+z0)) prior: ⟨N⟩ = M z0/(1+z0),
+        # Var(N) = M z0/(1+z0)².
+        ham0 = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        for z0 in (0.5, 2.0)
+            Random.seed!(42)
+            walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+            MC_grand_canonical_walk!(500, walker, ham0, 1e3, 0.0;
+                                     p_move=0.2, p_insert=0.4, z0=z0)
+            acc_N = 0.0
+            n_samples = 3000
+            for _ in 1:n_samples
+                MC_grand_canonical_walk!(10, walker, ham0, 1e3, 0.0;
+                                         p_move=0.2, p_insert=0.4, z0=z0)
+                acc_N += sum(walker.configuration.components[1])
+            end
+            p0 = z0 / (1 + z0)
+            @test isapprox(acc_N / n_samples, igref_n_sites * p0; atol=0.5)
+        end
+
+        # z0 must be positive
+        walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+        @test_throws ArgumentError MC_grand_canonical_walk!(
+            1, walker, ham0, 1e3, 0.0; z0=0.0)
+    end
+
+    # ================================================================
+    @testset "Langmuir closed form (non-interacting reference)" begin
+        # Zero neighbor interactions, on-site adsorption only: E = ε_ads·N, so
+        # Ξ(μ,T) = (1 + z·e^{-βε})^M exactly (Langmuir isotherm) — the lattice
+        # analog of the atomistic IdealGasParameters validation.
+        eps_ads = -0.04
+        ham_ni = GenericLatticeHamiltonian(eps_ads, [0.0, 0.0], u"eV")
+        n_walkers = 100
+
+        df, live_E, live_N = igref_run(igref_template, ham_ni, 1.0, n_walkers, 3000)
+        @test nrow(df) > 0
+        @test names(df) == ["iter", "emax", "num_particles"]
+        # E-sorted NS: recorded energy ceilings are non-increasing
+        @test issorted(df.emax, rev=true)
+
+        # μ grid spans the reliable reweighting window around μ_ref(T) = kT·ln z0 = 0
+        # plus one deliberately out-of-window point (μ = -0.08) for the N_eff check
+        μs = [-0.08, -0.04, -0.03, -0.02]
+        Ts = [200.0, 300.0, 500.0]
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, 1.0, μs, Ts, n_walkers;
+            ω0=(n_walkers + 1) / n_walkers, live_emax=live_E, live_numbers=live_N)
+        stats_notail = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, 1.0, μs, Ts, n_walkers)
+
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            i == 1 && continue  # skip the out-of-window point
+            β = 1 / (kb * T)
+            x = exp(β * μ) * exp(-β * eps_ads)
+            logXi_exact = igref_n_sites * log1p(x)
+            meanN_exact = igref_n_sites * x / (1 + x)
+            @test isapprox(stats.logXi[i, j], logXi_exact; atol=0.5)
+            @test isapprox(stats.mean_N[i, j], meanN_exact; rtol=0.10)
+            @test isapprox(stats.mean_U[i, j], eps_ads * meanN_exact; rtol=0.10)
+        end
+
+        # The live-set tail adds positive prior mass: logΞ strictly increases
+        @test all(stats.logXi .> stats_notail.logXi)
+
+        # N_eff collapses out of the reweighting window: the far point
+        # (μ = -0.08 at T = 200 K, |βμ - ln z0| ≈ 4.6) must have a much
+        # smaller effective sample size than an in-window point
+        @test stats.N_eff[1, 1] < stats.N_eff[4, 1] / 10
+        @test all(stats.N_eff .<= nrow(df) + length(live_E))
+    end
+
+    # ================================================================
+    @testset "Interacting lattice vs exact enumeration (z0 ≠ 1)" begin
+        # NN + NNN attractive lattice gas; reference fugacity centered on the
+        # target (μ = -0.05 eV, T = 300 K), i.e. z0 = exp(βμ) ≈ 0.145. This
+        # exercises the z0-weighted insert/delete ratios, the Bernoulli(p0)
+        # initialization, and the (1+z0)^M absolute normalization end to end.
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        μ_center = -0.05
+        T_center = 300.0
+        z0 = exp(μ_center / (kb * T_center))
+        n_walkers = 100
+
+        df, live_E, live_N = igref_run(igref_template, ham, z0, n_walkers, 4000; seed=11)
+        @test nrow(df) > 0
+        @test issorted(df.emax, rev=true)
+        # The energy ladder must reach deep order (ground state E = -1.04 eV:
+        # full lattice, 16·(-0.04) + 32·(-0.01) + 32·(-0.0025))
+        @test minimum(df.emax) < -1.0
+
+        μs = [-0.06, -0.05]
+        Ts = [300.0, 400.0]
+
+        # Exact grand-canonical reference: enumerate all 2^16 microstates once
+        E_vals = Vector{Float64}(undef, 2^igref_n_sites)
+        N_vals = Vector{Int}(undef, 2^igref_n_sites)
+        lattice = deepcopy(igref_template)
+        for mask in 0:(2^igref_n_sites - 1)
+            for site in 1:igref_n_sites
+                lattice.components[1][site] = ((mask >> (site - 1)) & 1) == 1
+            end
+            E_vals[mask+1] = interacting_energy(lattice, ham).val
+            N_vals[mask+1] = sum(lattice.components[1])
+        end
+
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, z0, μs, Ts, n_walkers;
+            ω0=(n_walkers + 1) / n_walkers, live_emax=live_E, live_numbers=live_N)
+
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            β = 1 / (kb * T)
+            log_w = β .* μ .* N_vals .- β .* E_vals
+            max_log = maximum(log_w)
+            w = exp.(log_w .- max_log)
+            Z = sum(w)
+            logXi_exact = max_log + log(Z)
+            meanN_exact = sum(w .* N_vals) / Z
+            meanU_exact = sum(w .* E_vals) / Z
+            varN_exact = sum(w .* N_vals .^ 2) / Z - meanN_exact^2
+
+            # Tolerances: logΞ atol = 1.5 ≈ 2.7x the observed worst
+            # seed-to-seed error (±0.55 over 6 seeds), kept below the ≈2.2
+            # shift a missing (1+z0)^M normalization would cause so the test
+            # still discriminates; ⟨N⟩/⟨U⟩ rtol = 0.10 ≈ 4x the ±0.27 spread.
+            # This is the first absolute-Ξ check in the test suite.
+            @test isapprox(stats.logXi[i, j], logXi_exact; atol=1.5)
+            @test isapprox(stats.mean_N[i, j], meanN_exact; rtol=0.10)
+            @test isapprox(stats.mean_U[i, j], meanU_exact; rtol=0.10)
+            @test isapprox(stats.var_N[i, j], varN_exact; rtol=0.25)
+        end
+    end
+
+    # ================================================================
+    @testset "Exact Skilling closure (E ≡ 0)" begin
+        # With a zero Hamiltonian every configuration has E = 0 (up to the
+        # 1e-12 tie-breaking tags), so at z = z0 the reweighting factor is 1
+        # and logΞ must equal M·ln(1+z0) EXACTLY when the dead weights use
+        # ω0 = (K+n_cull)/K and the live-set tail closes the ladder:
+        # Σω = (1 - r^n) + r^n = 1, independent of n and of the sampled N_j.
+        # This is an algebraic identity test of the weight bookkeeping — it
+        # would catch any ω0/tail double counting.
+        ham0 = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        n_walkers = 50
+        df, live_E, live_N = igref_run(igref_template, ham0, 1.0, n_walkers, 300;
+                                       seed=17, mc_steps=30)
+        @test nrow(df) > 0
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, 1.0, [0.0], [300.0], n_walkers;
+            ω0=(n_walkers + 1) / n_walkers, live_emax=live_E, live_numbers=live_N)
+        # β|E| ≲ 4e-11 from the tie-breaking tags; atol dominated by that
+        @test isapprox(stats.logXi[1, 1], igref_n_sites * log(2.0); atol=1e-6)
+    end
+
+    # ================================================================
+    @testset "gc_thermodynamic_stats_ideal_ref argument validation" begin
+        df_ok = DataFrame(iter=[1, 2], emax=[-0.1, -0.2], num_particles=[3, 4])
+        μs = [-0.05]
+        Ts = [300.0]
+
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 0.0, μs, Ts, 100)
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_ok, 0, 1.0, μs, Ts, 100)
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 1.0, μs, Ts, 100; live_emax=[-0.1])
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 1.0, μs, Ts, 100; live_numbers=[1])
+        @test_throws DimensionMismatch gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 1.0, μs, Ts, 100; live_emax=[-0.1], live_numbers=[1, 2])
+
+        df_empty = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_empty, 16, 1.0, μs, Ts, 100)
+
+        # Live walkers alone are a valid input (a run that never culled:
+        # n_iters = 0, each live walker carries weight 1/K) — check the
+        # closed form logΞ = M·ln(1+z0) + logsumexp(-ln K + N·βμ - β·E)
+        live_E = [-0.1, -0.2]
+        live_N = [1, 2]
+        stats_live = gc_thermodynamic_stats_ideal_ref(
+            df_empty, 16, 1.0, μs, Ts, 100;
+            live_emax=live_E, live_numbers=live_N)
+        β = 1 / (kb * Ts[1])
+        terms = [exp(-log(100) + live_N[k] * β * μs[1] - β * live_E[k]) for k in 1:2]
+        logXi_expected = 16 * log(2.0) + log(sum(terms))
+        @test isapprox(stats_live.logXi[1, 1], logXi_expected; rtol=1e-10)
+        @test isapprox(stats_live.mean_N[1, 1],
+                       sum(terms .* live_N) / sum(terms); rtol=1e-10)
+
+        # Output shape
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df_ok, 16, 1.0, [-0.05, -0.04, -0.03], [200.0, 300.0], 100)
+        @test size(stats.logXi) == (3, 2)
+        @test size(stats.var_N) == (3, 2)
+        @test size(stats.N_eff) == (3, 2)
+    end
+
+    # ================================================================
+    @testset "Cluster moves through the IG-ref step" begin
+        # Exercise the clusters_freq > 0 path: geometric cluster moves inside
+        # MC_grand_canonical_walk! plus the adaptive cluster_p machinery on
+        # IdealGasReferencedGCNSParameters
+        Random.seed!(21)
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        walkers = [LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+                   for _ in 1:20]
+        liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(mc_steps=50, reference_fugacity=0.5)
+        mc_routine = MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25,
+                                           clusters_freq=1, swaps_freq=1)
+        save = SaveEveryN("test_igref_cl.csv", "test_igref_cl.traj", "test_igref_cl.ls",
+                          100000, 100000, 100000)
+        df, _, params_out = ideal_gas_referenced_nested_sampling(
+            liveset, params, Int64(400), mc_routine, save)
+        rm("test_igref_cl.csv", force=true)
+        rm("test_igref_cl.traj", force=true)
+        rm("test_igref_cl.ls", force=true)
+
+        @test nrow(df) > 0
+        # Adaptation must have fired: history populated, cluster_p in bounds
+        @test !isempty(params_out.cluster_p_history)
+        @test all(mc_routine.cluster_p_floor .<= params_out.cluster_p_history
+                  .<= mc_routine.cluster_p_ceiling)
+        @test length(params_out.cluster_accept_history) ==
+              length(params_out.cluster_p_history)
+    end
+
+    # ================================================================
+    @testset "Same-seed reproducibility" begin
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        df1, live_E1, _ = igref_run(igref_template, ham, 2.0, 30, 300; seed=99, mc_steps=50)
+        df2, live_E2, _ = igref_run(igref_template, ham, 2.0, 30, 300; seed=99, mc_steps=50)
+        @test df1.emax == df2.emax
+        @test df1.num_particles == df2.num_particles
+        @test live_E1 == live_E2
+    end
+end

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -588,4 +588,130 @@
         @test dfA.num_particles == dfB.num_particles
         @test live_EA == live_EB
     end
+
+    # ================================================================
+    @testset "dead-point callback and energy substitution (IG-ref route)" begin
+        using Random
+        dpc_lat = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full)
+        dpc_ham_a = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        dpc_ham_b = GenericLatticeHamiltonian(-0.04, [-0.02, -0.0025], u"eV")
+        dpc_save = SaveEveryN("t_dpc_ig.csv", "t_dpc_ig.traj", "t_dpc_ig.ls",
+                              1000000, 1000000, 1000000)
+        dpc_cleanup() = rm.(["t_dpc_ig.csv", "t_dpc_ig.traj", "t_dpc_ig.ls"],
+                            force=true)
+
+        # Exact grand sums for both Hamiltonians by per-sector enumeration
+        # over all 2^16 configurations, computed before any seeding because
+        # exact_enumeration consumes the global RNG
+        dpc_kb = 8.617333262e-5
+        dpc_T = 600.0
+        dpc_mu = 0.0
+        dpc_beta = 1 / (dpc_kb * dpc_T)
+        function dpc_exact_lnXi(h)
+            lnZs = Float64[]
+            for N in 0:16
+                occ = vcat(fill(true, N), fill(false, 16 - N))
+                latN = deepcopy(dpc_lat)
+                latN.components[1] .= occ
+                dfe, _ = exact_enumeration(latN, h)
+                Es = [ustrip(u"eV", e) for e in dfe.energy]
+                Emin = minimum(Es)
+                push!(lnZs, dpc_beta * dpc_mu * N - dpc_beta * Emin +
+                            log(sum(exp.(-dpc_beta .* (Es .- Emin)))))
+            end
+            m = maximum(lnZs)
+            return m + log(sum(exp.(lnZs .- m)))
+        end
+        lnXi_a = dpc_exact_lnXi(dpc_ham_a)
+        lnXi_b = dpc_exact_lnXi(dpc_ham_b)
+
+        # One seeded ladder under Hamiltonian A, configurations collected
+        # through the callback; K = 64, full descent against the
+        # 16·ln 2 ≈ 11.1 nat reference depth
+        dpc_K = 64
+        Random.seed!(4371)
+        walkers = [LatticeWalker(deepcopy(dpc_lat), energy=0.0u"eV", iter=0)
+                   for _ in 1:dpc_K]
+        ls = LatticeGasWalkers(walkers, dpc_ham_a; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(mc_steps=40,
+            reference_fugacity=1.0, energy_perturbation=1e-9)
+        configs = Vector{Bool}[]
+        seen = Tuple{Int,Float64,Int}[]
+        df, ls_out, _ = ideal_gas_referenced_nested_sampling(ls, params,
+            Int64(820), MCGrandCanonicalMoves(), dpc_save;
+            dead_point_callback=(iter, w) -> begin
+                push!(configs, copy(w.configuration.components[1]))
+                push!(seen, (iter, w.energy.val,
+                             sum(w.configuration.components[1])))
+            end)
+        dpc_cleanup()
+
+        # Invocation count equals nrow(df); the (iter, energy, N) triple seen
+        # by the callback matches the ledger row bit-exactly
+        @test nrow(df) > 0
+        @test length(seen) == nrow(df)
+        @test [t[1] for t in seen] == df.iter
+        @test [t[2] for t in seen] == df.emax
+        @test [t[3] for t in seen] == df.num_particles
+
+        # Energy faithfulness: recomputing Hamiltonian A on a collected
+        # configuration matches the ledger energy within the perturbation
+        # half-width (uniform on ±energy_perturbation/2)
+        dpc_probe = deepcopy(dpc_lat)
+        function dpc_recompute(h, c)
+            dpc_probe.components[1] .= c
+            return ustrip(u"eV", interacting_energy(dpc_probe, h))
+        end
+        @test all(abs(dpc_recompute(dpc_ham_a, c) - e) <= 5.1e-10
+                  for (c, e) in zip(configs, df.emax))
+
+        # Substitution closure: Hamiltonian B's energies, recomputed offline
+        # from the collected configurations, replace the ledger column and
+        # the live tail, and gc_thermodynamic_stats_ideal_ref then closes
+        # against Hamiltonian B's exact grand sum with the SAME Skilling
+        # weights; the control route closes against Hamiltonian A's.
+        # Tolerances calibrated at seeds 4371/4372/4373: max |dev| 0.236 (A)
+        # and 0.343 (B) against σ = √(16·ln 2/64) ≈ 0.42; shipped at ≥ 3×.
+        live_Ea = [w.energy.val for w in ls_out.walkers]
+        live_N = [Int(sum(w.configuration.components[1])) for w in ls_out.walkers]
+        sa = gc_thermodynamic_stats_ideal_ref(df, 16, 1.0, [dpc_mu], [dpc_T],
+            dpc_K; ω0=(dpc_K + 1) / dpc_K, live_emax=live_Ea, live_numbers=live_N)
+        df_b = copy(df)
+        df_b.emax = [dpc_recompute(dpc_ham_b, c) for c in configs]
+        live_Eb = [dpc_recompute(dpc_ham_b, w.configuration.components[1])
+                   for w in ls_out.walkers]
+        sb = gc_thermodynamic_stats_ideal_ref(df_b, 16, 1.0, [dpc_mu], [dpc_T],
+            dpc_K; ω0=(dpc_K + 1) / dpc_K, live_emax=live_Eb, live_numbers=live_N)
+        @test abs(sa.logXi[1, 1] - lnXi_a) < 0.75
+        @test abs(sb.logXi[1, 1] - lnXi_b) < 1.1
+        # The substituted estimator's Kish N_eff is a real diagnostic: finite,
+        # positive, and no larger than the control's at the same grid point
+        @test 0 < sb.N_eff[1, 1] <= sa.N_eff[1, 1]
+
+        # Stream neutrality: same-seed A/B with and without the callback
+        function dpc_ab(seed, cb)
+            Random.seed!(seed)
+            ws = [LatticeWalker(deepcopy(dpc_lat), energy=0.0u"eV", iter=0)
+                  for _ in 1:16]
+            l = LatticeGasWalkers(ws, dpc_ham_a; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=20,
+                reference_fugacity=1.0, energy_perturbation=1e-9)
+            d, _, _ = ideal_gas_referenced_nested_sampling(l, p, Int64(100),
+                MCGrandCanonicalMoves(), dpc_save; dead_point_callback=cb)
+            dpc_cleanup()
+            return d
+        end
+        dfA = dpc_ab(4373, nothing)
+        dfB = dpc_ab(4373, (iter, w) -> nothing)
+        @test dfA.iter == dfB.iter
+        @test dfA.emax == dfB.emax
+        @test dfA.num_particles == dfB.num_particles
+    end
 end

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -16,13 +16,13 @@
         adsorptions=:full
     )
 
-    function igref_run(template, ham, z0, n_walkers, n_steps; seed=7, mc_steps=100)
+    function igref_run(template, ham, z0, n_walkers, n_steps; seed=7, mc_steps=100,
+                       mc_routine=MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3))
         Random.seed!(seed)
         walkers = [LatticeWalker(deepcopy(template), energy=0.0u"eV", iter=0)
                    for _ in 1:n_walkers]
         liveset = LatticeGasWalkers(walkers, ham; assign_energy=false)
         params = IdealGasReferencedGCNSParameters(mc_steps=mc_steps, reference_fugacity=z0)
-        mc_routine = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
         save = SaveEveryN("test_igref.csv", "test_igref.traj", "test_igref.ls",
                           100000, 100000, 100000)
         df, final_ls, params = ideal_gas_referenced_nested_sampling(
@@ -45,6 +45,9 @@
         @test params.allowed_fail_count == 10
         @test params.cluster_p == 0.3
         @test isempty(params.cluster_p_history)
+        # move_stats defaults (issue #158)
+        @test params.move_stats isa Dict{Symbol,Int}
+        @test isempty(params.move_stats)
 
         params2 = IdealGasReferencedGCNSParameters(reference_fugacity=0.25, mc_steps=50)
         @test params2.reference_fugacity == 0.25
@@ -109,10 +112,182 @@
             @test isapprox(acc_N / n_samples, igref_n_sites * p0; atol=0.5)
         end
 
+        # ---- Biased-insertion stationarity grid (issue #158) ----
+        # p_bias mixes uniform insertion with insertion restricted to
+        # lattice_biased_sites(; predicate, shells=1); the composite MH
+        # correction must leave the same Bernoulli(p0) product prior
+        # invariant. p_bias = 0.5: the uniform component keeps the chain
+        # irreducible, so a single-chain time average must reproduce
+        # (N) = M p0, per-site occupancy p0, and Var(N) = M p0 (1 - p0).
+        for (cell, (z0, pred)) in enumerate(Iterators.product((0.5, 2.0), (:contact, :cavity)))
+            Random.seed!(4200 + cell)
+            walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+            MC_grand_canonical_walk!(300, walker, ham0, 1e3, 0.0;
+                                     p_move=0.2, p_insert=0.4, z0=z0,
+                                     p_bias=0.5, bias_predicate=pred, bias_shells=1)
+            n_blocks = 1500
+            Nsum = 0.0
+            N2sum = 0.0
+            site_sum = zeros(igref_n_sites)
+            for _ in 1:n_blocks
+                MC_grand_canonical_walk!(10, walker, ham0, 1e3, 0.0;
+                                         p_move=0.2, p_insert=0.4, z0=z0,
+                                         p_bias=0.5, bias_predicate=pred, bias_shells=1)
+                occ = walker.configuration.components[1]
+                Nsum += sum(occ)
+                N2sum += sum(occ)^2
+                site_sum .+= occ
+            end
+            p0 = z0 / (1 + z0)
+            meanN = Nsum / n_blocks
+            varN = N2sum / n_blocks - meanN^2
+            # Tolerance model (10-step blocks, n = 1500 samples; Var(N) =
+            # M p0 (1 - p0) = 3.56 at both z0): sigma((N)) ~ 0.10,
+            # sigma(site) ~ 0.024 iid, SE(Var) ~ 0.26, all inflated by
+            # residual block autocorrelation. Three-seed calibration (seed
+            # bases 4200/5200/6200, all 4 cells): max |d(N)| = 0.145, max
+            # site |d| = 0.052, max |dVar| = 0.361; shipped gates >= 3x the
+            # maxima (0.5, 0.16, 1.2).
+            @test isapprox(meanN, igref_n_sites * p0; atol=0.5)
+            @test maximum(abs.(site_sum ./ n_blocks .- p0)) < 0.16
+            @test isapprox(varN, igref_n_sites * p0 * (1 - p0); atol=1.2)
+        end
+
+        # p_bias = 1.0: the kernel is still prior-invariant (each sub-kernel
+        # is in detailed balance) but REDUCIBLE: :contact cannot leave N = 0
+        # and :cavity can never insert next to the occupied region, so dense
+        # states are unreachable and time averages are meaningless (hence the
+        # constructor warning and the non-ergodicity pin below). Invariance is
+        # what the composite MH factor must guarantee, so test it directly: an
+        # ensemble of chains started from EXACT prior draws must remain
+        # prior-distributed after any number of steps.
+        for (cell, (z0, pred)) in enumerate(Iterators.product((0.5, 2.0), (:contact, :cavity)))
+            Random.seed!(4300 + cell)
+            p0 = z0 / (1 + z0)
+            n_chains = 1200
+            Nsum = 0.0
+            N2sum = 0.0
+            site_sum = zeros(igref_n_sites)
+            for _ in 1:n_chains
+                walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+                random_microstate!(walker.configuration; p=p0)   # exact prior draw
+                MC_grand_canonical_walk!(25, walker, ham0, 1e3, 0.0;
+                                         p_move=0.2, p_insert=0.4, z0=z0,
+                                         p_bias=1.0, bias_predicate=pred, bias_shells=1)
+                occ = walker.configuration.components[1]
+                Nsum += sum(occ)
+                N2sum += sum(occ)^2
+                site_sum .+= occ
+            end
+            meanN = Nsum / n_chains
+            varN = N2sum / n_chains - meanN^2
+            # Chains are iid (fresh prior starts): sigma((N)) = 0.054,
+            # sigma(site) = 0.0136, SE(Var) ~ 0.145 at n = 1200. Three-seed
+            # calibration (seed bases 4300/5300/6300, all 4 cells): max
+            # |d(N)| = 0.083, max site |d| = 0.038, max |dVar| = 0.272;
+            # shipped gates >= 3x the maxima (0.35, 0.12, 0.85).
+            @test isapprox(meanN, igref_n_sites * p0; atol=0.35)
+            @test maximum(abs.(site_sum ./ n_chains .- p0)) < 0.12
+            @test isapprox(varN, igref_n_sites * p0 * (1 - p0); atol=0.85)
+        end
+
         # z0 must be positive
         walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
         @test_throws ArgumentError MC_grand_canonical_walk!(
             1, walker, ham0, 1e3, 0.0; z0=0.0)
+    end
+
+    # ================================================================
+    @testset "Exact microstate distribution on 2x2 (biased kernel)" begin
+        # 2x2 torus: each site's 4 NN collapse onto 2 distinct sites, so the
+        # default min-image construction warns; multiplicity lists are exact
+        # here and the bias predicates only read occupancy, so duplicated
+        # neighbor entries are harmless.
+        tiny_template = MLattice{1,SquareLattice}(
+            lattice_constant=1.0, basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(2, 2, 1), periodicity=(true, true, false),
+            cutoff_radii=[1.1], components=[[false for _ in 1:4]],
+            adsorptions=:full, image_multiplicity=true)
+        ham0 = GenericLatticeHamiltonian(0.0, [0.0], u"eV")
+        z0 = 2.0
+        # Zero Hamiltonian, non-binding ceiling: the walk must sample the
+        # Bernoulli product prior exactly, P(state) = z0^N / (1+z0)^4
+        for (ip, pred) in enumerate((:contact, :cavity))
+            Random.seed!(5150 + ip)
+            walker = LatticeWalker(deepcopy(tiny_template), energy=0.0u"eV", iter=0)
+            MC_grand_canonical_walk!(200, walker, ham0, 1e3, 0.0;
+                                     p_move=0.2, p_insert=0.4, z0=z0,
+                                     p_bias=0.5, bias_predicate=pred, bias_shells=1)
+            n_samples = 20_000
+            counts = zeros(Int, 16)
+            Nsum = 0.0
+            for _ in 1:n_samples
+                # 8-step blocks (~2 sweeps of the 4-site lattice) decorrelate
+                MC_grand_canonical_walk!(8, walker, ham0, 1e3, 0.0;
+                                         p_move=0.2, p_insert=0.4, z0=z0,
+                                         p_bias=0.5, bias_predicate=pred, bias_shells=1)
+                occ = walker.configuration.components[1]
+                mask = sum(Int(occ[s]) << (s - 1) for s in 1:4)
+                counts[mask + 1] += 1
+                Nsum += sum(occ)
+            end
+            # Multinomial gates: per cell sigma = sqrt(p(1-p)/n) at n = 20000;
+            # the max over 16 cells x 2 predicates of ~3 sigma is the
+            # expected extreme of 32 comparisons, inflated by residual block
+            # autocorrelation. Three-seed calibration (seed bases 5150/6150/
+            # 7150): max |dev| = 3.0 iid-sigma, max |d(N)| = 0.023; shipped
+            # gates >= 3x the maxima (k = 9, atol 0.07). Discrimination: a
+            # deliberately broken kernel (reverse density on the pre-delete
+            # configuration, or the uniform-proposal ratio on biased draws)
+            # fails these gates at 20-55 sigma on the discriminating cells;
+            # per-state residuals below ~5e-3 sit under them, the honest
+            # floor at feasible n.
+            for mask in 0:15
+                p = z0^count_ones(mask) / (1 + z0)^4
+                sig = sqrt(p * (1 - p) / n_samples)
+                @test abs(counts[mask + 1] / n_samples - p) < 9 * sig
+            end
+            @test isapprox(Nsum / n_samples, 4 * z0 / (1 + z0); atol=0.07)
+        end
+    end
+
+    # ================================================================
+    @testset "p_bias = 1.0 :contact is non-ergodic from empty" begin
+        # From N = 0 the contact set is empty, the biased branch has no
+        # proposal, and the uniform branch is never selected: N == 0 is an
+        # exact invariant even at z0 = 2 insertion pressure. This is the
+        # reducibility the MCGrandCanonicalMoves constructor warns about.
+        ham0_ne = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        Random.seed!(158)
+        walker = LatticeWalker(deepcopy(igref_template), energy=0.0u"eV", iter=0)
+        for _ in 1:10
+            MC_grand_canonical_walk!(200, walker, ham0_ne, 1e3, 0.0;
+                p_move=0.2, p_insert=0.4, z0=2.0,
+                p_bias=1.0, bias_predicate=:contact, bias_shells=1)
+            @test sum(walker.configuration.components[1]) == 0
+        end
+    end
+
+    # ================================================================
+    @testset "insert branch split matches p_bias (counters)" begin
+        ham0_bs = GenericLatticeHamiltonian(0.0, [0.0, 0.0], u"eV")
+        Random.seed!(31)
+        lat_bs = deepcopy(igref_template)
+        lat_bs.components[1][1:8] .= true
+        walker = LatticeWalker(lat_bs, energy=0.0u"eV", iter=0)
+        _, _, _, _, _, c = MC_grand_canonical_walk!(
+            6000, walker, ham0_bs, 1e3, 0.0;
+            p_move=0.2, p_insert=0.4, z0=1.0,
+            p_bias=0.5, bias_predicate=:contact, bias_shells=1)
+        k = c.insert_biased_attempted
+        n = k + c.insert_uniform_attempted
+        # n ~ 0.4 x 6000 = 2400 insert-branch trials, branch coin
+        # Bernoulli(1/2): k ~ Binomial(n, 1/2), sigma = sqrt(n/4) ~ 24.5;
+        # gate 4 sigma (~98 counts, alpha ~ 6e-5). :contact skips only at
+        # N = 0 (prior weight 2^-16 at z0 = 1: well under one expected
+        # skipped trial over the run), negligible against the gate.
+        @test n > 2000
+        @test abs(k - n / 2) <= 4 * sqrt(n / 4)
     end
 
     # ================================================================
@@ -223,6 +398,76 @@
     end
 
     # ================================================================
+    @testset "Interacting lattice vs exact enumeration (biased :contact)" begin
+        # Same physics as the unbiased z0 != 1 testset above, driven through
+        # the composite kernel with p_bias = 0.5 :contact via the NS step:
+        # the end-to-end check that biased insertion leaves the ideal-gas
+        # reference bookkeeping (weights, (1+z0)^M normalization) intact.
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        μ_center = -0.05
+        T_center = 300.0
+        z0 = exp(μ_center / (kb * T_center))
+        n_walkers = 100
+
+        mc_bias = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3, p_bias=0.5)
+        df, live_E, live_N = igref_run(igref_template, ham, z0, n_walkers, 4000;
+                                       seed=13, mc_routine=mc_bias)
+        @test nrow(df) > 0
+        @test issorted(df.emax, rev=true)
+        # The ladder reaches deep order (ground state -1.04 eV)
+        @test minimum(df.emax) < -1.0
+
+        # mu grid: two in-window points plus one deliberately out-of-window
+        # point (mu = -0.08) for the Kish N_eff gate
+        μs = [-0.08, -0.06, -0.05]
+        Ts = [300.0, 400.0]
+
+        E_vals = Vector{Float64}(undef, 2^igref_n_sites)
+        N_vals = Vector{Int}(undef, 2^igref_n_sites)
+        lattice = deepcopy(igref_template)
+        for mask in 0:(2^igref_n_sites - 1)
+            for site in 1:igref_n_sites
+                lattice.components[1][site] = ((mask >> (site - 1)) & 1) == 1
+            end
+            E_vals[mask+1] = interacting_energy(lattice, ham).val
+            N_vals[mask+1] = sum(lattice.components[1])
+        end
+
+        stats = gc_thermodynamic_stats_ideal_ref(
+            df, igref_n_sites, z0, μs, Ts, n_walkers;
+            ω0=(n_walkers + 1) / n_walkers, live_emax=live_E, live_numbers=live_N)
+
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            i == 1 && continue  # the out-of-window point feeds only the N_eff gate
+            β = 1 / (kb * T)
+            log_w = β .* μ .* N_vals .- β .* E_vals
+            max_log = maximum(log_w)
+            w = exp.(log_w .- max_log)
+            Z = sum(w)
+            logXi_exact = max_log + log(Z)
+            meanN_exact = sum(w .* N_vals) / Z
+            meanU_exact = sum(w .* E_vals) / Z
+            varN_exact = sum(w .* N_vals .^ 2) / Z - meanN_exact^2
+            # Tolerances recalibrated for the biased kernel over 3 seeds
+            # (13/14/15; every in-window point gated at N_eff >= 1747): max
+            # |d logXi| = 0.45, max relative d(N) = 0.044, d(U) = 0.052;
+            # shipped >= 3x the maxima (1.5, 0.15, 0.16), still below the
+            # ~2.2 shift a missing (1+z0)^M normalization would cause. Var N
+            # is not gated here: at these near-step grid points its
+            # reweighting noise reaches 0.28 relative (a >= 3x gate would be
+            # vacuous), and it is exercised by the unbiased register above.
+            @test isapprox(stats.logXi[i, j], logXi_exact; atol=1.5)
+            @test isapprox(stats.mean_N[i, j], meanN_exact; rtol=0.15)
+            @test isapprox(stats.mean_U[i, j], meanU_exact; rtol=0.16)
+        end
+
+        # Kish N_eff degrades out of the reweighting window; every reweighted
+        # point stays bounded by the sample count
+        @test stats.N_eff[1, 1] < stats.N_eff[3, 1]
+        @test all(stats.N_eff .<= nrow(df) + length(live_E))
+    end
+
+    # ================================================================
     @testset "Exact Skilling closure (E ≡ 0)" begin
         # With a zero Hamiltonian every configuration has E = 0 (up to the
         # 1e-12 tie-breaking tags), so at z = z0 the reweighting factor is 1
@@ -325,5 +570,22 @@
         @test df1.emax == df2.emax
         @test df1.num_particles == df2.num_particles
         @test live_E1 == live_E2
+    end
+
+    # ================================================================
+    @testset "Same-seed A/B: p_bias = 0.0 is RNG-identical to default" begin
+        # The p_bias = 0 code path must draw exactly the same RNG stream as
+        # a routine that never mentions p_bias; any extra rand() would
+        # silently break reproducibility of published runs.
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        mcA = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+        mcB = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3, p_bias=0.0)
+        dfA, live_EA, _ = igref_run(igref_template, ham, 2.0, 30, 300;
+                                    seed=99, mc_steps=50, mc_routine=mcA)
+        dfB, live_EB, _ = igref_run(igref_template, ham, 2.0, 30, 300;
+                                    seed=99, mc_steps=50, mc_routine=mcB)
+        @test dfA.emax == dfB.emax
+        @test dfA.num_particles == dfB.num_particles
+        @test live_EA == live_EB
     end
 end

--- a/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
@@ -81,6 +81,12 @@
 
     # ================================================================
     @testset "exact-enumeration validation (3x3 lattice, real NS runs)" begin
+        using Random
+        # The NS tolerance checks below are statistical: seed the global RNG
+        # so they do not depend on which test files ran before this one.
+        # (The random_seed field on the NS parameters is not consumed.)
+        Random.seed!(1000)
+
         M = 9
         ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
 

--- a/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
@@ -38,6 +38,33 @@
         # a nonzero-N sector with no discarded samples and no live tail
         @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
             [empty_df(), empty_df()], [0, 1], 4, μs, Ts)
+        # duplicate entries in N_values
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [empty_df(), good_df(), good_df()], [0, 1, 1], 4, μs, Ts)
+        # non-positive temperature
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            dfs, [0, 1], 4, μs, [0.0u"K"])
+    end
+
+    # ================================================================
+    @testset "_fixed_N_log_evidence: single-configuration sectors" begin
+        # An empty ladder plus a live tail carries the sector's entire prior
+        # mass, exactly 1 — independent of ω0 and of how many live energies
+        # are supplied — so log_Z_NS = -βE exactly.
+        fe = FreeBird.AnalysisTools._fixed_N_log_evidence
+        empty_df = DataFrame(iter=Int[], emax=Float64[])
+        Ts = [200.0, 400.0] .* u"K"
+        E = -0.3
+        K = 25
+        for ω0 in (1.0, (K + 1) / K), live in (fill(E, K), [E])
+            logZ, meanE = fe(empty_df, Ts;
+                n_walkers=K, n_cull=1, ω0=ω0, live_energies=live, kb=kb)
+            for (j, T) in enumerate(Ts)
+                β = 1.0 / (kb * ustrip(u"K", T))
+                @test isapprox(logZ[j], -β * E, rtol=1e-12)
+                @test isapprox(meanE[j], E, rtol=1e-12)
+            end
+        end
     end
 
     # ================================================================
@@ -58,6 +85,11 @@
         dfs = [DataFrame(iter=collect(1:n_iters), emax=fill(N * ε, n_iters))
                for N in N_values]
         live = [fill(N * ε, K) for N in N_values]
+        # The N = M sector uses the documented single-configuration recipe
+        # (empty DataFrame + live tail), pinning it at tight tolerance: the
+        # tail carries exactly the sector's prior mass 1, matching the flat
+        # ladders' 1 + O(r^n/K) closure within rtol.
+        dfs[end] = DataFrame(iter=Int[], emax=Float64[])
 
         μ_grid = [-0.08, -0.04, 0.0] .* u"eV"
         T_grid = [250.0, 300.0, 400.0] .* u"K"
@@ -160,7 +192,6 @@
             liveset = LatticeGasWalkers(walkers, ham, perturb_energy=1e-12)
             ns_params = LatticeNestedSamplingParameters(
                 mc_steps=60,
-                random_seed=1000 + N,
                 allowed_fail_count=100_000)
             df, final_ls, _ = nested_sampling(
                 liveset, ns_params, n_iters, MCRandomWalkClone(), save_strategy)

--- a/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
@@ -109,6 +109,17 @@
             @test isapprox(stats.var_N[k, j], M * θ / (1 + zeff), rtol=1e-8)
             @test isapprox(stats.mean_U[k, j], ε * M * θ, rtol=1e-8)
         end
+
+        # Per-N evidence slices: log_Z_N = log[C(M,N) · Z_NS^{(N)}(β)], with
+        # Z_NS^{(N)} = e^{-βNε} for the flat ladders (Σω = 1 per sector).
+        @test stats.N_values == N_values
+        @test size(stats.log_Z_N) == (length(N_values), length(T_grid))
+        lb = FreeBird.AnalysisTools._log_binomial
+        for (j, T) in enumerate(T_grid), N in N_values
+            β = 1.0 / (kb * ustrip(u"K", T))
+            @test isapprox(stats.log_Z_N[N + 1, j], lb(M, N) - β * N * ε,
+                           rtol=1e-8)
+        end
     end
 
     # ================================================================

--- a/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
@@ -1,0 +1,196 @@
+@testset "Lattice GC-NS, fixed-N construction" begin
+
+    kb = 8.617333262e-5 # eV/K
+
+    # ================================================================
+    @testset "_log_binomial" begin
+        lb = FreeBird.AnalysisTools._log_binomial
+        @test lb(16, 0) == 0.0
+        @test lb(16, 16) == 0.0
+        @test isapprox(lb(16, 8), log(binomial(16, 8)), rtol=1e-12)
+        # Beyond Int64 overflow of binomial(M, N)
+        @test isapprox(lb(200, 100),
+                       Float64(log(binomial(big(200), big(100)))), rtol=1e-10)
+        @test_throws ArgumentError lb(4, 5)
+        @test_throws ArgumentError lb(4, -1)
+    end
+
+    # ================================================================
+    @testset "argument validation" begin
+        μs = [0.0u"eV"]
+        Ts = [300.0u"K"]
+        empty_df() = DataFrame(iter=Int[], emax=Float64[])
+        good_df() = DataFrame(iter=[1, 2], emax=[-0.1, -0.1])
+        dfs = [empty_df(), good_df()]
+
+        # ns_outputs / N_values length mismatch
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            dfs, [0, 1, 2], 4, μs, Ts)
+        # N_values must include 0
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            dfs, [1, 2], 4, μs, Ts)
+        # N_values must lie in 0:n_sites
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            dfs, [0, 5], 4, μs, Ts)
+        # live_emax length mismatch
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            dfs, [0, 1], 4, μs, Ts; live_emax=[Float64[]])
+        # a nonzero-N sector with no discarded samples and no live tail
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [empty_df(), empty_df()], [0, 1], 4, μs, Ts)
+    end
+
+    # ================================================================
+    @testset "Langmuir closed form from synthetic ladders" begin
+        # On-site-only lattice gas: every N-particle configuration has
+        # E = N ε_ads, so each per-N NS ladder is exactly flat and can be
+        # synthesized without running a sampler. With Skilling weights
+        # ω0 = (K+1)/K plus the live-set tail, Σω = 1 per sector (up to
+        # O(r^n/K)) and the assembly must reproduce the Langmuir closed form
+        # Ξ = (1 + z e^{-βε})^M to floating-point accuracy.
+        M = 16
+        ε = -0.04
+        K = 25
+        n_iters = 600
+        ω0 = (K + 1) / K
+        N_values = collect(0:M)
+
+        dfs = [DataFrame(iter=collect(1:n_iters), emax=fill(N * ε, n_iters))
+               for N in N_values]
+        live = [fill(N * ε, K) for N in N_values]
+
+        μ_grid = [-0.08, -0.04, 0.0] .* u"eV"
+        T_grid = [250.0, 300.0, 400.0] .* u"K"
+
+        stats = gc_thermodynamic_stats_fixed_N(dfs, N_values, M, μ_grid, T_grid;
+            n_walkers=K, n_cull=1, ω0=ω0, live_emax=live)
+
+        @test stats.logXi isa Matrix{Float64}
+        @test size(stats.logXi) == (length(μ_grid), length(T_grid))
+
+        for (j, T) in enumerate(T_grid), (k, μ) in enumerate(μ_grid)
+            β = 1.0 / (kb * ustrip(u"K", T))
+            zeff = exp(β * (ustrip(u"eV", μ) - ε))
+            θ = zeff / (1 + zeff)
+            @test isapprox(stats.logXi[k, j], M * log1p(zeff), rtol=1e-8)
+            @test isapprox(stats.mean_N[k, j], M * θ, rtol=1e-8)
+            @test isapprox(stats.var_N[k, j], M * θ / (1 + zeff), rtol=1e-8)
+            @test isapprox(stats.mean_U[k, j], ε * M * θ, rtol=1e-8)
+        end
+    end
+
+    # ================================================================
+    @testset "exact-enumeration validation (3x3 lattice, real NS runs)" begin
+        M = 9
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+
+        # A 3x3 periodic square lattice with the first N sites occupied.
+        function lattice_at(N::Int)
+            lat = MLattice{1,SquareLattice}(
+                lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(3, 3, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1, 1.5],
+                components=:equal,
+                adsorptions=:full)
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            return lat
+        end
+
+        # Exact per-N energy lists from fixed-N enumeration (512 configs total).
+        exact_E = Dict{Int,Vector{Float64}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(lattice_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            @test length(exact_E[N]) == binomial(M, N)
+        end
+
+        # Exact grand-canonical reference from the full spectrum.
+        function exact_stats(μ_val::Float64, T_val::Float64)
+            β = 1.0 / (kb * T_val)
+            log_terms = Float64[]
+            Ns = Int[]
+            Es = Float64[]
+            for N in 0:M, E in exact_E[N]
+                push!(log_terms, N * β * μ_val - β * E)
+                push!(Ns, N)
+                push!(Es, E)
+            end
+            max_log = maximum(log_terms)
+            w = exp.(log_terms .- max_log)
+            sw = sum(w)
+            logXi = max_log + log(sw)
+            mean_N = sum(w .* Ns) / sw
+            var_N = sum(w .* (Ns .^ 2)) / sw - mean_N^2
+            mean_U = sum(w .* Es) / sw
+            return logXi, mean_N, var_N, mean_U
+        end
+
+        # Canonical NS at each intermediate N; the walk (site hops) conserves N.
+        K = 100
+        n_iters = 800
+        save_strategy = SaveEveryN(
+            df_filename="test_lfn_df.csv",
+            wk_filename="test_lfn.traj.extxyz",
+            ls_filename="test_lfn.ls.extxyz",
+            n_traj=1_000_000, n_snap=1_000_000, n_info=1_000_000)
+
+        dfs = Vector{DataFrame}(undef, M + 1)
+        live = Vector{Vector{Float64}}(undef, M + 1)
+
+        # N = 0: empty lattice, handled internally (DataFrame ignored).
+        dfs[1] = DataFrame(iter=Int[], emax=Float64[])
+        live[1] = Float64[]
+
+        for N in 1:(M - 1)
+            walkers = [
+                begin
+                    lat = lattice_at(N)
+                    generate_random_new_lattice_sample!(lat)
+                    LatticeWalker(lat)
+                end for _ in 1:K]
+            liveset = LatticeGasWalkers(walkers, ham, perturb_energy=1e-12)
+            ns_params = LatticeNestedSamplingParameters(
+                mc_steps=60,
+                random_seed=1000 + N,
+                allowed_fail_count=100_000)
+            df, final_ls, _ = nested_sampling(
+                liveset, ns_params, n_iters, MCRandomWalkClone(), save_strategy)
+            dfs[N + 1] = df
+            live[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
+        end
+
+        # N = M: a single configuration, so NS cannot progress; the live-set
+        # tail carries the whole sector (empty DataFrame + K copies of E_full).
+        dfs[M + 1] = DataFrame(iter=Int[], emax=Float64[])
+        live[M + 1] = fill(only(exact_E[M]), K)
+
+        rm("test_lfn_df.csv", force=true)
+        rm("test_lfn.traj.extxyz", force=true)
+        rm("test_lfn.ls.extxyz", force=true)
+
+        μ_grid = [-0.10, -0.06, -0.03] .* u"eV"
+        T_grid = [300.0, 500.0] .* u"K"
+
+        stats = gc_thermodynamic_stats_fixed_N(dfs, collect(0:M), M,
+            μ_grid, T_grid;
+            n_walkers=K, n_cull=1, ω0=(K + 1) / K, live_emax=live)
+
+        for (j, T) in enumerate(T_grid), (k, μ) in enumerate(μ_grid)
+            ref_logXi, ref_mean_N, ref_var_N, ref_mean_U = exact_stats(
+                ustrip(u"eV", μ), ustrip(u"K", T))
+            @test isapprox(stats.logXi[k, j], ref_logXi, atol=0.1)
+            @test isapprox(stats.mean_N[k, j], ref_mean_N, rtol=0.05, atol=0.1)
+            @test isapprox(stats.var_N[k, j], ref_var_N, rtol=0.25, atol=0.2)
+            @test isapprox(stats.mean_U[k, j], ref_mean_U, rtol=0.05, atol=0.02)
+        end
+
+        # Monotonicity: ⟨N⟩ increases with μ at fixed T.
+        for j in eachindex(T_grid)
+            @test issorted(stats.mean_N[:, j])
+        end
+    end
+
+end

--- a/test/test-SamplingSchemes/test-nested_sampling.jl
+++ b/test/test-SamplingSchemes/test-nested_sampling.jl
@@ -800,4 +800,99 @@
             @test ns_params.cluster_accept_history == [0.1, 0.5, 0.0, 0.5]
         end
     end
+
+    @testset "dead-point callback (canonical route)" begin
+        using Random
+        dpc_lat = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full)
+        dpc_ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        dpc_save = SaveEveryN("t_dpc.csv", "t_dpc.traj", "t_dpc.ls",
+                              1000000, 1000000, 1000000)
+        dpc_cleanup() = rm.(["t_dpc.csv", "t_dpc.traj", "t_dpc.ls"], force=true)
+
+        # Fixed-N liveset at N = 6, freshly seeded per run so A/B pairs share
+        # their streams
+        function dpc_fresh(seed)
+            Random.seed!(seed)
+            walkers = [LatticeWalker(deepcopy(dpc_lat), energy=0.0u"eV", iter=0)
+                       for _ in 1:12]
+            for w in walkers
+                occ = vcat(fill(true, 6), fill(false, 10))
+                shuffle!(occ)
+                w.configuration.components[1] .= occ
+            end
+            ls = LatticeGasWalkers(walkers, dpc_ham; perturb_energy=1e-9)
+            params = LatticeNestedSamplingParameters(mc_steps=20,
+                energy_perturbation=1e-9, allowed_fail_count=100000)
+            return ls, params
+        end
+
+        # Invocation count equals nrow(df), and the (iter, energy) pair seen
+        # by the callback matches the ledger row bit-exactly (the pairing
+        # guard's contract, from the caller's side)
+        ls, params = dpc_fresh(31)
+        seen = Tuple{Int,Float64}[]
+        df, _, _ = nested_sampling(ls, params, Int64(150),
+            MCRandomWalkClone(), dpc_save;
+            dead_point_callback=(iter, w) -> push!(seen, (iter, w.energy.val)))
+        dpc_cleanup()
+        @test nrow(df) > 0
+        @test length(seen) == nrow(df)
+        @test [t[1] for t in seen] == df.iter
+        @test [t[2] for t in seen] == df.emax
+
+        # Offline reproduction and energy faithfulness: occupation vectors
+        # collected through the callback re-evaluate the run's recorded
+        # observable column exactly, and recomputing the Hamiltonian on a
+        # collected configuration matches the ledger energy within the
+        # energy_perturbation half-width (the perturbation is uniform on
+        # ±energy_perturbation/2)
+        ls, params = dpc_fresh(32)
+        configs = Vector{Bool}[]
+        df2, _, _ = nested_sampling(ls, params, Int64(150),
+            MCRandomWalkClone(), dpc_save;
+            observables=[:nocc => (cfg -> Float64(sum(cfg.components[1])))],
+            dead_point_callback=(iter, w) ->
+                push!(configs, copy(w.configuration.components[1])))
+        dpc_cleanup()
+        @test length(configs) == nrow(df2)
+        @test [Float64(sum(c)) for c in configs] == df2.nocc
+        dpc_probe = deepcopy(dpc_lat)
+        for (c, e) in zip(configs, df2.emax)
+            dpc_probe.components[1] .= c
+            @test abs(ustrip(u"eV", interacting_energy(dpc_probe, dpc_ham)) - e) <= 5.1e-10
+        end
+
+        # Stream neutrality: a same-seed A/B pair with and without the
+        # callback leaves the ledger byte-identical (the callback path draws
+        # no randomness)
+        lsA, paramsA = dpc_fresh(33)
+        dfA, _, _ = nested_sampling(lsA, paramsA, Int64(120),
+            MCRandomWalkClone(), dpc_save)
+        dpc_cleanup()
+        lsB, paramsB = dpc_fresh(33)
+        dfB, _, _ = nested_sampling(lsB, paramsB, Int64(120),
+            MCRandomWalkClone(), dpc_save;
+            dead_point_callback=(iter, w) -> nothing)
+        dpc_cleanup()
+        @test dfA.iter == dfB.iter
+        @test dfA.emax == dfB.emax
+
+        # Guards: a non-Function argument fails at the keyword's type
+        # boundary; parallel/multi-cull routines are rejected up front when
+        # only the callback is requested
+        ls, params = dpc_fresh(34)
+        @test_throws TypeError nested_sampling(ls, params, Int64(1),
+            MCRandomWalkClone(), dpc_save; dead_point_callback=42)
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(1),
+            MCRandomWalkMaxEParallel(), dpc_save;
+            dead_point_callback=(i, w) -> nothing)
+        dpc_cleanup()
+    end
 end

--- a/test/test-SamplingSchemes/test-nested_sampling.jl
+++ b/test/test-SamplingSchemes/test-nested_sampling.jl
@@ -488,9 +488,11 @@
                 ns_params_copy = deepcopy(ns_params)
                 df, updated_liveset, updated_params = nested_sampling(
                     liveset, ns_params_copy, n_steps, MCRandomWalkMaxE(), save_strategy)
-                
+
                 @test df isa DataFrame
-                @test names(df) == ["iter", "emax"]
+                # Serial atomistic ledgers carry the per-cull log-compression
+                # column (plateau-aware culling); parallel ledgers do not.
+                @test names(df) == ["iter", "emax", "log_compression"]
                 @test nrow(df) ≤ n_steps
                 @test length(updated_liveset.walkers) == length(liveset.walkers)
                 @test eltype(df.iter) == Int

--- a/test/test-SamplingSchemes/test-nested_sampling.jl
+++ b/test/test-SamplingSchemes/test-nested_sampling.jl
@@ -1,21 +1,21 @@
 @testset "nested_sampling.jl tests" begin
     @testset "NestedSamplingParameters struct tests" begin
         params = NestedSamplingParameters(
-            1000,    # mc_steps
-            0.1,     # initial_step_size
-            0.1,     # step_size
-            0.01,    # step_size_lo
-            1.0,     # step_size_up
-            (0.5,0.5),  # acceptance ratio range
-            0,       # fail_count
-            100,     # allowed_fail_count
-            1e-12,   # energy_perturbation
-            1234,    # random_seed
-            0.3,     # cluster_p
-            0.0,     # cluster_accepted
-            0.0      # cluster_total
+            mc_steps=1000,
+            initial_step_size=0.1,
+            step_size=0.1,
+            step_size_lo=0.01,
+            step_size_up=1.0,
+            accept_range=(0.5,0.5),
+            fail_count=0,
+            allowed_fail_count=100,
+            energy_perturbation=1e-12,
+            random_seed=1234,
+            cluster_p=0.3,
+            cluster_accepted=0.0,
+            cluster_total=0.0,
         )
-        
+
         @test params isa SamplingSchemes.SamplingParameters
         @test params.mc_steps == 1000
         @test params.initial_step_size == 0.1
@@ -199,21 +199,21 @@
             liveset_surf = LJSurfaceWalkers(walkers, ljs, surface; assign_energy=true)
             
             ns_params = NestedSamplingParameters(
-                1000,    # mc_steps
-                0.1,     # initial_step_size
-                0.1,     # step_size
-                0.01,    # step_size_lo
-                1.0,     # step_size_up
-                (0.5,0.5),  # acceptance ratio range
-                0,       # fail_count
-                100,     # allowed_fail_count
-                1e-12,   # energy_perturbation
-                1234,    # random_seed
-                0.3,     # cluster_p
-                0.0,     # cluster_accepted
-                0.0      # cluster_total
+                mc_steps=1000,
+                initial_step_size=0.1,
+                step_size=0.1,
+                step_size_lo=0.01,
+                step_size_up=1.0,
+                accept_range=(0.5,0.5),
+                fail_count=0,
+                allowed_fail_count=100,
+                energy_perturbation=1e-12,
+                random_seed=1234,
+                cluster_p=0.3,
+                cluster_accepted=0.0,
+                cluster_total=0.0,
             )
-            
+
             for liveset in [liveset_at, liveset_surf]
                 @testset "MCRandomWalkMaxE" begin
                     mc_routine = MCRandomWalkMaxE()
@@ -388,19 +388,19 @@
     @testset "adjust_step_size function tests" begin
 
         ns_params = NestedSamplingParameters(
-                1000,    # mc_steps
-                0.1,     # initial_step_size
-                0.1,     # step_size
-                0.01,    # step_size_lo
-                1.0,     # step_size_up
-                (0.5,0.5),  # acceptance ratio range
-                0,       # fail_count
-                100,     # allowed_fail_count
-                1e-12,   # energy_perturbation
-                1234,    # random_seed
-                0.3,     # cluster_p
-                0.0,     # cluster_accepted
-                0.0      # cluster_total
+                mc_steps=1000,
+                initial_step_size=0.1,
+                step_size=0.1,
+                step_size_lo=0.01,
+                step_size_up=1.0,
+                accept_range=(0.5,0.5),
+                fail_count=0,
+                allowed_fail_count=100,
+                energy_perturbation=1e-12,
+                random_seed=1234,
+                cluster_p=0.3,
+                cluster_accepted=0.0,
+                cluster_total=0.0,
             )
 
         @testset "Step size increases" begin
@@ -459,21 +459,21 @@
             liveset = LJAtomWalkers(walkers, lj)
             
             ns_params = NestedSamplingParameters(
-                1000,    # mc_steps
-                0.1,     # initial_step_size
-                0.1,     # step_size
-                0.01,    # step_size_lo
-                1.0,     # step_size_up
-                (0.5,0.5),  # acceptance ratio range
-                0,       # fail_count
-                100,     # allowed_fail_count
-                1e-12,   # energy_perturbation
-                1234,    # random_seed
-                0.3,     # cluster_p
-                0.0,     # cluster_accepted
-                0.0      # cluster_total
+                mc_steps=1000,
+                initial_step_size=0.1,
+                step_size=0.1,
+                step_size_lo=0.01,
+                step_size_up=1.0,
+                accept_range=(0.5,0.5),
+                fail_count=0,
+                allowed_fail_count=100,
+                energy_perturbation=1e-12,
+                random_seed=1234,
+                cluster_p=0.3,
+                cluster_accepted=0.0,
+                cluster_total=0.0,
             )
-            
+
             save_strategy = SaveEveryN(
                 df_filename = "test_df.csv",
                 wk_filename = "test.traj.extxyz",
@@ -775,23 +775,29 @@
             ns_params.cluster_p = 0.5
 
             # Rate below target → p decreases
-            SamplingSchemes.adjust_cluster_p(ns_params, 0.1; target=0.3)
+            SamplingSchemes.adjust_cluster_p(ns_params, 0.1, 1; target=0.3)
             @test ns_params.cluster_p ≈ 0.5 * 0.9
 
             # Rate above target → p increases
             ns_params.cluster_p = 0.5
-            SamplingSchemes.adjust_cluster_p(ns_params, 0.5; target=0.3)
+            SamplingSchemes.adjust_cluster_p(ns_params, 0.5, 2; target=0.3)
             @test ns_params.cluster_p ≈ 0.5 * 1.1
 
             # Clamping lower bound
             ns_params.cluster_p = 0.011
-            SamplingSchemes.adjust_cluster_p(ns_params, 0.0; target=0.3)
+            SamplingSchemes.adjust_cluster_p(ns_params, 0.0, 3; target=0.3)
             @test ns_params.cluster_p == 0.01
 
             # Clamping upper bound
             ns_params.cluster_p = 0.95
-            SamplingSchemes.adjust_cluster_p(ns_params, 0.5; target=0.3)
+            SamplingSchemes.adjust_cluster_p(ns_params, 0.5, 4; target=0.3)
             @test ns_params.cluster_p == 1.0
+
+            # Verify history was recorded
+            @test length(ns_params.cluster_p_history) == 4
+            @test length(ns_params.cluster_accept_history) == 4
+            @test ns_params.cluster_adjust_iterations == [1, 2, 3, 4]
+            @test ns_params.cluster_accept_history == [0.1, 0.5, 0.0, 0.5]
         end
     end
 end

--- a/test/test-SamplingSchemes/test-nested_sampling.jl
+++ b/test/test-SamplingSchemes/test-nested_sampling.jl
@@ -10,7 +10,10 @@
             0,       # fail_count
             100,     # allowed_fail_count
             1e-12,   # energy_perturbation
-            1234     # random_seed
+            1234,    # random_seed
+            0.3,     # cluster_p
+            0.0,     # cluster_accepted
+            0.0      # cluster_total
         )
         
         @test params isa SamplingSchemes.SamplingParameters
@@ -43,9 +46,12 @@
         @test params.allowed_fail_count == 100
         @test params.energy_perturbation == 1e-12
         @test params.random_seed == 1234
+        @test params.cluster_p == 0.3
+        @test params.cluster_accepted == 0.0
+        @test params.cluster_total == 0.0
 
     end
-    
+
 
     @testset "LatticeNestedSamplingParameters struct tests" begin
         params = LatticeNestedSamplingParameters(
@@ -74,6 +80,7 @@
         @test params.fail_count == 0
         @test params.allowed_fail_count == 10
         @test params.random_seed == 1234
+        @test params.cluster_p == 0.3
 
     end
     
@@ -201,7 +208,10 @@
                 0,       # fail_count
                 100,     # allowed_fail_count
                 1e-12,   # energy_perturbation
-                1234     # random_seed
+                1234,    # random_seed
+                0.3,     # cluster_p
+                0.0,     # cluster_accepted
+                0.0      # cluster_total
             )
             
             for liveset in [liveset_at, liveset_surf]
@@ -387,7 +397,10 @@
                 0,       # fail_count
                 100,     # allowed_fail_count
                 1e-12,   # energy_perturbation
-                1234     # random_seed
+                1234,    # random_seed
+                0.3,     # cluster_p
+                0.0,     # cluster_accepted
+                0.0      # cluster_total
             )
 
         @testset "Step size increases" begin
@@ -455,7 +468,10 @@
                 0,       # fail_count
                 100,     # allowed_fail_count
                 1e-12,   # energy_perturbation
-                1234     # random_seed
+                1234,    # random_seed
+                0.3,     # cluster_p
+                0.0,     # cluster_accepted
+                0.0      # cluster_total
             )
             
             save_strategy = SaveEveryN(
@@ -617,6 +633,165 @@
             if isfile("test.ls")
                 rm("test.ls", force=true)
             end
+        end
+    end
+
+
+    @testset "MCMixedMoves cluster move integration" begin
+
+        @testset "MCMixedMoves backward compatibility" begin
+            mc = MCMixedMoves(5, 1)
+            @test mc.walks_freq == 5
+            @test mc.swaps_freq == 1
+            @test mc.clusters_freq == 0
+            @test mc.initial_cluster_p == 0.3
+            @test mc.target_cluster_accept == 0.3
+            @test mc.cluster_adjust_interval == 50
+            @test mc isa MCRoutine
+        end
+
+        @testset "MCMixedMoves keyword constructor" begin
+            mc = MCMixedMoves(walks_freq=1, clusters_freq=2, initial_cluster_p=0.5)
+            @test mc.walks_freq == 1
+            @test mc.swaps_freq == 0
+            @test mc.clusters_freq == 2
+            @test mc.initial_cluster_p == 0.5
+        end
+
+        # Shared lattice setup for the remaining tests
+        square_lattice = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=:equal,
+            adsorptions=:full
+        )
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+
+        @testset "nested_sampling_step! with MCMixedMoves on LatticeGasWalkers" begin
+            walkers = [LatticeWalker(deepcopy(square_lattice), energy=5.0u"eV", iter=0) for _ in 1:5]
+            liveset = LatticeGasWalkers(walkers, ham)
+
+            ns_params = LatticeNestedSamplingParameters(mc_steps=20)
+            mc_routine = MCMixedMoves(walks_freq=1, swaps_freq=0, clusters_freq=2,
+                                      initial_cluster_p=0.3, target_cluster_accept=0.3,
+                                      cluster_adjust_interval=3)
+            ns_params.cluster_p = mc_routine.initial_cluster_p
+
+            e_type = typeof(walkers[1].energy)
+            iter, emax, updated_liveset, updated_params = nested_sampling_step!(liveset, ns_params, mc_routine)
+
+            @test iter isa Union{Missing,Int}
+            @test emax isa Union{Missing,e_type}
+            @test length(updated_liveset.walkers) == 5
+            @test updated_params.fail_count >= 0
+        end
+
+        @testset "NS loop runs with MCMixedMoves on LatticeGasWalkers" begin
+            walkers = [LatticeWalker(deepcopy(square_lattice), energy=5.0u"eV", iter=0) for _ in 1:5]
+            liveset = LatticeGasWalkers(walkers, ham)
+
+            ns_params = LatticeNestedSamplingParameters(mc_steps=50)
+            mc_routine = MCMixedMoves(walks_freq=1, swaps_freq=0, clusters_freq=2,
+                                      initial_cluster_p=0.3, target_cluster_accept=0.3,
+                                      cluster_adjust_interval=3)
+            save_strategy = SaveEveryN("test_mm_df.csv", "test_mm.traj", "test_mm.ls", 100, 100, 100)
+
+            df, updated_liveset, updated_params = nested_sampling(
+                liveset, ns_params, Int64(10), mc_routine, save_strategy)
+
+            @test df isa DataFrame
+            @test length(updated_liveset.walkers) == 5
+            @test all(walker -> walker isa LatticeWalker, updated_liveset.walkers)
+
+            rm("test_mm_df.csv", force=true)
+            rm("test_mm.traj", force=true)
+            rm("test_mm.ls", force=true)
+        end
+
+        @testset "Adaptive cluster_p tuning" begin
+            walkers = [LatticeWalker(deepcopy(square_lattice), energy=5.0u"eV", iter=0) for _ in 1:5]
+            liveset = LatticeGasWalkers(walkers, ham)
+
+            ns_params = LatticeNestedSamplingParameters(mc_steps=50)
+            mc_routine = MCMixedMoves(walks_freq=0, swaps_freq=0, clusters_freq=1,
+                                      initial_cluster_p=0.3, target_cluster_accept=0.3,
+                                      cluster_adjust_interval=2)
+            save_strategy = SaveEveryN("test_ap.csv", "test_ap.traj", "test_ap.ls", 1000, 1000, 1000)
+
+            _, _, updated_params = nested_sampling(
+                liveset, ns_params, Int64(20), mc_routine, save_strategy)
+
+            # p should have been adjusted at least once
+            @test updated_params.cluster_p != mc_routine.initial_cluster_p
+            @test 0.01 <= updated_params.cluster_p <= 1.0
+
+            rm("test_ap.csv", force=true)
+            rm("test_ap.traj", force=true)
+            rm("test_ap.ls", force=true)
+        end
+
+        @testset "Particle counts preserved through NS step" begin
+            walkers = [LatticeWalker(deepcopy(square_lattice), energy=5.0u"eV", iter=0) for _ in 1:5]
+            liveset = LatticeGasWalkers(walkers, ham)
+
+            ns_params = LatticeNestedSamplingParameters(mc_steps=20)
+            mc_routine = MCMixedMoves(walks_freq=1, swaps_freq=0, clusters_freq=2,
+                                      initial_cluster_p=0.3)
+            ns_params.cluster_p = mc_routine.initial_cluster_p
+
+            original_counts = [occupied_site_count(w.configuration) for w in liveset.walkers]
+            nested_sampling_step!(liveset, ns_params, mc_routine)
+            new_counts = [occupied_site_count(w.configuration) for w in liveset.walkers]
+
+            for (oc, nc) in zip(original_counts, new_counts)
+                @test oc == nc
+            end
+        end
+
+        @testset "Energy ordering maintained after NS step" begin
+            walkers = [LatticeWalker(deepcopy(square_lattice), energy=5.0u"eV", iter=0) for _ in 1:5]
+            liveset = LatticeGasWalkers(walkers, ham)
+
+            ns_params = LatticeNestedSamplingParameters(mc_steps=30)
+            mc_routine = MCMixedMoves(walks_freq=1, swaps_freq=0, clusters_freq=2,
+                                      initial_cluster_p=0.3)
+            ns_params.cluster_p = mc_routine.initial_cluster_p
+
+            sort_by_energy!(liveset)
+            emax_before = liveset.walkers[1].energy
+
+            nested_sampling_step!(liveset, ns_params, mc_routine)
+            sort_by_energy!(liveset)
+
+            # After step, worst energy should be <= previous worst
+            @test liveset.walkers[1].energy <= emax_before
+        end
+
+        @testset "adjust_cluster_p" begin
+            ns_params = LatticeNestedSamplingParameters()
+            ns_params.cluster_p = 0.5
+
+            # Rate below target → p decreases
+            SamplingSchemes.adjust_cluster_p(ns_params, 0.1; target=0.3)
+            @test ns_params.cluster_p ≈ 0.5 * 0.9
+
+            # Rate above target → p increases
+            ns_params.cluster_p = 0.5
+            SamplingSchemes.adjust_cluster_p(ns_params, 0.5; target=0.3)
+            @test ns_params.cluster_p ≈ 0.5 * 1.1
+
+            # Clamping lower bound
+            ns_params.cluster_p = 0.011
+            SamplingSchemes.adjust_cluster_p(ns_params, 0.0; target=0.3)
+            @test ns_params.cluster_p == 0.01
+
+            # Clamping upper bound
+            ns_params.cluster_p = 0.95
+            SamplingSchemes.adjust_cluster_p(ns_params, 0.5; target=0.3)
+            @test ns_params.cluster_p == 1.0
         end
     end
 end

--- a/test/test-SamplingSchemes/test-nested_sampling.jl
+++ b/test/test-SamplingSchemes/test-nested_sampling.jl
@@ -443,6 +443,85 @@
     end
 
 
+    @testset "accept_range forwarding (issue #182)" begin
+        using Random
+
+        # Same-seed A/B pair on the serial atomistic path, the issue #182
+        # reproducer verbatim. adjust_step_size draws no randomness, so the
+        # two runs share every random stream and can differ only through the
+        # forwarded acceptance window.
+        function step_size_trajectory(range::Tuple{Float64,Float64})
+            Random.seed!(1234)
+            walkers = AtomWalker.(generate_initial_configs(20, 562.5, 3))
+            ls = LJAtomWalkers(walkers, LJParameters(epsilon=0.1, sigma=2.5, cutoff=4.0))
+            ns_params = NestedSamplingParameters(mc_steps=100, step_size=0.1, accept_range=range)
+            traj = Float64[]
+            for i in 1:200
+                nested_sampling_step!(ls, ns_params, MCRandomWalkClone(); ns_iteration=i)
+                push!(traj, ns_params.step_size)
+            end
+            return traj
+        end
+
+        traj_default = step_size_trajectory((0.25, 0.75))
+        traj_extreme = step_size_trajectory((0.95, 0.99))
+
+        @test traj_default[end] != traj_extreme[end]
+        # The default-window final equals the pre-fix dev value bit-exactly
+        # (the forwarded field equals the previously hardcoded (0.25, 0.75)),
+        # pinning that the fix is behavior-preserving for every run that used
+        # the default window.
+        @test traj_default[end] == 0.5758006961260272
+        @test traj_extreme[end] == 0.02206751763986903
+        @test findfirst(i -> traj_default[i] != traj_extreme[i], 1:200) == 11
+
+        # Same-seed A/B pair on the serial LJSurfaceWalkers path: the frozen
+        # 4-H surface fixture from the step tests above, with deterministically
+        # offset free walkers so the initial live set carries no exact ties.
+        function surface_final_step_size(range::Tuple{Float64,Float64})
+            Random.seed!(4321)
+            box = [[10.0u"Å", 0u"Å", 0u"Å"],
+                   [0u"Å", 10.0u"Å", 0u"Å"],
+                   [0u"Å", 0u"Å", 10.0u"Å"]]
+            lj = LJParameters(epsilon=0.1, sigma=2.5, cutoff=3.5, shift=false)
+            ljs = CompositeParameterSets(3, [lj for _ in 1:6])
+            surf_list = [:H => [0.0, 0.0, 0.0],
+                         :H => [0.0, 0.5, 0.0],
+                         :H => [0.5, 0.0, 0.0],
+                         :H => [0.5, 0.5, 0.0]]
+            surface = AtomWalker(FastSystem(periodic_system(surf_list, box, fractional=true)); freeze_species=[:H])
+            surface.energy_frozen_part = interacting_energy(surface.configuration, lj)
+            walkers = [AtomWalker(FastSystem(periodic_system(
+                           [:H => [0.2 + 0.02k, 0.5, 0.5],
+                            :H => [0.4, 0.5 + 0.02k, 0.5],
+                            :O => [0.6, 0.5, 0.5 + 0.02k]],
+                           box, fractional=true))) for k in 1:5]
+            ls = LJSurfaceWalkers(walkers, ljs, surface; assign_energy=true)
+            ns_params = NestedSamplingParameters(mc_steps=100, step_size=0.1, accept_range=range)
+            for i in 1:120
+                nested_sampling_step!(ls, ns_params, MCRandomWalkClone(); ns_iteration=i)
+            end
+            return ns_params.step_size
+        end
+
+        surf_default = surface_final_step_size((0.25, 0.75))
+        surf_extreme = surface_final_step_size((0.95, 0.99))
+
+        @test surf_default != surf_extreme
+        # Calibrated on this fixture (first divergence at step 1), so the
+        # inequality above is not vacuous; both windows leave the hardcoded
+        # pre-fix behavior.
+        @test surf_default == 0.1676010422687346
+        @test surf_extreme == 0.0019666745633144527
+
+        # The "adjust_step_size function tests" testset above covers the
+        # helper itself, including an explicit custom range, and passes
+        # unchanged. The threaded, distributed, and mixed-moves call sites
+        # carry the identical one-line forward and are covered by the shared
+        # pattern (issue #182 test plan, item 3).
+    end
+
+
     @testset "nested_sampling_loop functions tests" begin
         @testset "AtomWalkers cases tests" begin
             # Setup test system

--- a/test/test-SamplingSchemes/test-nested_sampling.jl
+++ b/test/test-SamplingSchemes/test-nested_sampling.jl
@@ -265,13 +265,17 @@
 
                     original_ls = deepcopy(liveset)
 
-                    if !(liveset isa LJSurfaceWalkers) # TODO: LJSurfaceWalkers does not support 2D walks yet
+                    if !(liveset isa LJSurfaceWalkers)
                         iter, emax, updated_liveset, updated_params = nested_sampling_step!(deepcopy(original_ls), ns_params, mc_routine)
-                        
+
                         @test iter isa Union{Missing,Int}
                         @test emax isa Union{Missing,typeof(0.0u"eV")}
                         @test length(updated_liveset.walkers) == length(original_ls.walkers)
                         @test updated_params.fail_count >= 0
+                    else
+                        # Surface walks are 3D-only: the step refuses a 2D dims
+                        # explicitly (issue #185, option 1).
+                        @test_throws ErrorException nested_sampling_step!(deepcopy(original_ls), ns_params, mc_routine)
                     end
 
                 end
@@ -306,6 +310,57 @@
                     @test_throws ErrorException begin
                         nested_sampling_step!(liveset, ns_params, Unsupported())
                     end
+                end
+            end
+
+            @testset "2D dims dispatch and forwarding (issue #185)" begin
+                using Random
+                # The serial surface refusal supplies the reference message for
+                # the parallel surface dispatch (issue #185, option 1).
+                serial_err = try
+                    nested_sampling_step!(deepcopy(liveset_surf), deepcopy(ns_params), MCRandomWalkClone(dims=[1, 2]))
+                    nothing
+                catch err
+                    err
+                end
+                @test serial_err isa ErrorException
+                @test occursin("Unsupported dimensions", serial_err.msg)
+
+                for mc_routine in [MCRandomWalkCloneParallel(dims=[1, 2]), MCRandomWalkMaxEParallel(dims=[1, 2])]
+                    @test_throws ErrorException nested_sampling_step!(deepcopy(liveset_surf), deepcopy(ns_params), mc_routine)
+                    parallel_err = try
+                        nested_sampling_step!(deepcopy(liveset_surf), deepcopy(ns_params), mc_routine)
+                        nothing
+                    catch err
+                        err
+                    end
+                    @test parallel_err isa ErrorException && parallel_err.msg == serial_err.msg
+                end
+
+                # Distinct-coordinate walkers: a dims=[1, 3] walk must leave every
+                # dim-2 coordinate bit-identical, so after any number of steps each
+                # liveset coordinate must stay inside the starting per-dimension
+                # value set of its dimension.
+                coor_lists = [[:H => [0.20, 0.11, 0.30], :H => [0.40, 0.17, 0.48]],
+                              [:H => [0.60, 0.23, 0.40], :H => [0.42, 0.29, 0.58]],
+                              [:H => [0.70, 0.35, 0.50], :H => [0.50, 0.41, 0.28]]]
+                walkers_2d = [AtomWalker(FastSystem(periodic_system(cl, box, fractional=true))) for cl in coor_lists]
+                coords(ls, d) = Set(ustrip(u"Å", position(w.configuration, i)[d]) for w in ls.walkers for i in 1:2)
+                start_ls = LJAtomWalkers(deepcopy(walkers_2d), lj)
+                xs0, ys0, zs0 = coords(start_ls, 1), coords(start_ls, 2), coords(start_ls, 3)
+
+                for (seed, mc_routine) in [(4661, MCRandomWalkCloneParallel(dims=[1, 3])),
+                                           (4662, MCDistributed(dims=[1, 3])),
+                                           (4663, MCRandomWalkClone(dims=[1, 3]))]
+                    Random.seed!(seed)
+                    ls = LJAtomWalkers(deepcopy(walkers_2d), lj)
+                    params = deepcopy(ns_params)
+                    for _ in 1:4
+                        nested_sampling_step!(ls, params, mc_routine)
+                    end
+                    @test issubset(coords(ls, 2), ys0)
+                    # Non-vacuity: at least one dim-1 or dim-3 coordinate moved.
+                    @test !issubset(coords(ls, 1), xs0) || !issubset(coords(ls, 3), zs0)
                 end
             end
         end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -240,6 +240,149 @@
         @test names(df2) == ["iter", "emax"]
     end
 
+    # ================================================================
+    @testset "bragg_amplitude and order_parameter_stripe" begin
+        lat = obs_square_lattice(4, 4)
+        # Occupation from a predicate on the integer coordinates; site
+        # ordering: dimension 1 fastest, so x = (s-1) % d1, y = (s-1) ÷ d1
+        function fill_xy!(l, pred)
+            d1, d2 = l.supercell_dimensions[1], l.supercell_dimensions[2]
+            l.components[1] .= [pred((s - 1) % d1, ((s - 1) ÷ d1) % d2)
+                                for s in 1:d1*d2]
+            l
+        end
+
+        # k = (π, π) is order_parameter_c2x2: the two code paths agree on
+        # random occupations, and indices wrap modulo the dimensions
+        Random.seed!(1234)
+        for _ in 1:20
+            lat.components[1] .= rand(Bool, 16)
+            @test bragg_amplitude(lat, 2, 2) == order_parameter_c2x2(lat)
+            @test bragg_amplitude(lat, 1, 3) == bragg_amplitude(lat, 5, 3)
+            @test bragg_amplitude(lat, 1, 3) == bragg_amplitude(lat, -3, 3)
+        end
+
+        # Perfect (2x1) stripes, both orientations, both phases: 1/2, with
+        # order_parameter_c2x2 blind to all four (the :49 anti-case, from
+        # the other side); the perfect checkerboard is the converse
+        for pred in [(x, y) -> x % 2 == 0, (x, y) -> x % 2 == 1,
+                     (x, y) -> y % 2 == 0, (x, y) -> y % 2 == 1]
+            fill_xy!(lat, pred)
+            @test order_parameter_stripe(lat) ≈ 1 / 2 atol = 1e-12
+            @test order_parameter_c2x2(lat) == 0.0
+        end
+        fill_xy!(lat, (x, y) -> iseven(x + y))
+        @test order_parameter_stripe(lat) == 0.0
+
+        # Period-4 axial double stripes, both orientations, all four phases,
+        # on 4x4 and 8x8: sqrt(2)/4 at the stripe harmonic, exactly 0 at the
+        # period-2 harmonic (wrong-harmonic blindness)
+        for (d1, d2) in [(4, 4), (8, 8)]
+            latp = obs_square_lattice(d1, d2)
+            for p in 0:3, pred in [(x, y) -> mod(x - p, 4) < 2,
+                                   (x, y) -> mod(y - p, 4) < 2]
+                fill_xy!(latp, pred)
+                @test order_parameter_stripe(latp, period=4) ≈ sqrt(2) / 4 atol = 1e-12
+                @test order_parameter_stripe(latp, period=2) == 0.0
+            end
+        end
+
+        # Block and diagonal period-4 states: the axial stripe order
+        # parameter is exactly 0 while the documented diagonal quadrature
+        # resolves the k = (π/2, ±π/2) manifold at sqrt(2)/4
+        diag_quad(cfg) = sqrt(bragg_amplitude(cfg, 1, 1)^2 +
+                              bragg_amplitude(cfg, 1, -1)^2)
+        fill_xy!(lat, (x, y) -> x ÷ 2 == y ÷ 2)
+        @test order_parameter_stripe(lat, period=4) == 0.0
+        @test bragg_amplitude(lat, 1, 1) ≈ 1 / 4 atol = 1e-12
+        @test bragg_amplitude(lat, 1, -1) ≈ 1 / 4 atol = 1e-12
+        @test diag_quad(lat) ≈ sqrt(2) / 4 atol = 1e-12
+        fill_xy!(lat, (x, y) -> mod(x + y, 4) < 2)
+        @test order_parameter_stripe(lat, period=4) == 0.0
+        @test bragg_amplitude(lat, 1, 1) ≈ sqrt(2) / 4 atol = 1e-12
+        @test bragg_amplitude(lat, 1, -1) == 0.0
+        @test diag_quad(lat) ≈ sqrt(2) / 4 atol = 1e-12
+
+        # Empty and full lattices scatter nothing off the (0, 0) rod
+        lat.components[1] .= false
+        @test bragg_amplitude(lat, 1, 0) == 0.0
+        @test order_parameter_stripe(lat) == 0.0
+        lat.components[1] .= true
+        for (m, n) in [(1, 0), (0, 1), (2, 2), (3, 1)]
+            @test bragg_amplitude(lat, m, n) == 0.0
+        end
+        @test order_parameter_stripe(lat) == 0.0
+        @test order_parameter_stripe(lat, period=4) == 0.0
+
+        # Single particle: 1/M at any k, sqrt(2)/M in quadrature
+        lat.components[1] .= false
+        lat.components[1][1] = true
+        @test bragg_amplitude(lat, 1, 0) == 1 / 16
+        @test bragg_amplitude(lat, 2, 3) == 1 / 16
+        @test order_parameter_stripe(lat) ≈ sqrt(2) / 16 atol = 1e-12
+
+        # Two-site basis
+        lat2b = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[0.8],
+            components=[[false for _ in 1:32]],
+            adsorptions=:full)
+        @test_throws ArgumentError bragg_amplitude(lat2b, 1, 0)
+        @test_throws ArgumentError order_parameter_stripe(lat2b)
+
+        # Three-dimensional supercell
+        lat3d = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 2),
+            periodicity=(true, true, true),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:32]],
+            adsorptions=:full)
+        @test_throws ArgumentError bragg_amplitude(lat3d, 1, 0)
+        @test_throws ArgumentError order_parameter_stripe(lat3d)
+
+        # Incommensurate and degenerate periods
+        @test_throws ArgumentError order_parameter_stripe(
+            obs_square_lattice(4, 4), period=3)
+        @test_throws ArgumentError order_parameter_stripe(
+            obs_square_lattice(6, 4), period=4)
+        @test_throws ArgumentError order_parameter_stripe(
+            obs_square_lattice(4, 4), period=1)
+        @test_throws ArgumentError order_parameter_stripe(
+            obs_square_lattice(4, 4), period=0)
+
+        # A short seeded canonical NS run records the stripe Binder moments
+        # through the moment-callback pattern from the docstring
+        Random.seed!(23)
+        walkers = [LatticeWalker(deepcopy(obs_square_lattice(4, 4)),
+                                 energy=0.0u"eV", iter=0) for _ in 1:20]
+        # Fixed-N ladder at N = 6: place 6 particles per walker
+        for w in walkers
+            occ = vcat(fill(true, 6), fill(false, 10))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls = LatticeGasWalkers(walkers, obs_ham; perturb_energy=1e-9)
+        params = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+
+        df, _, _ = nested_sampling(ls, params, Int64(200),
+            MCRandomWalkClone(), obs_save;
+            observables=[:stripe => order_parameter_stripe,
+                         :stripe2 => (cfg -> order_parameter_stripe(cfg)^2),
+                         :stripe4 => (cfg -> order_parameter_stripe(cfg)^4)])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "stripe", "stripe2", "stripe4"]
+        @test all(0.0 .<= df.stripe .<= 1 / 2)
+        @test all(isapprox.(df.stripe2, df.stripe .^ 2; rtol=1e-12))
+        @test all(isapprox.(df.stripe4, df.stripe .^ 4; rtol=1e-12))
+    end
+
     @testset "observable hook: validation" begin
         lat = obs_square_lattice(4, 4)
         walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:8]

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -73,6 +73,173 @@
     obs_cleanup() = rm.(["t_obs.csv", "t_obs.traj", "t_obs.ls"], force=true)
     count_N(cfg) = Float64(sum(cfg.components[1]))
 
+    # ================================================================
+    @testset "order_parameter_sqrt3" begin
+        # Shared single-component triangular-lattice builder (NN shell only)
+        function obs_tri_lattice(d1, d2)
+            MLattice{1,TriangularLattice}(
+                lattice_constant=1.0,
+                supercell_dimensions=(d1, d2, 1),
+                periodicity=(true, true, false),
+                cutoff_radii=[1.1],
+                components=[[false for _ in 1:2*d1*d2]],
+                adsorptions=:full)
+        end
+
+        # Independent geometric decoder: recover the triangular integer
+        # coordinates (m, n) by inverting [t1 t2] on the stored positions and
+        # color with c = (m - n) mod 3, so the labels are derived from the
+        # geometry rather than from the index arithmetic under test
+        function sqrt3_labels(lat)
+            a = lat.lattice_vectors[1, 1]
+            map(1:size(lat.positions, 1)) do s
+                x, y = lat.positions[s, 1], lat.positions[s, 2]
+                n = round(Int, 2 * y / (sqrt(3) * a))
+                m = round(Int, x / a - n / 2)
+                mod(m - n, 3)
+            end
+        end
+
+        for (d1, d2) in [(3, 3), (6, 2)]
+            lat = obs_tri_lattice(d1, d2)
+            M = 2 * d1 * d2
+            labels = sqrt3_labels(lat)
+            # The hardcoded decoder inside order_parameter_sqrt3, recomputed
+            # here, must match the geometric labels site by site
+            hard = [begin
+                        b = (s - 1) % 2
+                        ci = ((s - 1) ÷ 2) % d1
+                        b == 0 ? ci % 3 : (ci + 2) % 3
+                    end for s in 1:M]
+            @test labels == hard
+            # Each sublattice holds exactly M/3 sites
+            @test [count(==(c), labels) for c in 0:2] == fill(M ÷ 3, 3)
+            # A proper 3-coloring: no first-shell neighbor pair shares a
+            # label (this also pins the neighbor lists)
+            @test all(labels[nb] != labels[s]
+                      for s in 1:M for nb in lat.neighbors[s][1])
+        end
+
+        # Exact values on the 18-site commensurate cell
+        lat = obs_tri_lattice(3, 3)
+        labels = sqrt3_labels(lat)
+
+        # Empty and full lattices carry no sqrt3 order (1 + ω + ω² = 0)
+        @test order_parameter_sqrt3(lat) == 0.0
+        lat.components[1] .= true
+        @test order_parameter_sqrt3(lat) == 0.0
+
+        # Each pure sublattice state, built from the geometric labels: 1/3
+        for c in 0:2
+            lat.components[1] .= (labels .== c)
+            @test order_parameter_sqrt3(lat) == 1 / 3
+        end
+
+        # Single particle: 1/M
+        lat.components[1] .= false
+        lat.components[1][1] = true
+        @test order_parameter_sqrt3(lat) == 1 / 18
+
+        # Mixed state with sublattice counts (2, 1, 0): |2 + ω| / 18 = √3/18
+        lat.components[1] .= false
+        a_sites = findall(==(0), labels)
+        b_sites = findall(==(1), labels)
+        lat.components[1][a_sites[1]] = true
+        lat.components[1][a_sites[2]] = true
+        lat.components[1][b_sites[1]] = true
+        @test order_parameter_sqrt3(lat) ≈ sqrt(3) / 18 rtol = 1e-12
+
+        # The shipped default (4, 2, 1) cell is incommensurate: d1 % 3 != 0
+        @test_throws ArgumentError order_parameter_sqrt3(obs_tri_lattice(4, 2))
+
+        # Three-dimensional supercell
+        lat3d = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(3, 3, 2),
+            periodicity=(true, true, true),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:36]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_sqrt3(lat3d)
+
+        # One-site basis
+        lat1b = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(3, 3, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:9]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_sqrt3(lat1b)
+
+        # A distorted basis breaks the tripartition arithmetic
+        latdb = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.3, 0.3, 0.0)],
+            supercell_dimensions=(3, 3, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:18]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_sqrt3(latdb)
+
+        # lattice_constant != 1 scales lattice_vectors but not the default
+        # basis, so the geometry is no longer triangular; the basis-values
+        # guard rejects it
+        latlc = MLattice{1,TriangularLattice}(
+            lattice_constant=2.0,
+            supercell_dimensions=(3, 3, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.2],
+            components=[[false for _ in 1:18]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_sqrt3(latlc)
+
+        # A short seeded canonical NS run records psi and its square through
+        # the moment-callback pattern from the docstring
+        Random.seed!(21)
+        tri_ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        walkers = [LatticeWalker(deepcopy(obs_tri_lattice(3, 3)),
+                                 energy=0.0u"eV", iter=0) for _ in 1:20]
+        # Fixed-N ladder at N = 6: place 6 particles per walker
+        for w in walkers
+            occ = vcat(fill(true, 6), fill(false, 12))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls = LatticeGasWalkers(walkers, tri_ham; perturb_energy=1e-9)
+        params = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+
+        df, _, _ = nested_sampling(ls, params, Int64(200),
+            MCRandomWalkClone(), obs_save;
+            observables=[:psi => order_parameter_sqrt3,
+                         :psi2 => (cfg -> order_parameter_sqrt3(cfg)^2)])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "psi", "psi2"]
+        @test all(0.0 .<= df.psi .<= 1 / 3)
+        @test all(isapprox.(df.psi2, df.psi .^ 2; rtol=1e-12))
+
+        # Schema is unchanged when observables are not requested
+        Random.seed!(21)
+        walkers2 = [LatticeWalker(deepcopy(obs_tri_lattice(3, 3)),
+                                  energy=0.0u"eV", iter=0) for _ in 1:20]
+        for w in walkers2
+            occ = vcat(fill(true, 6), fill(false, 12))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls2 = LatticeGasWalkers(walkers2, tri_ham; perturb_energy=1e-9)
+        params2 = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+        df2, _, _ = nested_sampling(ls2, params2, Int64(50),
+            MCRandomWalkClone(), obs_save)
+        obs_cleanup()
+        @test names(df2) == ["iter", "emax"]
+    end
+
     @testset "observable hook: validation" begin
         lat = obs_square_lattice(4, 4)
         walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:8]

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -403,6 +403,192 @@
         @test all(isapprox.(df.stripe4, df.stripe .^ 4; rtol=1e-12))
     end
 
+    # ================================================================
+    @testset "triangular bragg_amplitude and order_parameter_p2x2" begin
+        # Axial coordinates from the stored positions: r = i·t₁ + j·t₂ with
+        # t₁ = (1, 0)·a and t₂ = (1/2, √3/2)·a, so j = 2y/(√3·a) and
+        # i = x/a − j/2. Occupation predicates on (i, j) build the ordered
+        # phases geometrically, independent of the index arithmetic under
+        # test: p(2×2) = {i, j both even}, a p(2×1) row phase = {j even}
+        # (plus its two rotations), the √3×√3 state = {(i − j) mod 3 == 0}.
+        function axial_ij(lat)
+            a = lat.lattice_vectors[1, 1]
+            map(1:size(lat.positions, 1)) do s
+                x, y = lat.positions[s, 1], lat.positions[s, 2]
+                j = round(Int, 2 * y / (sqrt(3) * a))
+                i = round(Int, x / a - j / 2)
+                (i, j)
+            end
+        end
+        fill_ij!(lat, pred) = (lat.components[1] .=
+            [pred(i, j) for (i, j) in axial_ij(lat)]; lat)
+
+        # Independent oracle: the raw phasor sum over the stored positions,
+        # sharing no code with the integer-table implementation
+        function tri_oracle(lat, m, n)
+            a = lat.lattice_vectors[1, 1]
+            d1, d2 = lat.supercell_dimensions[1], lat.supercell_dimensions[2]
+            kx = 2 * pi * m / (d1 * a)
+            ky = 2 * pi * n / (sqrt(3) * d2 * a)
+            z = sum(exp(im * (kx * lat.positions[s, 1] + ky * lat.positions[s, 2]))
+                    for s in 1:size(lat.positions, 1) if lat.components[1][s];
+                    init=0.0 + 0.0im)
+            return abs(z) / (2 * d1 * d2)
+        end
+
+        # The three M points on an even-dimension cell
+        mpoints(d1, d2) = [(d1 ÷ 2, -(d2 ÷ 2)), (0, d2), (d1 ÷ 2, d2 ÷ 2)]
+
+        # Oracle agreement on random occupations at the M points and at
+        # generic indices, and the primitive-reciprocal wrapping identities,
+        # exact by the joint mod reduction
+        lat = obs_tri_lattice(6, 4)
+        Random.seed!(4164)
+        for _ in 1:20
+            lat.components[1] .= rand(Bool, 48)
+            for (m, n) in vcat(mpoints(6, 4), [(1, 0), (0, 1), (2, 3), (-1, 2)])
+                @test isapprox(bragg_amplitude(lat, m, n), tri_oracle(lat, m, n);
+                               atol=1e-12)
+                @test bragg_amplitude(lat, m, n) == bragg_amplitude(lat, m + 6, n - 4)
+                @test bragg_amplitude(lat, m, n) == bragg_amplitude(lat, m, n + 8)
+            end
+        end
+
+        # Perfect-phase table on (6, 4) and (12, 6): p(2×2) puts exactly 1/4
+        # on every M point (quadrature √3/4); each p(2×1) orientation puts
+        # exactly 1/2 on one M point and 0 on the other two (quadrature
+        # 1/2); the √3×√3 state scatters off the K points only, and the two
+        # order parameters are blind to each other's phase
+        for (d1, d2) in [(6, 4), (12, 6)]
+            latp = obs_tri_lattice(d1, d2)
+            M = 2 * d1 * d2
+
+            fill_ij!(latp, (i, j) -> iseven(i) && iseven(j))
+            @test count(latp.components[1]) == M ÷ 4
+            for (m, n) in mpoints(d1, d2)
+                @test bragg_amplitude(latp, m, n) == 1 / 4
+            end
+            @test order_parameter_p2x2(latp) ≈ sqrt(3) / 4 atol = 1e-12
+            @test order_parameter_sqrt3(latp) == 0.0
+
+            for pred in [(i, j) -> iseven(j), (i, j) -> iseven(i),
+                         (i, j) -> iseven(i - j)]
+                fill_ij!(latp, pred)
+                @test count(latp.components[1]) == M ÷ 2
+                amps = sort([bragg_amplitude(latp, m, n)
+                             for (m, n) in mpoints(d1, d2)])
+                @test amps[1] == 0.0 && amps[2] == 0.0 && amps[3] == 1 / 2
+                @test order_parameter_p2x2(latp) ≈ 1 / 2 atol = 1e-12
+                @test order_parameter_sqrt3(latp) == 0.0
+            end
+
+            fill_ij!(latp, (i, j) -> mod(i - j, 3) == 0)
+            @test count(latp.components[1]) == M ÷ 3
+            for (m, n) in mpoints(d1, d2)
+                @test bragg_amplitude(latp, m, n) == 0.0
+            end
+            @test order_parameter_p2x2(latp) == 0.0
+            @test order_parameter_sqrt3(latp) == 1 / 3
+        end
+
+        # Empty and full lattices scatter nothing off the reciprocal-lattice
+        # rods: exactly at the M points (half-turn phases are exact), to
+        # roundoff at generic indices (the phase rationals are not
+        # representable); a single particle gives 1/M
+        lat.components[1] .= false
+        for (m, n) in vcat(mpoints(6, 4), [(1, 1)])
+            @test bragg_amplitude(lat, m, n) == 0.0
+        end
+        @test order_parameter_p2x2(lat) == 0.0
+        lat.components[1] .= true
+        for (m, n) in mpoints(6, 4)
+            @test bragg_amplitude(lat, m, n) == 0.0
+        end
+        @test bragg_amplitude(lat, 1, 1) < 1e-15
+        @test order_parameter_p2x2(lat) == 0.0
+        lat.components[1] .= false
+        lat.components[1][1] = true
+        @test bragg_amplitude(lat, 1, 1) == 1 / 48
+        @test bragg_amplitude(lat, 0, 4) == 1 / 48
+        @test order_parameter_p2x2(lat) ≈ sqrt(3) / 48 atol = 1e-12
+
+        # Dispatch separation: the square methods are untouched by the new
+        # triangular method
+        sq = obs_square_lattice(4, 4)
+        Random.seed!(4165)
+        sq.components[1] .= rand(Bool, 16)
+        @test bragg_amplitude(sq, 2, 2) == order_parameter_c2x2(sq)
+        @test order_parameter_stripe(sq) == sqrt(bragg_amplitude(sq, 2, 0)^2 +
+                                                 bragg_amplitude(sq, 0, 2)^2)
+
+        # Guard paths: a three-dimensional supercell rejects both functions;
+        # odd in-plane dimensions reject the quadrature while the
+        # always-representable M₂ amplitude still evaluates; a nonstandard
+        # two-site basis rejects the amplitude
+        lat3d = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(6, 4, 2),
+            periodicity=(true, true, true),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:96]],
+            adsorptions=:full)
+        @test_throws ArgumentError bragg_amplitude(lat3d, 1, 0)
+        @test_throws ArgumentError order_parameter_p2x2(lat3d)
+        for (d1, d2) in [(3, 3), (5, 4)]
+            lodd = obs_tri_lattice(d1, d2)
+            @test_throws ArgumentError order_parameter_p2x2(lodd)
+            lodd.components[1][1] = true
+            @test bragg_amplitude(lodd, 0, d2) == 1 / (2 * d1 * d2)
+        end
+        latnb = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.0)],
+            supercell_dimensions=(6, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[0.75],
+            components=[[false for _ in 1:48]],
+            adsorptions=:full,
+            image_multiplicity=true)
+        @test_throws ArgumentError bragg_amplitude(latnb, 1, 0)
+        @test_throws ArgumentError order_parameter_p2x2(latnb)
+
+        # The shipped default (4, 2, 1) cell passes this function's guards
+        # while order_parameter_sqrt3 rejects it (the docstring claim)
+        latdef = obs_tri_lattice(4, 2)
+        latdef.components[1][1] = true
+        @test order_parameter_p2x2(latdef) ≈ sqrt(3) / 16 atol = 1e-12
+        @test_throws ArgumentError order_parameter_sqrt3(latdef)
+
+        # A short seeded canonical NS run records the Binder moments through
+        # the moment-callback pattern from the docstring
+        Random.seed!(4166)
+        tri_ham1 = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        walkers = [LatticeWalker(deepcopy(obs_tri_lattice(6, 2)),
+                                 energy=0.0u"eV", iter=0) for _ in 1:20]
+        # Fixed-N ladder at N = 6: place 6 particles per walker
+        for w in walkers
+            occ = vcat(fill(true, 6), fill(false, 18))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls = LatticeGasWalkers(walkers, tri_ham1; perturb_energy=1e-9)
+        params = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+
+        df, _, _ = nested_sampling(ls, params, Int64(200),
+            MCRandomWalkClone(), obs_save;
+            observables=[:psi => order_parameter_p2x2,
+                         :psi2 => (cfg -> order_parameter_p2x2(cfg)^2),
+                         :psi4 => (cfg -> order_parameter_p2x2(cfg)^4)])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "psi", "psi2", "psi4"]
+        @test nrow(df) > 0
+        @test all(0.0 .<= df.psi .<= 1 / 2)
+        @test all(isapprox.(df.psi2, df.psi .^ 2; rtol=1e-12))
+        @test all(isapprox.(df.psi4, df.psi .^ 4; rtol=1e-12))
+    end
+
     @testset "observable hook: validation" begin
         lat = obs_square_lattice(4, 4)
         walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:8]

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -3182,6 +3182,362 @@
     end
 
     # ================================================================
+    # Shared fixture (issue #186 (a)/(b)): the 12-vertex cuboctahedral shell
+    # -- the first coordination shell of the fcc crystal, i.e. the
+    # adsorption-site shell of a 13-atom cuboctahedral cluster -- as a FINITE
+    # lattice through the MLattice{1,GenericLattice} inner constructor:
+    # supercell (1, 1, 1), periodicity (false, false, false), the twelve
+    # vertices supplied as an explicit Cartesian basis. Keyword constructors
+    # exist only for the square and triangular tags
+    # (src/AbstractWalkers/lattice_walkers.jl), so the generic tag -- and
+    # with it any irregular finite cluster model -- is reachable only
+    # through the inner constructor.
+    #
+    # Geometry: vertices (+-1, +-1, 0), (+-1, 0, +-1), (0, +-1, +-1) scaled
+    # by d/sqrt(2) about a positive center, with nearest-neighbor spacing
+    # d = 2^(1/6) sigma (sigma = 1 lattice units, the Lennard-Jones pair
+    # minimum). The inter-vertex distances fall in shells
+    # {1, sqrt(2), sqrt(3), 2} d with per-site counts [4, 2, 4, 1]
+    # (unordered pair counts [24, 12, 24, 6]); the cutoff ladder
+    # d * [1.1, 1.5, 1.8, 2.05] brackets exactly one distance class per
+    # shell. A 12-6 pair potential tabulates to exactly rational couplings
+    # at the shell distances: J_k / eps = -1, -15/64, 3^-6 - 2*3^-3,
+    # -127/4096.
+    cb_d = 2.0^(1 / 6)
+    cb_s = cb_d / sqrt(2.0)
+    cb_vertices = [(1, 1, 0), (1, -1, 0), (-1, 1, 0), (-1, -1, 0),
+                   (1, 0, 1), (1, 0, -1), (-1, 0, 1), (-1, 0, -1),
+                   (0, 1, 1), (0, 1, -1), (0, -1, 1), (0, -1, -1)]
+    cb_basis = [(cb_d + p[1] * cb_s, cb_d + p[2] * cb_s, cb_d + p[3] * cb_s)
+                for p in cb_vertices]
+    cb_radii = cb_d .* [1.1, 1.5, 1.8, 2.05]
+    # Non-periodic: no minimum-image reduction exists to go wrong, and
+    # construction is warning-free
+    cb = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,GenericLattice}(
+        [2.0 * cb_d 0.0 0.0; 0.0 2.0 * cb_d 0.0; 0.0 0.0 2.0 * cb_d],
+        cb_basis, (1, 1, 1), (false, false, false), cb_radii,
+        [fill(false, 12)], fill(true, 12))
+
+    # SiteFieldLatticeHamiltonian over a zero-on-site GenericLatticeHamiltonian
+    # base: the couplings carry the four-shell LJ tabulation above, and a
+    # three-class site field (one class per coordinate plane of the shell:
+    # vertices with z, y, x displacement zero respectively) breaks the
+    # site-transitivity the base Hamiltonians assume
+    cb_eps = 0.01
+    cb_J = cb_eps .* [-1.0, -15 / 64, 3.0^-6 - 2 * 3.0^-3, -127 / 4096]
+    cb_field = vcat(fill(-0.03, 4), fill(-0.02, 4), fill(-0.012, 4))
+    cb_ham = SiteFieldLatticeHamiltonian(
+        GenericLatticeHamiltonian(0.0, cb_J, u"eV"), cb_field, u"eV")
+
+    # Independent geometry: brute-force pair-shell table from the stored
+    # positions (no images: the model is finite), sharing no code with
+    # compute_neighbors
+    cb_pos = [(cb.positions[s, 1], cb.positions[s, 2], cb.positions[s, 3])
+              for s in 1:12]
+    cb_dist(i, j) = sqrt(sum((cb_pos[i][k] - cb_pos[j][k])^2 for k in 1:3))
+    cb_pair_shell = Dict{Tuple{Int,Int},Int}()
+    for i in 1:12, j in (i+1):12
+        r = cb_dist(i, j)
+        r > cb_radii[end] && continue
+        sh = findfirst(rr -> r <= rr, cb_radii)
+        sh === nothing || (cb_pair_shell[(i, j)] = sh)
+    end
+    cb_brute_E(occ) = sum(cb_field[i] for i in 1:12 if occ[i]; init=0.0) +
+                      sum((occ[p[1]] && occ[p[2]]) ? cb_J[sh] : 0.0
+                          for (p, sh) in cb_pair_shell; init=0.0)
+
+    # ================================================================
+    @testset "finite non-periodic generic lattice: cuboctahedral shell" begin
+        @test cb isa GLattice{1}
+        @test num_sites(cb) == 12
+        @test cb.periodicity == (false, false, false)
+        # supercell (1, 1, 1): the stored positions are exactly the basis
+        @test all(Tuple(cb.positions[s, :]) == cb_basis[s] for s in 1:12)
+
+        # Neighbor-shell audit against the brute-force adjacency
+        cb_brute = [[Int[] for _ in 1:4] for _ in 1:12]
+        for ((i, j), sh) in cb_pair_shell
+            push!(cb_brute[i][sh], j)
+            push!(cb_brute[j][sh], i)
+        end
+        @test all(nb -> length.(nb) == [4, 2, 4, 1], cb.neighbors)
+        @test all(sort(cb.neighbors[s][k]) == sort(cb_brute[s][k])
+                  for s in 1:12, k in 1:4)
+        # symmetric and duplicate-free
+        cb_sym = true
+        for s in 1:12, k in 1:4, nb in cb.neighbors[s][k]
+            cb_sym &= (s in cb.neighbors[nb][k])
+        end
+        @test cb_sym
+        @test all(allunique(vcat(cb.neighbors[s]...)) for s in 1:12)
+        # unordered pair counts per shell
+        @test [sum(length(cb.neighbors[s][k]) for s in 1:12) ÷ 2 for k in 1:4] ==
+              [24, 12, 24, 6]
+
+        # Energy identity against the explicit pair-plus-field sum
+        # (the additive contract of SiteFieldLatticeHamiltonian). Single
+        # occupancies pin the field per site exactly: no pair term
+        # contributes, so E = field[i], bit-exactly
+        cb_occ = cb.components[1]
+        cb_single_ok = true
+        for i in 1:12
+            cb_occ .= false
+            cb_occ[i] = true
+            cb_single_ok &= (ustrip(u"eV", interacting_energy(cb, cb_ham)) ==
+                             cb_field[i])
+        end
+        @test cb_single_ok
+        # 222 masks: the 12 singles, the 66 pairs, and 144 seeded random
+        # masks (calibrated worst deviation 1.1102230246251565e-16 eV)
+        cb_masks = Int[]
+        for i in 1:12
+            push!(cb_masks, 1 << (i - 1))
+        end
+        for i in 1:12, j in (i+1):12
+            push!(cb_masks, (1 << (i - 1)) | (1 << (j - 1)))
+        end
+        Random.seed!(7401)
+        for _ in 1:144
+            push!(cb_masks, rand(0:4095))
+        end
+        @test length(cb_masks) == 222
+        cb_worst = 0.0
+        for m in cb_masks
+            for s in 1:12
+                cb_occ[s] = ((m >> (s - 1)) & 1) == 1
+            end
+            cb_worst = max(cb_worst,
+                abs(ustrip(u"eV", interacting_energy(cb, cb_ham)) -
+                    cb_brute_E(cb_occ)))
+        end
+        @test cb_worst <= 1e-13
+        # Full-occupancy closed form: field sum plus the pair-count-weighted
+        # couplings (calibrated deviation 4.440892098500626e-16 eV)
+        cb_occ .= true
+        cb_full = sum(cb_field) + 24 * cb_J[1] + 12 * cb_J[2] +
+                  24 * cb_J[3] + 6 * cb_J[4]
+        @test abs(ustrip(u"eV", interacting_energy(cb, cb_ham)) - cb_full) < 1e-12
+        cb_occ .= false
+    end
+
+    # ================================================================
+    # Issue #186 (b): ideal-gas-referenced closure on the finite lattice --
+    # the first GenericLattice coverage of ideal_gas_referenced_nested_sampling,
+    # gc_thermodynamic_stats_ideal_ref, and (last member) the :contact
+    # biased-insertion kernel. Exact reference: full 2^12 enumeration,
+    # computed here in-test.
+    #
+    # ============== calibration ledger (record, do not retype) ==============
+    # Grid: mus = [-0.07569, -0.04461, -0.01358] (coverage 0.05 at 200 K,
+    # 0.50 at 250 K, 0.95 at 200 K by bisection on the exact sums, rounded
+    # to 1e-5), Ts = [200, 250, 300] K; grid-wide exact coverage spans
+    # [0.0500, 0.9500]. z0 = exp(beta_250 * mu_mid) = 0.12609619465789468.
+    # E_gs = -0.5354339112332822 eV (full occupancy).
+    #
+    # Members: seeds 71/72/73 (unbiased) + 74 (:contact, p_bias = 0.5), all
+    # K = 120, n_steps = 3500, mc_steps = 100; seeds are the first scanned,
+    # not selected on their deviations. Offsets are folded into the gates as
+    # issue #186 specifies (offset-aware K = 120 gates): per stat per mu row,
+    # offset = the mean deviation from the exact grand sums over the three
+    # unbiased seeds and the row's three temperatures; gate = 3x the maximum
+    # residual |dev - offset| over ALL FOUR members (so every member sits
+    # >= 3x inside its gate). Digit-for-digit residual maxima (reproduced by
+    # running this file with FREEBIRD_CUBOCT_IGREF_CALIBRATE=1; gates
+    # evaluate after all RNG use, so comment/tolerance edits never
+    # invalidate the calibration):
+    #
+    #   lnXi  row 1: offset +0.015549904629894596
+    #     unbiased max 0.0756902696062428   (seed 72, 200 K)
+    #     contact  max 0.18422345940164508  (200 K)      gate 0.5527
+    #   lnXi  row 2: offset -0.012233619456831275
+    #     unbiased max 0.3169651201965435   (seed 73, 300 K)
+    #     contact  max 0.42874254779132176  (200 K)      gate 1.2863
+    #   lnXi  row 3: offset -0.15657333856486272
+    #     unbiased max 0.6655533323089293   (seed 73, 200 K)
+    #     contact  max 0.9442795529943964   (200 K)      gate 2.8329
+    #   meanN row 1: offset -0.01322238703461942
+    #     unbiased max 0.1518554036133445   (seed 73, 300 K)
+    #     contact  max 0.20149496329287075  (250 K)      gate 0.6045
+    #   meanN row 2: offset -0.13610795675848053
+    #     unbiased max 0.40111004303506903  (seed 73, 200 K)
+    #     contact  max 0.8105573891917334   (200 K)      gate 2.4317
+    #   meanN row 3: offset -0.029388454031590665
+    #     unbiased max 0.33924860365093973  (seed 71, 300 K)
+    #     contact  max 0.11001799842401343  (300 K)      gate 1.0178
+    #   varN  row 1: offset +0.03305623604750547
+    #     unbiased max 0.2138071159273987   (seed 73, 300 K)
+    #     contact  max 0.033976982900384915 (200 K)      gate 0.6415
+    #   varN  row 2: offset -0.2671108767327802
+    #     unbiased max 0.8165602033979901   (seed 71, 200 K)
+    #     contact  max 0.3062663641025275   (300 K)      gate 2.4497
+    #   varN  row 3: offset +0.04913320271407429
+    #     unbiased max 0.20047113177004405  (seed 71, 250 K)
+    #     contact  max 0.21139588976394919  (300 K)      gate 0.6342
+    #   meanU row 1: offset +0.0002199685765479365
+    #     unbiased max 0.004859023401123861 (seed 73, 300 K)
+    #     contact  max 0.005156558737498416 (300 K)      gate 0.015470
+    #   meanU row 2: offset +0.0063656655773413244
+    #     unbiased max 0.01797782612331277  (seed 73, 200 K)
+    #     contact  max 0.03751881712916904  (200 K)      gate 0.11256
+    #   meanU row 3: offset +0.0014783976304835683
+    #     unbiased max 0.02022309469461337  (seed 71, 300 K)
+    #     contact  max 0.006516969480520046 (300 K)      gate 0.060670
+    #
+    # Failability: every gate sits at <= 0.41 of its row's smallest
+    # per-point attainable deviation sup (mean_N sup = max(N_ex, 12 - N_ex)
+    # >= 6.0; var_N sup = max(V_ex, 36 - V_ex) >= 29.2; mean_U sup =
+    # max(|E_gs - U_ex|, |U_ex|) >= 0.214; lnXi is a log-sum estimator,
+    # unbounded below at every point). The worst ratio is mean_N row 2:
+    # 2.4317 / 6.0 = 0.41.
+    #
+    # Kish N_eff minima (floor 60 gated on every grid point): seed 71
+    # 89.8626807564595, seed 72 95.22891484341172, seed 73 89.75703787575497,
+    # contact 86.1519052984775 -- the LOW-fugacity corner (mu_lo, 200 K)
+    # binds for all four members.
+    #
+    # Finite-K note (the issue #186 calibration decision): at the shipped
+    # depth (n_steps/K ~ 29 nats, full descent to E_gs plus the live tail)
+    # the measured common offsets are small -- |offset| <= 0.157 nats for
+    # lnXi, above -- rather than the +0.19/+0.32 nats the issue's probes
+    # recorded, so the offset fold is retained as specified but is not
+    # load-bearing at this depth. K = 480 measurement (nearest-neighbor-only
+    # variant, own coverage-matched grid mus = [-0.08757, -0.04066, 0.00622],
+    # z0 = 0.15147134295752862, seeds 91/92/93, n_steps = 14000): center-row
+    # mean lnXi deviation +0.013846 nats, grid-wide max |dev| 0.228308; the
+    # same variant at K = 120 (seeds 81/82/83, n_steps = 3500) measures
+    # center-row mean -0.017549, grid-wide max 0.572417 -- the spread
+    # contracts ~2x at 4x K while the mean stays ~0.01-0.02 nats, the
+    # finite-K attribution of the residual scatter.
+    # ========================================================================
+    @testset "ideal-gas-referenced closure on the finite cuboctahedral shell" begin
+        cb_kb = 8.617333262e-5
+        # Full 2^12 enumeration through the library energy (the identity to
+        # the independent pair-plus-field sum is pinned in the testset above)
+        cb_e_tab = Vector{Float64}(undef, 4096)
+        cb_n_tab = Vector{Int}(undef, 4096)
+        cb_occ = cb.components[1]
+        for m in 0:4095
+            for s in 1:12
+                cb_occ[s] = ((m >> (s - 1)) & 1) == 1
+            end
+            cb_e_tab[m+1] = ustrip(u"eV", interacting_energy(cb, cb_ham))
+            cb_n_tab[m+1] = count_ones(m)
+        end
+        cb_occ .= false
+        cb_e_gs = minimum(cb_e_tab)
+        @test cb_e_gs ≈ -0.5354339112332822 rtol = 1e-12
+
+        function cb_exact(mu, T)
+            beta = 1 / (cb_kb * T)
+            lt = beta .* (mu .* cb_n_tab .- cb_e_tab)
+            mx = maximum(lt)
+            w = exp.(lt .- mx)
+            Z = sum(w)
+            mN = sum(w .* cb_n_tab) / Z
+            (logXi=mx + log(Z), mean_N=mN,
+             var_N=sum(w .* cb_n_tab .^ 2) / Z - mN^2,
+             mean_U=sum(w .* cb_e_tab) / Z)
+        end
+
+        # mu grid from the calibration ledger; the exact-coverage pins keep
+        # the grid honest (coverage 0.05-0.95 grid-wide, 0.50 center row)
+        cb_mus = [-0.07569, -0.04461, -0.01358]
+        cb_Ts = [200.0, 250.0, 300.0]
+        @test cb_exact(cb_mus[1], 200.0).mean_N / 12 ≈ 0.05 atol = 1e-3
+        @test cb_exact(cb_mus[2], 250.0).mean_N / 12 ≈ 0.50 atol = 1e-3
+        @test cb_exact(cb_mus[3], 200.0).mean_N / 12 ≈ 0.95 atol = 1e-3
+        cb_z0 = exp(cb_mus[2] / (cb_kb * 250.0))
+
+        function cb_run(seed; routine=MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3))
+            Random.seed!(seed)   # the parameters' random_seed field is not consumed
+            ws = [LatticeWalker(deepcopy(cb), energy=0.0u"eV", iter=0)
+                  for _ in 1:120]
+            ls = LatticeGasWalkers(ws, cb_ham; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=100,
+                reference_fugacity=cb_z0, energy_perturbation=1e-9,
+                allowed_fail_count=100_000)
+            df, out, pout = ideal_gas_referenced_nested_sampling(
+                ls, p, Int64(3500), routine, obs_save)
+            obs_cleanup()
+            liveE = [w.energy.val for w in out.walkers]
+            liveN = [Int(sum(w.configuration.components[1])) for w in out.walkers]
+            st = gc_thermodynamic_stats_ideal_ref(df, 12, cb_z0, cb_mus, cb_Ts,
+                120; ω0=121 / 120, live_emax=liveE, live_numbers=liveN)
+            return (df=df, st=st, pout=pout)
+        end
+
+        # ---- all RNG use happens here; every gate below evaluates afterwards ----
+        cb_runs = [cb_run(71), cb_run(72), cb_run(73),
+                   cb_run(74; routine=MCGrandCanonicalMoves(p_move=0.4,
+                       p_insert=0.3, p_bias=0.5, bias_predicate=:contact,
+                       bias_shells=1))]
+
+        if get(ENV, "FREEBIRD_CUBOCT_IGREF_CALIBRATE", "0") == "1"
+            for (mem, seed) in zip(cb_runs, (71, 72, 73, 74))
+                println("calib cuboct seed $seed: Neff_min=",
+                        repr(minimum(mem.st.N_eff)), " argmin=",
+                        argmin(mem.st.N_eff))
+                for s in (:logXi, :mean_N, :var_N, :mean_U)
+                    for i in 1:3
+                        devs = [getfield(mem.st, s)[i, j] -
+                                getfield(cb_exact(cb_mus[i], cb_Ts[j]), s)
+                                for j in 1:3]
+                        println("  $s mu[$i]: ", join(repr.(devs), "  "))
+                    end
+                end
+            end
+        end
+
+        # offsets and gates from the calibration ledger above
+        cb_off_XI = [0.015550, -0.012234, -0.156573]
+        cb_off_N = [-0.013222, -0.136108, -0.029388]
+        cb_off_V = [0.033056, -0.267111, 0.049133]
+        cb_off_U = [0.000220, 0.006366, 0.001478]
+        cb_gate_XI = [0.5527, 1.2863, 2.8329]
+        cb_gate_N = [0.6045, 2.4317, 1.0178]
+        cb_gate_V = [0.6415, 2.4497, 0.6342]
+        cb_gate_U = [0.015470, 0.11256, 0.060670]
+
+        for mem in cb_runs
+            # ledger shape: the lattice route keeps the three-column ledger
+            # (no log_compression column: the lattice step methods keep the
+            # four-value return; pinned for MCRandomWalkClone ladders in
+            # test-ns-plateau-ties.jl)
+            @test names(mem.df) == ["iter", "emax", "num_particles"]
+            @test issorted(mem.df.emax, rev=true)
+            # the ladder reaches the ground manifold (full occupancy), up to
+            # the run's 1e-9 tie-breaking perturbation
+            @test minimum(mem.df.emax) <= cb_e_gs + 1e-6
+            # geometric cluster moves have no GenericLattice method (the
+            # guard in MonteCarloMoves throws); clusters_freq stays 0 in
+            # every member and no cluster move is ever attempted
+            @test mem.pout.move_stats[:cluster_attempted] == 0
+            @test mem.pout.move_stats[:swap_attempted] > 0
+        end
+        # the :contact member really drove the biased sub-channel
+        @test cb_runs[4].pout.move_stats[:insert_biased_attempted] > 0
+        @test cb_runs[4].pout.move_stats[:insert_biased_accepted] > 0
+
+        for mem in cb_runs
+            for (i, mu) in enumerate(cb_mus), (j, T) in enumerate(cb_Ts)
+                ex = cb_exact(mu, T)
+                # Kish floor: gates run only on points passing it, and every
+                # grid point passes (calibrated minima 86.2-95.2 at the
+                # low-fugacity 200 K corner, which binds for all members)
+                @test mem.st.N_eff[i, j] >= 60
+                @test abs(mem.st.logXi[i, j] - ex.logXi - cb_off_XI[i]) <=
+                      cb_gate_XI[i]
+                @test abs(mem.st.mean_N[i, j] - ex.mean_N - cb_off_N[i]) <=
+                      cb_gate_N[i]
+                @test abs(mem.st.var_N[i, j] - ex.var_N - cb_off_V[i]) <=
+                      cb_gate_V[i]
+                @test abs(mem.st.mean_U[i, j] - ex.mean_U - cb_off_U[i]) <=
+                      cb_gate_U[i]
+            end
+        end
+    end
+
+    # ================================================================
     @testset "Langmuir closure off the keyword-square path" begin
         # On-site term only (zero couplings): E = eps N exactly, so
         # Xi(mu, T) = (1 + z e^{-beta eps})^M with z = e^{beta mu}, and

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -13,6 +13,17 @@
             adsorptions=:full)
     end
 
+    # Shared single-component triangular-lattice builder (NN shell only)
+    function obs_tri_lattice(d1, d2)
+        MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(d1, d2, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:2*d1*d2]],
+            adsorptions=:full)
+    end
+
     # ================================================================
     @testset "order_parameter_c2x2" begin
         lat = obs_square_lattice(4, 4)
@@ -75,17 +86,6 @@
 
     # ================================================================
     @testset "order_parameter_sqrt3" begin
-        # Shared single-component triangular-lattice builder (NN shell only)
-        function obs_tri_lattice(d1, d2)
-            MLattice{1,TriangularLattice}(
-                lattice_constant=1.0,
-                supercell_dimensions=(d1, d2, 1),
-                periodicity=(true, true, false),
-                cutoff_radii=[1.1],
-                components=[[false for _ in 1:2*d1*d2]],
-                adsorptions=:full)
-        end
-
         # Independent geometric decoder: recover the triangular integer
         # coordinates (m, n) by inverting [t1 t2] on the stored positions and
         # color with c = (m - n) mod 3, so the labels are derived from the
@@ -757,6 +757,156 @@
                            st_fn.observables[:psi][i, j], atol=0.07)
             @test isapprox(st_ig.var_U[i, j], st_fn.var_U[i, j],
                            rtol=0.5, atol=0.005)
+        end
+    end
+
+    # ================================================================
+    @testset "end-to-end: triangular (3x3), NN repulsion, igref + omega-sorted" begin
+        # First triangular coverage of both grand-canonical routes and the
+        # first omega-sorted observable ledger. Tolerances sized at or above
+        # 3 sigma of three-seed scatter at this configuration (max observed
+        # over Kish-gated points: |dlnXi| 0.61, |dN| 0.18, |dU| 0.0038,
+        # |dvar_U| 4.7e-4, |dcov_UN| 0.0075, |dpsi| 0.013, all gated
+        # N_eff >= 206; sigma(lnXi) ≈ √(D/K) ≈ 0.29 at the full-compression
+        # depth D = 18·ln 2, so atol = 0.9 ≈ 3.1σ).
+        Random.seed!(11)
+        kb = 8.617333262e-5
+
+        M = 18
+        J = 0.1                      # eV, repulsive nearest-neighbor coupling
+        tri_ham = GenericLatticeHamiltonian(0.0, [J], u"eV")
+        tri_at(N) = begin
+            lat = obs_tri_lattice(3, 3)
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            lat
+        end
+        # Independent psi: geometric labels from the positions (inverting
+        # [t1 t2]) and the sublattice sum evaluated with complex arithmetic,
+        # sharing no code with order_parameter_sqrt3's integer identity
+        tri_labels = let tpl = obs_tri_lattice(3, 3), a = 1.0
+            map(1:size(tpl.positions, 1)) do s
+                x, y = tpl.positions[s, 1], tpl.positions[s, 2]
+                n = round(Int, 2 * y / (sqrt(3) * a))
+                m = round(Int, x / a - n / 2)
+                mod(m - n, 3)
+            end
+        end
+        tri_psi(occ) = abs(sum(occ[s] ? cis(2π * tri_labels[s] / 3) : 0.0im
+                               for s in eachindex(occ))) / length(occ)
+
+        # Exact per-configuration (E, N, psi) from fixed-N enumeration of all
+        # 2^18 configurations
+        exact_E = Dict{Int,Vector{Float64}}()
+        exact_psi = Dict{Int,Vector{Float64}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(tri_at(N), tri_ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            exact_psi[N] = [tri_psi(cfg[1]) for cfg in df_exact.config]
+            @test length(exact_E[N]) == binomial(M, N)
+        end
+
+        function exact_stats_tri(μ_val, T_val)
+            β = 1.0 / (kb * T_val)
+            lt = Float64[]; Ns = Float64[]; Es = Float64[]; Ps = Float64[]
+            for N in 0:M, i in eachindex(exact_E[N])
+                push!(lt, N * β * μ_val - β * exact_E[N][i])
+                push!(Ns, N); push!(Es, exact_E[N][i]); push!(Ps, exact_psi[N][i])
+            end
+            w = exp.(lt .- maximum(lt)); sw = sum(w)
+            u = sum(w .* Es) / sw; n = sum(w .* Ns) / sw
+            (logXi=maximum(lt) + log(sw), mean_N=n, mean_U=u,
+             var_U=sum(w .* Es .^ 2) / sw - u^2,
+             cov_UN=sum(w .* Es .* Ns) / sw - u * n,
+             psi=sum(w .* Ps) / sw)
+        end
+
+        # μ = 0.05 eV probes the Kish-window edge: it fails the gate at
+        # 300 K (N_eff ≈ 20-50 across seeds) and passes at 450 K in most
+        # seeds — the trust-window behavior the gate exists to detect
+        μs = [-0.010, 0.000, 0.010, 0.050]
+        Ts = [300.0, 450.0]
+
+        # ---- igref route with psi recording ----
+        z0 = 1.0
+        K_ig = 150
+        n_ig = ceil(Int, 1.15 * K_ig * M * log1p(1 / z0)) + 2 * K_ig
+        walkers = [LatticeWalker(deepcopy(tri_at(0)), energy=0.0u"eV", iter=0)
+                   for _ in 1:K_ig]
+        ls = LatticeGasWalkers(walkers, tri_ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        df_ig, final_ig, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(n_ig), MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3),
+            obs_save; observables=[:psi => order_parameter_sqrt3])
+        obs_cleanup()
+        live_E_ig = [w.energy.val for w in final_ig.walkers]
+        live_N_ig = [sum(w.configuration.components[1]) for w in final_ig.walkers]
+        live_psi_ig = [order_parameter_sqrt3(w.configuration) for w in final_ig.walkers]
+
+        st_ig = gc_thermodynamic_stats_ideal_ref(df_ig, M, z0, μs, Ts, K_ig;
+            ω0=(K_ig + 1) / K_ig, live_emax=live_E_ig, live_numbers=live_N_ig,
+            observable_cols=[:psi], live_observables=Dict(:psi => live_psi_ig))
+
+        # Ledger integrity: on this cell every configuration obeys psi <= 1/3
+        @test names(df_ig) == ["iter", "emax", "num_particles", "psi"]
+        @test all(0.0 .<= df_ig.psi .<= 1 / 3)
+
+        n_gated = 0
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            st_ig.N_eff[i, j] >= 200 || continue
+            n_gated += 1
+            ex = exact_stats_tri(μ, T)
+            @test isapprox(st_ig.logXi[i, j], ex.logXi, atol=0.9)
+            @test isapprox(st_ig.mean_N[i, j], ex.mean_N, atol=0.5)
+            @test isapprox(st_ig.mean_U[i, j], ex.mean_U, atol=0.01)
+            @test isapprox(st_ig.var_U[i, j], ex.var_U, rtol=0.4, atol=0.001)
+            @test isapprox(st_ig.cov_UN[i, j], ex.cov_UN, rtol=0.4, atol=0.015)
+            @test isapprox(st_ig.observables[:psi][i, j], ex.psi, atol=0.025)
+        end
+        # The inner window (μ = 0, ±0.01) sits inside the z0 trust region
+        @test n_gated >= 4
+
+        # ---- omega-sorted route at μ = 0.05 eV with psi recording ----
+        Random.seed!(11)
+        K_gc = 100
+        μ_gc = 0.05
+        walkers_gc = [LatticeWalker(deepcopy(tri_at(0)), energy=0.0u"eV", iter=0)
+                      for _ in 1:K_gc]
+        ls_gc = LatticeGasWalkers(walkers_gc, tri_ham; assign_energy=false)
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=100, chemical_potential=μ_gc,
+            energy_perturbation=1e-9, init_occupation_p=0.3)
+        df_gc, _, _ = grand_canonical_nested_sampling(
+            ls_gc, gc_params, Int64(3000),
+            MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25), obs_save;
+            observables=[:psi => order_parameter_sqrt3])
+        obs_cleanup()
+
+        @test names(df_gc) == ["iter", "omega", "energy", "num_particles", "psi"]
+        @test all(0.0 .<= df_gc.psi .<= 1 / 3)
+
+        β300 = 1.0 / (kb * 300.0)
+        mean_E_gc, _, mean_N_gc = gc_thermodynamic_stats(df_gc, [β300], K_gc, μ_gc)
+        ex300 = exact_stats_tri(μ_gc, 300.0)
+        @test isapprox(mean_E_gc[1], ex300.mean_U, rtol=0.3)
+        @test isapprox(mean_N_gc[1], ex300.mean_N, rtol=0.3)
+
+        # Caller-side <psi> from the documented Ω-weight construction (the
+        # legacy stats function carries no observable machinery by design;
+        # this records the recipe): w_i ∝ Γ_i·exp(-β·Ω_i)
+        ψ_at(β) = begin
+            w = ωᵢ(df_gc.iter, K_gc) .*
+                exp.(-β .* (df_gc.omega .- minimum(df_gc.omega)))
+            sum(w .* df_gc.psi) / sum(w)
+        end
+        @test isapprox(ψ_at(β300), ex300.psi, atol=0.025)
+
+        # ---- route consistency at the shared (μ, T) where igref is trusted ----
+        β450 = 1.0 / (kb * 450.0)
+        if st_ig.N_eff[4, 2] >= 200
+            @test isapprox(st_ig.observables[:psi][4, 2], ψ_at(β450), atol=0.05)
         end
     end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -352,4 +352,163 @@
             [df0, df1, df2], N_values, M, μ_grid, T_grid;
             n_walkers=K, live_emax=live_E, live_observables=live_psi)
     end
+
+    # ================================================================
+    @testset "end-to-end: exact reference and route consistency (4x4, NN repulsion)" begin
+        # Statistical NS checks: seed the global RNG (the random_seed field on
+        # the NS parameters is not consumed). The igref tolerances were sized
+        # at or above 3 sigma of three-seed scatter at this configuration
+        # (max observed: |dlnXi| 0.23, |dN| 0.17, |dU| 0.0011, |dvar_U| 1e-4,
+        # |dcov_UN| 0.0024, |dpsi| 0.014, all N_eff >= 248); the fixed-N
+        # tolerances follow the existing exact-enumeration testset pattern.
+        # The prior must sit near the target ensemble: with repulsive
+        # couplings, z0 = 1 centers the Bernoulli prior at N = M/2 and the
+        # mu grid at ln z0 = 0, and the ladder-depth formula below is the
+        # full-compression depth M ln(1 + 1/z0).
+        Random.seed!(4400)
+        kb = 8.617333262e-5
+
+        M = 16
+        J = 0.1                      # eV, repulsive nearest-neighbor coupling
+        ham = GenericLatticeHamiltonian(0.0, [J, 0.0], u"eV")
+        lattice_at(N) = begin
+            lat = obs_square_lattice(4, 4)
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            lat
+        end
+        psi_from_occ(occ) = abs(sum(occ[s] ?
+            (iseven(((s - 1) % 4) + ((s - 1) ÷ 4)) ? 1 : -1) : 0
+            for s in eachindex(occ))) / length(occ)
+
+        # Exact per-configuration (E, N, psi) from fixed-N enumeration of all
+        # 2^16 configurations
+        exact_E = Dict{Int,Vector{Float64}}()
+        exact_psi = Dict{Int,Vector{Float64}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(lattice_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            exact_psi[N] = [psi_from_occ(cfg[1]) for cfg in df_exact.config]
+            @test length(exact_E[N]) == binomial(M, N)
+        end
+
+        function exact_stats(μ_val, T_val)
+            β = 1.0 / (kb * T_val)
+            lt = Float64[]; Ns = Float64[]; Es = Float64[]; Ps = Float64[]
+            for N in 0:M, i in eachindex(exact_E[N])
+                push!(lt, N * β * μ_val - β * exact_E[N][i])
+                push!(Ns, N); push!(Es, exact_E[N][i]); push!(Ps, exact_psi[N][i])
+            end
+            w = exp.(lt .- maximum(lt)); sw = sum(w)
+            u = sum(w .* Es) / sw; n = sum(w .* Ns) / sw
+            (logXi=maximum(lt) + log(sw), mean_N=n,
+             var_N=sum(w .* Ns .^ 2) / sw - n^2, mean_U=u,
+             var_U=sum(w .* Es .^ 2) / sw - u^2,
+             cov_UN=sum(w .* Es .* Ns) / sw - u * n,
+             psi=sum(w .* Ps) / sw)
+        end
+
+        μs = [-0.010, 0.000, 0.010]
+        Ts = [300.0, 450.0]
+
+        # ---- igref route with psi recording ----
+        z0 = 1.0
+        K_ig = 150
+        n_ig = ceil(Int, 1.15 * K_ig * M * log1p(1 / z0)) + 2 * K_ig
+        walkers = [LatticeWalker(deepcopy(lattice_at(0)), energy=0.0u"eV", iter=0)
+                   for _ in 1:K_ig]
+        ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        df_ig, final_ig, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(n_ig), MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3),
+            obs_save; observables=[:psi => order_parameter_c2x2])
+        obs_cleanup()
+        live_E_ig = [w.energy.val for w in final_ig.walkers]
+        live_N_ig = [sum(w.configuration.components[1]) for w in final_ig.walkers]
+        live_psi_ig = [order_parameter_c2x2(w.configuration) for w in final_ig.walkers]
+
+        st_ig = gc_thermodynamic_stats_ideal_ref(df_ig, M, z0, μs, Ts, K_ig;
+            ω0=(K_ig + 1) / K_ig, live_emax=live_E_ig, live_numbers=live_N_ig,
+            observable_cols=[:psi], live_observables=Dict(:psi => live_psi_ig))
+
+        n_gated = 0
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            st_ig.N_eff[i, j] >= 200 || continue
+            n_gated += 1
+            ex = exact_stats(μ, T)
+            @test isapprox(st_ig.logXi[i, j], ex.logXi, atol=0.7)
+            @test isapprox(st_ig.mean_N[i, j], ex.mean_N, atol=0.5)
+            @test isapprox(st_ig.mean_U[i, j], ex.mean_U, atol=0.01)
+            @test isapprox(st_ig.var_U[i, j], ex.var_U, rtol=0.4, atol=0.001)
+            @test isapprox(st_ig.cov_UN[i, j], ex.cov_UN, rtol=0.4, atol=0.01)
+            @test isapprox(st_ig.observables[:psi][i, j], ex.psi, atol=0.05)
+        end
+        # The grid was chosen inside the z0 window, so most points must pass
+        # the Kish gate
+        @test n_gated >= 4
+
+        # ---- fixed-N route with psi recording ----
+        K_fn = 100
+        n_fn = 1200
+        dfs = Vector{DataFrame}(undef, M + 1)
+        live_E_fn = Vector{Vector{Float64}}(undef, M + 1)
+        live_psi_fn = Vector{Dict{Symbol,Vector{Float64}}}(undef, M + 1)
+
+        dfs[1] = DataFrame(iter=Int[], emax=Float64[])
+        live_E_fn[1] = Float64[]
+        live_psi_fn[1] = Dict(:psi => [0.0])          # psi of the empty lattice
+
+        for N in 1:(M - 1)
+            walkers = [
+                begin
+                    lat = lattice_at(N)
+                    generate_random_new_lattice_sample!(lat)
+                    LatticeWalker(lat)
+                end for _ in 1:K_fn]
+            liveset = LatticeGasWalkers(walkers, ham, perturb_energy=1e-9)
+            ns_params = LatticeNestedSamplingParameters(
+                mc_steps=60, energy_perturbation=1e-9,
+                allowed_fail_count=100_000)
+            df, final_ls, _ = nested_sampling(
+                liveset, ns_params, n_fn, MCRandomWalkClone(), obs_save;
+                observables=[:psi => order_parameter_c2x2])
+            dfs[N + 1] = df
+            live_E_fn[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
+            live_psi_fn[N + 1] = Dict(
+                :psi => [order_parameter_c2x2(w.configuration) for w in final_ls.walkers])
+        end
+        obs_cleanup()
+
+        # N = M: single configuration; empty ladder + live tail with K copies
+        dfs[M + 1] = DataFrame(iter=Int[], emax=Float64[])
+        live_E_fn[M + 1] = fill(only(exact_E[M]), K_fn)
+        live_psi_fn[M + 1] = Dict(:psi => fill(0.0, K_fn))   # full lattice: psi = 0
+
+        st_fn = gc_thermodynamic_stats_fixed_N(dfs, collect(0:M), M,
+            μs .* u"eV", Ts .* u"K";
+            n_walkers=K_fn, n_cull=1, ω0=(K_fn + 1) / K_fn,
+            live_emax=live_E_fn,
+            observable_cols=[:psi], live_observables=live_psi_fn)
+
+        for (j, T) in enumerate(Ts), (k, μ) in enumerate(μs)
+            ex = exact_stats(μ, T)
+            @test isapprox(st_fn.logXi[k, j], ex.logXi, atol=0.3)
+            @test isapprox(st_fn.mean_N[k, j], ex.mean_N, rtol=0.05, atol=0.3)
+            @test isapprox(st_fn.mean_U[k, j], ex.mean_U, rtol=0.05, atol=0.03)
+            @test isapprox(st_fn.var_U[k, j], ex.var_U, rtol=0.3, atol=0.015)
+            @test isapprox(st_fn.cov_UN[k, j], ex.cov_UN, rtol=0.3, atol=0.08)
+            @test isapprox(st_fn.observables[:psi][k, j], ex.psi, atol=0.04)
+        end
+
+        # ---- route consistency where the igref window is healthy ----
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            st_ig.N_eff[i, j] >= 200 || continue
+            @test isapprox(st_ig.observables[:psi][i, j],
+                           st_fn.observables[:psi][i, j], atol=0.07)
+            @test isapprox(st_ig.var_U[i, j], st_fn.var_U[i, j],
+                           rtol=0.5, atol=0.005)
+        end
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -24,6 +24,26 @@
             adsorptions=:full)
     end
 
+    # Shared single-component square slab builder, d3 layers of d1 x d2
+    # sites. At d1 = d2 = 2 the first shell wraps the periodic cell (each
+    # in-plane pair is connected through both images), which the default
+    # minimum-image lists warn about at construction; build with
+    # image_multiplicity=true so construction stays silent. The doubled
+    # in-plane bonds are energetically irrelevant everywhere the builder
+    # is used (J = 0 throughout, and the layer helpers never read
+    # neighbor lists).
+    function obs_slab_lattice(d1, d2, d3)
+        MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(d1, d2, d3),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:d1*d2*d3]],
+            adsorptions=:full,
+            image_multiplicity=true)
+    end
+
     # ================================================================
     @testset "order_parameter_c2x2" begin
         lat = obs_square_lattice(4, 4)
@@ -1421,5 +1441,250 @@
         # N_eff >= 330 across the calibration seeds (floor 200); one point
         # of slack retained, per the square end-to-end precedent
         @test n_gated >= 2
+    end
+
+    # ================================================================
+    @testset "layer helpers: site_layers, layer_coverage, occupancy_profile, layer_field" begin
+        slab = obs_slab_lattice(2, 2, 3)
+
+        # lattice_positions ordering: basis innermost, dimension 1 fastest,
+        # dimension 3 outermost, so layers are contiguous blocks
+        @test site_layers(slab) == [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+
+        # Hand coverages: layer 1 full, one site of layer 2, layer 3 empty
+        slab.components[1] .= false
+        slab.components[1][1:4] .= true
+        slab.components[1][6] = true
+        @test layer_coverage(slab, 1) == 1.0
+        @test layer_coverage(slab, 2) == 0.25
+        @test layer_coverage(slab, 3) == 0.0
+        @test occupancy_profile(slab) == [1.0, 0.25, 0.0]
+
+        # mean(occupancy_profile) == N/M holds exactly in Float64: each
+        # n_k/4 is a dyadic rational, their sum is exact, and the single
+        # rounding of /3 equals the single rounding of N/12
+        Random.seed!(29)
+        for _ in 1:20
+            occ = rand(Bool, 12)
+            slab.components[1] .= occ
+            @test mean(occupancy_profile(slab)) == sum(occ) / 12
+        end
+
+        # Two-site planar basis: n_basis enters the layer block size (8/layer)
+        slab2b = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.0)],
+            supercell_dimensions=(2, 2, 2),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full,
+            image_multiplicity=true)   # d1 = d2 = 2 wraps shell 1; see obs_slab_lattice
+        @test site_layers(slab2b) == vcat(fill(1, 8), fill(2, 8))
+        slab2b.components[1] .= false
+        slab2b.components[1][1:3] .= true
+        @test layer_coverage(slab2b, 1) == 3 / 8
+        @test occupancy_profile(slab2b) == [3 / 8, 0.0]
+
+        # d3 = 1 degenerates to the total coverage (documented, allowed)
+        flat = obs_square_lattice(4, 4)
+        flat.components[1] .= false
+        flat.components[1][1:5] .= true
+        @test site_layers(flat) == fill(1, 16)
+        @test layer_coverage(flat, 1) == 5 / 16
+        @test occupancy_profile(flat) == [5 / 16]
+
+        # layer_field broadcast pins; element type preserved
+        vals = [-0.27, -0.03375, -0.01]
+        @test layer_field(obs_slab_lattice(2, 2, 3), vals) ==
+              vcat(fill(-0.27, 4), fill(-0.03375, 4), fill(-0.01, 4))
+        fu = layer_field(obs_slab_lattice(2, 2, 3), vals .* u"eV")
+        @test eltype(fu) == typeof(1.0u"eV")
+        @test fu == vcat(fill(-0.27, 4), fill(-0.03375, 4), fill(-0.01, 4)) .* u"eV"
+        @test layer_field(flat, [0.5]) == fill(0.5, 16)
+        # ... and the unitful profile feeds SiteFieldLatticeHamiltonian
+        # directly, as the docstring recipe promises
+        @test SiteFieldLatticeHamiltonian(
+            GenericLatticeHamiltonian(0.0, [0.0], u"eV"), fu) isa
+              SiteFieldLatticeHamiltonian
+
+        # Layer bounds: 1 <= layer <= d3
+        @test_throws ArgumentError layer_coverage(obs_slab_lattice(2, 2, 3), 0)
+        @test_throws ArgumentError layer_coverage(obs_slab_lattice(2, 2, 3), 4)
+        @test_throws ArgumentError layer_coverage(flat, 2)
+        # layer_field length must equal d3
+        @test_throws ArgumentError layer_field(obs_slab_lattice(2, 2, 3), [-0.27, -0.01])
+        @test_throws ArgumentError layer_field(flat, [0.5, 0.5])
+        # Non-planar basis: the z-block layer index is ill-defined, so all
+        # four helpers refuse
+        tilted = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.5)],
+            supercell_dimensions=(2, 2, 2),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full,
+            image_multiplicity=true)
+        @test_throws ArgumentError site_layers(tilted)
+        @test_throws ArgumentError layer_coverage(tilted, 1)
+        @test_throws ArgumentError occupancy_profile(tilted)
+        @test_throws ArgumentError layer_field(tilted, [0.0, 0.0])
+    end
+
+    # ================================================================
+    @testset "end-to-end: inhomogeneous Langmuir slab (2,2,3), site field, igref + theta ledger" begin
+        # J = 0 with the inverse-cube layer profile eps_k = B/k^3,
+        # B = -0.27 eV (the layer_field docstring example): the grand
+        # ensemble factorizes exactly, Xi = prod_k (1 + x_k)^4 with
+        # x_k = e^{beta(mu - eps_k)}, and theta_k = x_k/(1 + x_k), an
+        # independent closed form sharing no code with the field energy
+        # path. First end-to-end trip of a three-dimensional supercell
+        # through enumeration, sampling, and the stats layer.
+        # Statistical NS checks: seed the global RNG (the random_seed field
+        # on the NS parameters is not consumed); the seed is planted after
+        # the enumeration block, which consumes RNG. Tolerances sized at or
+        # above 3x the maximum three-seed deviation at this configuration
+        # (seeds 4701/4702/4703; max observed over the 18 gated points:
+        # |dlnXi| 0.324, |dN| 0.136, |dU| 0.0034, |dtheta| 0.019, every
+        # grid point gated in every seed at N_eff >= 549), sanity-checked
+        # against sigma(lnXi) ~ sqrt(D/K) ~ 0.30 at the full-compression
+        # depth D = 12 log1p(1/0.5) = 13.2 nats.
+        kb = 8.617333262e-5
+
+        M = 12
+        eps_layer = [-0.27, -0.03375, -0.01]     # eV, B/k^3 with B = -0.27
+        slab_at(N) = begin
+            lat = obs_slab_lattice(2, 2, 3)
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            lat
+        end
+        base = GenericLatticeHamiltonian(0.0, [0.0], u"eV")   # J = 0
+        field = layer_field(obs_slab_lattice(2, 2, 3), eps_layer .* u"eV")
+        ham = SiteFieldLatticeHamiltonian(base, field)
+
+        # Independent per-site profile from hardcoded index arithmetic,
+        # sharing no code with site_layers/layer_field
+        site_eps = [eps_layer[(s - 1) ÷ 4 + 1] for s in 1:M]
+        @test field == site_eps .* u"eV"   # welds the two oracles at the entrance
+
+        # Exact per-configuration (E, N, n_k) from fixed-N enumeration of
+        # all 2^12 = 4096 configurations; every energy must be the masked
+        # field sum to 1e-12 eV, the exactness bound applied exhaustively
+        exact_E = Dict{Int,Vector{Float64}}()
+        exact_nk = Dict{Int,Vector{Vector{Int}}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(slab_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            occs = [Vector{Bool}(cfg[1]) for cfg in df_exact.config]
+            @test length(exact_E[N]) == binomial(M, N)
+            for (e, occ) in zip(exact_E[N], occs)
+                @test isapprox(e, sum(site_eps[occ]; init=0.0); atol=1e-12)
+            end
+            exact_nk[N] = [[sum(occ[4k-3:4k]) for k in 1:3] for occ in occs]
+        end
+
+        # Closed forms from the layer factorization
+        langmuir(μ_val, T_val) = begin
+            β = 1 / (kb * T_val)
+            x = exp.(β .* (μ_val .- eps_layer))
+            θ = x ./ (1 .+ x)
+            (logXi=4 * sum(log1p, x), θ=θ,
+             mean_N=4 * sum(θ), mean_U=4 * sum(eps_layer .* θ))
+        end
+
+        # Grand sums from the enumeration, assembled in the log domain
+        function enum_stats(μ_val, T_val)
+            β = 1 / (kb * T_val)
+            lt = Float64[]; Ns = Float64[]; Es = Float64[]
+            th = [Float64[] for _ in 1:3]
+            for N in 0:M, i in eachindex(exact_E[N])
+                push!(lt, N * β * μ_val - β * exact_E[N][i])
+                push!(Ns, N); push!(Es, exact_E[N][i])
+                for k in 1:3
+                    push!(th[k], exact_nk[N][i][k] / 4)
+                end
+            end
+            w = exp.(lt .- maximum(lt)); sw = sum(w)
+            (logXi=maximum(lt) + log(sw),
+             mean_N=sum(w .* Ns) / sw, mean_U=sum(w .* Es) / sw,
+             θ=[sum(w .* th[k]) / sw for k in 1:3])
+        end
+
+        # mu grid inside the igref trust window of z0 = 0.5 at 300 K; the
+        # layers discriminate strongly across it (theta1 ~ 1, theta2 and
+        # theta3 partially filled)
+        μs = [-0.03, -0.015, 0.0]
+        Ts = [300.0, 600.0]
+
+        # Deterministic weld: enumeration == closed form at every grid
+        # point (pure summation, house deterministic tolerance; the
+        # extensive mean_N and mean_U carry a factor-M headroom)
+        for T in Ts, μ in μs
+            ex = langmuir(μ, T); en = enum_stats(μ, T)
+            @test isapprox(en.logXi, ex.logXi; atol=1e-10)
+            @test isapprox(en.mean_N, ex.mean_N; atol=1e-9)
+            @test isapprox(en.mean_U, ex.mean_U; atol=1e-9)
+            @test all(isapprox.(en.θ, ex.θ; atol=1e-10))
+        end
+
+        # ---- igref route recording theta1..theta3 (the sampler-hook
+        # check rides this same run: identical fixture and ledger) ----
+        Random.seed!(4701)
+        z0 = 0.5                     # ln z0 = -0.69 centers the mu grid at 300 K
+        K_ig = 150
+        n_ig = ceil(Int, 1.15 * K_ig * M * log1p(1 / z0)) + 2 * K_ig
+        walkers = [LatticeWalker(deepcopy(slab_at(0)), energy=0.0u"eV", iter=0)
+                   for _ in 1:K_ig]
+        ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        df_ig, final_ig, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(n_ig), MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3),
+            obs_save;
+            observables=[Symbol(:theta, k) => (cfg -> layer_coverage(cfg, k))
+                         for k in 1:3])
+        obs_cleanup()
+
+        # Ledger integrity: columns, range, and the quarter-integer
+        # lattice of 4-site-layer coverages
+        @test names(df_ig) == ["iter", "emax", "num_particles",
+                               "theta1", "theta2", "theta3"]
+        for col in (df_ig.theta1, df_ig.theta2, df_ig.theta3)
+            @test all(0.0 .<= col .<= 1.0)
+            @test all(isinteger.(4 .* col))
+        end
+
+        live_E = [w.energy.val for w in final_ig.walkers]
+        live_N = [sum(w.configuration.components[1]) for w in final_ig.walkers]
+        live_th = Dict(Symbol(:theta, k) =>
+                       [layer_coverage(w.configuration, k) for w in final_ig.walkers]
+                       for k in 1:3)
+        st = gc_thermodynamic_stats_ideal_ref(df_ig, M, z0, μs, Ts, K_ig;
+            ω0=(K_ig + 1) / K_ig, live_emax=live_E, live_numbers=live_N,
+            observable_cols=[:theta1, :theta2, :theta3], live_observables=live_th)
+
+        # var_U and cov_UN are exercised by the existing end-to-end
+        # testsets; the new code under test here is the field energy and
+        # the theta observables, so those are what the gate asserts
+        n_gated = 0
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            st.N_eff[i, j] >= 200 || continue
+            n_gated += 1
+            ex = langmuir(μ, T)
+            @test isapprox(st.logXi[i, j], ex.logXi, atol=1.0)
+            @test isapprox(st.mean_N[i, j], ex.mean_N, atol=0.5)
+            @test isapprox(st.mean_U[i, j], ex.mean_U, atol=0.011)
+            for k in 1:3
+                @test isapprox(st.observables[Symbol(:theta, k)][i, j],
+                               ex.θ[k], atol=0.06)
+            end
+        end
+        # ln z0 centered on the 300 K grid: all six points gated at
+        # N_eff >= 549 across the calibration seeds (floor 200); one
+        # point of slack retained, per the end-to-end precedents
+        @test n_gated >= 5
     end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -65,4 +65,118 @@
             adsorptions=:full)
         @test_throws ArgumentError order_parameter_c2x2(lat2b)
     end
+
+    # ================================================================
+    obs_ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+    obs_save = SaveEveryN("t_obs.csv", "t_obs.traj", "t_obs.ls",
+                          1000000, 1000000, 1000000)
+    obs_cleanup() = rm.(["t_obs.csv", "t_obs.traj", "t_obs.ls"], force=true)
+    count_N(cfg) = Float64(sum(cfg.components[1]))
+
+    @testset "observable hook: validation" begin
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:8]
+        ls = LatticeGasWalkers(walkers, obs_ham)
+        params = LatticeNestedSamplingParameters(mc_steps=10, energy_perturbation=1e-9)
+
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(2),
+            MCRandomWalkClone(), obs_save;
+            observables=[:a => order_parameter_c2x2, :a => order_parameter_c2x2])
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(2),
+            MCRandomWalkClone(), obs_save;
+            observables=[:emax => order_parameter_c2x2])
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(2),
+            MCRandomWalkClone(), obs_save;
+            observables=Pair{Symbol,Function}[])
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(2),
+            MCRandomWalkClone(), obs_save;
+            observables=[:bad => (cfg -> "not a number")])
+        # Non-finite probe values warn but do not throw
+        @test_logs (:warn, r"non-finite") min_level=Base.CoreLogging.Warn match_mode=:any nested_sampling(
+            ls, params, Int64(2), MCRandomWalkClone(), obs_save;
+            observables=[:nanobs => (cfg -> NaN)])
+        obs_cleanup()
+    end
+
+    # ================================================================
+    @testset "observable hook: exact dead-point pairing (igref route)" begin
+        Random.seed!(42)
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:30]
+        ls = LatticeGasWalkers(walkers, obs_ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(mc_steps=30, reference_fugacity=1.0)
+        mc = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+
+        df, final_ls, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(400), mc, obs_save;
+            observables=[:n_check => count_N, :psi => order_parameter_c2x2])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "num_particles", "n_check", "psi"]
+        @test eltype(df.n_check) == Float64
+        @test eltype(df.psi) == Float64
+        # The load-bearing check: the observable column, evaluated on the
+        # captured culled walker, reproduces the independently recorded
+        # num_particles column row by row over a full run
+        @test df.n_check == Float64.(df.num_particles)
+        @test all(0.0 .<= df.psi .<= 0.5)
+
+        # Schema is unchanged when observables are not requested
+        Random.seed!(42)
+        walkers2 = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:30]
+        ls2 = LatticeGasWalkers(walkers2, obs_ham; assign_energy=false)
+        params2 = IdealGasReferencedGCNSParameters(mc_steps=30, reference_fugacity=1.0)
+        df2, _, _ = ideal_gas_referenced_nested_sampling(
+            ls2, params2, Int64(50), mc, obs_save)
+        obs_cleanup()
+        @test names(df2) == ["iter", "emax", "num_particles"]
+    end
+
+    # ================================================================
+    @testset "observable hook: exact dead-point pairing (omega-sorted route)" begin
+        Random.seed!(11)
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:20]
+        ls = LatticeGasWalkers(walkers, obs_ham; assign_energy=false)
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=30, chemical_potential=-0.02)
+        mc = MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3)
+
+        df, _, _ = grand_canonical_nested_sampling(
+            ls, gc_params, Int64(200), mc, obs_save;
+            observables=[:n_check => count_N])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "omega", "energy", "num_particles", "n_check"]
+        @test df.n_check == Float64.(df.num_particles)
+    end
+
+    # ================================================================
+    @testset "observable hook: exact dead-point pairing (canonical route)" begin
+        Random.seed!(7)
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:20]
+        # Fixed-N ladder at N = 5: place 5 particles per walker
+        for w in walkers
+            occ = vcat(fill(true, 5), fill(false, 11))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls = LatticeGasWalkers(walkers, obs_ham; perturb_energy=1e-9)
+        params = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+
+        df, _, _ = nested_sampling(ls, params, Int64(200),
+            MCRandomWalkClone(), obs_save;
+            observables=[:e_check => (cfg -> interacting_energy(cfg, obs_ham).val),
+                         :psi => order_parameter_c2x2])
+        obs_cleanup()
+
+        @test names(df) == ["iter", "emax", "e_check", "psi"]
+        # N is conserved on the canonical route, so pair the recomputed
+        # (unperturbed) energy against the recorded emax instead; they differ
+        # only by the tie-breaking perturbation
+        @test all(isapprox.(df.e_check, df.emax; atol=1e-8))
+        @test all(0.0 .<= df.psi .<= 0.5)
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -99,6 +99,44 @@
     end
 
     # ================================================================
+    # The pairing-guard test needs a step method that violates the cull
+    # invariant; structs and method extensions must live at module top level
+    @eval begin
+        struct BrokenObsRoutine <: MCRoutine end
+        function FreeBird.SamplingSchemes.nested_sampling_step!(
+                liveset::LatticeGasWalkers,
+                ns_params::NestedSamplingParameters,
+                mc_routine::BrokenObsRoutine;
+                ns_iteration::Int=0)
+            # Claims an accepted iteration whose emax does not belong to the
+            # pre-sorted worst walker
+            return 1, liveset.walkers[1].energy + 1.0u"eV", liveset, ns_params
+        end
+    end
+
+    @testset "observable hook: parallel rejection and pairing guard" begin
+        lat = obs_square_lattice(4, 4)
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                   for _ in 1:6]
+        ls = LatticeGasWalkers(walkers, obs_ham)
+        params = LatticeNestedSamplingParameters(mc_steps=5,
+            energy_perturbation=1e-9)
+
+        # Parallel/multi-cull routines cull several walkers per recorded row,
+        # so they are rejected up front rather than corrupting the ledger
+        @test_throws ArgumentError nested_sampling(ls, params, Int64(1),
+            MCRandomWalkMaxEParallel(), obs_save;
+            observables=[:psi => order_parameter_c2x2])
+
+        # A step that reports a different walker than the pre-sorted worst
+        # trips the bit-exact pairing guard
+        @test_throws ErrorException nested_sampling(ls, params, Int64(1),
+            BrokenObsRoutine(), obs_save;
+            observables=[:psi => order_parameter_c2x2])
+        obs_cleanup()
+    end
+
+    # ================================================================
     @testset "observable hook: exact dead-point pairing (igref route)" begin
         Random.seed!(42)
         lat = obs_square_lattice(4, 4)
@@ -218,13 +256,28 @@
 
         # Self-consistency: averaging the ledger's own columns reproduces
         # mean_N and mean_U
+        # Mixed value types (Vector{Int} + Vector{Float64} typejoin to
+        # Dict{Symbol,Vector}) pin the loosened Dict annotation: this is
+        # exactly the documented self-consistency call
         stats2 = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K;
             ω0=ω0, live_emax=live_E, live_numbers=live_N,
             observable_cols=[:num_particles, :emax],
-            live_observables=Dict(:num_particles => Float64.(live_N),
-                                  :emax => live_E))
+            live_observables=Dict(:num_particles => live_N, :emax => live_E))
         @test stats2.observables[:num_particles] ≈ stats2.mean_N rtol = 1e-12
         @test stats2.observables[:emax] ≈ stats2.mean_U rtol = 1e-12
+
+        # Live-tail-only analysis: a zero-row ledger need not carry the
+        # observable columns (mirrors the fixed-N empty-sector convention)
+        df_empty = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
+        st_tail = gc_thermodynamic_stats_ideal_ref(df_empty, M, z0, μs, Ts, K;
+            ω0=ω0, live_emax=live_E, live_numbers=live_N,
+            observable_cols=[:a], live_observables=Dict(:a => live_a))
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            β = 1 / (kb * T)
+            w = exp.(β * μ .* Float64.(live_N) .- β .* live_E)
+            @test st_tail.observables[:a][i, j] ≈
+                  sum(w .* live_a) / sum(w) rtol = 1e-12
+        end
 
         # Backward compatibility: pre-existing fields keep their order, new
         # fields are appended, positional destructuring still works
@@ -312,6 +365,34 @@
             # The N = 0 sector contributes psi = 0 with weight wN[1]
             @test stats.observables[:psi][k, j] ≈
                   (wN[2] * p1 + wN[3] * p2) / sw rtol = 1e-10
+        end
+
+        # The N = 0 live_observables entry is USED (its live_emax counterpart
+        # is ignored): with a nonzero Int-typed sentinel — which also pins the
+        # loosened heterogeneous-Dict annotation — the empty sector's
+        # contribution wN[1] * 10 must appear in <b>, and it dominates at the
+        # strongly negative mu grid point
+        df1b = DataFrame(iter=[1, 2], emax=[0.3, 0.1], psi=[0.2, 0.4],
+                         b=[1.0, 3.0])
+        live_b = [Dict{Symbol,Vector}(:psi => [0.0], :b => [10]),
+                  Dict{Symbol,Vector}(:psi => [0.6, 0.8], :b => [5.0, 7.0]),
+                  Dict{Symbol,Vector}(:psi => [0.5, 0.5, 0.5],
+                                      :b => [2.0, 2.0, 2.0])]
+        stats_b = gc_thermodynamic_stats_fixed_N(
+            [df0, df1b, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0, live_emax=live_E,
+            observable_cols=[:psi, :b], live_observables=live_b)
+        @test stats_b.observables[:psi] ≈ stats.observables[:psi] rtol = 1e-12
+        for (j, T) in enumerate([300.0, 600.0]), (k, μ) in enumerate([-0.05, 0.02])
+            β = 1 / (kb * T)
+            b1v = w1 .* exp.(-β .* E1)
+            z1 = sum(b1v)
+            bb1 = sum(b1v .* vcat(df1b.b, live_b[2][:b])) / z1
+            z2 = exp(-β * 0.02)
+            wN = binom .* [1.0, z1, z2] .* exp.(β * μ .* [0.0, 1.0, 2.0])
+            sw = sum(wN)
+            @test stats_b.observables[:b][k, j] ≈
+                  (wN[1] * 10.0 + wN[2] * bb1 + wN[3] * 2.0) / sw rtol = 1e-10
         end
 
         # Backward compatibility: field order preserved, new fields appended

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -2502,4 +2502,428 @@
         @test params_b.move_stats[:insert_biased_accepted] <=
               params_b.move_stats[:insert_biased_attempted]
     end
+
+    # ================================================================
+    @testset "end-to-end: triangular eight-shell + trio cluster expansion, igref" begin
+        # Independent geometry for the triangular cells: explicit-image torus
+        # distances from the stored positions, no FreeBird neighbor or
+        # embedding code
+        tce_sq3 = sqrt(3.0)
+        function tce_tdist(p, q, Lx, Ly)
+            best = Inf
+            for ix in -1:1, iy in -1:1
+                best = min(best, hypot(p[1] - q[1] + ix * Lx, p[2] - q[2] + iy * Ly))
+            end
+            return best
+        end
+
+        # Structural pins on the 18-site (3, 3, 1) cell: the NN-triangle
+        # motif counts 42 embeddings under the torus convention (36 faces
+        # plus 6 winding three-cycles) and the linear trio 36 (aliasing),
+        # then the full 2^18 spectrum of the pair + two-trio expansion is
+        # checked configuration-resolved against an independent evaluation
+        tri18 = obs_tri_lattice(3, 3)
+        tri18_tris = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            tri18, [1.0, 1.0, 1.0]; expected_count=42)
+        tri18_lins = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            tri18, [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)])
+        @test length(tri18_lins) == 36
+        tce_ham18 = ClusterLatticeHamiltonian(
+            GenericLatticeHamiltonian(0.0, [0.1], u"eV"),
+            [ClusterInteraction(0.05u"eV", tri18_tris),
+             ClusterInteraction(-0.02u"eV", tri18_lins)])
+        p18 = [(tri18.positions[s, 1], tri18.positions[s, 2]) for s in 1:18]
+        pairs18 = [(i, j) for i in 1:18 for j in (i+1):18
+                   if abs(tce_tdist(p18[i], p18[j], 3.0, 3 * tce_sq3) - 1.0) < 1e-9]
+        @test length(pairs18) == 54
+        probe18 = deepcopy(tri18)
+        worst18 = 0.0
+        for mask in 0:(2^18-1)
+            occ = probe18.components[1]
+            for s in 1:18
+                occ[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            e_own = 0.1 * count(pr -> occ[pr[1]] && occ[pr[2]], pairs18) +
+                    0.05 * count(t -> occ[t[1]] && occ[t[2]] && occ[t[3]], tri18_tris) -
+                    0.02 * count(t -> occ[t[1]] && occ[t[2]] && occ[t[3]], tri18_lins)
+            worst18 = max(worst18, abs(ustrip(u"eV", interacting_energy(probe18, tce_ham18)) - e_own))
+        end
+        @test worst18 <= 1e-12
+
+        # End-to-end cell: (4, 2, 1) with image_multiplicity (the bulk-tiled
+        # convention restores the coordination sequence (6, 6, 6, 12, 6, 6,
+        # 12, 6) on the small cell), eight pair shells plus both trio motifs
+        # enumerated on this cell with independently counted expected_count.
+        # The NN-triangle enumeration is faithful here (shortest circumference
+        # 2sqrt(3) > 3·1); the linear trio wraps and warns.
+        tce_lat = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(4, 2, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.05, 1.75, 2.05, 2.7, 3.05, 3.5, 3.65, 4.05],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full,
+            image_multiplicity=true)
+        @test all(nb -> length.(nb) == [6, 6, 6, 12, 6, 6, 12, 6], tce_lat.neighbors)
+        p16 = [(tce_lat.positions[s, 1], tce_lat.positions[s, 2]) for s in 1:16]
+        function tce_trios(dists)
+            found = NTuple{3,Int}[]
+            for a in 1:16, b in (a+1):16, c in (b+1):16
+                ds = sort([tce_tdist(p16[a], p16[b], 4.0, 2 * tce_sq3),
+                           tce_tdist(p16[a], p16[c], 4.0, 2 * tce_sq3),
+                           tce_tdist(p16[b], p16[c], 4.0, 2 * tce_sq3)])
+                all(abs.(ds .- dists) .< 1e-9) && push!(found, (a, b, c))
+            end
+            return found
+        end
+        own_tris = tce_trios([1.0, 1.0, 1.0])
+        own_lins = tce_trios([1.0, 1.0, 2.0])
+        tce_tris = enumerate_motif_embeddings(tce_lat, [1.0, 1.0, 1.0];
+            expected_count=length(own_tris))
+        tce_lins = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            tce_lat, [1.0, 1.0, 2.0]; expected_count=length(own_lins))
+        @test sort(collect(tce_tris)) == sort(own_tris)
+        @test sort(collect(tce_lins)) == sort(own_lins)
+        tce_J8 = [0.10, -0.02, 0.01, -0.005, 0.004, -0.003, 0.002, -0.001]
+        tce_ham = ClusterLatticeHamiltonian(
+            GenericLatticeHamiltonian(0.0, tce_J8, u"eV"),
+            [ClusterInteraction(0.05u"eV", tce_tris),
+             ClusterInteraction(-0.02u"eV", tce_lins)])
+
+        # Independent multiplicity-weighted bond multiset from explicit image
+        # enumeration, then the full 2^16 own-energy table and the
+        # configuration-resolved spectrum check; the E_min(N) ladder's ends
+        # pin the empty lattice at exactly zero and the full lattice at the
+        # bulk-tiled closed form
+        tce_radii = [1.05, 1.75, 2.05, 2.7, 3.05, 3.5, 3.65, 4.05]
+        bonds16 = Tuple{Int,Int,Int}[]
+        for i in 1:16, j in 1:16
+            for ix in -3:3, iy in -3:3
+                (j == i && ix == 0 && iy == 0) && continue
+                d = hypot(p16[i][1] - p16[j][1] + ix * 4.0,
+                          p16[i][2] - p16[j][2] + iy * 2 * tce_sq3)
+                d > tce_radii[end] && continue
+                sh = findfirst(r -> d <= r, tce_radii)
+                sh === nothing || push!(bonds16, (i, j, sh))
+            end
+        end
+        occ16 = fill(false, 16)
+        e_own16 = zeros(2^16)
+        for mask in 0:(2^16-1)
+            for s in 1:16
+                occ16[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            e = 0.0
+            for (i, j, sh) in bonds16
+                (occ16[i] && occ16[j]) && (e += tce_J8[sh] / 2)
+            end
+            e += 0.05 * count(t -> occ16[t[1]] && occ16[t[2]] && occ16[t[3]], tce_tris)
+            e -= 0.02 * count(t -> occ16[t[1]] && occ16[t[2]] && occ16[t[3]], tce_lins)
+            e_own16[mask+1] = e
+        end
+        probe16 = deepcopy(tce_lat)
+        psi16 = zeros(2^16)
+        n16 = zeros(Int, 2^16)
+        worst16 = 0.0
+        for mask in 0:(2^16-1)
+            occ = probe16.components[1]
+            for s in 1:16
+                occ[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            worst16 = max(worst16, abs(ustrip(u"eV", interacting_energy(probe16, tce_ham)) - e_own16[mask+1]))
+            psi16[mask+1] = order_parameter_p2x2(probe16)
+            n16[mask+1] = count_ones(mask)
+        end
+        @test worst16 <= 1e-12
+        emin16 = [minimum(e_own16[mask+1] for mask in 0:(2^16-1) if count_ones(mask) == N)
+                  for N in 0:16]
+        @test emin16[1] == 0.0
+        tce_zbulk = [6, 6, 6, 12, 6, 6, 12, 6]
+        tce_full = 16 / 2 * sum(tce_zbulk .* tce_J8) +
+                   0.05 * length(tce_tris) - 0.02 * length(tce_lins)
+        @test abs(emin16[17] - tce_full) < 1e-12
+
+        # Constructed-configuration pins on the perfect p(2x2): axial
+        # coordinates from the positions, occupied where both are even
+        tce_ij = map(1:16) do s
+            x, y = tce_lat.positions[s, 1], tce_lat.positions[s, 2]
+            j = round(Int, 2 * y / tce_sq3)
+            (round(Int, x - j / 2), j)
+        end
+        probe16.components[1] .= [iseven(i) && iseven(j) for (i, j) in tce_ij]
+        @test count(probe16.components[1]) == 4
+        @test order_parameter_p2x2(probe16) ≈ sqrt(3) / 4 atol = 1e-12
+        for (m, n) in [(2, -1), (0, 2), (2, 1)]
+            @test bragg_amplitude(probe16, m, n) == 1 / 4
+        end
+
+        # Exact grand references and the seeded igref run with the M-point
+        # order parameter recorded through the hook. Tolerances: three-seed
+        # calibrated (seeds 5301/5302/5303), per stat, >= 3x the maximum
+        # deviation (lnXi 0.279, N 0.508, U 0.021, Psi 0.0142); sigma =
+        # sqrt(16 ln 2 / 100) ~ 0.33 for lnXi. Both mu = +-0.1 corners of
+        # the 800 K row sit deliberately at the |ln(z/z0)| ~ 1.45
+        # trust-window edge; the low-fugacity corner (mu = -0.1,
+        # z = e^{beta mu} ~ 0.23 against z0 = 1) binds, with calibrated
+        # minimum Kish N_eff 23.5, so the health floor is 15, not a
+        # production-grade gate
+        tce_kb = 8.617333262e-5
+        tce_mus = [-0.1, 0.0, 0.1]
+        tce_Ts = [800.0, 1200.0, 2000.0]
+        function tce_exact(mu, T)
+            beta = 1 / (tce_kb * T)
+            w = [exp(beta * (mu * n16[k] - e_own16[k])) for k in 1:2^16]
+            Z = sum(w)
+            return (log(Z), sum(w .* n16) / Z, sum(w .* e_own16) / Z, sum(w .* psi16) / Z)
+        end
+        Random.seed!(5301)
+        tce_walkers = [LatticeWalker(deepcopy(tce_lat), energy=0.0u"eV", iter=0)
+                       for _ in 1:100]
+        tce_ls = LatticeGasWalkers(tce_walkers, tce_ham; assign_energy=false)
+        tce_params = IdealGasReferencedGCNSParameters(mc_steps=60,
+            reference_fugacity=1.0, energy_perturbation=1e-9)
+        tce_df, tce_out, _ = ideal_gas_referenced_nested_sampling(tce_ls,
+            tce_params, Int64(1280), MCGrandCanonicalMoves(), obs_save;
+            observables=[:psi => order_parameter_p2x2])
+        obs_cleanup()
+        tce_liveE = [w.energy.val for w in tce_out.walkers]
+        tce_liveN = [Int(sum(w.configuration.components[1])) for w in tce_out.walkers]
+        tce_livePsi = Dict(:psi => [order_parameter_p2x2(w.configuration) for w in tce_out.walkers])
+        tce_st = gc_thermodynamic_stats_ideal_ref(tce_df, 16, 1.0, tce_mus, tce_Ts,
+            100; ω0=101 / 100, live_emax=tce_liveE, live_numbers=tce_liveN,
+            observable_cols=[:psi], live_observables=tce_livePsi)
+        for (i, mu) in enumerate(tce_mus), (j, T) in enumerate(tce_Ts)
+            lnXi, mN, mU, mPsi = tce_exact(mu, T)
+            @test tce_st.N_eff[i, j] >= 15
+            @test abs(tce_st.logXi[i, j] - lnXi) < 0.9
+            @test abs(tce_st.mean_N[i, j] - mN) < 1.6
+            @test abs(tce_st.mean_U[i, j] - mU) < 0.07
+            @test abs(tce_st.observables[:psi][i, j] - mPsi) < 0.045
+        end
+    end
+
+    # ================================================================
+    @testset "end-to-end: cross-Hamiltonian reweighting closure (3x3 triangular)" begin
+        # Sample the reference ladder under the pair Hamiltonian A, record
+        # the trio-augmented Hamiltonian B per dead point through the
+        # observables hook and the occupation vectors through the dead-point
+        # callback; the substituted ledger (B's energies replacing emax and
+        # the live tail) closes against B's exact grand sum over the same
+        # prior-volume weights, and the substituted estimator's Kish N_eff
+        # never exceeds the control's
+        xh_lat = obs_tri_lattice(3, 3)
+        xh_hamA = GenericLatticeHamiltonian(0.0, [0.1], u"eV")
+        xh_tris = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            xh_lat, [1.0, 1.0, 1.0]; expected_count=42)
+        xh_hamB = ClusterLatticeHamiltonian(GenericLatticeHamiltonian(0.0, [0.1], u"eV"),
+            [ClusterInteraction(0.05u"eV", xh_tris)])
+
+        # Independent energies for both Hamiltonians over all 2^18 configs
+        xh_sq3 = sqrt(3.0)
+        function xh_tdist(p, q)
+            best = Inf
+            for ix in -1:1, iy in -1:1
+                best = min(best, hypot(p[1] - q[1] + ix * 3.0, p[2] - q[2] + iy * 3 * xh_sq3))
+            end
+            return best
+        end
+        xp = [(xh_lat.positions[s, 1], xh_lat.positions[s, 2]) for s in 1:18]
+        xh_pairs = [(i, j) for i in 1:18 for j in (i+1):18
+                    if abs(xh_tdist(xp[i], xp[j]) - 1.0) < 1e-9]
+        eA = zeros(2^18)
+        eB = zeros(2^18)
+        nX = zeros(Int, 2^18)
+        xocc = fill(false, 18)
+        for mask in 0:(2^18-1)
+            for s in 1:18
+                xocc[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            pa = 0.1 * count(pr -> xocc[pr[1]] && xocc[pr[2]], xh_pairs)
+            tri = 0.05 * count(t -> xocc[t[1]] && xocc[t[2]] && xocc[t[3]], xh_tris)
+            eA[mask+1] = pa
+            eB[mask+1] = pa + tri
+            nX[mask+1] = count_ones(mask)
+        end
+        xprobe = deepcopy(xh_lat)
+        Random.seed!(5400)
+        for _ in 1:50
+            mask = rand(0:(2^18-1))
+            for s in 1:18
+                xprobe.components[1][s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            @test abs(ustrip(u"eV", interacting_energy(xprobe, xh_hamA)) - eA[mask+1]) <= 1e-12
+            @test abs(ustrip(u"eV", interacting_energy(xprobe, xh_hamB)) - eB[mask+1]) <= 1e-12
+        end
+        xh_kb = 8.617333262e-5
+        function xh_exact(evec, mu, T)
+            beta = 1 / (xh_kb * T)
+            mx = maximum(beta * (mu * nX[k] - evec[k]) for k in 1:2^18)
+            return log(sum(exp(beta * (mu * nX[k] - evec[k]) - mx) for k in 1:2^18)) + mx
+        end
+        xh_mus = [-0.05, 0.0, 0.05]
+        xh_Ts = [800.0, 1200.0, 2000.0]
+
+        # One seeded ladder under A. Tolerances: three-seed calibrated
+        # (seeds 5401/5402/5403), per route, >= 3x the maximum deviation
+        # (control 0.324, substituted 0.325); sigma = sqrt(18 ln 2 / 200)
+        # ~ 0.25; the N_eff monotonicity held on every calibration seed
+        Random.seed!(5401)
+        xh_walkers = [LatticeWalker(deepcopy(xh_lat), energy=0.0u"eV", iter=0)
+                      for _ in 1:200]
+        xh_ls = LatticeGasWalkers(xh_walkers, xh_hamA; assign_energy=false)
+        xh_params = IdealGasReferencedGCNSParameters(mc_steps=100,
+            reference_fugacity=1.0, energy_perturbation=1e-9)
+        xh_configs = Vector{Bool}[]
+        xh_df, xh_out, _ = ideal_gas_referenced_nested_sampling(xh_ls, xh_params,
+            Int64(2870), MCGrandCanonicalMoves(), obs_save;
+            observables=[:U_b => (cfg -> ustrip(u"eV", interacting_energy(cfg, xh_hamB)))],
+            dead_point_callback=(iter, w) ->
+                push!(xh_configs, copy(w.configuration.components[1])))
+        obs_cleanup()
+        @test nrow(xh_df) > 0
+        @test length(xh_configs) == nrow(xh_df)
+        # The callback-collected configurations re-evaluate to the recorded
+        # H_b column exactly
+        xrecomp = [begin
+                       xprobe.components[1] .= c
+                       ustrip(u"eV", interacting_energy(xprobe, xh_hamB))
+                   end for c in xh_configs]
+        @test xrecomp == xh_df.U_b
+
+        xh_liveE = [w.energy.val for w in xh_out.walkers]
+        xh_liveN = [Int(sum(w.configuration.components[1])) for w in xh_out.walkers]
+        xh_stA = gc_thermodynamic_stats_ideal_ref(xh_df, 18, 1.0, xh_mus, xh_Ts,
+            200; ω0=201 / 200, live_emax=xh_liveE, live_numbers=xh_liveN)
+        xh_dfB = copy(xh_df)
+        xh_dfB.emax = copy(xh_df.U_b)
+        xh_liveEB = [begin
+                         xprobe.components[1] .= w.configuration.components[1]
+                         ustrip(u"eV", interacting_energy(xprobe, xh_hamB))
+                     end for w in xh_out.walkers]
+        xh_stB = gc_thermodynamic_stats_ideal_ref(xh_dfB, 18, 1.0, xh_mus, xh_Ts,
+            200; ω0=201 / 200, live_emax=xh_liveEB, live_numbers=xh_liveN)
+        for (i, mu) in enumerate(xh_mus), (j, T) in enumerate(xh_Ts)
+            @test abs(xh_stA.logXi[i, j] - xh_exact(eA, mu, T)) < 1.0
+            @test abs(xh_stB.logXi[i, j] - xh_exact(eB, mu, T)) < 1.0
+            @test 0 < xh_stB.N_eff[i, j] <= xh_stA.N_eff[i, j]
+        end
+    end
+
+    # ================================================================
+    @testset "end-to-end: honeycomb recipe through the generic lattice" begin
+        # The honeycomb adlattice through the MLattice{1,GenericLattice}
+        # inner constructor: rectangular doubled cell (orthogonal vectors
+        # keep the per-axis minimum-image reduction exact) with the
+        # four-site honeycomb basis. With the underlying triangular lattice
+        # constant a = 1 the honeycomb edge is d_nn = a/sqrt(3) ~ 0.577 and
+        # the successive neighbor distances are d_nn * (1, sqrt(3), 2,
+        # sqrt(7)) = (0.577, 1.000, 1.155, 1.528) with multiplicities
+        # (3, 6, 3, 6), so the ladder [0.7, 1.05, 1.30, 1.60] brackets
+        # exactly one distance class per shell. Geometric cluster moves have
+        # no GenericLattice method, so clusters_freq stays 0 throughout (a
+        # run with clusters_freq > 0 dies mid-run with the raw MethodError;
+        # documented exclusion, not exercised here).
+        hc_sq3 = sqrt(3.0)
+        hc_lv = [1.0 0.0 0.0; 0.0 hc_sq3 0.0; 0.0 0.0 1.0]
+        hc_basis = [(0.0, 0.0, 0.0),
+                    (0.5, 1 / (2 * hc_sq3), 0.0),
+                    (0.5, hc_sq3 / 2, 0.0),
+                    (0.0, hc_sq3 / 2 + 1 / (2 * hc_sq3), 0.0)]
+        hc = MLattice{1,GenericLattice}(hc_lv, hc_basis, (6, 4, 1),
+            (true, true, false), [0.7, 1.05, 1.30, 1.60],
+            [fill(false, 96)], fill(true, 96))
+        @test hc isa GLattice{1}
+        @test num_sites(hc) == 96
+        @test all(nb -> length.(nb) == [3, 6, 3, 6], hc.neighbors)
+
+        # Bent NN-trio motif: two nearest neighbors of a common center at
+        # 120 degrees, distance multiset [1/sqrt(3), 1/sqrt(3), 1]; exactly
+        # 3M embeddings (three per center), checked against an independent
+        # count from torus distances
+        hc_dnn = 1 / hc_sq3
+        function hc_tdist(p, q, Lx, Ly)
+            best = Inf
+            for ix in -1:1, iy in -1:1
+                best = min(best, hypot(p[1] - q[1] + ix * Lx, p[2] - q[2] + iy * Ly))
+            end
+            return best
+        end
+        hp = [(hc.positions[s, 1], hc.positions[s, 2]) for s in 1:96]
+        hc_own = NTuple{3,Int}[]
+        for a in 1:96
+            nbs = [b for b in 1:96
+                   if b != a && abs(hc_tdist(hp[a], hp[b], 6.0, 4 * hc_sq3) - hc_dnn) < 1e-9]
+            for x in 1:length(nbs), y in (x+1):length(nbs)
+                b, c = nbs[x], nbs[y]
+                abs(hc_tdist(hp[b], hp[c], 6.0, 4 * hc_sq3) - 1.0) < 1e-9 &&
+                    push!(hc_own, tuple(sort([a, b, c])...))
+            end
+        end
+        sort!(hc_own)
+        @test length(hc_own) == 3 * 96
+        hc_tris = enumerate_motif_embeddings(hc, [hc_dnn, hc_dnn, 1.0];
+            expected_count=length(hc_own))
+        @test sort(collect(hc_tris)) == hc_own
+
+        # Full-occupancy closed form: on-site plus half the coordination-
+        # weighted couplings
+        hc_ham = GenericLatticeHamiltonian(-0.04,
+            [-0.01, -0.005, -0.0025, -0.00125], u"eV")
+        hc.components[1] .= true
+        hc_closed = 96 * (-0.04) +
+                    96 / 2 * sum([3, 6, 3, 6] .* [-0.01, -0.005, -0.0025, -0.00125])
+        @test abs(ustrip(u"eV", interacting_energy(hc, hc_ham)) - hc_closed) < 1e-12
+
+        # Small-cell enumeration closure: the C(16, 4) spectrum on the
+        # (2, 2, 1) cell against an independent NN-bond evaluation
+        hc2 = MLattice{1,GenericLattice}(hc_lv, hc_basis, (2, 2, 1),
+            (true, true, false), [0.7], [vcat(fill(true, 4), fill(false, 12))],
+            fill(true, 16))
+        hc2_ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        hc2_df, _ = exact_enumeration(hc2, hc2_ham)
+        @test nrow(hc2_df) == binomial(16, 4)
+        hp2 = [(hc2.positions[s, 1], hc2.positions[s, 2]) for s in 1:16]
+        hc2_pairs = [(i, j) for i in 1:16 for j in (i+1):16
+                     if abs(hc_tdist(hp2[i], hp2[j], 2.0, 2 * hc_sq3) - hc_dnn) < 1e-9]
+        @test length(hc2_pairs) == 24
+        hc2_brute = Float64[]
+        hocc = fill(false, 16)
+        for mask in 0:(2^16-1)
+            count_ones(mask) == 4 || continue
+            for s in 1:16
+                hocc[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            push!(hc2_brute,
+                  4 * (-0.04) - 0.01 * count(pr -> hocc[pr[1]] && hocc[pr[2]], hc2_pairs))
+        end
+        @test sort([ustrip(u"eV", e) for e in hc2_df.energy]) ≈ sort(hc2_brute) atol = 1e-12
+
+        # A short seeded grand-canonical run on the (3, 2, 1) cell returns a
+        # well-formed, monotone ledger (swap-only decorrelation)
+        Random.seed!(5501)
+        hc3 = MLattice{1,GenericLattice}(hc_lv, hc_basis, (3, 2, 1),
+            (true, true, false), [0.7, 1.05, 1.2], [fill(false, 24)],
+            fill(true, 24))
+        @test all(nb -> length.(nb) == [3, 6, 3], hc3.neighbors)
+        hc3_ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.005, -0.0025], u"eV")
+        hc3_walkers = [LatticeWalker(deepcopy(hc3), energy=0.0u"eV", iter=0)
+                       for _ in 1:10]
+        hc3_ls = LatticeGasWalkers(hc3_walkers, hc3_ham; assign_energy=false)
+        hc3_gc = GrandCanonicalNestedSamplingParameters(mc_steps=50,
+            chemical_potential=-0.05, energy_perturbation=1e-9)
+        hc3_df, _, _ = grand_canonical_nested_sampling(hc3_ls, hc3_gc, Int64(300),
+            MCGrandCanonicalMoves(), obs_save)
+        obs_cleanup()
+        @test nrow(hc3_df) > 0
+        @test all(isfinite, hc3_df.omega)
+        @test issorted(hc3_df.omega, rev=true)
+        # Stats leg: the Omega-sorted ledger post-processes to finite
+        # thermodynamics (the first GenericLattice trip through the stats)
+        hc3_beta = 1 / (8.617333262e-5 * 600.0)
+        hc3_E, hc3_Cv, hc3_N = gc_thermodynamic_stats(hc3_df, [hc3_beta], 10, -0.05)
+        @test all(isfinite, hc3_E)
+        @test all(isfinite, hc3_Cv)
+        @test all(isfinite, hc3_N)
+        @test 0 <= hc3_N[1] <= 24
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -257,4 +257,99 @@
             df, M, z0, μs, Ts, K;
             live_observables=Dict(:a => live_a))
     end
+
+    # ================================================================
+    @testset "fixed-N stats: var_U, cov_UN, and observable averages" begin
+        kb = 8.617333262e-5
+        M = 4
+        K = 3
+        ω0 = (K + 1) / K
+        N_values = [0, 1, 2]
+        T_grid = [300.0, 600.0] .* u"K"
+        μ_grid = [-0.05, 0.02] .* u"eV"
+
+        df0 = DataFrame(iter=Int[], emax=Float64[])
+        df1 = DataFrame(iter=[1, 2], emax=[0.3, 0.1], psi=[0.2, 0.4])
+        df2 = DataFrame(iter=Int[], emax=Float64[])   # single-config convention
+        live_E = [Float64[], [0.05, 0.01], [0.02, 0.02, 0.02]]
+        live_psi = [Dict(:psi => [0.0]),
+                    Dict(:psi => [0.6, 0.8]),
+                    Dict(:psi => [0.5, 0.5, 0.5])]
+
+        stats = gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0, live_emax=live_E,
+            observable_cols=[:psi], live_observables=live_psi)
+
+        # Independent linear-space reference. Sector 1: two dead points plus
+        # a two-entry tail (n_iters = 2). Sector 2: empty ladder, tail mass
+        # exactly 1 split over three copies of the sector energy.
+        w1 = vcat(ω0 * (1 / (K + 1)) .* (K / (K + 1)) .^ df1.iter,
+                  fill(ω0 * (K / (K + 1))^2 / 2, 2))
+        E1 = vcat(df1.emax, live_E[2])
+        a1 = vcat(df1.psi, live_psi[2][:psi])
+        binom = [1.0, 4.0, 6.0]                       # C(4, N)
+        for (j, T) in enumerate([300.0, 600.0]), (k, μ) in enumerate([-0.05, 0.02])
+            β = 1 / (kb * T)
+            b1 = w1 .* exp.(-β .* E1)
+            z1 = sum(b1)
+            e1 = sum(b1 .* E1) / z1
+            e1sq = sum(b1 .* E1 .^ 2) / z1
+            p1 = sum(b1 .* a1) / z1
+            z2 = exp(-β * 0.02)
+            e2, e2sq, p2 = 0.02, 0.02^2, 0.5
+            wN = binom .* [1.0, z1, z2] .* exp.(β * μ .* [0.0, 1.0, 2.0])
+            sw = sum(wN)
+            U = (wN[2] * e1 + wN[3] * e2) / sw
+            Nbar = (wN[2] * 1 + wN[3] * 2) / sw
+            @test stats.logXi[k, j] ≈ log(sw) rtol = 1e-10
+            @test stats.mean_N[k, j] ≈ Nbar rtol = 1e-10
+            @test stats.mean_U[k, j] ≈ U rtol = 1e-10
+            @test stats.var_U[k, j] ≈
+                  (wN[2] * e1sq + wN[3] * e2sq) / sw - U^2 rtol = 1e-8
+            @test stats.cov_UN[k, j] ≈
+                  (wN[2] * 1 * e1 + wN[3] * 2 * e2) / sw - U * Nbar rtol = 1e-8
+            # The N = 0 sector contributes psi = 0 with weight wN[1]
+            @test stats.observables[:psi][k, j] ≈
+                  (wN[2] * p1 + wN[3] * p2) / sw rtol = 1e-10
+        end
+
+        # Backward compatibility: field order preserved, new fields appended
+        stats_nc = gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, ω0=ω0, live_emax=live_E)
+        @test keys(stats_nc) == (:logXi, :mean_N, :var_N, :mean_U,
+                                 :log_Z_N, :N_values, :var_U, :cov_UN,
+                                 :observables)
+        @test isempty(stats_nc.observables)
+        @test stats_nc.logXi ≈ stats.logXi rtol = 1e-14
+
+        # Validation traps
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi])
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, observable_cols=[:psi], live_observables=live_psi)
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi],
+            live_observables=live_psi[1:2])
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi],
+            live_observables=[Dict(:other => [0.0]), live_psi[2], live_psi[3]])
+        @test_throws DimensionMismatch gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi],
+            live_observables=[live_psi[1], Dict(:psi => [0.6]), live_psi[3]])
+        df1_nocol = DataFrame(iter=[1, 2], emax=[0.3, 0.1])
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1_nocol, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, observable_cols=[:psi],
+            live_observables=live_psi)
+        @test_throws ArgumentError gc_thermodynamic_stats_fixed_N(
+            [df0, df1, df2], N_values, M, μ_grid, T_grid;
+            n_walkers=K, live_emax=live_E, live_observables=live_psi)
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -179,4 +179,82 @@
         @test all(isapprox.(df.e_check, df.emax; atol=1e-8))
         @test all(0.0 .<= df.psi .<= 0.5)
     end
+
+    # ================================================================
+    @testset "igref stats: var_U, cov_UN, and observable averages" begin
+        kb = 8.617333262e-5
+        df = DataFrame(iter=[1, 2, 3], emax=[0.5, 0.3, 0.1],
+                       num_particles=[2, 1, 0], a=[1.0, 2.0, 4.0])
+        live_E = [0.05, 0.02]
+        live_N = [1, 2]
+        live_a = [8.0, 16.0]
+        K, z0, M = 4, 1.0, 16
+        ω0 = (K + 1) / K
+        μs = [-0.02, 0.03]
+        Ts = [300.0, 600.0]
+
+        stats = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K;
+            ω0=ω0, live_emax=live_E, live_numbers=live_N,
+            observable_cols=[:a], live_observables=Dict(:a => live_a))
+
+        # Independent linear-space reference for the closed-form weighted sums
+        w0 = ω0 * (1 / (K + 1)) .* (K / (K + 1)) .^ df.iter
+        wt = fill((K / (K + 1))^3 / K, 2)      # tail carries no ω0 factor
+        w_all = vcat(w0, wt)
+        E_all = vcat(df.emax, live_E)
+        N_all = vcat(Float64.(df.num_particles), Float64.(live_N))
+        a_all = vcat(df.a, live_a)
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            β = 1 / (kb * T)
+            w = w_all .* exp.(β * μ .* N_all .- β .* E_all)   # z0 = 1
+            sw = sum(w)
+            u = sum(w .* E_all) / sw
+            n = sum(w .* N_all) / sw
+            @test stats.mean_U[i, j] ≈ u rtol = 1e-12
+            @test stats.var_U[i, j] ≈ sum(w .* E_all .^ 2) / sw - u^2 rtol = 1e-10
+            @test stats.cov_UN[i, j] ≈ sum(w .* E_all .* N_all) / sw - u * n rtol = 1e-10
+            @test stats.observables[:a][i, j] ≈ sum(w .* a_all) / sw rtol = 1e-12
+        end
+
+        # Self-consistency: averaging the ledger's own columns reproduces
+        # mean_N and mean_U
+        stats2 = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K;
+            ω0=ω0, live_emax=live_E, live_numbers=live_N,
+            observable_cols=[:num_particles, :emax],
+            live_observables=Dict(:num_particles => Float64.(live_N),
+                                  :emax => live_E))
+        @test stats2.observables[:num_particles] ≈ stats2.mean_N rtol = 1e-12
+        @test stats2.observables[:emax] ≈ stats2.mean_U rtol = 1e-12
+
+        # Backward compatibility: pre-existing fields keep their order, new
+        # fields are appended, positional destructuring still works
+        stats3 = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K)
+        @test isempty(stats3.observables)
+        @test keys(stats3) == (:logXi, :mean_N, :var_N, :mean_U, :N_eff,
+                               :var_U, :cov_UN, :observables)
+        lX, mN, vN, mU, Ne = stats3
+        @test lX == stats3.logXi && Ne == stats3.N_eff
+
+        # Validation traps
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:nope])
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:a, :a],
+            live_emax=live_E, live_numbers=live_N,
+            live_observables=Dict(:a => live_a))
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:a],
+            live_emax=live_E, live_numbers=live_N)
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:a],
+            live_emax=live_E, live_numbers=live_N,
+            live_observables=Dict(:b => live_a))
+        @test_throws DimensionMismatch gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K; observable_cols=[:a],
+            live_emax=live_E, live_numbers=live_N,
+            live_observables=Dict(:a => [1.0]))
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, M, z0, μs, Ts, K;
+            live_observables=Dict(:a => live_a))
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -1052,4 +1052,374 @@
             @test isapprox(st_ig.observables[:psi][4, 2], ψ_at(β450), atol=0.05)
         end
     end
+
+    # ================================================================
+    @testset "end-to-end: J1-J2 stripe model (4x4), igref + omega-sorted" begin
+        # First multi-shell, mixed-sign end-to-end on both grand-canonical
+        # routes: J1 = -0.1 eV (attractive first shell) with J2 = +0.1 eV
+        # (repulsive second shell) selects the (2x1) superantiferromagnetic
+        # stripe at half filling [Binder & Landau, PRB 21, 1941 (1980)].
+        # Both shells are image-faithful at L = 4 (diagonal circumference
+        # bound 2*sqrt(2) < 4), so the stock lattice fixture applies.
+        # Statistical NS checks: seed the global RNG (the random_seed field
+        # on the NS parameters is not consumed); the seeds are planted after
+        # the enumeration block, which consumes RNG. Tolerances sized at or
+        # above 3x the maximum three-seed deviation at this configuration
+        # (max observed over the six Kish-gated points: |dlnXi| 0.201,
+        # |dN| 0.218, |dU| 0.0223, |dvarU| 0.00256, |dcovUN| 0.0143 against
+        # the exactly-zero mu = 0 covariance, |dpsi| 0.0137, all gated
+        # N_eff >= 304), sanity-checked against sigma(lnXi) ~ sqrt(D/K)
+        # ~ 0.27 at the full-compression depth D = 16 ln 2. The var_U and
+        # cov_UN atol floors carry the 3x cushion unconditionally (3 x
+        # 0.00256 -> 0.008; 3 x 0.0143 -> 0.045), independent of which grid
+        # point produced the maximum; the rtol terms track the 600 K scale.
+        kb = 8.617333262e-5
+
+        M = 16
+        ham = GenericLatticeHamiltonian(0.0, [-0.1, 0.1], u"eV")
+        lattice_at(N) = begin
+            lat = obs_square_lattice(4, 4)
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            lat
+        end
+        # Independent stripe psi from the occupations: the two axial
+        # period-2 Bragg amplitudes evaluated as (-1)^x / (-1)^y phase
+        # sums, sharing no code with bragg_amplitude
+        xy_of(s) = ((s - 1) % 4, ((s - 1) ÷ 4) % 4)
+        psi_from_occ(occ) = begin
+            zx = sum(occ[s] ? (-1.0)^xy_of(s)[1] : 0.0 for s in eachindex(occ))
+            zy = sum(occ[s] ? (-1.0)^xy_of(s)[2] : 0.0 for s in eachindex(occ))
+            sqrt(zx^2 + zy^2) / length(occ)
+        end
+
+        # Exact per-configuration (E, N, psi) from fixed-N enumeration of
+        # all 2^16 configurations
+        exact_E = Dict{Int,Vector{Float64}}()
+        exact_psi = Dict{Int,Vector{Float64}}()
+        exact_occ = Dict{Int,Vector{Vector{Bool}}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(lattice_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            exact_psi[N] = [psi_from_occ(cfg[1]) for cfg in df_exact.config]
+            exact_occ[N] = [Vector{Bool}(cfg[1]) for cfg in df_exact.config]
+            @test length(exact_E[N]) == binomial(M, N)
+        end
+
+        # Ground-state pins, in units of the 0.1 eV coupling, over the
+        # whole filling range
+        @test [minimum(exact_E[N]) for N in 0:M] ≈
+              0.1 .* [0, 0, -1, -2, -4, -4, -5, -6, -8,
+                      -6, -5, -4, -4, -2, -1, 0, 0] atol = 1e-9
+        # Shell coordinations and couplings cancel, 4*(-0.1) + 4*(+0.1) = 0,
+        # so the model is exactly particle-hole symmetric: the full fixed-N
+        # spectra mirror about N = 8
+        @test all(isapprox(sort(exact_E[N]), sort(exact_E[M - N]); atol=1e-12)
+                  for N in 0:M)
+        # The N = 8 minimum, -0.8 eV, is attained by exactly the four
+        # single-orientation stripe states (two row, two column), each with
+        # full stripe order and no c(2x2) order
+        gs8 = findall(e -> e <= minimum(exact_E[8]) + 1e-9, exact_E[8])
+        @test length(gs8) == 4
+        stripe_states = Set(
+            Vector{Bool}([pred(xy_of(s)...) for s in 1:M])
+            for pred in [(x, y) -> x % 2 == 0, (x, y) -> x % 2 == 1,
+                         (x, y) -> y % 2 == 0, (x, y) -> y % 2 == 1])
+        @test Set(exact_occ[8][i] for i in gs8) == stripe_states
+        for i in gs8
+            lat = lattice_at(0)
+            lat.components[1] .= exact_occ[8][i]
+            @test order_parameter_stripe(lat) ≈ 1 / 2 atol = 1e-12
+            @test order_parameter_c2x2(lat) == 0.0
+        end
+
+        function exact_stats(μ_val, T_val)
+            β = 1.0 / (kb * T_val)
+            lt = Float64[]; Ns = Float64[]; Es = Float64[]; Ps = Float64[]
+            for N in 0:M, i in eachindex(exact_E[N])
+                push!(lt, N * β * μ_val - β * exact_E[N][i])
+                push!(Ns, N); push!(Es, exact_E[N][i]); push!(Ps, exact_psi[N][i])
+            end
+            w = exp.(lt .- maximum(lt)); sw = sum(w)
+            u = sum(w .* Es) / sw; n = sum(w .* Ns) / sw
+            (logXi=maximum(lt) + log(sw), mean_N=n, mean_U=u,
+             var_U=sum(w .* Es .^ 2) / sw - u^2,
+             cov_UN=sum(w .* Es .* Ns) / sw - u * n,
+             psi=sum(w .* Ps) / sw)
+        end
+
+        # ... and the symmetric chemical potential is mu* = 0: from the
+        # exact grand sums, <N> = 8 exactly at mu = 0 at any temperature
+        @test exact_stats(0.0, 300.0).mean_N ≈ 8.0 atol = 1e-9
+        @test exact_stats(0.0, 600.0).mean_N ≈ 8.0 atol = 1e-9
+
+        # The stripe lobe is stable for mu in (-0.1, +0.1) eV; the grid
+        # sits inside it, centered on the symmetric chemical potential
+        μs = [-0.050, 0.000, 0.050]
+        Ts = [300.0, 600.0]
+
+        # ---- igref route with stripe recording ----
+        Random.seed!(4501)
+        z0 = 1.0
+        K_ig = 150
+        n_ig = ceil(Int, 1.15 * K_ig * M * log1p(1 / z0)) + 2 * K_ig
+        walkers = [LatticeWalker(deepcopy(lattice_at(0)), energy=0.0u"eV", iter=0)
+                   for _ in 1:K_ig]
+        ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        df_ig, final_ig, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(n_ig), MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3),
+            obs_save; observables=[:stripe => (cfg -> order_parameter_stripe(cfg))])
+        obs_cleanup()
+        live_E_ig = [w.energy.val for w in final_ig.walkers]
+        live_N_ig = [sum(w.configuration.components[1]) for w in final_ig.walkers]
+        live_psi_ig = [order_parameter_stripe(w.configuration) for w in final_ig.walkers]
+
+        st_ig = gc_thermodynamic_stats_ideal_ref(df_ig, M, z0, μs, Ts, K_ig;
+            ω0=(K_ig + 1) / K_ig, live_emax=live_E_ig, live_numbers=live_N_ig,
+            observable_cols=[:stripe], live_observables=Dict(:stripe => live_psi_ig))
+
+        # Ledger integrity: 0 <= Psi <= 1/2 row by row
+        @test names(df_ig) == ["iter", "emax", "num_particles", "stripe"]
+        @test all(0.0 .<= df_ig.stripe .<= 1 / 2)
+
+        n_gated = 0
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            st_ig.N_eff[i, j] >= 200 || continue
+            n_gated += 1
+            ex = exact_stats(μ, T)
+            @test isapprox(st_ig.logXi[i, j], ex.logXi, atol=0.7)
+            @test isapprox(st_ig.mean_N[i, j], ex.mean_N, atol=0.7)
+            @test isapprox(st_ig.mean_U[i, j], ex.mean_U, atol=0.07)
+            @test isapprox(st_ig.var_U[i, j], ex.var_U, rtol=0.4, atol=0.008)
+            @test isapprox(st_ig.cov_UN[i, j], ex.cov_UN, rtol=0.55, atol=0.045)
+            @test isapprox(st_ig.observables[:stripe][i, j], ex.psi, atol=0.05)
+        end
+        # z0 = 1 centers the reference on the mu grid: all six points gated
+        # at N_eff >= 304 across the calibration seeds (floor 200); one
+        # point of slack retained, per the square end-to-end precedent
+        @test n_gated >= 5
+
+        # ---- omega-sorted route at mu = 0 eV with stripe recording ----
+        Random.seed!(4501)
+        K_gc = 100
+        μ_gc = 0.0
+        walkers_gc = [LatticeWalker(deepcopy(lattice_at(0)), energy=0.0u"eV", iter=0)
+                      for _ in 1:K_gc]
+        ls_gc = LatticeGasWalkers(walkers_gc, ham; assign_energy=false)
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=100, chemical_potential=μ_gc,
+            energy_perturbation=1e-9, init_occupation_p=0.3)
+        df_gc, _, _ = grand_canonical_nested_sampling(
+            ls_gc, gc_params, Int64(3000),
+            MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25), obs_save;
+            observables=[:stripe => (cfg -> order_parameter_stripe(cfg))])
+        obs_cleanup()
+
+        @test names(df_gc) == ["iter", "omega", "energy", "num_particles", "stripe"]
+        @test all(0.0 .<= df_gc.stripe .<= 1 / 2)
+
+        β300 = 1.0 / (kb * 300.0)
+        β600 = 1.0 / (kb * 600.0)
+        mean_E_gc, _, mean_N_gc = gc_thermodynamic_stats(
+            df_gc, [β300, β600], K_gc, μ_gc)
+        ex300 = exact_stats(μ_gc, 300.0)
+        ex600 = exact_stats(μ_gc, 600.0)
+        @test isapprox(mean_E_gc[1], ex300.mean_U, rtol=0.3)
+        @test isapprox(mean_N_gc[1], ex300.mean_N, rtol=0.3)
+        @test isapprox(mean_E_gc[2], ex600.mean_U, rtol=0.3)
+        @test isapprox(mean_N_gc[2], ex600.mean_N, rtol=0.3)
+
+        # Caller-side <psi> from the documented Ω-weight construction (the
+        # legacy stats function carries no observable machinery by design;
+        # this re-records the recipe): w_i ∝ Γ_i·exp(-β·Ω_i)
+        ψ_at(β) = begin
+            w = ωᵢ(df_gc.iter, K_gc) .*
+                exp.(-β .* (df_gc.omega .- minimum(df_gc.omega)))
+            sum(w .* df_gc.stripe) / sum(w)
+        end
+        @test isapprox(ψ_at(β300), ex300.psi, atol=0.025)
+        @test isapprox(ψ_at(β600), ex600.psi, atol=0.03)
+
+        # ---- route consistency at the shared mu = 0 where igref is trusted ----
+        for (j, β) in enumerate([β300, β600])
+            if st_ig.N_eff[2, j] >= 200
+                @test isapprox(st_ig.observables[:stripe][2, j], ψ_at(β), atol=0.05)
+            end
+        end
+    end
+
+    # ================================================================
+    @testset "end-to-end: J1-J3 image-multiplicity model (4x4), igref" begin
+        # First full-stack trip of image-multiplicity neighbor lists through
+        # exact_enumeration, the igref sampler, and the stats layer, on the
+        # nearest-neighbor-attraction plus isotropic third-neighbor-repulsion
+        # model [Landau & Binder, PRB 31, 5946 (1985)]: J1 = -3u and
+        # J3 = +2u with u = 1/30 eV, so every configuration energy is an
+        # integer multiple of u. T = 0 bond count: the axial period-4 double
+        # stripe pays (-3|J1| + 2*J3)/2 per site — three occupied NN entries
+        # at J1/2 each plus two multiplicity-2 third-shell entries at J3/2 —
+        # i.e. -1/12 eV per site, -0.6667 eV total at N = 8, strictly above
+        # -0.8 eV; p(2x2) blocks and diagonal period-4 stripes pay -|J1| per
+        # occupied site (two occupied NN entries) with zero third-shell
+        # cost, winning for J3 > |J1|/2. Enumeration remains the arbiter of
+        # every pinned value below.
+        # Statistical NS checks: seed the global RNG (the random_seed field
+        # on the NS parameters is not consumed); the seed is planted after
+        # the enumeration block, which consumes RNG. Tolerances sized at or
+        # above 3x the maximum three-seed deviation at this configuration
+        # (max observed over the gated points: |dlnXi| 0.520, |dN| 0.335,
+        # |dU| 0.0123, |dpsi| 0.0169, all gated N_eff >= 330); the ladder is
+        # deeper than the J1-J2 one — D = 16 ln(1 + 1/0.075) ~ 42.6 nats,
+        # sigma(lnXi) ~ sqrt(D/K) ~ 0.53 — so the lnXi gate is
+        # proportionally looser (atol 1.6 ~ 3 sigma).
+        kb = 8.617333262e-5
+
+        M = 16
+        uJ = 1 / 30                  # eV; J1 = -3*uJ, J3 = +2*uJ
+        ham = GenericLatticeHamiltonian(0.0, [-0.1, 0.0, 1 / 15], u"eV")
+        j3_lattice() = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5, 2.1],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full,
+            image_multiplicity=true)
+        lattice_at(N) = begin
+            lat = j3_lattice()
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            lat
+        end
+
+        # Structural pins: per-site shell coordinations exactly [4, 4, 4] —
+        # the third shell reaches 2 distinct partner sites, each through 2
+        # periodic images at L = 4
+        tpl = j3_lattice()
+        @test all(length.(tpl.neighbors[s]) == [4, 4, 4] for s in 1:M)
+        @test all(length(unique(tpl.neighbors[s][3])) == 2 for s in 1:M)
+
+        # Independent diagonal quadrature from the occupations, evaluated
+        # as i^phase class sums, sharing no code with bragg_amplitude
+        xy_of(s) = ((s - 1) % 4, ((s - 1) ÷ 4) % 4)
+        psi_from_occ(occ) = begin
+            zp = sum(occ[s] ? im^mod(xy_of(s)[1] + xy_of(s)[2], 4) : 0.0im
+                     for s in eachindex(occ))
+            zm = sum(occ[s] ? im^mod(xy_of(s)[1] - xy_of(s)[2], 4) : 0.0im
+                     for s in eachindex(occ))
+            sqrt(abs(zp)^2 + abs(zm)^2) / length(occ)
+        end
+        # The recorded observable: the diagonal k = (pi/2, +-pi/2)
+        # quadrature composed caller-side from bragg_amplitude (the hook's
+        # arbitrary-callable contract)
+        diag_quad(cfg) = sqrt(bragg_amplitude(cfg, 1, 1)^2 +
+                              bragg_amplitude(cfg, 1, -1)^2)
+
+        # Exact per-configuration (E, N, psi) from fixed-N enumeration of
+        # all 2^16 configurations, through the multiplicity neighbor lists
+        exact_E = Dict{Int,Vector{Float64}}()
+        exact_psi = Dict{Int,Vector{Float64}}()
+        exact_occ = Dict{Int,Vector{Vector{Bool}}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(lattice_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            exact_psi[N] = [psi_from_occ(cfg[1]) for cfg in df_exact.config]
+            exact_occ[N] = [Vector{Bool}(cfg[1]) for cfg in df_exact.config]
+            @test length(exact_E[N]) == binomial(M, N)
+        end
+
+        # Every configuration energy is an integer multiple of u
+        @test all(all(isapprox(e / uJ, round(e / uJ); atol=1e-9)
+                      for e in exact_E[N]) for N in 0:M)
+        # Ground-state pins, in units of u, over the whole filling range
+        @test [minimum(exact_E[N]) for N in 0:M] ≈
+              uJ .* [0, 0, -3, -6, -12, -12, -15, -18, -24,
+                     -22, -23, -24, -28, -26, -27, -28, -32] atol = 1e-9
+        # The N = 8 minimum, -0.8 eV (-24u), has degeneracy exactly 16 —
+        # the k = (pi/2, +-pi/2) manifold of p(2x2) blocks and diagonal
+        # period-4 stripes; every member carries the full diagonal
+        # quadrature and exactly no axial period-4 stripe order
+        gs8 = findall(e -> e <= minimum(exact_E[8]) + 1e-9, exact_E[8])
+        @test length(gs8) == 16
+        for i in gs8
+            lat = j3_lattice()
+            lat.components[1] .= exact_occ[8][i]
+            @test diag_quad(lat) ≈ sqrt(2) / 4 atol = 1e-12
+            @test order_parameter_stripe(lat, period=4) == 0.0
+            @test psi_from_occ(exact_occ[8][i]) ≈ sqrt(2) / 4 atol = 1e-12
+        end
+
+        # Grand-canonical stability from the E_min(N) convex hull: the
+        # N = 8 phase is stable for mu in (-0.1, -1/30) eV, centered at
+        # -1/15 eV — the igref grid below sits inside the lobe
+        emin = [minimum(exact_E[N]) for N in 0:M]
+        @test maximum((emin[9] - emin[N + 1]) / (8 - N) for N in 0:7) ≈
+              -0.1 atol = 1e-9
+        @test minimum((emin[N + 1] - emin[9]) / (N - 8) for N in 9:16) ≈
+              -1 / 30 atol = 1e-9
+
+        function exact_stats(μ_val, T_val)
+            β = 1.0 / (kb * T_val)
+            lt = Float64[]; Ns = Float64[]; Es = Float64[]; Ps = Float64[]
+            for N in 0:M, i in eachindex(exact_E[N])
+                push!(lt, N * β * μ_val - β * exact_E[N][i])
+                push!(Ns, N); push!(Es, exact_E[N][i]); push!(Ps, exact_psi[N][i])
+            end
+            w = exp.(lt .- maximum(lt)); sw = sum(w)
+            u = sum(w .* Es) / sw; n = sum(w .* Ns) / sw
+            (logXi=maximum(lt) + log(sw), mean_N=n, mean_U=u,
+             psi=sum(w .* Ps) / sw)
+        end
+
+        μs = [-0.08, -1 / 15, -0.05]
+        Ts = [300.0]
+
+        # ---- igref route with the composed :psi_diag recording ----
+        Random.seed!(4601)
+        z0 = 0.075                   # ln z0 ~ beta*mu at the lobe center at 300 K
+        K_ig = 150
+        n_ig = ceil(Int, 1.15 * K_ig * M * log1p(1 / z0)) + 2 * K_ig
+        walkers = [LatticeWalker(deepcopy(lattice_at(0)), energy=0.0u"eV", iter=0)
+                   for _ in 1:K_ig]
+        ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        df_ig, final_ig, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(n_ig), MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3),
+            obs_save; observables=[:psi_diag => diag_quad])
+        obs_cleanup()
+        live_E_ig = [w.energy.val for w in final_ig.walkers]
+        live_N_ig = [sum(w.configuration.components[1]) for w in final_ig.walkers]
+        live_psi_ig = [diag_quad(w.configuration) for w in final_ig.walkers]
+
+        st_ig = gc_thermodynamic_stats_ideal_ref(df_ig, M, z0, μs, Ts, K_ig;
+            ω0=(K_ig + 1) / K_ig, live_emax=live_E_ig, live_numbers=live_N_ig,
+            observable_cols=[:psi_diag],
+            live_observables=Dict(:psi_diag => live_psi_ig))
+
+        # Ledger integrity: the class-count bound (n0 - n2)^2 + (n1 - n3)^2
+        # <= 32 per quadrature component caps the diagonal quadrature at 1/2
+        @test names(df_ig) == ["iter", "emax", "num_particles", "psi_diag"]
+        @test all(0.0 .<= df_ig.psi_diag .<= 1 / 2 + 1e-12)
+
+        n_gated = 0
+        for (i, μ) in enumerate(μs)
+            st_ig.N_eff[i, 1] >= 200 || continue
+            n_gated += 1
+            ex = exact_stats(μ, 300.0)
+            @test isapprox(st_ig.logXi[i, 1], ex.logXi, atol=1.6)
+            @test isapprox(st_ig.mean_N[i, 1], ex.mean_N, atol=1.1)
+            @test isapprox(st_ig.mean_U[i, 1], ex.mean_U, atol=0.04)
+            @test isapprox(st_ig.observables[:psi_diag][i, 1], ex.psi, atol=0.06)
+        end
+        # ln z0 matched to the lobe center: all three points gated at
+        # N_eff >= 330 across the calibration seeds (floor 200); one point
+        # of slack retained, per the square end-to-end precedent
+        @test n_gated >= 2
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -1,0 +1,68 @@
+@testset "NS observables" begin
+    using Random
+
+    # Shared single-component square-lattice builder
+    function obs_square_lattice(d1, d2)
+        MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(d1, d2, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:d1*d2]],
+            adsorptions=:full)
+    end
+
+    # ================================================================
+    @testset "order_parameter_c2x2" begin
+        lat = obs_square_lattice(4, 4)
+
+        # Empty and full lattices carry no c(2x2) order
+        @test order_parameter_c2x2(lat) == 0.0
+        lat.components[1] .= true
+        @test order_parameter_c2x2(lat) == 0.0
+
+        # Single particle: |±1| / M
+        lat.components[1] .= false
+        lat.components[1][1] = true
+        @test order_parameter_c2x2(lat) == 1 / 16
+
+        # Perfect checkerboards (both sublattices) at half filling: 1/2.
+        # Site ordering: dimension 1 fastest, so i0 = (s-1) % d1, j0 = (s-1) ÷ d1.
+        checker = [iseven(((s - 1) % 4) + ((s - 1) ÷ 4)) for s in 1:16]
+        lat.components[1] .= checker
+        @test order_parameter_c2x2(lat) == 0.5
+        lat.components[1] .= .!checker
+        @test order_parameter_c2x2(lat) == 0.5
+
+        # A column stripe alternates parity along the column and cancels
+        lat.components[1] .= [(s - 1) % 4 == 0 for s in 1:16]
+        @test order_parameter_c2x2(lat) == 0.0
+
+        # Odd in-plane dimensions: the sublattices do not tile evenly
+        @test_throws ArgumentError order_parameter_c2x2(obs_square_lattice(3, 4))
+        @test_throws ArgumentError order_parameter_c2x2(obs_square_lattice(4, 3))
+
+        # Three-dimensional supercell
+        lat3d = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 2),
+            periodicity=(true, true, true),
+            cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:32]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_c2x2(lat3d)
+
+        # Multi-site basis
+        lat2b = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.0)],
+            supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[0.8],
+            components=[[false for _ in 1:32]],
+            adsorptions=:full)
+        @test_throws ArgumentError order_parameter_c2x2(lat2b)
+    end
+end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -1687,4 +1687,633 @@
         # point of slack retained, per the end-to-end precedents
         @test n_gated >= 5
     end
+
+    # ================================================================
+    @testset "end-to-end: contact-substrate slab (3,3,2), igref + fixed-N + omega-sorted" begin
+        # First three-dimensional end-to-end on the grand-canonical
+        # routes, and the first three-route closure (ideal-gas-referenced,
+        # fixed-N stitching, omega-sorted) on a single model: a bilayer
+        # lattice gas with nearest-neighbor attraction and a strictly
+        # contact substrate, the short-range-substrate layering regime of
+        # [Pandit, Schick & Wortis, PRB 26, 5112 (1982)] in the
+        # simple-cubic lattice-gas setting of [Binder & Landau, PRB 37,
+        # 1745 (1988)]. The isotropic cell merges the in-plane and axial
+        # nearest neighbors into one shell at distance 1.0; the in-plane
+        # circumference 3 > 2 x 1.1 keeps the default minimum-image lists
+        # bulk-tiled faithful, so construction is silent (contrast the
+        # (2,2,3) fixtures, which need image multiplicity).
+        # The igref row sits at 1450 K, the temperature that centers the
+        # reference fugacity z0 = e^{beta mu} ~ 0.074 on the inter-step
+        # midpoint: the reference walk's insertion acceptance scales as
+        # z0 while ceiling-blocked deletions freeze the constrained walk,
+        # so the route only mixes in N for z0 in the ~0.05-1 window every
+        # shipped igref regression uses. Matching that window at the
+        # staircase (mu ~ -0.33 eV) fixes the sampled row's temperature;
+        # a 600 K row (z0 ~ 1.9e-3) reproducibly collapses onto the
+        # full-lattice tail, <N> high by ~8. The crisp staircase physics
+        # is carried at 300 K by the fixed-N and omega-sorted routes
+        # below, which have no fugacity constraint.
+        # Statistical NS checks: seed the global RNG (the random_seed
+        # field on the NS parameters is not consumed); the seed is
+        # planted after the enumeration block, which consumes RNG, and
+        # re-planted at the start of each route so the three legs are
+        # stream-independent. Tolerances sized at or above 3x the
+        # maximum three-seed deviation at this configuration (seeds
+        # 4801/4802/4803; igref maxima over the nine Kish-gated grid
+        # evaluations: |dlnXi| 1.10, |dN| 1.10, |dU| 0.38,
+        # |dtheta| 0.084, all gated N_eff >= 2767 on a floor of 200;
+        # fixed-N maxima |dlnXi| 0.45, |dN| 0.18, |dU| 0.062,
+        # |dtheta| 0.017; omega-route maxima |dE| 0.17, |dN| 0.49,
+        # |dtheta| 7e-4 on the 300 K row and 0.041 (theta1) / 0.017
+        # (theta2) on the 600 K row, gated per column; route-consistency
+        # maxima |dtheta| 0.086 igref vs fixed-N and 0.134 igref vs
+        # omega), sanity-checked against sigma(lnXi) ~
+        # sqrt(D/K) ~ 0.57 at the reference-ladder depth
+        # D = 18 log1p(1/z0) ~ 48 nats (worst igref |dlnXi| = 1.9
+        # sigma).
+        kb = 8.617333262e-5
+
+        M = 18
+        slab_a() = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(3, 3, 2),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:18]],
+            adsorptions=:full)
+        lattice_at(N) = begin
+            lat = slab_a()
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            lat
+        end
+        field = layer_field(slab_a(), [-0.15, 0.0] .* u"eV")
+        ham = SiteFieldLatticeHamiltonian(
+            GenericLatticeHamiltonian(0.0, [-0.1], u"eV"), field)
+
+        # Independent per-site field from hardcoded index arithmetic,
+        # sharing no code with site_layers/layer_field: contact binding
+        # on the nine layer-1 sites only
+        site_eps = [s <= 9 ? -0.15 : 0.0 for s in 1:M]
+        @test field == site_eps .* u"eV"
+
+        # Faithfulness pins: one merged shell of five distinct partners
+        # (4 in-plane + 1 axial) on every site, no image-doubled entries
+        tpl = slab_a()
+        @test all(length.(tpl.neighbors[s]) == [5] for s in 1:M)
+        @test all(length(unique(tpl.neighbors[s][1])) == 5 for s in 1:M)
+        @test site_layers(tpl) == vcat(fill(1, 9), fill(2, 9))
+
+        # Exact per-configuration (E, N, n_k) from fixed-N enumeration
+        # of all 2^18 configurations
+        exact_E = Dict{Int,Vector{Float64}}()
+        exact_nk = Dict{Int,Vector{Vector{Int}}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(lattice_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            exact_nk[N] = [[sum(cfg[1][1:9]), sum(cfg[1][10:18])]
+                           for cfg in df_exact.config]
+            @test length(exact_E[N]) == binomial(M, N)
+        end
+
+        # T = 0 ladder. In-plane bond maxima on the 3x3 torus:
+        # b(n) = [0, 0, 1, 3, 4, 6, 9, 11, 14, 18] for n = 0..9 (a full
+        # row of three wraps into a 3-cycle; the complement identity
+        # b(9 - k) = 18 - 4k + b_holes(k) fills in the rest). For N <= 9
+        # the contact field wins and layer-1 packing is optimal:
+        # E_min = -0.15 N - 0.1 b(N); for N = 9 + m the full first layer
+        # is kept and each layer-2 site adds its axial bond:
+        # E_min = -3.15 - 0.1 m - 0.1 b(m). Every value is a multiple of
+        # 0.05 eV = gcd(|J|, eps_s); enumeration is the arbiter.
+        emin = [minimum(exact_E[N]) for N in 0:M]
+        @test emin ≈ 0.05 .* [0, -3, -8, -15, -20, -27, -36, -43, -52, -63,
+                              -65, -69, -75, -79, -85, -93, -99, -107, -117] atol = 1e-9
+        # The N = 9 ground state is unique and is exactly the full first
+        # layer
+        gs9 = findall(e -> e <= minimum(exact_E[9]) + 1e-9, exact_E[9])
+        @test length(gs9) == 1
+        @test exact_nk[9][only(gs9)] == [9, 0]
+
+        # T = 0 staircase from the convex hull of E_min(N) (vertices
+        # N = 0, 9, 18, so the isotherm has exactly two steps):
+        # mu_1 = 2J - eps_s, the per-site cost of the first layer (18
+        # in-plane bonds over 9 sites plus the contact field), and
+        # mu_2 = 3J, the per-site cost of the second layer (two in-plane
+        # bonds plus the axial bond, the T = 0 bulk-coexistence value).
+        # Only the first step is substrate-shifted: the structural
+        # signature of a strictly contact substrate.
+        μ1h = maximum((emin[10] - emin[N + 1]) / (9 - N) for N in 0:8)
+        μ2h = minimum((emin[N + 1] - emin[10]) / (N - 9) for N in 10:18)
+        @test μ1h ≈ -0.35 atol = 1e-9
+        @test μ2h ≈ -0.30 atol = 1e-9
+        @test μ1h < μ2h
+        μ_mid = (μ1h + μ2h) / 2
+
+        # Grand sums on flat arrays built once (2^18 entries; the
+        # isotherm scan below evaluates 51 grid points)
+        flat_E = Float64[]; flat_N = Float64[]
+        flat_t1 = Float64[]; flat_t2 = Float64[]
+        for N in 0:M, i in eachindex(exact_E[N])
+            push!(flat_E, exact_E[N][i]); push!(flat_N, N)
+            push!(flat_t1, exact_nk[N][i][1] / 9)
+            push!(flat_t2, exact_nk[N][i][2] / 9)
+        end
+        function exact_stats(μ_val, T_val)
+            β = 1.0 / (kb * T_val)
+            lt = β .* (μ_val .* flat_N .- flat_E)
+            w = exp.(lt .- maximum(lt)); sw = sum(w)
+            (logXi=maximum(lt) + log(sw),
+             mean_N=sum(w .* flat_N) / sw, mean_U=sum(w .* flat_E) / sw,
+             θ1=sum(w .* flat_t1) / sw, θ2=sum(w .* flat_t2) / sw)
+        end
+
+        # Exact-isotherm plateau gates at 300 K: at the inter-step
+        # midpoint mu = -0.325 the three cheapest excitations off the
+        # layer-1-full state all cost Delta Omega = 0.225 eV (layer-1
+        # hole 0.15 + 0.4 - 0.325; layer-2 adparticle -0.1 + 0.325;
+        # collective layer-2 condensation 9 x (0.325 - 0.30)), so
+        # exp(-0.225/kT) ~ 1.7e-4 and the 0.99/0.01 gates hold with
+        # ~30x margin (they stay valid up to ~479 K, where the
+        # multiplicity-weighted theta2 crosses 0.01). At the midpoint
+        # the model also has an exact particle-hole x layer-swap
+        # symmetry (2 mu - 5J + eps_s = 0 there), so <N> = 9 and
+        # theta1 + theta2 = 1 identically at every temperature
+        ex_p = exact_stats(μ_mid, 300.0)
+        @test ex_p.θ1 >= 0.99
+        @test ex_p.θ2 <= 0.01
+        @test ex_p.mean_N ≈ 9.0 atol = 0.01
+        @test exact_stats(-0.40, 300.0).mean_N <= 0.01
+        @test exact_stats(-0.25, 300.0).mean_N >= 17.99
+        # Staircase shape on a mu scan: layer ordering everywhere and
+        # <N> nondecreasing (d<N>/dmu = beta var N >= 0 exactly)
+        scan = [exact_stats(μ, 300.0) for μ in -0.45:0.005:-0.20]
+        @test all(s.θ1 >= s.θ2 - 1e-12 for s in scan)
+        @test all(diff([s.mean_N for s in scan]) .>= -1e-9)
+
+        # mu grid straddling both steps (the outer points sit on the
+        # smooth isotherm's risers); the 1450 K row is set by the z0
+        # mixing window (header comment), well above the in-plane
+        # condensation scale (2D Ising mapping kTc = 2.269 |J|/4,
+        # Tc ~ 658 K), so this leg gates the reweighting machinery
+        # against the exact grand sums rather than a sharp staircase
+        μs = [-0.36, μ_mid, -0.29]
+        Ts = [1450.0]
+
+        # ---- igref route with theta recording ----
+        Random.seed!(4801)
+        z0 = exp(μ_mid / (kb * 1450.0))
+        K_ig = 150
+        n_ig = ceil(Int, 1.15 * K_ig * M * log1p(1 / z0)) + 2 * K_ig
+        walkers = [LatticeWalker(deepcopy(lattice_at(0)), energy=0.0u"eV", iter=0)
+                   for _ in 1:K_ig]
+        ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(
+            mc_steps=100, reference_fugacity=z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        df_ig, final_ig, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, Int64(n_ig), MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3),
+            obs_save;
+            observables=[Symbol(:theta, k) => (cfg -> layer_coverage(cfg, k))
+                         for k in 1:2])
+        obs_cleanup()
+
+        # Ledger integrity: columns, range, and the ninth-integer
+        # lattice of 9-site-layer coverages
+        @test names(df_ig) == ["iter", "emax", "num_particles", "theta1", "theta2"]
+        for col in (df_ig.theta1, df_ig.theta2)
+            @test all(0.0 .<= col .<= 1.0)
+            @test all(isinteger.(9 .* col))
+        end
+
+        live_E_ig = [w.energy.val for w in final_ig.walkers]
+        live_N_ig = [sum(w.configuration.components[1]) for w in final_ig.walkers]
+        live_th_ig = Dict(Symbol(:theta, k) =>
+                          [layer_coverage(w.configuration, k) for w in final_ig.walkers]
+                          for k in 1:2)
+        st_ig = gc_thermodynamic_stats_ideal_ref(df_ig, M, z0, μs, Ts, K_ig;
+            ω0=(K_ig + 1) / K_ig, live_emax=live_E_ig, live_numbers=live_N_ig,
+            observable_cols=[:theta1, :theta2], live_observables=live_th_ig)
+
+        n_gated = 0
+        for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+            st_ig.N_eff[i, j] >= 200 || continue
+            n_gated += 1
+            ex = exact_stats(μ, T)
+            @test isapprox(st_ig.logXi[i, j], ex.logXi, atol=3.3)
+            @test isapprox(st_ig.mean_N[i, j], ex.mean_N, atol=3.4)
+            @test isapprox(st_ig.mean_U[i, j], ex.mean_U, atol=1.2)
+            @test isapprox(st_ig.observables[:theta1][i, j], ex.θ1, atol=0.26)
+            @test isapprox(st_ig.observables[:theta2][i, j], ex.θ2, atol=0.26)
+            @test st_ig.observables[:theta1][i, j] >=
+                  st_ig.observables[:theta2][i, j] - 0.05
+        end
+        # z0 centered on the mu grid: all three points gated at
+        # N_eff >= 2767 across the calibration seeds (floor 200); one
+        # point of slack retained, per the end-to-end precedents
+        @test n_gated >= 2
+
+        # ---- fixed-N route with theta recording, stitched over all 19
+        # sectors ----
+        Random.seed!(4801)
+        K_fn = 100
+        n_fn = 1300     # max sector depth ln C(18,9) ~ 10.8 nats -> 1.15 K x 10.8 ~ 1241
+        Ts_fn = [300.0, 1450.0]
+        dfs = Vector{DataFrame}(undef, M + 1)
+        live_E_fn = Vector{Vector{Float64}}(undef, M + 1)
+        live_th_fn = Vector{Dict{Symbol,Vector{Float64}}}(undef, M + 1)
+
+        dfs[1] = DataFrame(iter=Int[], emax=Float64[])
+        live_E_fn[1] = Float64[]
+        live_th_fn[1] = Dict(:theta1 => [0.0], :theta2 => [0.0])   # empty lattice
+
+        for N in 1:(M - 1)
+            walkers = [
+                begin
+                    lat = lattice_at(N)
+                    generate_random_new_lattice_sample!(lat)
+                    LatticeWalker(lat)
+                end for _ in 1:K_fn]
+            liveset = LatticeGasWalkers(walkers, ham, perturb_energy=1e-9)
+            ns_params = LatticeNestedSamplingParameters(
+                mc_steps=60, energy_perturbation=1e-9,
+                allowed_fail_count=100_000)
+            df, final_ls, _ = nested_sampling(
+                liveset, ns_params, n_fn, MCRandomWalkClone(), obs_save;
+                observables=[Symbol(:theta, k) => (cfg -> layer_coverage(cfg, k))
+                             for k in 1:2])
+            dfs[N + 1] = df
+            live_E_fn[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
+            live_th_fn[N + 1] = Dict(
+                Symbol(:theta, k) => [layer_coverage(w.configuration, k)
+                                      for w in final_ls.walkers] for k in 1:2)
+        end
+        obs_cleanup()
+
+        # N = M: single configuration; empty ladder + live tail with K
+        # copies; both layers full
+        dfs[M + 1] = DataFrame(iter=Int[], emax=Float64[])
+        live_E_fn[M + 1] = fill(only(exact_E[M]), K_fn)
+        live_th_fn[M + 1] = Dict(:theta1 => fill(1.0, K_fn),
+                                 :theta2 => fill(1.0, K_fn))
+
+        @test names(dfs[10]) == ["iter", "emax", "theta1", "theta2"]
+
+        st_fn = gc_thermodynamic_stats_fixed_N(dfs, collect(0:M), M,
+            μs .* u"eV", Ts_fn .* u"K";
+            n_walkers=K_fn, n_cull=1, ω0=(K_fn + 1) / K_fn,
+            live_emax=live_E_fn,
+            observable_cols=[:theta1, :theta2], live_observables=live_th_fn)
+
+        # The 300 K row carries the crisp sampled staircase (exact
+        # theta1 = 0.9997, theta2 = 3.4e-4 at the plateau midpoint), a
+        # resolution outside the igref route's fugacity mixing window;
+        # the fixed-N construction has no fugacity constraint. The
+        # 1450 K row doubles as the igref route-consistency row.
+        for (j, T) in enumerate(Ts_fn), (k, μ) in enumerate(μs)
+            ex = exact_stats(μ, T)
+            @test isapprox(st_fn.logXi[k, j], ex.logXi, atol=1.4)
+            @test isapprox(st_fn.mean_N[k, j], ex.mean_N, rtol=0.05, atol=0.6)
+            @test isapprox(st_fn.mean_U[k, j], ex.mean_U, rtol=0.05, atol=0.19)
+            @test isapprox(st_fn.observables[:theta1][k, j], ex.θ1, atol=0.06)
+            @test isapprox(st_fn.observables[:theta2][k, j], ex.θ2, atol=0.06)
+        end
+
+        # ---- omega-sorted route at the inter-step plateau ----
+        Random.seed!(4801)
+        K_gc = 100
+        μ_gc = μ_mid
+        walkers_gc = [LatticeWalker(deepcopy(lattice_at(0)), energy=0.0u"eV", iter=0)
+                      for _ in 1:K_gc]
+        ls_gc = LatticeGasWalkers(walkers_gc, ham; assign_energy=false)
+        gc_params = GrandCanonicalNestedSamplingParameters(
+            mc_steps=100, chemical_potential=μ_gc,
+            energy_perturbation=1e-9, init_occupation_p=0.3)
+        df_gc, _, _ = grand_canonical_nested_sampling(
+            ls_gc, gc_params, Int64(3000),
+            MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25), obs_save;
+            observables=[Symbol(:theta, k) => (cfg -> layer_coverage(cfg, k))
+                         for k in 1:2])
+        obs_cleanup()
+
+        @test names(df_gc) == ["iter", "omega", "energy", "num_particles",
+                               "theta1", "theta2"]
+        for col in (df_gc.theta1, df_gc.theta2)
+            @test all(0.0 .<= col .<= 1.0)
+            @test all(isinteger.(9 .* col))
+        end
+
+        β300 = 1.0 / (kb * 300.0)
+        β600 = 1.0 / (kb * 600.0)
+        β1450 = 1.0 / (kb * 1450.0)
+        mean_E_gc, _, mean_N_gc = gc_thermodynamic_stats(
+            df_gc, [β300, β600], K_gc, μ_gc)
+        ex300 = exact_stats(μ_gc, 300.0)
+        ex600 = exact_stats(μ_gc, 600.0)
+        @test isapprox(mean_E_gc[1], ex300.mean_U, rtol=0.3)
+        @test isapprox(mean_N_gc[1], ex300.mean_N, rtol=0.3)
+        @test isapprox(mean_E_gc[2], ex600.mean_U, rtol=0.3)
+        @test isapprox(mean_N_gc[2], ex600.mean_N, rtol=0.3)
+
+        # Caller-side <theta_k> from the documented Ω-weight construction
+        # (the legacy stats function carries no observable machinery by
+        # design; this re-records the recipe): w_i ∝ Γ_i·exp(-β·Ω_i)
+        θ_at(col, β) = begin
+            w = ωᵢ(df_gc.iter, K_gc) .*
+                exp.(-β .* (df_gc.omega .- minimum(df_gc.omega)))
+            sum(w .* col) / sum(w)
+        end
+        @test isapprox(θ_at(df_gc.theta1, β300), ex300.θ1, atol=0.03)
+        @test isapprox(θ_at(df_gc.theta2, β300), ex300.θ2, atol=0.02)
+        @test isapprox(θ_at(df_gc.theta1, β600), ex600.θ1, atol=0.13)
+        @test isapprox(θ_at(df_gc.theta2, β600), ex600.θ2, atol=0.06)
+        @test θ_at(df_gc.theta1, β300) >= θ_at(df_gc.theta2, β300)
+        @test θ_at(df_gc.theta1, β600) >= θ_at(df_gc.theta2, β600)
+
+        # ---- route consistency ----
+        # igref vs fixed-N on the shared 1450 K row, where the igref
+        # window is healthy
+        for (i, μ) in enumerate(μs)
+            st_ig.N_eff[i, 1] >= 200 || continue
+            @test isapprox(st_ig.observables[:theta1][i, 1],
+                           st_fn.observables[:theta1][i, 2], atol=0.26)
+            @test isapprox(st_ig.observables[:theta2][i, 1],
+                           st_fn.observables[:theta2][i, 2], atol=0.26)
+        end
+        # igref vs omega-sorted at the shared plateau point, with the
+        # omega ladder reweighted to the igref row's temperature
+        if st_ig.N_eff[2, 1] >= 200
+            @test isapprox(st_ig.observables[:theta1][2, 1],
+                           θ_at(df_gc.theta1, β1450), atol=0.41)
+            @test isapprox(st_ig.observables[:theta2][2, 1],
+                           θ_at(df_gc.theta2, β1450), atol=0.41)
+        end
+    end
+
+    # ================================================================
+    @testset "end-to-end: tetragonal inverse-cube slab (2,2,3), igref + contact-biased channel" begin
+        # The inverse-cube substrate staircase itself: nearest-neighbor
+        # attraction [J_par, J_perp] on a tetragonal (2,2,3) slab with
+        # the -eps_s/k^3 layer profile of [de Oliveira & Griffiths,
+        # Surf. Sci. 71, 687 (1978)], whose T = 0 steps
+        # mu_1 = 2 J_par - eps_s and mu_k = 2 J_par + J_perp - eps_s/k^3
+        # are strictly monotone: the splitting of the upper steps that
+        # part (a)'s strictly contact substrate collapses onto the
+        # single bulk value 3J. First slab trip of image-multiplicity
+        # neighbor lists and the interlayer-spacing geometry through
+        # enumeration, sampling, and the stats layer, and the first
+        # end-to-end exercise of the :contact biased insertion channel
+        # and its per-move-type counters.
+        # Statistical NS checks: seed the global RNG (the random_seed
+        # field on the NS parameters is not consumed); the seed is
+        # planted after the enumeration block, which consumes RNG, and
+        # re-planted before the biased rerun. The rerun is identical in
+        # parameters, not in stream: the biased channel consumes extra
+        # RNG draws (the channel coin and the biased-site draw), so the
+        # same seed diverges at the first insertion proposal; both runs
+        # are gated against the same exact sums. The igref rows sit at
+        # 1650 K, the temperature that centers z0 = e^{beta mu} ~ 0.073
+        # on the second-plateau midpoint, inside the ~0.05-1 fugacity
+        # window where the reference walk still mixes in N (see the
+        # (3,3,2) testset's header); the staircase physics is
+        # deterministic-only here. Tolerances sized at or above 3x the
+        # maximum three-seed deviation over BOTH legs at this
+        # configuration (seeds 4901/4902/4903; maxima over the eighteen
+        # Kish-gated evaluations across both legs: |dlnXi| 0.68,
+        # |dN| 0.88, |dU| 0.38, |dtheta| 0.13, all gated
+        # N_eff >= 1623 on a floor of 200), sanity-checked against
+        # sigma(lnXi) ~ sqrt(D/K) ~ 0.57 at the reference-ladder depth
+        # D = 12 log1p(1/z0) ~ 32 nats (worst |dlnXi| = 1.2 sigma).
+        kb = 8.617333262e-5
+
+        M = 12
+        eps_layer = [-0.27, -0.03375, -0.01]     # eV, -eps_s/k^3 with eps_s = 0.27
+        slab_b() = MLattice{1,SquareLattice}(
+            lattice_constant=1.0,
+            interlayer_spacing=1.25,
+            basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(2, 2, 3),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.35],
+            components=[[false for _ in 1:12]],
+            adsorptions=:full,
+            image_multiplicity=true)
+        slab_at(N) = begin
+            lat = slab_b()
+            lat.components[1] .= false
+            lat.components[1][1:N] .= true
+            lat
+        end
+        base = GenericLatticeHamiltonian(0.0, [-0.1, -0.15], u"eV")   # [J_par, J_perp]
+        field = layer_field(slab_b(), eps_layer .* u"eV")
+        ham = SiteFieldLatticeHamiltonian(base, field)
+
+        # Independent per-site profile from hardcoded index arithmetic,
+        # sharing no code with site_layers/layer_field
+        site_eps = [eps_layer[(s - 1) ÷ 4 + 1] for s in 1:M]
+        @test field == site_eps .* u"eV"
+
+        # Geometry pins. Shell 1 (in-plane, distance 1.0): the 2-wide
+        # cell wraps, and multiplicity restores the bulk-tiled
+        # coordination 4 as two distinct partners counted twice each.
+        # Shell 2 (axial, distance 1.25): one bond on the surface layers,
+        # two in the middle; the in-plane diagonal sqrt(2) and the axial
+        # diagonal sqrt(1 + 1.25^2) = 1.60 both sit outside the cutoffs.
+        tpl = slab_b()
+        sl = site_layers(tpl)
+        @test sl == [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+        @test tpl.lattice_vectors[3, 3] == 1.25
+        @test all(length(tpl.neighbors[s][1]) == 4 for s in 1:M)
+        @test all(length(unique(tpl.neighbors[s][1])) == 2 for s in 1:M)
+        @test all(length(tpl.neighbors[s][2]) == (sl[s] == 2 ? 2 : 1) for s in 1:M)
+
+        # Exact per-configuration (E, N, n_k) from fixed-N enumeration
+        # of all 2^12 = 4096 configurations
+        exact_E = Dict{Int,Vector{Float64}}()
+        exact_nk = Dict{Int,Vector{Vector{Int}}}()
+        for N in 0:M
+            df_exact, _ = exact_enumeration(slab_at(N), ham)
+            exact_E[N] = [ustrip(u"eV", e) for e in df_exact.energy]
+            exact_nk[N] = [[sum(cfg[1][4k-3:4k]) for k in 1:3]
+                           for cfg in df_exact.config]
+            @test length(exact_E[N]) == binomial(M, N)
+        end
+
+        # T = 0 ladder in the bulk-tiled doubled-bond convention (a full
+        # 2x2 layer carries 8 in-plane entries = per-site 2 J_par, the
+        # infinite-lattice value the multiplicity lists exist to
+        # restore). In-plane entry counts b(n) on the wrapped 2x2 layer:
+        # [0, 0, 2, 4, 8]. Layers fill bottom-up; each site in layer
+        # k >= 2 adds one axial bond to the full layer below:
+        #   N = 0..4:  E = -0.27 N - 0.1 b(N)
+        #   N = 4+m:   E = E(4) - (0.03375 + 0.15) m - 0.1 b(m)
+        #   N = 8+m:   E = E(8) - (0.01 + 0.15) m - 0.1 b(m)
+        # No clean single unit exists (gcd granularity 1/800 eV), so the
+        # decimal literals are pinned; enumeration is the arbiter.
+        emin = [minimum(exact_E[N]) for N in 0:M]
+        @test emin ≈ [0.0, -0.27, -0.74, -1.21, -1.88,
+                      -2.06375, -2.4475, -2.83125, -3.415,
+                      -3.575, -3.935, -4.295, -4.855] atol = 1e-9
+        # The one- and two-layer film ground states are unique and are
+        # exactly the bottom-up layer fillings
+        gs4 = findall(e -> e <= minimum(exact_E[4]) + 1e-9, exact_E[4])
+        @test length(gs4) == 1
+        @test exact_nk[4][only(gs4)] == [4, 0, 0]
+        gs8 = findall(e -> e <= minimum(exact_E[8]) + 1e-9, exact_E[8])
+        @test length(gs8) == 1
+        @test exact_nk[8][only(gs8)] == [4, 4, 0]
+
+        # Three-step staircase from the hull (vertices N = 0, 4, 8, 12):
+        # mu_1 = 2 J_par - eps_s; mu_k = 2 J_par + J_perp - eps_s/k^3
+        # for k = 2, 3 -- strictly monotone, the inverse-cube splitting
+        # this fixture exists to pin
+        μ1h = maximum((emin[5] - emin[N + 1]) / (4 - N) for N in 0:3)
+        μ2h = maximum((emin[9] - emin[N + 1]) / (8 - N) for N in 0:7)
+        μ3h = minimum((emin[N + 1] - emin[9]) / (N - 8) for N in 9:12)
+        @test μ1h ≈ -0.47 atol = 1e-9
+        @test μ2h ≈ -0.38375 atol = 1e-9
+        @test μ3h ≈ -0.36 atol = 1e-9
+        @test μ1h < μ2h < μ3h
+
+        # Grand sums on flat arrays built once
+        flat_E = Float64[]; flat_N = Float64[]
+        flat_th = [Float64[] for _ in 1:3]
+        for N in 0:M, i in eachindex(exact_E[N])
+            push!(flat_E, exact_E[N][i]); push!(flat_N, N)
+            for k in 1:3
+                push!(flat_th[k], exact_nk[N][i][k] / 4)
+            end
+        end
+        function exact_stats(μ_val, T_val)
+            β = 1.0 / (kb * T_val)
+            lt = β .* (μ_val .* flat_N .- flat_E)
+            w = exp.(lt .- maximum(lt)); sw = sum(w)
+            (logXi=maximum(lt) + log(sw),
+             mean_N=sum(w .* flat_N) / sw, mean_U=sum(w .* flat_E) / sw,
+             θ=[sum(w .* flat_th[k]) / sw for k in 1:3])
+        end
+
+        # Exact-isotherm plateau gates. The resolving temperature is set
+        # by the collective competitor, not the single-site one: on the
+        # second plateau the nearest competing states are N = 4 and
+        # N = 12 at Delta Omega = 4 x (0.02375/2) = 0.0475 eV
+        # (single-site defects cost 0.2119 eV), so the 0.99/0.01 form
+        # needs kT <= 0.0475/ln 100, i.e. T <= 120 K; at 300 K theta_3
+        # reaches 0.121 on this plateau. Shipped at 100 K:
+        # theta_2 = 0.9960, theta_3 = 0.0040, a 2.5x margin.
+        T_iso = 100.0
+        μ_c1 = (μ1h + μ2h) / 2     # first-plateau midpoint, -0.426875
+        μ_c2 = (μ2h + μ3h) / 2     # second-plateau midpoint, -0.371875
+        ex1 = exact_stats(μ_c1, T_iso)
+        @test ex1.θ[1] >= 0.99
+        @test ex1.θ[2] <= 0.01
+        @test ex1.mean_N ≈ 4.0 atol = 0.01
+        ex2 = exact_stats(μ_c2, T_iso)
+        @test ex2.θ[1] >= 0.99
+        @test ex2.θ[2] >= 0.99
+        @test ex2.θ[3] <= 0.01
+        @test ex2.mean_N ≈ 8.0 atol = 0.01
+        @test exact_stats(-0.50, T_iso).mean_N <= 0.01
+        @test exact_stats(-0.33, T_iso).mean_N >= 11.99
+        scan = [exact_stats(μ, T_iso) for μ in -0.50:0.005:-0.315]
+        @test all(s.θ[1] >= s.θ[2] - 1e-12 && s.θ[2] >= s.θ[3] - 1e-12
+                  for s in scan)
+        @test all(diff([s.mean_N for s in scan]) .>= -1e-9)
+
+        # mu grid straddling the second and third steps. The 1650 K row
+        # is set by the z0 mixing window (header comment); the sampled
+        # gates are against the exact grand sums at the same (mu, T),
+        # and the 0.27 eV contact field is ~2 kT there, so the layer
+        # profile stays column-discriminating
+        μs = [-0.40, μ_c2, -0.34]
+        Ts = [1650.0]
+        z0 = exp(μ_c2 / (kb * 1650.0))
+        K_ig = 100
+        n_ig = ceil(Int, 1.15 * K_ig * M * log1p(1 / z0)) + 2 * K_ig
+
+        # One igref run shape for both legs: identical parameters by
+        # construction, only the move routine differs
+        run_igref(mc) = begin
+            walkers = [LatticeWalker(deepcopy(slab_at(0)), energy=0.0u"eV", iter=0)
+                       for _ in 1:K_ig]
+            ls = LatticeGasWalkers(walkers, ham; assign_energy=false)
+            params = IdealGasReferencedGCNSParameters(
+                mc_steps=100, reference_fugacity=z0, energy_perturbation=1e-9,
+                allowed_fail_count=100_000)
+            df, final_ls, params_out = ideal_gas_referenced_nested_sampling(
+                ls, params, Int64(n_ig), mc, obs_save;
+                observables=[Symbol(:theta, k) => (cfg -> layer_coverage(cfg, k))
+                             for k in 1:3])
+            obs_cleanup()
+            (df, final_ls, params_out)
+        end
+
+        # One gate block for both legs: same ledger pins, same Kish
+        # gate, same tolerances
+        function gate_leg(df, final_ls)
+            @test names(df) == ["iter", "emax", "num_particles",
+                                "theta1", "theta2", "theta3"]
+            for col in (df.theta1, df.theta2, df.theta3)
+                @test all(0.0 .<= col .<= 1.0)
+                @test all(isinteger.(4 .* col))
+            end
+            live_E = [w.energy.val for w in final_ls.walkers]
+            live_N = [sum(w.configuration.components[1]) for w in final_ls.walkers]
+            live_th = Dict(Symbol(:theta, k) =>
+                           [layer_coverage(w.configuration, k) for w in final_ls.walkers]
+                           for k in 1:3)
+            st = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K_ig;
+                ω0=(K_ig + 1) / K_ig, live_emax=live_E, live_numbers=live_N,
+                observable_cols=[:theta1, :theta2, :theta3],
+                live_observables=live_th)
+            n_gated = 0
+            for (j, T) in enumerate(Ts), (i, μ) in enumerate(μs)
+                st.N_eff[i, j] >= 200 || continue
+                n_gated += 1
+                ex = exact_stats(μ, T)
+                @test isapprox(st.logXi[i, j], ex.logXi, atol=2.1)
+                @test isapprox(st.mean_N[i, j], ex.mean_N, atol=2.7)
+                @test isapprox(st.mean_U[i, j], ex.mean_U, atol=1.2)
+                for k in 1:3
+                    @test isapprox(st.observables[Symbol(:theta, k)][i, j],
+                                   ex.θ[k], atol=0.4)
+                end
+                @test st.observables[:theta1][i, j] >=
+                      st.observables[:theta2][i, j] - 0.05
+                @test st.observables[:theta2][i, j] >=
+                      st.observables[:theta3][i, j] - 0.05
+            end
+            # z0 centered on the mu grid: all three points gated at
+            # N_eff >= 1623 across the calibration seeds and both legs
+            # (floor 200); one point of slack retained, per the
+            # end-to-end precedents
+            @test n_gated >= 2
+            st
+        end
+
+        # ---- igref route, uniform insertions ----
+        Random.seed!(4901)
+        df_u, final_u, params_u = run_igref(
+            MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3))
+        gate_leg(df_u, final_u)
+        # The uniform run never touches the biased channel
+        @test get(params_u.move_stats, :insert_biased_attempted, 0) == 0
+
+        # ---- the identical run under the :contact biased channel ----
+        # bias_shells = 2 spans both bond classes (in-plane and axial),
+        # so a contact site is any empty site touching the film
+        Random.seed!(4901)
+        df_b, final_b, params_b = run_igref(MCGrandCanonicalMoves(
+            p_move=0.4, p_insert=0.3, p_bias=0.5,
+            bias_predicate=:contact, bias_shells=2))
+        gate_leg(df_b, final_b)
+        # First end-to-end trip of the biased channel: the run totals
+        # must show the 0.5 split really split, and biased proposals
+        # really accepted
+        @test params_b.move_stats[:insert_biased_attempted] > 0
+        @test params_b.move_stats[:insert_biased_accepted] > 0
+        @test params_b.move_stats[:insert_uniform_attempted] > 0
+        @test params_b.move_stats[:insert_biased_accepted] <=
+              params_b.move_stats[:insert_biased_attempted]
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -2926,4 +2926,342 @@
         @test all(isfinite, hc3_N)
         @test 0 <= hc3_N[1] <= 24
     end
+
+    # ================================================================
+    @testset "end-to-end: rectangular adlattice through the SquareLattice tag" begin
+        # The rectangular adlattice -- the adsorption geometry of the
+        # fcc(110) facet in the nested-sampling study of Lennard-Jones
+        # surface adsorption [Yang, Partay & Wexler, Phys. Chem. Chem.
+        # Phys. 26, 13862 (2024)] -- through the MLattice inner
+        # constructor with the SquareLattice tag retained: lattice
+        # vectors diag(a, sqrt(2) a, c), single-site basis. Every
+        # square-tag kernel is either metric-true (neighbor shells from
+        # image distances) or index-space (the geometric cluster move
+        # is a point inversion, valid on any Bravais lattice), so the
+        # tag carries the anisotropic in-plane metric; this testset is
+        # the regression pinning cluster-move correctness on an
+        # anisotropic in-plane metric. On the 1 x sqrt(2) cell the
+        # first four shell distances are d_k = sqrt(k) a, k = 1..4,
+        # with coordinations [2, 2, 4, 2], so a 12-6 pair potential
+        # tabulates to exactly rational couplings
+        # J_k / eps = k^-6 - 2 k^-3 at the shell distances.
+        ra_sq2 = sqrt(2.0)
+        ra_lv = [1.0 0.0 0.0; 0.0 ra_sq2 0.0; 0.0 0.0 1.0]
+        ra_radii = [1.05, 1.45, 1.8, 2.05]
+        ra_J = 0.01 .* [-1.0, -0.234375, -0.0727023319615912, -0.031005859375]
+        ra_ham = GenericLatticeHamiltonian(-0.03, ra_J, u"eV")
+        ra_z = [2, 2, 4, 2]
+
+        # (6, 4, 1): no shell wraps the cell (x-circumference 6a > 2 d_4,
+        # y-circumference 4 sqrt(2) a > 2 d_2), so the default
+        # minimum-image lists are exact and construction is warning-free
+        ra6 = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,SquareLattice}(
+            ra_lv, [(0.0, 0.0, 0.0)], (6, 4, 1), (true, true, false),
+            ra_radii, [fill(false, 24)], fill(true, 24))
+        @test num_sites(ra6) == 24
+        @test all(nb -> length.(nb) == ra_z, ra6.neighbors)
+
+        # Independent geometry: explicit-image bond multiset from the
+        # stored positions (coupling/2 per ordered entry, images counted
+        # individually), sharing no code with compute_neighbors
+        function ra_bonds(pos, Lx, Ly)
+            bonds = Tuple{Int,Int,Int}[]
+            for i in eachindex(pos), j in eachindex(pos)
+                for ix in -3:3, iy in -3:3
+                    (j == i && ix == 0 && iy == 0) && continue
+                    d = hypot(pos[i][1] - pos[j][1] + ix * Lx,
+                              pos[i][2] - pos[j][2] + iy * Ly)
+                    d > ra_radii[end] && continue
+                    sh = findfirst(r -> d <= r, ra_radii)
+                    sh === nothing || push!(bonds, (i, j, sh))
+                end
+            end
+            return bonds
+        end
+        rp6 = [(ra6.positions[s, 1], ra6.positions[s, 2]) for s in 1:24]
+        ra6_bonds = ra_bonds(rp6, 6.0, 4 * ra_sq2)
+        @test all(sort(ra6.neighbors[s][k]) ==
+                  sort([b[2] for b in ra6_bonds if b[1] == s && b[3] == k])
+                  for s in 1:24, k in 1:4)
+
+        # Configuration-resolved energy identity over random occupation
+        # masks: interacting_energy against the explicit-image truncated
+        # pair sum. The RNG draws here precede the seeded run below,
+        # which re-seeds
+        ra_brute(occ, bonds) = -0.03 * count(occ) +
+            sum((occ[b[1]] && occ[b[2]]) ? ra_J[b[3]] / 2 : 0.0 for b in bonds)
+        Random.seed!(7300)
+        ra_worst6 = 0.0
+        for _ in 1:100
+            mask = rand(0:(2^24 - 1))
+            occ = ra6.components[1]
+            for s in 1:24
+                occ[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            ra_worst6 = max(ra_worst6,
+                abs(ustrip(u"eV", interacting_energy(ra6, ra_ham)) -
+                    ra_brute(occ, ra6_bonds)))
+        end
+        @test ra_worst6 <= 1e-12
+
+        # Full coverage: on-site plus half the coordination-weighted
+        # couplings per site
+        ra6.components[1] .= true
+        ra_full6 = 24 * (-0.03) + 24 / 2 * sum(ra_z .* ra_J)
+        @test abs(ustrip(u"eV", interacting_energy(ra6, ra_ham)) - ra_full6) < 1e-12
+
+        # (4, 4, 1): the d_4 = 2a shell wraps the 4a x-circumference
+        # (the +2a and -2a images of the same partner both sit at
+        # distance 2a), so the cell is built with image_multiplicity =
+        # true; the bulk-tiled shell entries stay [2, 2, 4, 2] with the
+        # fourth shell listing one unique partner twice
+        ra4 = MLattice{1,SquareLattice}(ra_lv, [(0.0, 0.0, 0.0)], (4, 4, 1),
+            (true, true, false), ra_radii, [fill(false, 16)], fill(true, 16);
+            image_multiplicity=true)
+        @test all(nb -> length.(nb) == ra_z, ra4.neighbors)
+        @test all(length(unique(ra4.neighbors[s][4])) == 1 for s in 1:16)
+        rp4 = [(ra4.positions[s, 1], ra4.positions[s, 2]) for s in 1:16]
+        ra4_bonds = ra_bonds(rp4, 4.0, 4 * ra_sq2)
+        @test all(sort(ra4.neighbors[s][k]) ==
+                  sort([b[2] for b in ra4_bonds if b[1] == s && b[3] == k])
+                  for s in 1:16, k in 1:4)
+        ra_worst4 = 0.0
+        for _ in 1:100
+            mask = rand(0:(2^16 - 1))
+            occ = ra4.components[1]
+            for s in 1:16
+                occ[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            ra_worst4 = max(ra_worst4,
+                abs(ustrip(u"eV", interacting_energy(ra4, ra_ham)) -
+                    ra_brute(occ, ra4_bonds)))
+        end
+        @test ra_worst4 <= 1e-12
+
+        # Full 2^16 own-energy table from the bond multiset; the N = 4
+        # spectrum and every grand reference below derive from it
+        ra_e = zeros(2^16)
+        ra_n = zeros(Int, 2^16)
+        ra_occ = fill(false, 16)
+        for mask in 0:(2^16 - 1)
+            for s in 1:16
+                ra_occ[s] = ((mask >> (s - 1)) & 1) == 1
+            end
+            e = -0.03 * count(ra_occ)
+            for (i, j, sh) in ra4_bonds
+                (ra_occ[i] && ra_occ[j]) && (e += ra_J[sh] / 2)
+            end
+            ra_e[mask + 1] = e
+            ra_n[mask + 1] = count_ones(mask)
+        end
+
+        # exact_enumeration closure at N = 4: the C(16, 4) spectrum
+        ra_lat4 = deepcopy(ra4)
+        ra_lat4.components[1] .= false
+        ra_lat4.components[1][1:4] .= true
+        ra_df4, _ = exact_enumeration(ra_lat4, ra_ham)
+        @test nrow(ra_df4) == binomial(16, 4)
+        @test sort([ustrip(u"eV", e) for e in ra_df4.energy]) ≈
+              sort([ra_e[m + 1] for m in 0:(2^16 - 1) if count_ones(m) == 4]) atol = 1e-12
+
+        ra_kb = 8.617333262e-5
+        function ra_exact(mu, T)
+            beta = 1 / (ra_kb * T)
+            lt = beta .* (mu .* ra_n .- ra_e)
+            mx = maximum(lt)
+            w = exp.(lt .- mx)
+            Z = sum(w)
+            mN = sum(w .* ra_n) / Z
+            (logXi=mx + log(Z), mean_N=mN,
+             var_N=sum(w .* ra_n .^ 2) / Z - mN^2,
+             mean_U=sum(w .* ra_e) / Z)
+        end
+        # Particle-hole symmetry pins half coverage at mu* = eps_0 +
+        # (1/2) sum_k z_k J_k at every temperature. The mu grid is mu*
+        # rounded to 10^-5 plus the two mu values that bracket coverage
+        # 0.2 and 0.8 at 80 K, so the grid spans coverage ~0.2-0.8;
+        # beta |J_1| runs from 0.93 (125 K) to 1.45 (80 K)
+        ra_mu_sym = -0.03 + 0.5 * sum(ra_z .* ra_J)
+        @test ra_exact(ra_mu_sym, 80.0).mean_N ≈ 8.0 atol = 1e-9
+        @test ra_exact(ra_mu_sym, 125.0).mean_N ≈ 8.0 atol = 1e-9
+        ra_mus = [-0.04694, -0.04411, -0.04127]
+        ra_Ts = [80.0, 100.0, 125.0]
+        @test ra_mus[2] ≈ ra_mu_sym atol = 5e-6
+        @test ra_exact(ra_mus[1], ra_Ts[1]).mean_N ≈ 0.2 * 16 atol = 0.2
+        @test ra_exact(ra_mus[3], ra_Ts[1]).mean_N ≈ 0.8 * 16 atol = 0.2
+
+        # Seeded ideal-gas-referenced route with geometric cluster moves
+        # in the decorrelation loop (clusters_freq = swaps_freq = 1):
+        # K = 200 walkers, 20000 steps ~ 1.2 K M log1p(1/z0) at the
+        # full-descent depth M log1p(1/z0) ~ 82 nats, z0 = e^{beta mu*}
+        # at 100 K centering the reference on the grid; sigma(lnXi) ~
+        # sqrt(82/200) ~ 0.64 at the full-descent depth. K and the
+        # step count are doubled from the first cut of this closure
+        # because gates must be able to fail: the K = 100 run's
+        # grid-wide spread exceeded the attainable deviation range for
+        # <N> and <U>, whose estimators are confined to [0, 16] and
+        # [E_gs, 0] with E_gs = -0.70572568 eV. The global RNG is
+        # seeded here (the parameters' random_seed field is not
+        # consumed) and the gates run after all RNG use.
+        #
+        # Tolerances: three-seed calibrated (seeds 7301/7302/7303),
+        # per stat per temperature row (gate arrays indexed by the
+        # 80/100/125 K rows), >= 3x the three-seed maximum deviation
+        # from the exact grand sums over that row's gated points.
+        # Every gated-set maximum is set by seed 7303, whose 80 K row
+        # (beta |J_1| = 1.45) converges worst; the lnXi and mean_N
+        # maxima all sit at the coverage-0.8 flank. Per-point
+        # attainable sups: max(<N>, 16 - <N>) for mean_N and
+        # max(|E_gs - <U>|, |<U>|) for mean_U; gated points are (mu
+        # index, T index) pairs.
+        #   lnXi: gates 10.6/7.9/5.9 on all points (maxima 3.50/2.62/
+        #   1.96); failable low everywhere, the log-sum estimator
+        #   being unbounded below.
+        #   mean_N: gates 7.9/9.7/8.6 on the flanking-mu points only
+        #   (flank maxima 2.62/3.20/2.84 vs flank sups 12.80/11.27/
+        #   10.20). At the symmetric mu the sup is 16 - 8 = 8, below
+        #   every row's 3x spread (seed 7303 deviates 5.01 there at
+        #   80 K), so those points carry no mean_N gate and stay
+        #   closed by the exact particle-hole pins above, lnXi, and
+        #   the Kish floor.
+        #   mean_U: gates 0.41/0.21/0.33 on gated points (1,1),(3,1) /
+        #   (1,2) / (1,3),(2,3) (gated maxima 0.136/0.068/0.108 vs
+        #   minimum gated sups 0.54/0.53/0.40); the ungated points'
+        #   sups (0.39-0.46) sit below the 3x spread seed 7303 forces
+        #   (deviations up to 0.24).
+        #   var_N: no deviation gate at this effort level -- a >= 3x
+        #   gate would sit at 12.0-26.4 while the exact values span
+        #   6.9-15.2, so it could never fail low at any point (the
+        #   best point, the symmetric mu at 100 K, would leave a 3x
+        #   gate of 10.7 only 0.35 below the exact 11.06); Var N
+        #   mis-convergence still trips the lnXi gates and the Kish
+        #   floor.
+        # Shipped seed 7301, row maxima on the gated points: lnXi
+        # 0.997/0.325/0.133, mean_N 2.19/1.89/0.933, mean_U 0.115/
+        # 0.0129/0.0145; its Kish minimum is N_eff 805 at the
+        # coverage-0.8 corner of the 80 K row -- the same corner binds
+        # for all three seeds (three-seed minimum 709) -- on a floor
+        # of 100.
+        ra_z0 = exp(ra_mus[2] / (ra_kb * 100.0))
+        Random.seed!(7301)
+        ra_walkers = [LatticeWalker(deepcopy(ra4), energy=0.0u"eV", iter=0)
+                      for _ in 1:200]
+        ra_ls = LatticeGasWalkers(ra_walkers, ra_ham; assign_energy=false)
+        ra_params = IdealGasReferencedGCNSParameters(mc_steps=60,
+            reference_fugacity=ra_z0, energy_perturbation=1e-9,
+            allowed_fail_count=100_000)
+        ra_df, ra_out, ra_pout = ideal_gas_referenced_nested_sampling(
+            ra_ls, ra_params, Int64(20000),
+            MCGrandCanonicalMoves(p_move=0.5, p_insert=0.25,
+                clusters_freq=1, swaps_freq=1), obs_save)
+        obs_cleanup()
+        @test names(ra_df) == ["iter", "emax", "num_particles"]
+        @test issorted(ra_df.emax, rev=true)
+        # The fixed-N branch really alternated local swaps and cluster
+        # moves, and cluster proposals were accepted on the anisotropic
+        # metric
+        @test ra_pout.move_stats[:swap_attempted] > 0
+        @test ra_pout.move_stats[:cluster_attempted] > 0
+        @test ra_pout.move_stats[:cluster_accepted] > 0
+        ra_liveE = [w.energy.val for w in ra_out.walkers]
+        ra_liveN = [Int(sum(w.configuration.components[1])) for w in ra_out.walkers]
+        ra_st = gc_thermodynamic_stats_ideal_ref(ra_df, 16, ra_z0, ra_mus, ra_Ts,
+            200; ω0=201 / 200, live_emax=ra_liveE, live_numbers=ra_liveN)
+        ra_lnXi_tol = [10.6, 7.9, 5.9]
+        ra_N_tol = [7.9, 9.7, 8.6]
+        ra_U_tol = [0.41, 0.21, 0.33]
+        ra_U_gated = ((1, 1), (3, 1), (1, 2), (1, 3), (2, 3))
+        for (i, mu) in enumerate(ra_mus), (j, T) in enumerate(ra_Ts)
+            ex = ra_exact(mu, T)
+            @test ra_st.N_eff[i, j] >= 100
+            @test abs(ra_st.logXi[i, j] - ex.logXi) < ra_lnXi_tol[j]
+            i == 2 || @test abs(ra_st.mean_N[i, j] - ex.mean_N) < ra_N_tol[j]
+            (i, j) in ra_U_gated &&
+                @test abs(ra_st.mean_U[i, j] - ex.mean_U) < ra_U_tol[j]
+        end
+    end
+
+    # ================================================================
+    @testset "Langmuir closure off the keyword-square path" begin
+        # On-site term only (zero couplings): E = eps N exactly, so
+        # Xi(mu, T) = (1 + z e^{-beta eps})^M with z = e^{beta mu}, and
+        # with x = z e^{-beta eps}: <N> = M x / (1 + x), Var N =
+        # M x / (1 + x)^2, <U> = eps <N>. The closed forms are
+        # geometry-free, so closing them on the rectangular
+        # inner-constructor cell and on the keyword triangular cell
+        # pins the on-site/mu composition of the grand-canonical walk
+        # and the ideal-gas-referenced stats as geometry-independent.
+        lm_eps = -0.05
+        lm_ham = GenericLatticeHamiltonian(-0.05u"eV", [0.0u"eV"])
+        lm_kb = 8.617333262e-5
+        # Rectangular 1 x sqrt(2) cell through the inner constructor,
+        # nearest-neighbor shell only (2 partners at distance a);
+        # construction is warning-free
+        lm_rect = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,SquareLattice}(
+            [1.0 0.0 0.0; 0.0 sqrt(2.0) 0.0; 0.0 0.0 1.0], [(0.0, 0.0, 0.0)],
+            (6, 4, 1), (true, true, false), [1.05],
+            [fill(false, 24)], fill(true, 24))
+        @test num_sites(lm_rect) == 24
+        @test all(nb -> length.(nb) == [2], lm_rect.neighbors)
+        # Keyword triangular cell
+        lm_tri = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            supercell_dimensions=(4, 2, 1),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.05],
+            components=[[false for _ in 1:16]],
+            adsorptions=:full)
+        @test num_sites(lm_tri) == 16
+        @test all(nb -> length.(nb) == [6], lm_tri.neighbors)
+
+        # mu/T grid and gate structure of the keyword-square Langmuir
+        # closure (test-ideal-gas-ref-gcns.jl): z0 = 1, the first mu
+        # deliberately out of the reweighting window, skipped in the
+        # closure loop and used for the N_eff collapse check. The
+        # global RNG is seeded per run (the parameters' random_seed
+        # field is not consumed) and the gates run after all RNG use.
+        # Tolerances: three-seed calibrated (seeds 7501/7502/7503, both
+        # geometries), per stat over the nine in-window grid points and
+        # both geometries, >= 3x the maximum deviation from the closed
+        # forms (lnXi 0.209 absolute; N 0.0228, Var N 0.161, U 0.0228
+        # relative); in-window Kish N_eff >= 303 across the
+        # calibration, floor 100.
+        lm_mus = [-0.08, -0.04, -0.03, -0.02]
+        lm_Ts = [200.0, 300.0, 500.0]
+        for (lm_lat, lm_M) in ((lm_rect, 24), (lm_tri, 16))
+            Random.seed!(7501)
+            lm_walkers = [LatticeWalker(deepcopy(lm_lat), energy=0.0u"eV", iter=0)
+                          for _ in 1:100]
+            lm_ls = LatticeGasWalkers(lm_walkers, lm_ham; assign_energy=false)
+            lm_params = IdealGasReferencedGCNSParameters(mc_steps=100,
+                reference_fugacity=1.0, allowed_fail_count=100_000)
+            lm_df, lm_out, _ = ideal_gas_referenced_nested_sampling(lm_ls,
+                lm_params, Int64(3000),
+                MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3), obs_save)
+            obs_cleanup()
+            @test nrow(lm_df) > 0
+            @test names(lm_df) == ["iter", "emax", "num_particles"]
+            @test issorted(lm_df.emax, rev=true)
+            # Ledger-level composition pin: every dead point sits on
+            # E = eps N
+            @test maximum(abs.(lm_df.emax .- lm_eps .* lm_df.num_particles)) < 1e-9
+            lm_liveE = [w.energy.val for w in lm_out.walkers]
+            lm_liveN = [Int(sum(w.configuration.components[1])) for w in lm_out.walkers]
+            lm_st = gc_thermodynamic_stats_ideal_ref(lm_df, lm_M, 1.0, lm_mus,
+                lm_Ts, 100; ω0=101 / 100, live_emax=lm_liveE, live_numbers=lm_liveN)
+            for (j, T) in enumerate(lm_Ts), (i, mu) in enumerate(lm_mus)
+                i == 1 && continue      # the out-of-window point
+                beta = 1 / (lm_kb * T)
+                x = exp(beta * mu) * exp(-beta * lm_eps)
+                @test lm_st.N_eff[i, j] >= 100
+                @test abs(lm_st.logXi[i, j] - lm_M * log1p(x)) < 0.65
+                @test isapprox(lm_st.mean_N[i, j], lm_M * x / (1 + x); rtol=0.07)
+                @test isapprox(lm_st.var_N[i, j], lm_M * x / (1 + x)^2; rtol=0.5)
+                @test isapprox(lm_st.mean_U[i, j], lm_eps * lm_M * x / (1 + x); rtol=0.07)
+            end
+            # Out-of-window N_eff collapse, as in the keyword-square
+            # closure
+            @test lm_st.N_eff[1, 1] < lm_st.N_eff[4, 1] / 10
+        end
+    end
 end

--- a/test/test-SamplingSchemes/test-ns-plateau-ties.jl
+++ b/test/test-SamplingSchemes/test-ns-plateau-ties.jl
@@ -1,0 +1,652 @@
+# Regression coverage for plateau-aware tie eviction in the serial atomistic
+# nested-sampling steps (issue #181, option 1) and the log-compression method of
+# ωᵢ. Exact energy ties at the ceiling arise generically from truncated pair
+# potentials over configuration spaces with vacuum (lj_energy is exactly
+# 0.0 eV beyond the cutoff); the fix evicts tied walkers one by one without
+# replacement, compressing by (n_live - 1)/n_live with the shrinking live count
+# (Fowlie, Handley and Su, Mon. Not. R. Astron. Soc. 503, 1199 (2021)), records
+# the per-cull log-compression in a lazily added ledger column, and refills the
+# live set only once the plateau is exhausted.
+#
+# Fixture: the reduced-scale port of issue #181's inline reproducer, sites
+# verbatim: a frozen 13-atom cuboctahedral LJ cluster (eps = 0.01 eV,
+# sigma = 2.5 A, cutoff 3 sigma shifted) centered in an all-false-periodicity
+# cubic box padded by two cutoff radii of vacuum, with N ideal adsorbates
+# (adsorbate-adsorbate epsilon = 0 through CompositeParameterSets),
+# LJSurfaceWalkers, K = 48, MCRandomWalkClone. The exact per-N reference is
+# N*ln(z1) with z1 a midpoint-quadrature single-particle integral over the same
+# box, restricted to the walker-initialization prior E < 1e9 eV (the "m" fold
+# below divides by the admissible-point count, matching uniform_walker's
+# rejection). The surface's energy_frozen_part is set to 0 eV by hand, so walker
+# energies carry the adsorbate part only and no beta*E_frozen fold enters the
+# closure.
+#
+# ================= calibration ledger (record, do not retype) =================
+# All statistical gates below ship at >= 3x the maximum multi-seed deviation of
+# their own statistic (per stat, per N sector), calibrated on the shipped seeds
+# themselves at T = 100 K. Seeds are the first-scanned blocks 11-13 (N = 1),
+# 21-23 (N = 2), 41-43 (control); they were not selected on their deviations.
+# Digit-for-digit deviations (reproduced by running this file with
+# FREEBIRD_NS_PLATEAU_TIES_CALIBRATE=1; gates evaluate after all RNG use, so
+# comment/tolerance edits never invalidate the calibration):
+#
+#   N=1 (mc_steps=400, n_steps=400, K=48), dev_ev = lnZ - ln z1 at 100 K,
+#   dev_mass = ln(recorded plateau mass / f):
+#     seed 11: n_tie=40  dev_ev_new=-0.0013862869792976226  dev_ev_leg=+0.08734514794562426
+#              dev_mass_new=-0.08575642023567279  dev_mass_leg=-0.48028481527974104
+#     seed 12: n_tie=44  dev_ev_new=-0.02480029212362888  dev_ev_leg=+0.09662588733381072
+#              dev_mass_new=+0.009553759568652065  dev_mass_leg=-0.42033429427638
+#     seed 13: n_tie=43  dev_ev_new=-0.07190702381754824  dev_ev_leg=-0.04934557228207022
+#              dev_mass_new=-0.03405504585878227  dev_mass_leg=-0.45515436372078055
+#              (seed 13 culls one positive-energy walker before the block, so
+#              its block statistic carries one ordinary-cull X factor)
+#     GATE_EV_N1   = 0.2158 >= 3 x 0.07190702 = 0.21572107 (max |dev_ev_new|, seed 13)
+#     GATE_MASS_N1 = 0.2573 >= 3 x 0.08575642 = 0.25726926 (max |dev_mass_new|, seed 11)
+#     contrast margins on the mechanism ledger (seed 11):
+#       |dev_mass_leg| = 0.48028 = 1.87 x GATE_MASS_N1 (fails low: plateau mass
+#       under-assigned); sub-plateau mass overshoot ln(S_leg/S_true) = +1.56
+#       (fails high; structurally >= +1.37 for any n_tie <= K at this f,
+#       asserted > 1.0).
+#
+#   N=2 (mc_steps=400, n_steps=600, K=48):
+#     seed 21: n_tie=38  dev_ev_new=-0.08329687661812356  dev_ev_leg=+0.020386112867883957
+#              dev_mass_new=-0.16420030128135582
+#     seed 22: n_tie=38  dev_ev_new=-0.04519088682375805  dev_ev_leg=+0.03614436441601944
+#              dev_mass_new=-0.040484578064941684  (run ends inside a later
+#              micro-tie block: live=45, plateau_refill_target=48; the end-state
+#              contract assert covers both endings)
+#     seed 23: n_tie=42  dev_ev_new=-0.08820427561484093  dev_ev_leg=+0.02154990570166611
+#              dev_mass_new=+0.03897959328930537
+#     GATE_EV_N2 = 0.2647 >= 3 x 0.08820428 = 0.26461283 (max |dev_ev_new|, seed 23)
+#     The N=2 block-mass statistic is recorded (printed under the calibration
+#     flag) but not gated: several positive-energy pre-block culls can shift
+#     the block's starting prior mass (seed 21 drew -0.164), so an honest
+#     >= 3x gate would be too loose to mean anything at N=2, and the
+#     accounting it would probe is already locked at N=1.
+#
+#   control (cutoff=Inf, N=1, mc_steps=400, n_steps=400):
+#     seed 41: dev_ev_new=-0.0068748326320041825
+#     seed 42: dev_ev_new=+0.12225112083863904
+#     seed 43: dev_ev_new=-0.05334596167653882
+#     GATE_EV_CTRL = 0.3668 >= 3 x 0.12225112 = 0.36675336 (max |dev|, seed 42)
+#
+# Choice of closure sectors: N in {1, 2} rather than the issue's {1, 4}; N = 4
+# needs a ladder roughly 4x deeper for the same tail control and exercises no
+# accounting path beyond N = 2 (which already produces secondary micro-tie
+# blocks from clone energy-residue degeneracy). Gate temperature 100 K: the
+# 400-row ladders close tightly there (Boltzmann weight below the recorded
+# ladder is negligible and the live-set tail term covers the remainder). At
+# T <= 60 K the same ledgers under-estimate the evidence by up to ~1.5 nats
+# REGARDLESS of weighting: after the plateau is exhausted the refill clones the
+# few sub-plateau survivors (~K(1-f) ~ 4 walkers here), and the subsequent E(X)
+# mapping is ancestor-correlated for ~1-2 e-folds of compression. That is a
+# sampler-variance property of the fixture scale, not an accounting defect, and
+# it is why the legacy-vs-corrected contrast is asserted on the recorded
+# plateau prior mass (whose only noise is the binomial live-set draw, +-0.09
+# here) rather than on the low-T evidence, where the two effects are
+# comparable in size (verified over 20-seed scans at T = 40-300 K).
+# ==============================================================================
+
+using Random
+
+@testset "Atomistic NS plateau ties (issue #181)" begin
+
+    calib = get(ENV, "FREEBIRD_NS_PLATEAU_TIES_CALIBRATE", "0") == "1"
+
+    # ================= item 2: deterministic weight identities =================
+    # Synthetic log-compression vectors only; no sampling, no RNG.
+    @testset "log-compression ωᵢ: deterministic weight identities" begin
+        K = 32
+        n_pre, n_tie, n_post = 7, 12, 9
+        # n_pre ordinary culls, a hand-placed n_tie-row eviction block with the
+        # shrinking live count, n_post ordinary culls.
+        logc = vcat(fill(log(K / (K + 1)), n_pre),
+                    [log((K - 1 - j) / (K - j)) for j in 0:(n_tie - 1)],
+                    fill(log(K / (K + 1)), n_post))
+        shells = ωᵢ(logc)
+        @test all(shells .> 0)
+
+        # (a) the tie block reproduces the closed-form block factor
+        # (K - n_tie)/K: telescoping product of (n-1)/n for n = K..K-n_tie+1.
+        # Both routes measured exactly 0.0 at calibration; gates 1e-14.
+        X_pre = 1 - sum(shells[1:n_pre])
+        X_post = 1 - sum(shells[1:n_pre+n_tie])
+        @test abs(X_post / X_pre - (K - n_tie) / K) <= 1e-14
+        @test abs(exp(sum(logc[n_pre+1:n_pre+n_tie])) - (K - n_tie) / K) <= 1e-14
+        # hand-built 7-tie block from 16 live walkers: factor 9/16 (measured 0.0)
+        K7, n7 = 16, 7
+        logc7 = [log((K7 - 1 - j) / (K7 - j)) for j in 0:(n7 - 1)]
+        @test abs(exp(sum(logc7)) - (K7 - n7) / K7) <= 1e-14
+
+        # (b) tie-free uniform column: the new method with its ω0 = 1.0 default
+        # matches the legacy iteration-based weights called as
+        # ωᵢ(1:n, K; ω0=(K+1)/K). Calibrated max per-element rel dev 1.705e-14.
+        n = 250
+        shells_u = ωᵢ(fill(log(K / (K + 1)), n))
+        shells_l = ωᵢ(collect(1:n), K; ω0=(K + 1) / K)
+        @test all(shells_u .> 0)
+        @test all(abs.(shells_u .- shells_l) .<= 1e-12 .* shells_l)
+
+        # (c) legacy-method pins on fixed inputs: the iteration-based code path
+        # is untouched by the fix. Closed form ω0*(1/(K+1))*(K/(K+1))^i at
+        # K = 48, ω0 = 49/48, i in (1, 5, 20): exactly (1/49)*(48/49)^(i-1);
+        # digits below are the shipped code path's evaluation (repr, dev SHA
+        # cfa19b8 semantics).
+        w_leg = ωᵢ([1, 5, 20], 48; ω0=49 / 48)
+        @test isapprox(w_leg[1], 0.020408163265306117; rtol=1e-13)
+        @test isapprox(w_leg[2], 0.018792499586397383; rtol=1e-13)
+        @test isapprox(w_leg[3], 0.013793100784800585; rtol=1e-13)
+
+        # (d) shells all positive (above) and total mass + tail identity:
+        # sum(shells) + exp(sum(log_compression)) = 1 (measured 0.0).
+        @test abs(sum(shells) + exp(sum(logc)) - 1.0) <= 1e-12
+    end
+
+    # ================= shared fixture: issue #181 reproducer =================
+    kB = 8.617333262e-5              # eV K^-1
+
+    sig  = 2.5                       # Angstrom
+    eps0 = 0.01                      # eV
+    rcut = 3.0                       # cutoff, units of sigma
+    d_nn = 2.0^(1 / 6) * sig         # LJ pair-minimum distance
+    L    = 2 * d_nn + 4 * rcut * sig # cluster diameter + two cutoff radii per side
+    half = L / 2
+
+    # 13-atom cuboctahedral cluster sites, verbatim from the issue #181 body.
+    fcc_shell = [(1, 1, 0), (1, -1, 0), (-1, 1, 0), (-1, -1, 0),
+                 (1, 0, 1), (1, 0, -1), (-1, 0, 1), (-1, 0, -1),
+                 (0, 1, 1), (0, 1, -1), (0, -1, 1), (0, -1, -1)]
+    sites = vcat([(half, half, half)],
+                 [(half + p[1] * d_nn / sqrt(2), half + p[2] * d_nn / sqrt(2),
+                   half + p[3] * d_nn / sqrt(2)) for p in fcc_shell])
+
+    lj_field(cut) = LJParameters(epsilon=eps0, sigma=sig, cutoff=cut, shift=true)
+    lj_ideal(cut) = LJParameters(epsilon=0.0, sigma=sig, cutoff=cut, shift=false)
+    # [adsorbate-adsorbate (ideal), adsorbate-surface, surface-surface]
+    plateau_cps(cut) = CompositeParameterSets(2, [lj_ideal(cut), lj_field(cut), lj_field(cut)])
+
+    ties_box = [[L, 0.0, 0.0]u"Å", [0.0, L, 0.0]u"Å", [0.0, 0.0, L]u"Å"]
+    ties_pbc = (false, false, false)
+
+    surface_system() = FastSystem(atomic_system(
+        [:Ar => [x, y, z]u"Å" for (x, y, z) in sites], ties_box, ties_pbc))
+
+    # single-adsorbate field energy at a point, through the library's own pair fn
+    function field_energy(x, y, z, lj)
+        e = 0.0u"eV"
+        for (sx, sy, sz) in sites
+            r = sqrt((x - sx)^2 + (y - sy)^2 + (z - sz)^2)u"Å"
+            e += lj_energy(r, lj)
+        end
+        return ustrip(u"eV", e)
+    end
+
+    E_THRESH = 1.0e9                 # walker-initialization admissibility, eV
+    NGRID = 144                      # midpoint quadrature, as in the issue body
+
+    function field_grid(lj)
+        h = L / NGRID
+        E = Vector{Float64}(undef, NGRID^3)
+        k = 0
+        for iz in 1:NGRID, iy in 1:NGRID, ix in 1:NGRID
+            k += 1
+            E[k] = field_energy((ix - 0.5) * h, (iy - 0.5) * h, (iz - 0.5) * h, lj)
+        end
+        return E
+    end
+
+    # the m fold: mean over the admissible prior E < E_THRESH, matching the
+    # uniform_walker rejection below (issue reproducer identity, ported)
+    function ref_ln_z1(E, beta)
+        z = 0.0
+        m = 0
+        for e in E
+            e < E_THRESH || continue
+            m += 1
+            z += exp(-beta * e)
+        end
+        return log(z / m)
+    end
+
+    plateau_fraction(E) = count(iszero, (e for e in E if e < E_THRESH)) /
+                          count(<(E_THRESH), E)
+
+    function uniform_walker(N, ljs, surface)
+        while true
+            coor = [:Ar => [rand() * L, rand() * L, rand() * L]u"Å" for _ in 1:N]
+            w = AtomWalker(FastSystem(atomic_system(coor, ties_box, ties_pbc)))
+            E = ustrip(u"eV", interacting_energy(w.configuration, ljs, w.list_num_par,
+                                                 w.frozen, surface.configuration))
+            isfinite(E) && E < E_THRESH && return w
+        end
+    end
+
+    function run_plateau_ns(N, ljs, surface, seed; mc_steps=400, n_steps=400, K=48)
+        Random.seed!(seed)   # the parameters' random_seed field is not consumed
+        walkers = [uniform_walker(N, ljs, surface) for _ in 1:K]
+        ls = LJSurfaceWalkers(walkers, ljs, surface)
+        params = NestedSamplingParameters(mc_steps=mc_steps, step_size=1.0,
+                                          step_size_up=3.0, allowed_fail_count=100_000)
+        save = SaveEveryN(df_filename="_test_ties_df.csv",
+                          wk_filename="_test_ties.traj.extxyz",
+                          ls_filename="_test_ties.ls.extxyz",
+                          n_traj=10_000_000, n_snap=10_000_000, n_info=10_000_000)
+        df, ls_out, params_out = nested_sampling(ls, params, n_steps,
+                                                 MCRandomWalkClone(), save)
+        rm("_test_ties_df.csv", force=true)
+        rm("_test_ties.traj.extxyz", force=true)
+        rm("_test_ties.ls.extxyz", force=true)
+        live = [ustrip(u"eV", w.energy) for w in ls_out.walkers]
+        return df, live, params_out
+    end
+
+    # per-N evidence, new accounting: log-compression shells + live tail with
+    # mass exp(sum(log_compression)) split over the live walkers
+    function ln_evidence_new(df, live, beta)
+        w = vcat(ωᵢ(df.log_compression),
+                 fill(exp(sum(df.log_compression)) / length(live), length(live)))
+        E = vcat(df.emax, live)
+        return log(sum(w .* exp.(-beta .* E)))
+    end
+
+    # per-N evidence, legacy accounting on the same ledger: iteration-based
+    # shells with the conventional ω0 = (K+1)/K, tail q^n split over the live set
+    function ln_evidence_legacy(df, live, K, beta)
+        n = nrow(df)
+        q = K / (K + 1)
+        w = vcat(ωᵢ(df.iter, K; ω0=(K + 1) / K),
+                 fill(q^n / length(live), length(live)))
+        E = vcat(df.emax, live)
+        return log(sum(w .* exp.(-beta .* E)))
+    end
+
+    # count of bit-exact-zero rows and the longest consecutive run of them
+    function zero_tie_stats(df)
+        n0 = count(iszero, df.emax)
+        best = 0
+        cur = 0
+        for e in df.emax
+            cur = e == 0.0 ? cur + 1 : 0
+            best = max(best, cur)
+        end
+        return n0, best
+    end
+
+    # every legal per-cull charge: n/(n+1) for an ordinary cull from n live
+    # walkers, (n-1)/n for a plateau eviction; same expressions as src, so
+    # membership is bit-exact
+    charge_set(K) = Set{Float64}(vcat([log(m / (m + 1)) for m in 1:K],
+                                      [log((m - 1) / m) for m in 2:K]))
+
+    ljs_trunc = plateau_cps(rcut)
+    ljs_ctrl = plateau_cps(Inf)   # LJParameters accepts cutoff=Inf (its default)
+    surface = AtomWalker(surface_system(); freeze_species=[:Ar])
+    surface.energy_frozen_part = 0.0u"eV"   # by hand: adsorbate part only
+    @test surface.energy_frozen_part == 0.0u"eV"
+
+    E_grid_trunc = field_grid(lj_field(rcut))
+    E_grid_ctrl = field_grid(lj_field(Inf))
+    f_plateau = plateau_fraction(E_grid_trunc)
+    # the untruncated control field has no exact-zero set at all
+    @test plateau_fraction(E_grid_ctrl) == 0.0
+    # issue #181 measured f = 0.90795 on this same 144^3 grid
+    @test isapprox(f_plateau, 0.908; atol=0.002)
+
+    T_gate = 100.0
+    beta = 1 / (kB * T_gate)
+    ln_z1_trunc = ref_ln_z1(E_grid_trunc, beta)
+    ln_z1_ctrl = ref_ln_z1(E_grid_ctrl, beta)
+
+    K = 48
+    N1_SEEDS = (11, 12, 13)
+    N2_SEEDS = (21, 22, 23)
+    CTRL_SEEDS = (41, 42, 43)
+
+    # calibrated gates (see the calibration ledger in the header)
+    GATE_EV_N1 = 0.2158
+    GATE_MASS_N1 = 0.2573
+    GATE_EV_N2 = 0.2647
+    GATE_EV_CTRL = 0.3668
+
+    # ---- all RNG use happens here; every gate below is evaluated afterwards ----
+    runs_n1 = Dict(s => run_plateau_ns(1, ljs_trunc, surface, s) for s in N1_SEEDS)
+    runs_n2 = Dict(s => run_plateau_ns(2, ljs_trunc, surface, s; n_steps=600)
+                   for s in N2_SEEDS)
+    runs_ctrl = Dict(s => run_plateau_ns(1, ljs_ctrl, surface, s) for s in CTRL_SEEDS)
+
+    # recorded plateau prior mass under both weightings, against the quadrature
+    # reference f^N: the accounting statistic the fix changes, whose only
+    # sampling noise is the binomial live-set draw of the tie count
+    function plateau_mass_devs(df, N)
+        zrows = findall(iszero, df.emax)
+        shells_new = ωᵢ(df.log_compression)
+        P_new = sum(shells_new[zrows])
+        shells_leg = ωᵢ(df.iter, K; ω0=(K + 1) / K)
+        P_leg = sum(shells_leg[zrows])
+        return log(P_new / f_plateau^N), log(P_leg / f_plateau^N), P_leg
+    end
+
+    if calib
+        for (label, runs, N, lnz) in (("N=1", runs_n1, 1, ln_z1_trunc),
+                                      ("N=2", runs_n2, 2, 2 * ln_z1_trunc))
+            for s in sort(collect(keys(runs)))
+                df, live, po = runs[s]
+                dn = ln_evidence_new(df, live, beta) - lnz
+                dl = ln_evidence_legacy(df, live, K, beta) - lnz
+                dmn, dml, _ = plateau_mass_devs(df, N)
+                nz, blk = zero_tie_stats(df)
+                println("calib $label seed $s: n_tie=$nz block=$blk ",
+                        "live=$(length(live)) refill=$(po.plateau_refill_target)")
+                println("  dev_ev_new=$(repr(dn)) dev_ev_leg=$(repr(dl))")
+                println("  dev_mass_new=$(repr(dmn)) dev_mass_leg=$(repr(dml))")
+            end
+        end
+        for s in sort(collect(keys(runs_ctrl)))
+            df, live, _ = runs_ctrl[s]
+            dn = ln_evidence_new(df, live, beta) - ln_z1_ctrl
+            println("calib control seed $s: dev_ev_new=$(repr(dn))")
+        end
+    end
+
+    # ================= item 1: mechanism regression =================
+    @testset "mechanism regression: plateau eviction on the issue reproducer" begin
+        df, live, params_out = runs_n1[N1_SEEDS[1]]
+
+        # ledger shape: one row per accepted cull, consecutive iters
+        @test nrow(df) == 400
+        @test df.iter == collect(1:nrow(df))
+        @test names(df) == ["iter", "emax", "log_compression"]
+        @test all(diff(df.emax) .<= 0)
+
+        # (a) a single block of >= 30 consecutive rows bit-exactly at the
+        # plateau energy 0.0 (the issue measures 44-46 at full scale, this
+        # reduced scale draws 40-44 across the shipped seeds, expectation
+        # K*f = 43.6, binomial sigma = 2.0)
+        n_zero, block = zero_tie_stats(df)
+        @test block >= 30
+        @test block == n_zero          # all zero rows are one consecutive block
+        @test block < K                # a whole-live-set tie would fall back
+        zrows = findall(iszero, df.emax)
+        @test zrows == zrows[1]:zrows[end]
+        @test all(df.emax[zrows] .=== 0.0)
+
+        # the eviction schedule charges (n_live - 1)/n_live with the live count
+        # shrinking from K, bit-exactly, and the product telescopes to the
+        # closed-form block factor (K - n_tie)/K
+        @test df.log_compression[zrows] ==
+              [log((K - j) / (K - j + 1)) for j in 1:n_zero]
+        @test isapprox(exp(sum(df.log_compression[zrows])), (K - n_zero) / K;
+                       rtol=1e-12)
+        # after the refill the ledger continues below the plateau; the next cull
+        # may itself open a secondary micro-tie block from clone energy-residue
+        # degeneracy (this seed charges log(47/48) there), so no ordinary-cull
+        # assert is made on it beyond legal-charge membership below (guarded: a
+        # tie block ending at the final ledger row has no next charge to check)
+        if zrows[end] < nrow(df)
+            @test df.log_compression[zrows[end]+1] < 0
+        end
+        # every charge in the ledger is a legal ordinary-cull or eviction factor
+        legal = charge_set(K)
+        @test all(v -> v in legal, df.log_compression)
+
+        # (b) per-N evidence with the new accounting closes against the
+        # midpoint-quadrature reference N*ln z1 at T = 100 K
+        dev_ev_new = ln_evidence_new(df, live, beta) - ln_z1_trunc
+        @test abs(dev_ev_new) <= GATE_EV_N1
+        # and the recorded plateau prior mass closes against ln f
+        dev_mass_new, dev_mass_leg, P_leg = plateau_mass_devs(df, 1)
+        @test abs(dev_mass_new) <= GATE_MASS_N1
+
+        # (c) the flipped-accounting contrast on the SAME ledger: the legacy
+        # iteration-based ωᵢ(iters, K; ω0=(K+1)/K) charges the plateau
+        # n_tie*ln((K+1)/K), bounded below 1 nat, instead of ln(1/(1-f)):
+        #  - the recorded plateau mass fails the same calibrated gate
+        #    (1.87x the gate at calibration, low side);
+        @test abs(dev_mass_leg) > GATE_MASS_N1
+        @test dev_mass_leg < 0
+        #  - equivalently the prior mass assigned below the plateau, which
+        #    every evidence and reweighted observable below inherits, is
+        #    overestimated: ln(S_leg/S_true) fails high (+1.56 at calibration;
+        #    structurally >= +1.37 for any n_tie <= K at this f)
+        total_leg = sum(ωᵢ(df.iter, K; ω0=(K + 1) / K)) + (K / (K + 1))^nrow(df)
+        S_leg = total_leg - P_leg
+        S_true = 1 - f_plateau
+        @test log(S_leg / S_true) > 1.0
+        #  - and on the same ledger the legacy evidence is strictly biased high
+        #    relative to the plateau-aware evidence at any beta > 0 (the plateau
+        #    sits at E = 0 and every recorded row below it has E < 0)
+        dev_ev_leg = ln_evidence_legacy(df, live, K, beta) - ln_z1_trunc
+        @test dev_ev_leg > dev_ev_new
+
+        # (d) the live set is restored to K walkers and the plateau bookkeeping
+        # field is cleared
+        @test length(live) == K
+        @test params_out.plateau_refill_target == 0
+    end
+
+    # ================= item 3: exactly solvable per-N closure =================
+    @testset "per-N evidence closure, N in (1, 2)" begin
+        for (runs, N, seeds, gate_ev, gate_mass, lnz, blk_floor) in
+            ((runs_n1, 1, N1_SEEDS, GATE_EV_N1, GATE_MASS_N1, ln_z1_trunc, 30),
+             (runs_n2, 2, N2_SEEDS, GATE_EV_N2, nothing, 2 * ln_z1_trunc, 25))
+            for s in seeds
+                df, live, params_out = runs[s]
+                # evidence closure at T = 100 K, per-N calibrated gate
+                dev_ev_new = ln_evidence_new(df, live, beta) - lnz
+                @test abs(dev_ev_new) <= gate_ev
+                # recorded plateau mass vs the quadrature reference f^N;
+                # gated at N = 1 only (see the calibration ledger)
+                if gate_mass !== nothing
+                    dev_mass_new, _, _ = plateau_mass_devs(df, N)
+                    @test abs(dev_mass_new) <= gate_mass
+                end
+                # the same-ledger directional contrast holds for every seed
+                dev_ev_leg = ln_evidence_legacy(df, live, K, beta) - lnz
+                @test dev_ev_leg > dev_ev_new
+                # the initial plateau block is present (expectation K*f^N:
+                # 43.6 at N = 1, 39.6 at N = 2)
+                n_zero, block = zero_tie_stats(df)
+                @test block >= blk_floor
+                @test block == n_zero
+                # end-state contract: either the run ends outside a tie block
+                # with the live set restored, or inside one with the refill
+                # target still armed (N = 2 seed 22 ends mid-block)
+                @test (params_out.plateau_refill_target == 0 &&
+                       length(live) == K) ||
+                      (params_out.plateau_refill_target == K &&
+                       length(live) < K)
+            end
+        end
+    end
+
+    # ================= scope: untruncated control =================
+    @testset "scope: untruncated control (no plateau, uniform tie-free column)" begin
+        for s in CTRL_SEEDS
+            df, live, params_out = runs_ctrl[s]
+            @test nrow(df) == 400
+            # zero bit-exact tie rows: no exact zeros, strictly decreasing emax
+            n_zero, block = zero_tie_stats(df)
+            @test n_zero == 0
+            @test all(diff(df.emax) .< 0)
+            # the lazily added column is present and uniformly the fixed-K
+            # ordinary-cull factor, bit-exactly
+            @test names(df) == ["iter", "emax", "log_compression"]
+            @test all(df.log_compression .== log(K / (K + 1)))
+            # closure at T = 100 K within the control's own calibrated gate
+            dev = ln_evidence_new(df, live, beta) - ln_z1_ctrl
+            @test abs(dev) <= GATE_EV_CTRL
+            # no plateau bookkeeping was ever armed
+            @test params_out.plateau_refill_target == 0
+            @test length(live) == K
+        end
+    end
+
+    # ============= scope: lattice ledgers carry no column =============
+    @testset "scope: lattice ledgers carry no column (lazy column contract)" begin
+        lat = MLattice{1,SquareLattice}(
+            lattice_constant=1.0, basis=[(0.0, 0.0, 0.0)],
+            supercell_dimensions=(4, 4, 1), periodicity=(true, true, false),
+            cutoff_radii=[1.1, 1.5], components=[[false for _ in 1:16]],
+            adsorptions=:full)
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        function fresh_lattice(seed)
+            Random.seed!(seed)
+            ws = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                  for _ in 1:12]
+            for w in ws
+                occ = vcat(fill(true, 6), fill(false, 10))
+                shuffle!(occ)
+                w.configuration.components[1] .= occ
+            end
+            ls = LatticeGasWalkers(ws, ham; perturb_energy=1e-9)
+            p = LatticeNestedSamplingParameters(mc_steps=20,
+                energy_perturbation=1e-9, allowed_fail_count=100000)
+            return ls, p
+        end
+        lat_save = SaveEveryN("_test_ties_lat.csv", "_test_ties_lat.traj",
+                              "_test_ties_lat.ls", 1000000, 1000000, 1000000)
+        ls, p = fresh_lattice(61)
+        df, _, _ = nested_sampling(ls, p, 60, MCRandomWalkClone(), lat_save)
+        # the lattice step methods keep the four-value return, so their ledgers
+        # gain no log_compression column
+        @test nrow(df) > 0
+        @test names(df) == ["iter", "emax"]
+        @test !hasproperty(df, :log_compression)
+        # with observables the schema is iter, emax, then the observable columns
+        ls, p = fresh_lattice(62)
+        df2, _, _ = nested_sampling(ls, p, 60, MCRandomWalkClone(), lat_save;
+            observables=[:nocc => (cfg -> Float64(sum(cfg.components[1])))])
+        @test nrow(df2) > 0
+        @test names(df2) == ["iter", "emax", "nocc"]
+        @test !hasproperty(df2, :log_compression)
+        rm.(["_test_ties_lat.csv", "_test_ties_lat.traj", "_test_ties_lat.ls"],
+           force=true)
+    end
+
+    # ============ scope: serial LJAtomWalkers column ============
+    @testset "scope: serial LJAtomWalkers column (ledger carries log_compression)" begin
+        Random.seed!(51)
+        boxp = [[10.0u"Å", 0u"Å", 0u"Å"],
+                [0u"Å", 10.0u"Å", 0u"Å"],
+                [0u"Å", 0u"Å", 10.0u"Å"]]
+        ljp = LJParameters(epsilon=0.1, sigma=2.5, cutoff=4.0, shift=false)
+        mk_walker() = AtomWalker(FastSystem(periodic_system(
+            [:Ar => [rand(), rand(), rand()],
+             :Ar => [rand(), rand(), rand()],
+             :Ar => [rand(), rand(), rand()]], boxp, fractional=true)))
+        walkers = [mk_walker() for _ in 1:6]
+        ls = LJAtomWalkers(walkers, ljp)
+        p = NestedSamplingParameters(mc_steps=100, step_size=0.3,
+                                     allowed_fail_count=1000)
+        at_save = SaveEveryN(df_filename="_test_ties_at.csv",
+                             wk_filename="_test_ties_at.traj.extxyz",
+                             ls_filename="_test_ties_at.ls.extxyz",
+                             n_traj=10_000_000, n_snap=10_000_000,
+                             n_info=10_000_000)
+        df, ls_out, params_out = nested_sampling(ls, p, 60, MCRandomWalkClone(),
+                                                 at_save)
+        rm("_test_ties_at.csv", force=true)
+        rm("_test_ties_at.traj.extxyz", force=true)
+        rm("_test_ties_at.ls.extxyz", force=true)
+        @test nrow(df) > 0
+        @test names(df) == ["iter", "emax", "log_compression"]
+        @test all(isfinite, df.log_compression)
+        @test all(<(0), df.log_compression)
+        # uniform-or-tie contract: every charge is a legal ordinary-cull or
+        # eviction factor for a live count at most 6
+        legal6 = charge_set(6)
+        @test all(v -> v in legal6, df.log_compression)
+        @test length(ls_out.walkers) == 6
+        @test params_out.plateau_refill_target == 0
+    end
+
+    # ========== shared fixture: hand-built 6-walker LJAtomWalkers plateau ==========
+    # Exercises the OTHER serial step method (plain AtomWalkers; the ledger scope
+    # testset above covers it tie-free only) by driving nested_sampling_step!
+    # directly through a fully deterministic 4-walker tie block. Cubic all-periodic
+    # 30 A box; K = 6 walkers of two H atoms each: 4 walkers hold their pair 12 A
+    # apart -- beyond the cutoff radius 3.5*2.5 = 8.75 A, so bit-exactly 0.0 eV --
+    # at walker-distinct positions, and 2 walkers hold their pair at the LJ
+    # minimum distance (energy < 0). The eviction schedule is then exact:
+    # log(5/6), log(4/5), log(3/4), log(2/3), refill on the last step.
+    tie6_L = 30.0
+    tie6_box = [[tie6_L, 0.0, 0.0]u"Å", [0.0, tie6_L, 0.0]u"Å",
+                [0.0, 0.0, tie6_L]u"Å"]
+    tie6_lj = LJParameters(epsilon=0.1, sigma=2.5, cutoff=3.5, shift=false)
+    tie6_dmin = 2.0^(1 / 6) * 2.5    # LJ pair-minimum distance, Angstrom
+
+    function tie6_liveset()
+        pair(x, y, z, dx, dy) = AtomWalker(FastSystem(atomic_system(
+            [:H => [x, y, z]u"Å", :H => [x + dx, y + dy, z]u"Å"],
+            tie6_box, (true, true, true))))
+        # 4 plateau walkers at distinct positions (distinct z per walker), pair
+        # split 12 A along y; 2 sub-plateau walkers at the pair minimum along x
+        plateau = [pair(4.0 + 2.0 * i, 6.0, 3.0 + 3.0 * i, 0.0, 12.0)
+                   for i in 1:4]
+        bound = [pair(15.0, 20.0, 16.0 + 5.0 * i, tie6_dmin, 0.0) for i in 1:2]
+        return LJAtomWalkers(vcat(plateau, bound), tie6_lj)
+    end
+
+    tie6_params() = NestedSamplingParameters(mc_steps=100, step_size=0.5,
+                                             allowed_fail_count=1000)
+    TIE6_SCHEDULE = (log(5 / 6), log(4 / 5), log(3 / 4), log(2 / 3))
+
+    all_z(ls) = [ustrip(u"Å", position(w.configuration, i)[3])
+                 for w in ls.walkers for i in 1:length(w.configuration)]
+
+    @testset "AtomWalkers serial tie path" begin
+        Random.seed!(42)
+        ls = tie6_liveset()
+        # the constructed plateau is exact: four walkers bit-exactly at 0.0 eV,
+        # two strictly below
+        @test count(w -> ustrip(u"eV", w.energy) === 0.0, ls.walkers) == 4
+        @test count(w -> w.energy < 0.0u"eV", ls.walkers) == 2
+        p = tie6_params()
+        @test p.plateau_refill_target == 0
+        for (k, lt) in enumerate(TIE6_SCHEDULE)
+            _, emax, ls, p, log_t = FreeBird.SamplingSchemes.nested_sampling_step!(
+                ls, p, MCRandomWalkClone())
+            # every step of the block culls at the plateau ceiling, bit-exactly
+            @test ustrip(u"eV", emax) === 0.0
+            # the eviction schedule charges (n_live - 1)/n_live with the
+            # shrinking live count, bit-exactly
+            @test log_t === lt
+            if k < 4
+                # mid-block: the refill target is armed and no refill has run
+                @test p.plateau_refill_target == 6
+                @test length(ls.walkers) == 6 - k
+            end
+        end
+        # the last tied walker (unique ceiling, target armed) triggered the
+        # refill: live set restored, bookkeeping cleared, plateau gone --
+        # refilled clones sit strictly below it
+        @test length(ls.walkers) == 6
+        @test p.plateau_refill_target == 0
+        @test all(w -> w.energy < 0.0u"eV", ls.walkers)
+    end
+
+    @testset "2D-dims refill stays on the constrained manifold" begin
+        Random.seed!(43)
+        ls = tie6_liveset()
+        @test count(w -> ustrip(u"eV", w.energy) === 0.0, ls.walkers) == 4
+        @test count(w -> w.energy < 0.0u"eV", ls.walkers) == 2
+        # the z multiset of the live set before any step; 2D walks and 2D
+        # refills never move z (2D dims are only supported on the plain
+        # AtomWalkers method, exactly the method under test)
+        z0 = Set(all_z(ls))
+        p = tie6_params()
+        for lt in TIE6_SCHEDULE
+            _, emax, ls, p, log_t = FreeBird.SamplingSchemes.nested_sampling_step!(
+                ls, p, MCRandomWalkClone(dims=[1, 2]))
+            @test ustrip(u"eV", emax) === 0.0
+            @test log_t === lt
+        end
+        @test length(ls.walkers) == 6
+        @test p.plateau_refill_target == 0
+        @test all(w -> w.energy < 0.0u"eV", ls.walkers)
+        # every z in the refilled live set is exactly a member of the original
+        # z multiset: survivors keep theirs, 2D-refilled clones inherit their
+        # ancestor's (a 3D refill regression would move z off the manifold)
+        @test all(z -> z in z0, all_z(ls))
+    end
+end

--- a/test/test-lattice-random-walks.jl
+++ b/test/test-lattice-random-walks.jl
@@ -284,6 +284,60 @@
             @test sl.components == replica.components
         end
 
+        @testset "GenericLattice guard" begin
+            using Random
+            # Geometric cluster moves carry square and triangular reflection
+            # maps only; a GenericLattice configuration gets the same loud
+            # guard so a cluster-armed routine fails at the move's definition
+            # with a descriptive ArgumentError instead of a raw MethodError
+            # from inside the sampling loop (the keyword MCMixedMoves
+            # constructor arms cluster moves by default).
+            gen = MLattice{1,GenericLattice}(
+                [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0],
+                [(0.0, 0.0, 0.0)],
+                (3, 1, 1),
+                (false, false, false),
+                [1.1],
+                [[true, false, false]],
+                fill(false, 3))
+            err = try
+                geometric_cluster_swap!(gen, 0.3)
+                nothing
+            catch e
+                e
+            end
+            @test err isa ArgumentError
+            @test occursin("square and triangular", err.msg)
+            @test occursin("GenericLattice", err.msg)
+
+            # The guard consumes no randomness: a guarded throw leaves the
+            # global RNG stream untouched.
+            Random.seed!(11)
+            probe = rand(UInt64)
+            Random.seed!(11)
+            try
+                geometric_cluster_swap!(gen, 0.3)
+            catch
+            end
+            @test rand(UInt64) === probe
+
+            # End to end: the cluster-armed keyword routine surfaces the
+            # guard's ArgumentError through the sampling step, while the
+            # positional back-compat form stays clusters-free and completes.
+            ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+            walkers = [LatticeWalker(deepcopy(gen), energy=0.0u"eV", iter=0) for _ in 1:4]
+            ls = LatticeGasWalkers(walkers, ham)
+            params = NestedSamplingParameters(mc_steps=10)
+            @test_throws ArgumentError SamplingSchemes.nested_sampling_step!(ls, params, MCMixedMoves())
+            Random.seed!(99)
+            walkers2 = [LatticeWalker(deepcopy(gen), energy=0.0u"eV", iter=0) for _ in 1:4]
+            ls2 = LatticeGasWalkers(walkers2, ham)
+            save_strategy = SaveEveryN(n_traj=10^6, n_snap=10^6, n_info=10^6)
+            df, ls3, _ = nested_sampling(ls2, NestedSamplingParameters(mc_steps=10), 30, MCMixedMoves(5, 1), save_strategy)
+            @test size(df, 1) >= 1
+            @test length(ls3.walkers) == 4
+        end
+
         # ---- triangular lattice (two-site centered-rectangular basis) ----
 
         @testset "triangular reflection: half-grid round-trip" begin

--- a/test/test-lattice-random-walks.jl
+++ b/test/test-lattice-random-walks.jl
@@ -39,48 +39,84 @@
 
     @testset "geometric cluster move tests" begin
 
-        @testset "reflection map is self-inverse" begin
-            Lx, Ly = 6, 6
+        @testset "reflection map is self-inverse (2D)" begin
+            Lx, Ly, Lz = 6, 6, 1
             for pivot_gx in [0, 1, 3, 5], pivot_gy in [0, 2, 4, 5]
-                for site in 1:(Lx * Ly)
-                    r = MonteCarloMoves._reflect_site(site, pivot_gx, pivot_gy, Lx, Ly)
-                    rr = MonteCarloMoves._reflect_site(r, pivot_gx, pivot_gy, Lx, Ly)
+                for site in 1:(Lx * Ly * Lz)
+                    r = MonteCarloMoves._reflect_site(site, pivot_gx, pivot_gy, Lx, Ly, Lz)
+                    rr = MonteCarloMoves._reflect_site(r, pivot_gx, pivot_gy, Lx, Ly, Lz)
                     @test rr == site
                 end
             end
         end
 
+        @testset "reflection map is self-inverse (3D)" begin
+            Lx, Ly, Lz = 4, 4, 3
+            for pivot_gx in [0, 1, 3], pivot_gy in [0, 2, 3]
+                for site in 1:(Lx * Ly * Lz)
+                    r = MonteCarloMoves._reflect_site(site, pivot_gx, pivot_gy, Lx, Ly, Lz)
+                    rr = MonteCarloMoves._reflect_site(r, pivot_gx, pivot_gy, Lx, Ly, Lz)
+                    @test rr == site
+                end
+            end
+        end
+
+        @testset "reflection preserves z-coordinate (3D)" begin
+            Lx, Ly, Lz = 4, 4, 3
+            for pivot_gx in [0, 1, 2], pivot_gy in [0, 1, 3]
+                for site in 1:(Lx * Ly * Lz)
+                    _, _, gz_orig = MonteCarloMoves._site_to_grid(site, Lx, Ly)
+                    r = MonteCarloMoves._reflect_site(site, pivot_gx, pivot_gy, Lx, Ly, Lz)
+                    _, _, gz_refl = MonteCarloMoves._site_to_grid(r, Lx, Ly)
+                    @test gz_refl == gz_orig
+                end
+            end
+        end
+
         @testset "reflection wraps correctly under PBC" begin
-            Lx, Ly = 4, 4
+            Lx, Ly, Lz = 4, 4, 1
             # Pivot at (0,0): R(1,0) -> (2*0 - 1 mod 4, 0) = (3, 0)
-            site_10 = MonteCarloMoves._grid_to_site(1, 0, Lx)  # site at grid (1,0)
-            reflected = MonteCarloMoves._reflect_site(site_10, 0, 0, Lx, Ly)
-            gx, gy = MonteCarloMoves._site_to_grid(reflected, Lx)
+            site_10 = MonteCarloMoves._grid_to_site(1, 0, 0, Lx, Ly)  # site at grid (1,0,0)
+            reflected = MonteCarloMoves._reflect_site(site_10, 0, 0, Lx, Ly, Lz)
+            gx, gy, gz = MonteCarloMoves._site_to_grid(reflected, Lx, Ly)
             @test gx == 3
             @test gy == 0
+            @test gz == 0
 
             # Pivot at (2,2): R(0,0) -> (4 mod 4, 4 mod 4) = (0, 0) — fixed point
-            site_00 = MonteCarloMoves._grid_to_site(0, 0, Lx)
-            reflected = MonteCarloMoves._reflect_site(site_00, 2, 2, Lx, Ly)
-            gx, gy = MonteCarloMoves._site_to_grid(reflected, Lx)
+            site_00 = MonteCarloMoves._grid_to_site(0, 0, 0, Lx, Ly)
+            reflected = MonteCarloMoves._reflect_site(site_00, 2, 2, Lx, Ly, Lz)
+            gx, gy, gz = MonteCarloMoves._site_to_grid(reflected, Lx, Ly)
             @test gx == 0
             @test gy == 0
 
             # Pivot at (1,1): R(3,3) -> (2-3 mod 4, 2-3 mod 4) = (3, 3) — check wrap
-            site_33 = MonteCarloMoves._grid_to_site(3, 3, Lx)
-            reflected = MonteCarloMoves._reflect_site(site_33, 1, 1, Lx, Ly)
-            gx, gy = MonteCarloMoves._site_to_grid(reflected, Lx)
+            site_33 = MonteCarloMoves._grid_to_site(3, 3, 0, Lx, Ly)
+            reflected = MonteCarloMoves._reflect_site(site_33, 1, 1, Lx, Ly, Lz)
+            gx, gy, gz = MonteCarloMoves._site_to_grid(reflected, Lx, Ly)
             @test gx == mod(2*1 - 3, 4)  # 3
             @test gy == mod(2*1 - 3, 4)  # 3
         end
 
-        @testset "site ↔ grid round-trip" begin
-            Lx, Ly = 5, 7
-            for site in 1:(Lx * Ly)
-                gx, gy = MonteCarloMoves._site_to_grid(site, Lx)
-                @test MonteCarloMoves._grid_to_site(gx, gy, Lx) == site
+        @testset "site ↔ grid round-trip (2D)" begin
+            Lx, Ly, Lz = 5, 7, 1
+            for site in 1:(Lx * Ly * Lz)
+                gx, gy, gz = MonteCarloMoves._site_to_grid(site, Lx, Ly)
+                @test MonteCarloMoves._grid_to_site(gx, gy, gz, Lx, Ly) == site
                 @test 0 <= gx < Lx
                 @test 0 <= gy < Ly
+                @test gz == 0
+            end
+        end
+
+        @testset "site ↔ grid round-trip (3D)" begin
+            Lx, Ly, Lz = 4, 4, 3
+            for site in 1:(Lx * Ly * Lz)
+                gx, gy, gz = MonteCarloMoves._site_to_grid(site, Lx, Ly)
+                @test MonteCarloMoves._grid_to_site(gx, gy, gz, Lx, Ly) == site
+                @test 0 <= gx < Lx
+                @test 0 <= gy < Ly
+                @test 0 <= gz < Lz
             end
         end
 
@@ -141,6 +177,37 @@
             geometric_cluster_swap!(ml, 0.4)
 
             @test ml.components == original_components
+        end
+
+        @testset "particle count preserved 3D (C=1)" begin
+            sl = SLattice{SquareLattice}(
+                supercell_dimensions=(4, 4, 3),
+                periodicity=(true, true, false),
+                components=[[1, 5, 20, 35]]
+            )
+            original_count = occupied_site_count(sl)
+            for _ in 1:50
+                geometric_cluster_swap!(sl, 0.3)
+                @test occupied_site_count(sl) == original_count
+            end
+        end
+
+        @testset "self-inverse for fixed cluster 3D" begin
+            using Random
+            sl = SLattice{SquareLattice}(
+                supercell_dimensions=(4, 4, 3),
+                periodicity=(true, true, false),
+                components=[[1, 5, 17, 33, 40]]
+            )
+            original_components = deepcopy(sl.components)
+
+            seed = 42
+            Random.seed!(seed)
+            geometric_cluster_swap!(sl, 0.3)
+            Random.seed!(seed)
+            geometric_cluster_swap!(sl, 0.3)
+
+            @test sl.components == original_components
         end
 
         @testset "cluster move can change configuration" begin

--- a/test/test-lattice-random-walks.jl
+++ b/test/test-lattice-random-walks.jl
@@ -228,6 +228,62 @@
             @test changed
         end
 
+        @testset "multi-site basis guard" begin
+            using Random
+            # The keyword constructor admits an arbitrary basis, so the
+            # index-space reflection's single-basis contract gets the same
+            # loud guard the triangular method has. (Basis offset and cutoff
+            # chosen so the intra-basis shell is unambiguous — a warning-free
+            # construction.)
+            two_site = MLattice{1,SquareLattice}(
+                basis=[(0.0, 0.0, 0.0), (0.25, 0.25, 0.0)],
+                supercell_dimensions=(4, 4, 1),
+                cutoff_radii=[0.5],
+                components=[[1, 2, 3]]
+            )
+            @test_throws ArgumentError geometric_cluster_swap!(two_site, 0.3)
+
+            # The guard consumes no randomness: a guarded throw leaves the
+            # global RNG stream untouched.
+            Random.seed!(7)
+            probe = rand(UInt64)
+            Random.seed!(7)
+            try
+                geometric_cluster_swap!(two_site, 0.3)
+            catch
+            end
+            @test rand(UInt64) === probe
+
+            # On a single-site-basis lattice the guarded method's same-seed
+            # trajectory is identical to the pre-guard body, replicated here
+            # through the same internal helpers.
+            sl = SLattice{SquareLattice}(
+                supercell_dimensions=(8, 8, 1),
+                components=[[1, 2, 3, 10, 15, 20, 30, 40, 50, 60]]
+            )
+            replica = deepcopy(sl)
+            Random.seed!(4242)
+            for _ in 1:25
+                geometric_cluster_swap!(sl, 0.3)
+            end
+            Random.seed!(4242)
+            for _ in 1:25
+                Lx, Ly, Lz = replica.supercell_dimensions
+                pivot_gx = rand(0:Lx-1)
+                pivot_gy = rand(0:Ly-1)
+                seed_site = rand(1:num_sites(replica))
+                reflect = s -> MonteCarloMoves._reflect_site(s, pivot_gx, pivot_gy, Lx, Ly, Lz)
+                cluster = MonteCarloMoves._build_geometric_cluster(replica, seed_site, reflect, 0.3)
+                for (a, b) in cluster
+                    if a != b
+                        replica.components[1][a], replica.components[1][b] =
+                            replica.components[1][b], replica.components[1][a]
+                    end
+                end
+            end
+            @test sl.components == replica.components
+        end
+
         # ---- triangular lattice (two-site centered-rectangular basis) ----
 
         @testset "triangular reflection: half-grid round-trip" begin

--- a/test/test-lattice-random-walks.jl
+++ b/test/test-lattice-random-walks.jl
@@ -228,5 +228,178 @@
             @test changed
         end
 
+        # ---- triangular lattice (two-site centered-rectangular basis) ----
+
+        @testset "triangular reflection: half-grid round-trip" begin
+            for (nx, ny) in ((3, 3), (6, 4))
+                M = 2 * nx * ny
+                for s in 1:M
+                    hx, hy = MonteCarloMoves._tri_site_to_halfgrid(s, nx)
+                    # The centered-rectangular condition: hx ≡ hy (mod 2)
+                    @test (hx & 1) == (hy & 1)
+                    @test 0 <= hx < 2 * nx
+                    @test 0 <= hy < 2 * ny
+                    @test MonteCarloMoves._tri_halfgrid_to_site(hx, hy, nx) == s
+                end
+            end
+        end
+
+        @testset "triangular reflection: involution and bijection" begin
+            using Random
+            Random.seed!(5)
+            for (nx, ny) in ((3, 3), (6, 4))
+                M = 2 * nx * ny
+                for _ in 1:25
+                    h1 = MonteCarloMoves._tri_site_to_halfgrid(rand(1:M), nx)
+                    h2 = MonteCarloMoves._tri_site_to_halfgrid(rand(1:M), nx)
+                    hpx, hpy = h1[1] + h2[1], h1[2] + h2[2]
+                    σ = [MonteCarloMoves._tri_reflect_site(s, hpx, hpy, nx, ny)
+                         for s in 1:M]
+                    @test sort(σ) == collect(1:M)          # bijection on sites
+                    @test all(σ[σ[s]] == s for s in 1:M)   # involution
+                end
+            end
+        end
+
+        @testset "triangular reflection is a lattice symmetry" begin
+            # Geometric check against the stored positions, independent of
+            # the half-grid index arithmetic: 2·pivot − r(s) − r(σ(s)) must
+            # be a supercell lattice vector (periods Ax = nx·a, Ay = ny·√3·a)
+            using Random
+            Random.seed!(6)
+            for (nx, ny) in ((3, 3), (6, 4))
+                lat = MLattice{1,TriangularLattice}(
+                    supercell_dimensions=(nx, ny, 1),
+                    cutoff_radii=[1.1],
+                    components=[[1]],
+                    adsorptions=:full)
+                M = 2 * nx * ny
+                Ax = nx * 1.0
+                Ay = ny * sqrt(3)
+                for _ in 1:10
+                    s1 = rand(1:M)
+                    s2 = rand(1:M)
+                    h1 = MonteCarloMoves._tri_site_to_halfgrid(s1, nx)
+                    h2 = MonteCarloMoves._tri_site_to_halfgrid(s2, nx)
+                    px = (lat.positions[s1, 1] + lat.positions[s2, 1]) / 2
+                    py = (lat.positions[s1, 2] + lat.positions[s2, 2]) / 2
+                    for s in 1:M
+                        r = MonteCarloMoves._tri_reflect_site(
+                            s, h1[1] + h2[1], h1[2] + h2[2], nx, ny)
+                        fx = (2 * px - lat.positions[s, 1] - lat.positions[r, 1]) / Ax
+                        fy = (2 * py - lat.positions[s, 2] - lat.positions[r, 2]) / Ay
+                        @test isapprox(fx, round(fx), atol=1e-9)
+                        @test isapprox(fy, round(fy), atol=1e-9)
+                    end
+                end
+            end
+        end
+
+        @testset "triangular basis-sublattice rule" begin
+            nx, ny = 3, 3
+            M = 2 * nx * ny
+            basis_of(s) = (s - 1) % 2
+            # Site pivots (s1 == s2, parity sum even): basis index preserved
+            for s1 in (1, 4, 18)
+                h = MonteCarloMoves._tri_site_to_halfgrid(s1, nx)
+                for s in 1:M
+                    r = MonteCarloMoves._tri_reflect_site(s, 2 * h[1], 2 * h[2], nx, ny)
+                    @test basis_of(r) == basis_of(s)
+                end
+            end
+            # Midpoint pivot with odd parity sum: basis 0 and basis 1 exchange
+            h1 = MonteCarloMoves._tri_site_to_halfgrid(1, nx)   # basis 0
+            h2 = MonteCarloMoves._tri_site_to_halfgrid(2, nx)   # basis 1
+            @test isodd(h1[1] + h2[1])
+            for s in 1:M
+                r = MonteCarloMoves._tri_reflect_site(
+                    s, h1[1] + h2[1], h1[2] + h2[2], nx, ny)
+                @test basis_of(r) == 1 - basis_of(s)
+            end
+        end
+
+        @testset "particle count preserved (triangular, C=1)" begin
+            sl = SLattice{TriangularLattice}(
+                supercell_dimensions=(6, 4, 1),
+                cutoff_radii=[1.1],
+                components=[[1, 2, 5, 10, 17, 24, 33, 40]],
+                adsorptions=:full)
+            original_count = occupied_site_count(sl)
+            for _ in 1:50
+                geometric_cluster_swap!(sl, 0.3)
+                @test occupied_site_count(sl) == original_count
+            end
+        end
+
+        @testset "particle count preserved (triangular, C=2)" begin
+            ml = MLattice{2,TriangularLattice}(
+                supercell_dimensions=(3, 3, 1),
+                cutoff_radii=[1.1],
+                components=[[1, 3, 5, 7], [2, 4, 6, 8]],
+                adsorptions=:full)
+            original_counts = occupied_site_count(ml)
+            for _ in 1:50
+                geometric_cluster_swap!(ml, 0.4)
+                @test occupied_site_count(ml) == original_counts
+            end
+        end
+
+        @testset "self-inverse for fixed cluster (triangular)" begin
+            using Random
+            sl = SLattice{TriangularLattice}(
+                supercell_dimensions=(6, 4, 1),
+                cutoff_radii=[1.1],
+                components=[[1, 5, 10, 20, 30, 40]],
+                adsorptions=:full)
+            original_components = deepcopy(sl.components)
+
+            seed = 42
+            Random.seed!(seed)
+            geometric_cluster_swap!(sl, 0.3)
+            Random.seed!(seed)
+            geometric_cluster_swap!(sl, 0.3)
+
+            @test sl.components == original_components
+        end
+
+        @testset "cluster move can change configuration (triangular)" begin
+            sl = SLattice{TriangularLattice}(
+                supercell_dimensions=(6, 4, 1),
+                cutoff_radii=[1.1],
+                components=[[1, 2, 3, 4, 5, 6]],
+                adsorptions=:full)
+            original_components = deepcopy(sl.components)
+            changed = false
+            for _ in 1:100
+                test_sl = deepcopy(sl)
+                geometric_cluster_swap!(test_sl, 0.5)
+                if test_sl.components != original_components
+                    changed = true
+                    break
+                end
+            end
+            @test changed
+        end
+
+        @testset "triangular guards" begin
+            # One-site basis: the half-grid index arithmetic does not apply
+            lat1b = MLattice{1,TriangularLattice}(
+                basis=[(0.0, 0.0, 0.0)],
+                supercell_dimensions=(3, 3, 1),
+                cutoff_radii=[1.1],
+                components=[[1]],
+                adsorptions=:full)
+            @test_throws ArgumentError geometric_cluster_swap!(lat1b, 0.3)
+
+            # Three-dimensional supercell: not supported on triangular
+            lat3d = MLattice{1,TriangularLattice}(
+                supercell_dimensions=(3, 3, 2),
+                periodicity=(true, true, true),
+                cutoff_radii=[1.1],
+                components=[[1]],
+                adsorptions=:full)
+            @test_throws ArgumentError geometric_cluster_swap!(lat3d, 0.3)
+        end
+
     end
 end

--- a/test/test-lattice-random-walks.jl
+++ b/test/test-lattice-random-walks.jl
@@ -36,4 +36,130 @@
         @test new_ml.components[2][1] == 1
         @test new_ml.components[2][2] == 0
     end
+
+    @testset "geometric cluster move tests" begin
+
+        @testset "reflection map is self-inverse" begin
+            Lx, Ly = 6, 6
+            for pivot_gx in [0, 1, 3, 5], pivot_gy in [0, 2, 4, 5]
+                for site in 1:(Lx * Ly)
+                    r = MonteCarloMoves._reflect_site(site, pivot_gx, pivot_gy, Lx, Ly)
+                    rr = MonteCarloMoves._reflect_site(r, pivot_gx, pivot_gy, Lx, Ly)
+                    @test rr == site
+                end
+            end
+        end
+
+        @testset "reflection wraps correctly under PBC" begin
+            Lx, Ly = 4, 4
+            # Pivot at (0,0): R(1,0) -> (2*0 - 1 mod 4, 0) = (3, 0)
+            site_10 = MonteCarloMoves._grid_to_site(1, 0, Lx)  # site at grid (1,0)
+            reflected = MonteCarloMoves._reflect_site(site_10, 0, 0, Lx, Ly)
+            gx, gy = MonteCarloMoves._site_to_grid(reflected, Lx)
+            @test gx == 3
+            @test gy == 0
+
+            # Pivot at (2,2): R(0,0) -> (4 mod 4, 4 mod 4) = (0, 0) — fixed point
+            site_00 = MonteCarloMoves._grid_to_site(0, 0, Lx)
+            reflected = MonteCarloMoves._reflect_site(site_00, 2, 2, Lx, Ly)
+            gx, gy = MonteCarloMoves._site_to_grid(reflected, Lx)
+            @test gx == 0
+            @test gy == 0
+
+            # Pivot at (1,1): R(3,3) -> (2-3 mod 4, 2-3 mod 4) = (3, 3) — check wrap
+            site_33 = MonteCarloMoves._grid_to_site(3, 3, Lx)
+            reflected = MonteCarloMoves._reflect_site(site_33, 1, 1, Lx, Ly)
+            gx, gy = MonteCarloMoves._site_to_grid(reflected, Lx)
+            @test gx == mod(2*1 - 3, 4)  # 3
+            @test gy == mod(2*1 - 3, 4)  # 3
+        end
+
+        @testset "site ↔ grid round-trip" begin
+            Lx, Ly = 5, 7
+            for site in 1:(Lx * Ly)
+                gx, gy = MonteCarloMoves._site_to_grid(site, Lx)
+                @test MonteCarloMoves._grid_to_site(gx, gy, Lx) == site
+                @test 0 <= gx < Lx
+                @test 0 <= gy < Ly
+            end
+        end
+
+        @testset "particle count preserved (C=1)" begin
+            sl = SLattice{SquareLattice}(
+                supercell_dimensions=(8, 8, 1),
+                components=[[1, 2, 3, 10, 15, 20, 30, 40, 50, 60]]
+            )
+            original_count = occupied_site_count(sl)
+            for _ in 1:50
+                geometric_cluster_swap!(sl, 0.3)
+                @test occupied_site_count(sl) == original_count
+            end
+        end
+
+        @testset "particle count preserved (C=2)" begin
+            ml = MLattice{2,SquareLattice}(
+                supercell_dimensions=(6, 6, 1),
+                components=[[1, 3, 5, 7, 9, 11], [2, 4, 6, 8, 10, 12]]
+            )
+            original_counts = occupied_site_count(ml)
+            for _ in 1:50
+                geometric_cluster_swap!(ml, 0.4)
+                @test occupied_site_count(ml) == original_counts
+            end
+        end
+
+        @testset "self-inverse for fixed cluster" begin
+            using Random
+            sl = SLattice{SquareLattice}(
+                supercell_dimensions=(8, 8, 1),
+                components=[[1, 5, 10, 20, 30, 40, 50, 60]]
+            )
+            original_components = deepcopy(sl.components)
+
+            # Apply with seeded RNG, then apply again with same seed
+            seed = 42
+            Random.seed!(seed)
+            geometric_cluster_swap!(sl, 0.3)
+            Random.seed!(seed)
+            geometric_cluster_swap!(sl, 0.3)
+
+            @test sl.components == original_components
+        end
+
+        @testset "self-inverse for fixed cluster (C=2)" begin
+            using Random
+            ml = MLattice{2,SquareLattice}(
+                supercell_dimensions=(6, 6, 1),
+                components=[[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]]
+            )
+            original_components = deepcopy(ml.components)
+
+            seed = 123
+            Random.seed!(seed)
+            geometric_cluster_swap!(ml, 0.4)
+            Random.seed!(seed)
+            geometric_cluster_swap!(ml, 0.4)
+
+            @test ml.components == original_components
+        end
+
+        @testset "cluster move can change configuration" begin
+            sl = SLattice{SquareLattice}(
+                supercell_dimensions=(8, 8, 1),
+                components=[[1, 2, 3, 4, 5, 6, 7, 8]]
+            )
+            original_components = deepcopy(sl.components)
+            changed = false
+            for _ in 1:100
+                test_sl = deepcopy(sl)
+                geometric_cluster_swap!(test_sl, 0.5)
+                if test_sl.components != original_components
+                    changed = true
+                    break
+                end
+            end
+            @test changed
+        end
+
+    end
 end


### PR DESCRIPTION
Implements the test plan of #186, testsets (a), (b), and (c). Test-only, one commit: `Test the finite non-periodic generic lattice end-to-end and the all-false-periodicity surface liveset.` (0 src LOC).

- Testset (a), finite non-periodic GenericLattice end to end (`test/test-SamplingSchemes/test-ns-observables.jl`, after the rectangular fixture): the 12-vertex cuboctahedral shell (first fcc coordination shell, nearest-neighbor spacing d = 2<sup>1/6</sup>σ) through the `MLattice{1,GenericLattice}` inner constructor at supercell (1, 1, 1) and periodicity (false, false, false), warning-free, with the cutoff ladder d·[1.1, 1.5, 1.8, 2.05] bracketing the {1, √2, √3, 2}·d distance classes. Neighbor lists match an in-test brute-force adjacency exactly (per-site counts [4, 2, 4, 1], pair counts [24, 12, 24, 6], symmetric, duplicate-free), and a `SiteFieldLatticeHamiltonian` over a zero-on-site `GenericLatticeHamiltonian` base (three-class site field; couplings at the closed-form 12-6 shell values (−1, −15/64, 3<sup>−6</sup> − 2·3<sup>−3</sup>, −127/4096)·ε) matches the explicit pair-plus-field sum over 222 occupation masks (measured worst deviation 1.1×10<sup>−16</sup> eV, gated at 10<sup>−13</sup>) plus the full-occupancy closed form. A comment documents that the generic tag is reachable only through the inner constructor.
- Testset (b), ideal-gas-referenced closure on that lattice (same file, reusing the fixture): the first GenericLattice coverage of `ideal_gas_referenced_nested_sampling`, `gc_thermodynamic_stats_ideal_ref`, and the `:contact` biased-insertion kernel. Exact reference by full 2<sup>12</sup> enumeration computed in-test; three seeded K = 120 runs plus one `:contact` member (p_bias = 0.5), each gated per stat (ln Ξ, ⟨N⟩, Var N, ⟨U⟩) at every (μ, T) point of a 3×3 grid whose exact coverage spans [0.050, 0.950] (pinned in-test), on points passing a Kish N<sub>eff</sub> floor of 60. All 36 grid-point evaluations pass the floor; the measured minima are 86.2–95.2, and the low-fugacity 200 K corner binds for all four members.
- Testset (b) calibration (the offset-aware K = 120 gates of #186): per stat per μ row, the measured mean deviation over the three unbiased seeds is folded into the gate as an offset, and the gate ships at 3× the maximum residual over all four members, every residual recorded digit-for-digit in the test file's ledger and reproducible with `FREEBIRD_CUBOCT_IGREF_CALIBRATE=1`; the weld was checked by re-running the shipped seeds bit-identically. Failability is stated in the ledger: every gate sits at ≤ 0.41 of its row's smallest per-point attainable deviation sup, and ln Ξ is unbounded below. The K = 480 measurement is recorded in the comment as specified (nearest-neighbor variant: grid-wide max |Δln Ξ| 0.228 at K = 480 vs 0.572 at K = 120, center-row means +0.014 vs −0.018 nats).
- Disclosure (finite-K offset magnitude): at the shipped depth (n_steps/K ≈ 29 nats, full descent to the enumerated ground state plus the live-walker tail) the measured common offsets are small, |offset| ≤ 0.157 nats for ln Ξ, rather than the +0.19/+0.32 nats recorded in #186's calibration note; the offset fold is retained exactly as #186 specifies but is not load-bearing at this depth, and the seed spread, not the offset, sizes the gates.
- Testset (c), all-false-periodicity surface liveset (`test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl`): a frozen 13-atom cuboctahedral LJ cluster (ε = 0.01 eV, σ = 2.5 Å, cutoff 2.5σ) built through `atomic_system` with explicit (false, false, false) boundaries in the padded L ≈ 28.97 Å box, with the periodicity asserted on the surface and on every liveset walker, and the `periodic_system(...; fractional=true)` construction trap pinned as fully periodic alongside. Walker energies from the `CompositeParameterSets(2, ...)` constructor path (CP = C + 1 with `compute_frozen_energy=true`, the #183 contract) match the in-test brute-force sum adsorbate-adsorbate + adsorbate-cluster + frozen self-energy over 30 configurations at N = 1–6 (measured deviation 0.0, gated at 10<sup>−12</sup> relative), and beyond-cutoff references are bit-exact zeros.
- Testset (c) reflection pins: `periodic_boundary_wrap!` is pinned at all six walls at two excursion scales (upper walls mirror within one rounding ulp, lower walls bit-exact by negation, in-range and both closed endpoints identity), including the single-reflection overshoot characterization wrap(2L + δ) = −δ and wrap(−(L + δ)) = L + δ (both asserted to land outside [0, L]) and a 41-point sweep confirming one reflection maps all of [−L, 2L] into the box; the shipped runs cap the adaptive step at 2.0 Å, a 14.5× margin on that containment bound (≥ 10× asserted).
- Testset (c) canonical completion: K = 32 clone-move runs at N = 2 and N = 4 finish to live spans 4.0×10<sup>−7</sup> and 3.5×10<sup>−8</sup> eV (gate 2×10<sup>−4</sup>) with zero out-of-box dead points, checked coordinate-resolved on every culled walker through `dead_point_callback`, and the ledgers carry the `log_compression` third column. The span crossings are seed-dependent and loosely pinned: the shipped seeds cross at accepted culls 987 and 1864, where the issue's seeds measured 1158 and 2596.
- Disclosure (testsets (d) and (e) of #186): both were specced as regression locks before the fix PRs existed, and the fix PRs shipped them. (d) plateau closure: the ideal-adsorbate fixture, in-test 144<sup>3</sup> midpoint quadrature reference, and per-sector evidence closures at N = 1-2 shipped in #187 (`test/test-SamplingSchemes/test-ns-plateau-ties.jl`) at greater than the specced scale (three seeds per sector, plus the plateau-mass accounting gates and legacy-weighting contrast), and the deterministic truncated-Poisson stitching layer is already locked by the fcc(100) slab closure in `test-atomistic-gcns-fixed-n.jl`. (e) guard regression: the end-to-end `ArgumentError` through `nested_sampling_step!` with the type-naming message, the RNG-neutrality probe, and the clusters-free positional control shipped in #189 (`test/test-lattice-random-walks.jl`, GenericLattice guard testset). This PR therefore delivers (a)-(c) only and duplicates no shipped assertion.
- Cost: ≈ 24 s local for the whole addition ((b) dominates: `test-ns-observables.jl` standalone rises from 4m06s to 4m28s; the new atomistic testset runs in 1.6 s), inside the ≈ 40 s budget of #186.

Adversarially reviewed pre-PR in three charters (issue-promise round-trip item by item incl. the (d)/(e) redundancy audit above, independent-oracle physics with recomputed references, determinism and assertion-delta accounting); each edited file ran standalone green twice with identical outcomes (`test-ns-observables.jl` 6113 = dev 5893 + 220, `test-atomistic-gcns-fixed-n.jl` 344 = dev 265 + 79, both deltas reconciled against loop arithmetic), and the full test suite passes on the shipped bytes: SamplingSchemes 7803 (= dev 7504 + 299), all other testsets at dev counts.
