### PR TITLE
Finite-lattice and non-periodic-surface regression coverage for generic-lattice cluster models, the ideal-gas-referenced route, and all-false-periodicity livesets

### DIFF
--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -1567,3 +1567,266 @@ end
         @test isapprox(out.observables[:z_com][1, 1], z_direct, rtol=1e-10)
     end
 end
+
+# ================================================================
+@testset "Atomistic NS at all-false periodicity (13-atom cuboctahedral cluster)" begin
+    using Random
+
+    # Issue #186 (c): the first nested-sampling liveset in the suite at
+    # all-false periodicity. The library builds such systems as a matter of
+    # course (generate_random_starting_config constructs atomic_system with
+    # explicit (false, false, false) boundary conditions), and
+    # periodic_boundary_wrap! REFLECTS rather than wraps on every
+    # non-periodic axis; the surface blocks above build fully periodic
+    # walkers via periodic_system(...; fractional=true), which is correct
+    # for slabs, so the reflecting branch has no other nested-sampling
+    # coverage and no direct pins at any wall.
+    #
+    # Fixture: a frozen 13-atom cuboctahedral LJ cluster (eps = 0.01 eV,
+    # sigma = 2.5 A, cutoff 2.5 sigma shifted, nearest-neighbor spacing
+    # d = 2^(1/6) sigma; sites as in test-ns-plateau-ties.jl), centered in a
+    # cubic box of edge L = sqrt(2) d + 4 * 2.5 sigma ~ 28.97 A: the
+    # axis-aligned shell extent (the vertex coordinates sit at
+    # +- d/sqrt(2) about the center) padded by two cutoff radii of vacuum
+    # per side. Unlike the plateau-ties fixture, the adsorbates here
+    # interact (adsorbate-adsorbate LJ on), and energy_frozen_part carries
+    # the real cluster self-energy through the compute_frozen_energy path
+    # of the LJSurfaceWalkers constructors, which now REQUIRE a
+    # CompositeParameterSets with one component per walker component plus
+    # one for the surface (CP = C + 1, walker components first).
+    afp_sig = 2.5
+    afp_eps = 0.01
+    afp_rc = 2.5                       # cutoff, units of sigma
+    afp_dnn = 2.0^(1 / 6) * afp_sig
+    afp_L = sqrt(2.0) * afp_dnn + 4 * afp_rc * afp_sig
+    afp_half = afp_L / 2
+
+    afp_shell = [(1, 1, 0), (1, -1, 0), (-1, 1, 0), (-1, -1, 0),
+                 (1, 0, 1), (1, 0, -1), (-1, 0, 1), (-1, 0, -1),
+                 (0, 1, 1), (0, 1, -1), (0, -1, 1), (0, -1, -1)]
+    afp_sites = vcat([(afp_half, afp_half, afp_half)],
+                     [(afp_half + p[1] * afp_dnn / sqrt(2),
+                       afp_half + p[2] * afp_dnn / sqrt(2),
+                       afp_half + p[3] * afp_dnn / sqrt(2)) for p in afp_shell])
+
+    afp_lj = LJParameters(epsilon=afp_eps, sigma=afp_sig, cutoff=afp_rc, shift=true)
+    afp_ljs = CompositeParameterSets(2, [afp_lj, afp_lj, afp_lj])
+    afp_box = [[afp_L, 0.0, 0.0]u"Å", [0.0, afp_L, 0.0]u"Å", [0.0, 0.0, afp_L]u"Å"]
+    afp_pbc = (false, false, false)
+
+    afp_surface = AtomWalker(FastSystem(atomic_system(
+        [:Ar => [x, y, z]u"Å" for (x, y, z) in afp_sites], afp_box, afp_pbc));
+        freeze_species=[:Ar])
+
+    afp_walker(coords) = AtomWalker(FastSystem(atomic_system(
+        [:Ar => [x, y, z]u"Å" for (x, y, z) in coords], afp_box, afp_pbc)))
+
+    # in-test brute force through the library's own pair function only
+    function afp_pair(p, q)
+        r = sqrt(sum((p[k] - q[k])^2 for k in 1:3))u"Å"
+        return ustrip(u"eV", lj_energy(r, afp_lj))
+    end
+    afp_E_frozen = sum(afp_pair(afp_sites[i], afp_sites[j])
+                       for i in 1:13 for j in (i+1):13)
+
+    @testset "periodicity contract and construction trap" begin
+        @test periodicity(afp_surface.configuration) == (false, false, false)
+        # The construction trap this fixture locks out (without calling the
+        # slab idiom wrong): periodic_system(...; fractional=true) yields a
+        # FULLY periodic system, so a finite-cluster model must construct
+        # through atomic_system -- the periodicity assertion is what
+        # catches the mix-up.
+        afp_trap = FastSystem(periodic_system([:Ar => [0.5, 0.5, 0.5]],
+                                              afp_box, fractional=true))
+        @test periodicity(afp_trap) == (true, true, true)
+    end
+
+    @testset "CompositeParameterSets energy identity vs brute force" begin
+        # 30 configurations, N = 1-6 (five per N), against the in-test sum
+        # adsorbate-adsorbate + adsorbate-cluster + frozen self-energy.
+        # Calibrated: worst relative deviation 0.0, frozen self-energy
+        # deviation 0.0 (the constructor evaluates the same truncated pair
+        # sum; the gates allow accumulation-order rounding).
+        Random.seed!(7402)
+        afp_worst = 0.0
+        for N in 1:6
+            ws = [afp_walker([ntuple(_ -> rand() * afp_L, 3) for _ in 1:N])
+                  for _ in 1:5]
+            ls = LJSurfaceWalkers(ws, afp_ljs, afp_surface;
+                                  compute_frozen_energy=true)
+            @test all(w -> periodicity(w.configuration) == (false, false, false),
+                      ls.walkers)
+            for w in ls.walkers
+                coords = [Tuple(ustrip.(u"Å", position(w.configuration, i)))
+                          for i in 1:N]
+                E_aa = N < 2 ? 0.0 :
+                       sum(afp_pair(coords[i], coords[j])
+                           for i in 1:N for j in (i+1):N)
+                E_as = sum(afp_pair(c, s) for c in coords, s in afp_sites)
+                E_brute = E_aa + E_as + afp_E_frozen
+                afp_worst = max(afp_worst,
+                    abs(ustrip(u"eV", w.energy) - E_brute) /
+                    max(abs(E_brute), 1.0e-12))
+            end
+        end
+        @test afp_worst <= 1e-12
+        @test abs(ustrip(u"eV", afp_surface.energy_frozen_part) -
+                  afp_E_frozen) <= 1e-13
+        @test afp_E_frozen < 0.0    # all 78 cluster pairs sit inside the cutoff
+
+        # Beyond-cutoff references are exact zeros: two adsorbates farther
+        # than the cutoff from the cluster and from each other leave the
+        # adsorbate part bit-exactly 0.0 eV (the truncated-shifted pair
+        # energy is an exact zero beyond the cutoff), so the walker energy
+        # is bit-exactly the frozen self-energy
+        afp_far = afp_walker([(2.0, 2.0, 2.0), (2.0, 2.0, afp_L - 2.0)])
+        afp_far_ls = LJSurfaceWalkers([afp_far], afp_ljs, afp_surface;
+                                      compute_frozen_energy=true)
+        @test ustrip(u"eV", interacting_energy(afp_far.configuration, afp_ljs,
+                  afp_far.list_num_par, afp_far.frozen,
+                  afp_surface.configuration)) === 0.0
+        @test afp_far_ls.walkers[1].energy == afp_surface.energy_frozen_part
+    end
+
+    # reflection probe: wrap a single-axis excursion through the library
+    # call, returning the full wrapped vector
+    function afp_wrap(v, ax)
+        p = [10.0, 11.0, 12.0]
+        p[ax] = v
+        sv = SVector{3,typeof(1.0u"Å")}(p[1]u"Å", p[2]u"Å", p[3]u"Å")
+        out = FreeBird.MonteCarloMoves.periodic_boundary_wrap!(
+            sv, afp_surface.configuration)
+        return ustrip.(u"Å", out)
+    end
+
+    @testset "reflection pins at all six walls" begin
+        for ax in 1:3
+            others = [k for k in 1:3 if k != ax]
+            for δ in (0.75, 7.5)
+                # upper wall: mirror reflection (2L - pos arithmetic; the
+                # gate allows one rounding ulp)
+                up = afp_wrap(afp_L + δ, ax)
+                @test abs(up[ax] - (afp_L - δ)) <= 1e-9
+                # lower wall: pure negation, bit-exact
+                lo = afp_wrap(-δ, ax)
+                @test lo[ax] === δ
+                # untouched in-range axes come back bit-exact
+                @test all(up[k] === Float64(10 + k - 1) for k in others)
+                @test all(lo[k] === Float64(10 + k - 1) for k in others)
+            end
+            # interior points and both closed endpoints are identity
+            @test all(afp_wrap(v, ax)[ax] === v for v in (0.0, 3.25, afp_L))
+
+            # single-reflection overshoot characterization: the reflection
+            # is applied once, not iterated, so wrap(2L + δ) = -δ and
+            # wrap(-(L + δ)) = L + δ both land OUTSIDE [0, L]
+            ov_up = afp_wrap(2 * afp_L + 0.75, ax)
+            @test abs(ov_up[ax] - (-0.75)) <= 1e-9
+            @test ov_up[ax] < 0.0
+            ov_lo = afp_wrap(-(afp_L + 0.75), ax)
+            @test ov_lo[ax] === afp_L + 0.75
+            @test ov_lo[ax] > afp_L
+            # hence containment silently requires every per-axis proposal
+            # to stay within [-L, 2L]; inside that range one reflection
+            # maps back into the box
+            @test all(0.0 <= afp_wrap(v, ax)[ax] <= afp_L
+                      for v in range(-afp_L, 2 * afp_L; length=41))
+        end
+    end
+
+    # ===== canonical completion at N = 2 and N = 4 =====================
+    # K = 32 clone-move runs to a live span < 2e-4 eV with zero out-of-box
+    # dead points. A finite cluster in a padded box puts a macroscopic
+    # prior fraction at exactly zero adsorbate energy, so the runs traverse
+    # an initial exact-tie plateau (the eviction path of the plateau-aware
+    # accounting; its quadrature closures live in test-ns-plateau-ties.jl)
+    # and the ledgers carry the log_compression column.
+    afp_E_THRESH = 1.0e9
+    function afp_uniform_walker(N)
+        while true
+            w = afp_walker([ntuple(_ -> rand() * afp_L, 3) for _ in 1:N])
+            E = ustrip(u"eV", interacting_energy(w.configuration, afp_ljs,
+                    w.list_num_par, w.frozen, afp_surface.configuration))
+            isfinite(E) && E < afp_E_THRESH && return w
+        end
+    end
+
+    function afp_run(N, seed, n_steps)
+        Random.seed!(seed)   # the parameters' random_seed field is not consumed
+        walkers = [afp_uniform_walker(N) for _ in 1:32]
+        ls = LJSurfaceWalkers(walkers, afp_ljs, afp_surface;
+                              compute_frozen_energy=true)
+        # per-axis step bound: the adaptive step size is capped at
+        # step_size_up = 2.0 A, a 14.5x margin on the [-L, 2L] containment
+        # bound above (>= 10x asserted below)
+        p = NestedSamplingParameters(mc_steps=100, step_size=1.0,
+                                     step_size_up=2.0,
+                                     allowed_fail_count=100_000)
+        save = SaveEveryN(df_filename="_test_afp_df.csv",
+                          wk_filename="_test_afp.traj.extxyz",
+                          ls_filename="_test_afp.ls.extxyz",
+                          n_traj=10_000_000, n_snap=10_000_000,
+                          n_info=10_000_000)
+        n_dead = Ref(0)
+        n_oob = Ref(0)
+        dead_cb = (iter, w) -> begin
+            n_dead[] += 1
+            for i in 1:length(w.configuration)
+                pos = position(w.configuration, i)
+                for k in 1:3
+                    x = ustrip(u"Å", pos[k])
+                    (0.0 <= x <= afp_L) || (n_oob[] += 1)
+                end
+            end
+        end
+        df, ls_out, p_out = nested_sampling(ls, p, n_steps, MCRandomWalkClone(),
+                                            save; dead_point_callback=dead_cb)
+        rm("_test_afp_df.csv", force=true)
+        rm("_test_afp.traj.extxyz", force=true)
+        rm("_test_afp.ls.extxyz", force=true)
+        return df, ls_out, p_out, n_dead[], n_oob[]
+    end
+
+    # ---- all RNG use happens here; the asserts below evaluate afterwards ----
+    # n_steps is sized ~1.5-2x the measured span crossing so completion is
+    # seed-robust: the shipped seeds cross span < 2e-4 eV at accepted cull
+    # 987 (N = 2, seed 81) and 1864 (N = 4, seed 82); issue #186 measured
+    # 1158 and 2596 culls on its own seeds -- seed-dependent, pinned
+    # loosely via the acceptance floor below
+    afp_runs = [(2, afp_run(2, 81, 1600)...), (4, afp_run(4, 82, 3600)...)]
+
+    @testset "canonical completion at N = 2 and N = 4" begin
+        for (N, df, ls_out, p_out, n_dead, n_oob) in afp_runs
+            # ledger schema: serial atomistic steps emit the per-cull
+            # log-compression, so the ledger carries the third column
+            @test names(df) == ["iter", "emax", "log_compression"]
+            @test all(diff(df.emax) .<= 0)
+            # loose cull pin (acceptance health; culls are seed-dependent)
+            @test nrow(df) >= 0.9 * (N == 2 ? 1600 : 3600)
+            @test n_dead == nrow(df)
+            # zero out-of-box dead points, coordinate-resolved
+            @test n_oob == 0
+            # completion: live span below 2e-4 eV (calibrated final spans
+            # 3.98e-7 and 3.50e-8 eV), live set intact and in the box
+            liveE = [ustrip(u"eV", w.energy) for w in ls_out.walkers]
+            @test length(liveE) == 32
+            @test maximum(liveE) - minimum(liveE) < 2e-4
+            @test all(w -> periodicity(w.configuration) == (false, false, false),
+                      ls_out.walkers)
+            afp_live_in_box = true
+            for w in ls_out.walkers, i in 1:length(w.configuration)
+                pos = position(w.configuration, i)
+                for k in 1:3
+                    afp_live_in_box &= (0.0 <= ustrip(u"Å", pos[k]) <= afp_L)
+                end
+            end
+            @test afp_live_in_box
+            # the shipped seeds end outside any tie block
+            @test p_out.plateau_refill_target == 0
+            # the adaptive step size respected its cap, and the cap keeps
+            # >= 10x margin on the single-reflection containment bound
+            @test p_out.step_size <= 2.0
+            @test 10 * 2.0 <= afp_L
+        end
+    end
+end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -3182,6 +3182,362 @@
     end
 
     # ================================================================
+    # Shared fixture (issue #186 (a)/(b)): the 12-vertex cuboctahedral shell
+    # -- the first coordination shell of the fcc crystal, i.e. the
+    # adsorption-site shell of a 13-atom cuboctahedral cluster -- as a FINITE
+    # lattice through the MLattice{1,GenericLattice} inner constructor:
+    # supercell (1, 1, 1), periodicity (false, false, false), the twelve
+    # vertices supplied as an explicit Cartesian basis. Keyword constructors
+    # exist only for the square and triangular tags
+    # (src/AbstractWalkers/lattice_walkers.jl), so the generic tag -- and
+    # with it any irregular finite cluster model -- is reachable only
+    # through the inner constructor.
+    #
+    # Geometry: vertices (+-1, +-1, 0), (+-1, 0, +-1), (0, +-1, +-1) scaled
+    # by d/sqrt(2) about a positive center, with nearest-neighbor spacing
+    # d = 2^(1/6) sigma (sigma = 1 lattice units, the Lennard-Jones pair
+    # minimum). The inter-vertex distances fall in shells
+    # {1, sqrt(2), sqrt(3), 2} d with per-site counts [4, 2, 4, 1]
+    # (unordered pair counts [24, 12, 24, 6]); the cutoff ladder
+    # d * [1.1, 1.5, 1.8, 2.05] brackets exactly one distance class per
+    # shell. A 12-6 pair potential tabulates to exactly rational couplings
+    # at the shell distances: J_k / eps = -1, -15/64, 3^-6 - 2*3^-3,
+    # -127/4096.
+    cb_d = 2.0^(1 / 6)
+    cb_s = cb_d / sqrt(2.0)
+    cb_vertices = [(1, 1, 0), (1, -1, 0), (-1, 1, 0), (-1, -1, 0),
+                   (1, 0, 1), (1, 0, -1), (-1, 0, 1), (-1, 0, -1),
+                   (0, 1, 1), (0, 1, -1), (0, -1, 1), (0, -1, -1)]
+    cb_basis = [(cb_d + p[1] * cb_s, cb_d + p[2] * cb_s, cb_d + p[3] * cb_s)
+                for p in cb_vertices]
+    cb_radii = cb_d .* [1.1, 1.5, 1.8, 2.05]
+    # Non-periodic: no minimum-image reduction exists to go wrong, and
+    # construction is warning-free
+    cb = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,GenericLattice}(
+        [2.0 * cb_d 0.0 0.0; 0.0 2.0 * cb_d 0.0; 0.0 0.0 2.0 * cb_d],
+        cb_basis, (1, 1, 1), (false, false, false), cb_radii,
+        [fill(false, 12)], fill(true, 12))
+
+    # SiteFieldLatticeHamiltonian over a zero-on-site GenericLatticeHamiltonian
+    # base: the couplings carry the four-shell LJ tabulation above, and a
+    # three-class site field (one class per coordinate plane of the shell:
+    # vertices with z, y, x displacement zero respectively) breaks the
+    # site-transitivity the base Hamiltonians assume
+    cb_eps = 0.01
+    cb_J = cb_eps .* [-1.0, -15 / 64, 3.0^-6 - 2 * 3.0^-3, -127 / 4096]
+    cb_field = vcat(fill(-0.03, 4), fill(-0.02, 4), fill(-0.012, 4))
+    cb_ham = SiteFieldLatticeHamiltonian(
+        GenericLatticeHamiltonian(0.0, cb_J, u"eV"), cb_field, u"eV")
+
+    # Independent geometry: brute-force pair-shell table from the stored
+    # positions (no images: the model is finite), sharing no code with
+    # compute_neighbors
+    cb_pos = [(cb.positions[s, 1], cb.positions[s, 2], cb.positions[s, 3])
+              for s in 1:12]
+    cb_dist(i, j) = sqrt(sum((cb_pos[i][k] - cb_pos[j][k])^2 for k in 1:3))
+    cb_pair_shell = Dict{Tuple{Int,Int},Int}()
+    for i in 1:12, j in (i+1):12
+        r = cb_dist(i, j)
+        r > cb_radii[end] && continue
+        sh = findfirst(rr -> r <= rr, cb_radii)
+        sh === nothing || (cb_pair_shell[(i, j)] = sh)
+    end
+    cb_brute_E(occ) = sum(cb_field[i] for i in 1:12 if occ[i]; init=0.0) +
+                      sum((occ[p[1]] && occ[p[2]]) ? cb_J[sh] : 0.0
+                          for (p, sh) in cb_pair_shell; init=0.0)
+
+    # ================================================================
+    @testset "finite non-periodic generic lattice: cuboctahedral shell" begin
+        @test cb isa GLattice{1}
+        @test num_sites(cb) == 12
+        @test cb.periodicity == (false, false, false)
+        # supercell (1, 1, 1): the stored positions are exactly the basis
+        @test all(Tuple(cb.positions[s, :]) == cb_basis[s] for s in 1:12)
+
+        # Neighbor-shell audit against the brute-force adjacency
+        cb_brute = [[Int[] for _ in 1:4] for _ in 1:12]
+        for ((i, j), sh) in cb_pair_shell
+            push!(cb_brute[i][sh], j)
+            push!(cb_brute[j][sh], i)
+        end
+        @test all(nb -> length.(nb) == [4, 2, 4, 1], cb.neighbors)
+        @test all(sort(cb.neighbors[s][k]) == sort(cb_brute[s][k])
+                  for s in 1:12, k in 1:4)
+        # symmetric and duplicate-free
+        cb_sym = true
+        for s in 1:12, k in 1:4, nb in cb.neighbors[s][k]
+            cb_sym &= (s in cb.neighbors[nb][k])
+        end
+        @test cb_sym
+        @test all(allunique(vcat(cb.neighbors[s]...)) for s in 1:12)
+        # unordered pair counts per shell
+        @test [sum(length(cb.neighbors[s][k]) for s in 1:12) ÷ 2 for k in 1:4] ==
+              [24, 12, 24, 6]
+
+        # Energy identity against the explicit pair-plus-field sum
+        # (the additive contract of SiteFieldLatticeHamiltonian). Single
+        # occupancies pin the field per site exactly: no pair term
+        # contributes, so E = field[i], bit-exactly
+        cb_occ = cb.components[1]
+        cb_single_ok = true
+        for i in 1:12
+            cb_occ .= false
+            cb_occ[i] = true
+            cb_single_ok &= (ustrip(u"eV", interacting_energy(cb, cb_ham)) ==
+                             cb_field[i])
+        end
+        @test cb_single_ok
+        # 222 masks: the 12 singles, the 66 pairs, and 144 seeded random
+        # masks (calibrated worst deviation 1.1102230246251565e-16 eV)
+        cb_masks = Int[]
+        for i in 1:12
+            push!(cb_masks, 1 << (i - 1))
+        end
+        for i in 1:12, j in (i+1):12
+            push!(cb_masks, (1 << (i - 1)) | (1 << (j - 1)))
+        end
+        Random.seed!(7401)
+        for _ in 1:144
+            push!(cb_masks, rand(0:4095))
+        end
+        @test length(cb_masks) == 222
+        cb_worst = 0.0
+        for m in cb_masks
+            for s in 1:12
+                cb_occ[s] = ((m >> (s - 1)) & 1) == 1
+            end
+            cb_worst = max(cb_worst,
+                abs(ustrip(u"eV", interacting_energy(cb, cb_ham)) -
+                    cb_brute_E(cb_occ)))
+        end
+        @test cb_worst <= 1e-13
+        # Full-occupancy closed form: field sum plus the pair-count-weighted
+        # couplings (calibrated deviation 4.440892098500626e-16 eV)
+        cb_occ .= true
+        cb_full = sum(cb_field) + 24 * cb_J[1] + 12 * cb_J[2] +
+                  24 * cb_J[3] + 6 * cb_J[4]
+        @test abs(ustrip(u"eV", interacting_energy(cb, cb_ham)) - cb_full) < 1e-12
+        cb_occ .= false
+    end
+
+    # ================================================================
+    # Issue #186 (b): ideal-gas-referenced closure on the finite lattice --
+    # the first GenericLattice coverage of ideal_gas_referenced_nested_sampling,
+    # gc_thermodynamic_stats_ideal_ref, and (last member) the :contact
+    # biased-insertion kernel. Exact reference: full 2^12 enumeration,
+    # computed here in-test.
+    #
+    # ============== calibration ledger (record, do not retype) ==============
+    # Grid: mus = [-0.07569, -0.04461, -0.01358] (coverage 0.05 at 200 K,
+    # 0.50 at 250 K, 0.95 at 200 K by bisection on the exact sums, rounded
+    # to 1e-5), Ts = [200, 250, 300] K; grid-wide exact coverage spans
+    # [0.0500, 0.9500]. z0 = exp(beta_250 * mu_mid) = 0.12609619465789468.
+    # E_gs = -0.5354339112332822 eV (full occupancy).
+    #
+    # Members: seeds 71/72/73 (unbiased) + 74 (:contact, p_bias = 0.5), all
+    # K = 120, n_steps = 3500, mc_steps = 100; seeds are the first scanned,
+    # not selected on their deviations. Offsets are folded into the gates as
+    # issue #186 specifies (offset-aware K = 120 gates): per stat per mu row,
+    # offset = the mean deviation from the exact grand sums over the three
+    # unbiased seeds and the row's three temperatures; gate = 3x the maximum
+    # residual |dev - offset| over ALL FOUR members (so every member sits
+    # >= 3x inside its gate). Digit-for-digit residual maxima (reproduced by
+    # running this file with FREEBIRD_CUBOCT_IGREF_CALIBRATE=1; gates
+    # evaluate after all RNG use, so comment/tolerance edits never
+    # invalidate the calibration):
+    #
+    #   lnXi  row 1: offset +0.015549904629894596
+    #     unbiased max 0.0756902696062428   (seed 72, 200 K)
+    #     contact  max 0.18422345940164508  (200 K)      gate 0.5527
+    #   lnXi  row 2: offset -0.012233619456831275
+    #     unbiased max 0.3169651201965435   (seed 73, 300 K)
+    #     contact  max 0.42874254779132176  (200 K)      gate 1.2863
+    #   lnXi  row 3: offset -0.15657333856486272
+    #     unbiased max 0.6655533323089293   (seed 73, 200 K)
+    #     contact  max 0.9442795529943964   (200 K)      gate 2.8329
+    #   meanN row 1: offset -0.01322238703461942
+    #     unbiased max 0.1518554036133445   (seed 73, 300 K)
+    #     contact  max 0.20149496329287075  (250 K)      gate 0.6045
+    #   meanN row 2: offset -0.13610795675848053
+    #     unbiased max 0.40111004303506903  (seed 73, 200 K)
+    #     contact  max 0.8105573891917334   (200 K)      gate 2.4317
+    #   meanN row 3: offset -0.029388454031590665
+    #     unbiased max 0.33924860365093973  (seed 71, 300 K)
+    #     contact  max 0.11001799842401343  (300 K)      gate 1.0178
+    #   varN  row 1: offset +0.03305623604750547
+    #     unbiased max 0.2138071159273987   (seed 73, 300 K)
+    #     contact  max 0.033976982900384915 (200 K)      gate 0.6415
+    #   varN  row 2: offset -0.2671108767327802
+    #     unbiased max 0.8165602033979901   (seed 71, 200 K)
+    #     contact  max 0.3062663641025275   (300 K)      gate 2.4497
+    #   varN  row 3: offset +0.04913320271407429
+    #     unbiased max 0.20047113177004405  (seed 71, 250 K)
+    #     contact  max 0.21139588976394919  (300 K)      gate 0.6342
+    #   meanU row 1: offset +0.0002199685765479365
+    #     unbiased max 0.004859023401123861 (seed 73, 300 K)
+    #     contact  max 0.005156558737498416 (300 K)      gate 0.015470
+    #   meanU row 2: offset +0.0063656655773413244
+    #     unbiased max 0.01797782612331277  (seed 73, 200 K)
+    #     contact  max 0.03751881712916904  (200 K)      gate 0.11256
+    #   meanU row 3: offset +0.0014783976304835683
+    #     unbiased max 0.02022309469461337  (seed 71, 300 K)
+    #     contact  max 0.006516969480520046 (300 K)      gate 0.060670
+    #
+    # Failability: every gate sits at <= 0.41 of its row's smallest
+    # per-point attainable deviation sup (mean_N sup = max(N_ex, 12 - N_ex)
+    # >= 6.0; var_N sup = max(V_ex, 36 - V_ex) >= 29.2; mean_U sup =
+    # max(|E_gs - U_ex|, |U_ex|) >= 0.214; lnXi is a log-sum estimator,
+    # unbounded below at every point). The worst ratio is mean_N row 2:
+    # 2.4317 / 6.0 = 0.41.
+    #
+    # Kish N_eff minima (floor 60 gated on every grid point): seed 71
+    # 89.8626807564595, seed 72 95.22891484341172, seed 73 89.75703787575497,
+    # contact 86.1519052984775 -- the LOW-fugacity corner (mu_lo, 200 K)
+    # binds for all four members.
+    #
+    # Finite-K note (the issue #186 calibration decision): at the shipped
+    # depth (n_steps/K ~ 29 nats, full descent to E_gs plus the live tail)
+    # the measured common offsets are small -- |offset| <= 0.157 nats for
+    # lnXi, above -- rather than the +0.19/+0.32 nats the issue's probes
+    # recorded, so the offset fold is retained as specified but is not
+    # load-bearing at this depth. K = 480 measurement (nearest-neighbor-only
+    # variant, own coverage-matched grid mus = [-0.08757, -0.04066, 0.00622],
+    # z0 = 0.15147134295752862, seeds 91/92/93, n_steps = 14000): center-row
+    # mean lnXi deviation +0.013846 nats, grid-wide max |dev| 0.228308; the
+    # same variant at K = 120 (seeds 81/82/83, n_steps = 3500) measures
+    # center-row mean -0.017549, grid-wide max 0.572417 -- the spread
+    # contracts ~2x at 4x K while the mean stays ~0.01-0.02 nats, the
+    # finite-K attribution of the residual scatter.
+    # ========================================================================
+    @testset "ideal-gas-referenced closure on the finite cuboctahedral shell" begin
+        cb_kb = 8.617333262e-5
+        # Full 2^12 enumeration through the library energy (the identity to
+        # the independent pair-plus-field sum is pinned in the testset above)
+        cb_e_tab = Vector{Float64}(undef, 4096)
+        cb_n_tab = Vector{Int}(undef, 4096)
+        cb_occ = cb.components[1]
+        for m in 0:4095
+            for s in 1:12
+                cb_occ[s] = ((m >> (s - 1)) & 1) == 1
+            end
+            cb_e_tab[m+1] = ustrip(u"eV", interacting_energy(cb, cb_ham))
+            cb_n_tab[m+1] = count_ones(m)
+        end
+        cb_occ .= false
+        cb_e_gs = minimum(cb_e_tab)
+        @test cb_e_gs ≈ -0.5354339112332822 rtol = 1e-12
+
+        function cb_exact(mu, T)
+            beta = 1 / (cb_kb * T)
+            lt = beta .* (mu .* cb_n_tab .- cb_e_tab)
+            mx = maximum(lt)
+            w = exp.(lt .- mx)
+            Z = sum(w)
+            mN = sum(w .* cb_n_tab) / Z
+            (logXi=mx + log(Z), mean_N=mN,
+             var_N=sum(w .* cb_n_tab .^ 2) / Z - mN^2,
+             mean_U=sum(w .* cb_e_tab) / Z)
+        end
+
+        # mu grid from the calibration ledger; the exact-coverage pins keep
+        # the grid honest (coverage 0.05-0.95 grid-wide, 0.50 center row)
+        cb_mus = [-0.07569, -0.04461, -0.01358]
+        cb_Ts = [200.0, 250.0, 300.0]
+        @test cb_exact(cb_mus[1], 200.0).mean_N / 12 ≈ 0.05 atol = 1e-3
+        @test cb_exact(cb_mus[2], 250.0).mean_N / 12 ≈ 0.50 atol = 1e-3
+        @test cb_exact(cb_mus[3], 200.0).mean_N / 12 ≈ 0.95 atol = 1e-3
+        cb_z0 = exp(cb_mus[2] / (cb_kb * 250.0))
+
+        function cb_run(seed; routine=MCGrandCanonicalMoves(p_move=0.4, p_insert=0.3))
+            Random.seed!(seed)   # the parameters' random_seed field is not consumed
+            ws = [LatticeWalker(deepcopy(cb), energy=0.0u"eV", iter=0)
+                  for _ in 1:120]
+            ls = LatticeGasWalkers(ws, cb_ham; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=100,
+                reference_fugacity=cb_z0, energy_perturbation=1e-9,
+                allowed_fail_count=100_000)
+            df, out, pout = ideal_gas_referenced_nested_sampling(
+                ls, p, Int64(3500), routine, obs_save)
+            obs_cleanup()
+            liveE = [w.energy.val for w in out.walkers]
+            liveN = [Int(sum(w.configuration.components[1])) for w in out.walkers]
+            st = gc_thermodynamic_stats_ideal_ref(df, 12, cb_z0, cb_mus, cb_Ts,
+                120; ω0=121 / 120, live_emax=liveE, live_numbers=liveN)
+            return (df=df, st=st, pout=pout)
+        end
+
+        # ---- all RNG use happens here; every gate below evaluates afterwards ----
+        cb_runs = [cb_run(71), cb_run(72), cb_run(73),
+                   cb_run(74; routine=MCGrandCanonicalMoves(p_move=0.4,
+                       p_insert=0.3, p_bias=0.5, bias_predicate=:contact,
+                       bias_shells=1))]
+
+        if get(ENV, "FREEBIRD_CUBOCT_IGREF_CALIBRATE", "0") == "1"
+            for (mem, seed) in zip(cb_runs, (71, 72, 73, 74))
+                println("calib cuboct seed $seed: Neff_min=",
+                        repr(minimum(mem.st.N_eff)), " argmin=",
+                        argmin(mem.st.N_eff))
+                for s in (:logXi, :mean_N, :var_N, :mean_U)
+                    for i in 1:3
+                        devs = [getfield(mem.st, s)[i, j] -
+                                getfield(cb_exact(cb_mus[i], cb_Ts[j]), s)
+                                for j in 1:3]
+                        println("  $s mu[$i]: ", join(repr.(devs), "  "))
+                    end
+                end
+            end
+        end
+
+        # offsets and gates from the calibration ledger above
+        cb_off_XI = [0.015550, -0.012234, -0.156573]
+        cb_off_N = [-0.013222, -0.136108, -0.029388]
+        cb_off_V = [0.033056, -0.267111, 0.049133]
+        cb_off_U = [0.000220, 0.006366, 0.001478]
+        cb_gate_XI = [0.5527, 1.2863, 2.8329]
+        cb_gate_N = [0.6045, 2.4317, 1.0178]
+        cb_gate_V = [0.6415, 2.4497, 0.6342]
+        cb_gate_U = [0.015470, 0.11256, 0.060670]
+
+        for mem in cb_runs
+            # ledger shape: the lattice route keeps the three-column ledger
+            # (no log_compression column: the lattice step methods keep the
+            # four-value return; pinned for MCRandomWalkClone ladders in
+            # test-ns-plateau-ties.jl)
+            @test names(mem.df) == ["iter", "emax", "num_particles"]
+            @test issorted(mem.df.emax, rev=true)
+            # the ladder reaches the ground manifold (full occupancy), up to
+            # the run's 1e-9 tie-breaking perturbation
+            @test minimum(mem.df.emax) <= cb_e_gs + 1e-6
+            # geometric cluster moves have no GenericLattice method (the
+            # guard in MonteCarloMoves throws); clusters_freq stays 0 in
+            # every member and no cluster move is ever attempted
+            @test mem.pout.move_stats[:cluster_attempted] == 0
+            @test mem.pout.move_stats[:swap_attempted] > 0
+        end
+        # the :contact member really drove the biased sub-channel
+        @test cb_runs[4].pout.move_stats[:insert_biased_attempted] > 0
+        @test cb_runs[4].pout.move_stats[:insert_biased_accepted] > 0
+
+        for mem in cb_runs
+            for (i, mu) in enumerate(cb_mus), (j, T) in enumerate(cb_Ts)
+                ex = cb_exact(mu, T)
+                # Kish floor: gates run only on points passing it, and every
+                # grid point passes (calibrated minima 86.2-95.2 at the
+                # low-fugacity 200 K corner, which binds for all members)
+                @test mem.st.N_eff[i, j] >= 60
+                @test abs(mem.st.logXi[i, j] - ex.logXi - cb_off_XI[i]) <=
+                      cb_gate_XI[i]
+                @test abs(mem.st.mean_N[i, j] - ex.mean_N - cb_off_N[i]) <=
+                      cb_gate_N[i]
+                @test abs(mem.st.var_N[i, j] - ex.var_N - cb_off_V[i]) <=
+                      cb_gate_V[i]
+                @test abs(mem.st.mean_U[i, j] - ex.mean_U - cb_off_U[i]) <=
+                      cb_gate_U[i]
+            end
+        end
+    end
+
+    # ================================================================
     @testset "Langmuir closure off the keyword-square path" begin
         # On-site term only (zero couplings): E = eps N exactly, so
         # Xi(mu, T) = (1 + z e^{-beta eps})^M with z = e^{beta mu}, and


### PR DESCRIPTION
Implements the test plan of #186, testsets (a), (b), and (c). Test-only, one commit: `Test the finite non-periodic generic lattice end to end and the all-false-periodicity surface liveset.` (0 src LOC).

- Testset (a), finite non-periodic GenericLattice end to end (`test/test-SamplingSchemes/test-ns-observables.jl`, after the rectangular fixture): the 12-vertex cuboctahedral shell (first fcc coordination shell, nearest-neighbor spacing d = 2<sup>1/6</sup>σ) through the `MLattice{1,GenericLattice}` inner constructor at supercell (1, 1, 1) and periodicity (false, false, false), warning-free, with the cutoff ladder d·[1.1, 1.5, 1.8, 2.05] bracketing the {1, √2, √3, 2}·d distance classes. Neighbor lists match an in-test brute-force adjacency exactly (per-site counts [4, 2, 4, 1], pair counts [24, 12, 24, 6], symmetric, duplicate-free), and a `SiteFieldLatticeHamiltonian` over a zero-on-site `GenericLatticeHamiltonian` base (three-class site field; couplings at the closed-form 12-6 shell values (−1, −15/64, 3<sup>−6</sup> − 2·3<sup>−3</sup>, −127/4096)·ε) matches the explicit pair-plus-field sum over 222 occupation masks (measured worst deviation 1.1×10<sup>−16</sup> eV, gated at 10<sup>−13</sup>) plus the full-occupancy closed form. A comment documents that the generic tag is reachable only through the inner constructor.
- Testset (b), ideal-gas-referenced closure on that lattice (same file, reusing the fixture): the first GenericLattice coverage of `ideal_gas_referenced_nested_sampling`, `gc_thermodynamic_stats_ideal_ref`, and the `:contact` biased-insertion kernel. Exact reference by full 2<sup>12</sup> enumeration computed in-test; three seeded K = 120 runs plus one `:contact` member (p_bias = 0.5), each gated per stat (ln Ξ, ⟨N⟩, Var N, ⟨U⟩) at every (μ, T) point of a 3×3 grid whose exact coverage spans [0.050, 0.950] (pinned in-test), on points passing a Kish N<sub>eff</sub> floor of 60. All 36 grid-point evaluations pass the floor; the measured minima are 86.2–95.2, and the low-fugacity 200 K corner binds for all four members.
- Testset (b) calibration (the offset-aware K = 120 gates of #186): per stat per μ row, the measured mean deviation over the three unbiased seeds is folded into the gate as an offset, and the gate ships at 3× the maximum residual over all four members, every residual recorded digit-for-digit in the test file's ledger and reproducible with `FREEBIRD_CUBOCT_IGREF_CALIBRATE=1`; the weld was checked by re-running the shipped seeds bit-identically. Failability is stated in the ledger: every gate sits at ≤ 0.41 of its row's smallest per-point attainable deviation sup, and ln Ξ is unbounded below. The K = 480 measurement is recorded in the comment as specified (nearest-neighbor variant: grid-wide max |Δln Ξ| 0.228 at K = 480 vs 0.572 at K = 120, center-row means +0.014 vs −0.018 nats).
- Disclosure (finite-K offset magnitude): at the shipped depth (n_steps/K ≈ 29 nats, full descent to the enumerated ground state plus the live-walker tail) the measured common offsets are small, |offset| ≤ 0.157 nats for ln Ξ, rather than the +0.19/+0.32 nats recorded in #186's calibration note; the offset fold is retained exactly as #186 specifies but is not load-bearing at this depth, and the seed spread, not the offset, sizes the gates.
- Testset (c), all-false-periodicity surface liveset (`test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl`): a frozen 13-atom cuboctahedral LJ cluster (ε = 0.01 eV, σ = 2.5 Å, cutoff 2.5σ) built through `atomic_system` with explicit (false, false, false) boundaries in the padded L ≈ 28.97 Å box, with the periodicity asserted on the surface and on every liveset walker, and the `periodic_system(...; fractional=true)` construction trap pinned as fully periodic alongside. Walker energies from the `CompositeParameterSets(2, ...)` constructor path (CP = C + 1 with `compute_frozen_energy=true`, the #183 contract) match the in-test brute-force sum adsorbate-adsorbate + adsorbate-cluster + frozen self-energy over 30 configurations at N = 1–6 (measured deviation 0.0, gated at 10<sup>−12</sup> relative), and beyond-cutoff references are bit-exact zeros.
- Testset (c) reflection pins: `periodic_boundary_wrap!` is pinned at all six walls at two excursion scales (upper walls mirror within one rounding ulp, lower walls bit-exact by negation, in-range and both closed endpoints identity), including the single-reflection overshoot characterization wrap(2L + δ) = −δ and wrap(−(L + δ)) = L + δ (both asserted to land outside [0, L]) and a 41-point sweep confirming one reflection maps all of [−L, 2L] into the box; the shipped runs cap the adaptive step at 2.0 Å, a 14.5× margin on that containment bound (≥ 10× asserted).
- Testset (c) canonical completion: K = 32 clone-move runs at N = 2 and N = 4 finish to live spans 4.0×10<sup>−7</sup> and 3.5×10<sup>−8</sup> eV (gate 2×10<sup>−4</sup>) with zero out-of-box dead points, checked coordinate-resolved on every culled walker through `dead_point_callback`, and the ledgers carry the `log_compression` third column. The span crossings are seed-dependent and loosely pinned: the shipped seeds cross at accepted culls 987 and 1864, where the issue's seeds measured 1158 and 2596.
- Disclosure (testsets (d) and (e) of #186): both were specced as regression locks before the fix PRs existed, and the fix PRs shipped them. (d) plateau closure: the ideal-adsorbate fixture, in-test 144<sup>3</sup> midpoint quadrature reference, and per-sector evidence closures at N = 1-2 shipped in #187 (`test/test-SamplingSchemes/test-ns-plateau-ties.jl`) at greater than the specced scale (three seeds per sector, plus the plateau-mass accounting gates and legacy-weighting contrast), and the deterministic truncated-Poisson stitching layer is already locked by the fcc(100) slab closure in `test-atomistic-gcns-fixed-n.jl`. (e) guard regression: the end-to-end `ArgumentError` through `nested_sampling_step!` with the type-naming message, the RNG-neutrality probe, and the clusters-free positional control shipped in #189 (`test/test-lattice-random-walks.jl`, GenericLattice guard testset). This PR therefore delivers (a)-(c) only and duplicates no shipped assertion.
- Cost: ≈ 24 s local for the whole addition ((b) dominates: `test-ns-observables.jl` standalone rises from 4m06s to 4m28s; the new atomistic testset runs in 1.6 s), inside the ≈ 40 s budget of #186.

Adversarially reviewed pre-PR in three charters (issue-promise round-trip item by item incl. the (d)/(e) redundancy audit above, independent-oracle physics with recomputed references, determinism and assertion-delta accounting); each edited file ran standalone green twice with identical outcomes (`test-ns-observables.jl` 6113 = dev 5893 + 220, `test-atomistic-gcns-fixed-n.jl` 344 = dev 265 + 79, both deltas reconciled against loop arithmetic), and the full test suite passes on the shipped bytes: SamplingSchemes 7803 (= dev 7504 + 299), all other testsets at dev counts.
