### PR TITLE
Add empty-configuration support to the atomistic walker helpers and pairwise energy paths

### DIFF
--- a/src/AbstractWalkers/atomistic_walkers.jl
+++ b/src/AbstractWalkers/atomistic_walkers.jl
@@ -53,6 +53,10 @@ Constructs an `AtomWalker` object with the given configuration.
 # Returns
 - `AtomWalker{C}`: The constructed `AtomWalker` object.
 
+An empty configuration is rejected with an `ArgumentError`: the number of components
+cannot be inferred from zero atoms. Construct `AtomWalker{1}(configuration)` directly for
+a zero-particle single-component walker.
+
 # Example
 ```jldoctest
 julia> at = FreeBirdIO.generate_multi_type_random_starting_config(10.0,[2,1,3,4,5,6];particle_types=[:H,:O,:H,:Fe,:Au,:Cl])
@@ -83,6 +87,9 @@ AtomWalker{5}(FastSystem(Au₅Cl₆Fe₄H₅O, periodic = FFF, bounding_box = [[
 
 """
 function AtomWalker(configuration::AbstractSystem; freeze_species::Vector{Symbol}=Symbol[], merge_same_species=true)
+    if length(configuration) == 0
+        throw(ArgumentError("empty configuration: the number of components cannot be inferred; construct AtomWalker{1}(configuration) directly for a zero-particle single-component walker."))
+    end
     if isa(configuration, FlexibleSystem)
         new_list = [Atom(atomic_symbol(i),position(i)) for i in configuration.particles]
         configuration = FastSystem(new_list, cell_vectors(configuration), periodicity(configuration))

--- a/src/AbstractWalkers/helpers.jl
+++ b/src/AbstractWalkers/helpers.jl
@@ -12,13 +12,15 @@ Split the system into components based on the number of particles in each compon
 # Returns
 - `components`: An array of `FastSystem` objects representing the components of the system.
 
+An empty system, or a zero-count component, yields a zero-atom `FastSystem` carrying the
+parent system's cell and periodicity.
 """
 function split_components(at::AbstractSystem, list_num_par::Vector{Int})
     components = Array{FastSystem}(undef, length(list_num_par))
     comp_cut = vcat([0],cumsum(list_num_par))
     comp_split = [comp_cut[i]+1:comp_cut[i+1] for i in 1:length(list_num_par)]
     for i in 1:length(list_num_par)
-        new_list = empty([Symbol(atomic_symbol(at[1])) => position(at[1])])
+        new_list = Pair{Symbol, eltype(position(at, :))}[]
         pos = position(at, comp_split[i])
         symbols = [Symbol(atomic_symbol(at[i])) for i in comp_split[i]]
         for i in 1:length(pos)
@@ -41,6 +43,7 @@ Split an `AbstractSystem` into multiple components based on the chemical species
 
 # Returns
 An array of `FastSystem` objects, each representing a component of the input system.
+An empty system returns an empty array.
 
 # Example
 ```jldoctest
@@ -78,7 +81,7 @@ function split_components_by_chemical_species(at::AbstractSystem)
     species = sort!(unique(list_species))
     components = Array{FastSystem}(undef, length(species))
     for i in 1:length(species)
-        new_list = empty([Symbol(atomic_symbol(at[1])) => position(at[1])])
+        new_list = Pair{Symbol, eltype(position(at, :))}[]
         pos = position(at, findall(x->x==species[i],list_species))
         symbols = [Symbol(atomic_symbol(at[i])) for i in findall(x->x==species[i],list_species)]
         for i in 1:length(pos)
@@ -124,7 +127,7 @@ Sorts the components of an `AbstractSystem` object `at` by their atomic number.
 - `list_num_par::Vector{Int64}`: A vector containing the number of each component species.
 - `new_list::FastSystem`: A new `FastSystem` object with the sorted components.
 
-The function first extracts the atomic numbers of the components in `at`. If `merge_same_species` is `true`, it sorts the unique species and counts the number of each species. If `merge_same_species` is `false`, it creates a list of species and their counts. It then sorts the species and counts by atomic number. Finally, it constructs a new `FastSystem` object with the sorted components and returns the list of species counts and the new `FastSystem` object.
+The function first extracts the atomic numbers of the components in `at`. If `merge_same_species` is `true`, it sorts the unique species and counts the number of each species. If `merge_same_species` is `false`, it creates a list of species and their counts. It then sorts the species and counts by atomic number. Finally, it constructs a new `FastSystem` object with the sorted components and returns the list of species counts and the new `FastSystem` object. An empty system returns an empty `list_num_par` and a zero-atom system, under either flag.
 
 # Examples
 ```jldoctest
@@ -157,12 +160,12 @@ julia> AbstractWalkers.sort_components_by_atomic_number(at)
 """
 function sort_components_by_atomic_number(at::AbstractSystem; merge_same_species=true)
     list_species = [atomic_number(at, i) for i in 1:length(at)]
-    new_list = empty([Symbol(atomic_symbol(at[1])) => position(at[1])])
+    new_list = Pair{Symbol, eltype(position(at, :))}[]
     if merge_same_species
         species = sort!(unique(list_species))
         list_num_par = [count(x->x==s, list_species) for s in species]
     elseif !merge_same_species
-        species = [list_species[1]; [list_species[i] for i in 2:length(list_species) if list_species[i] != list_species[i-1]]]
+        species = isempty(list_species) ? empty(list_species) : [list_species[1]; [list_species[i] for i in 2:length(list_species) if list_species[i] != list_species[i-1]]]
         list_num_par = Vector{Int64}()
         i = 1
         while i <= length(list_species)

--- a/src/EnergyEval/atomistic_energies.jl
+++ b/src/EnergyEval/atomistic_energies.jl
@@ -27,6 +27,7 @@ function frozen_energy(at::AbstractSystem,
                        frozen::Vector{Bool}
                        ) where {C,P}
     check_num_components(C, list_num_par, frozen)
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions
@@ -74,6 +75,7 @@ function frozen_energy(at::AbstractSystem,
     if length(list_num_par) != length(frozen)
         throw(ArgumentError("The number of frozen and free parts does not match the length of the number of components."))
     end
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions

--- a/src/EnergyEval/atomistic_pairwise.jl
+++ b/src/EnergyEval/atomistic_pairwise.jl
@@ -99,6 +99,7 @@ function interacting_energy(at::AbstractSystem,
                             frozen::Vector{Bool}
                             ) where {C,P<:SingleComponentPotential{Pairwise}}
     check_num_components(C, list_num_par, frozen)
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions
@@ -143,6 +144,7 @@ function interacting_energy(at::AbstractSystem,
                             frozen::Vector{Bool},
                             surface::AbstractSystem
                             ) where {C,P<:SingleComponentPotential{Pairwise}}
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components_at = split_components(at, list_num_par)
     components = [components_at..., surface] # combine components from at and surface
@@ -195,6 +197,7 @@ function interacting_energy(at::AbstractSystem,
     if length(list_num_par) != length(frozen)
         throw(ArgumentError("The number of frozen and free parts does not match the length of the number of components."))
     end
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -1290,5 +1290,72 @@
             end
         end
     end
-    
+
+    @testset "empty-configuration handling tests" begin
+        box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+        pbc = (true, true, true)
+        at1 = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        empty_at = FastSystem(cell_vectors(at1), periodicity(at1),
+                              empty(position(at1, :)), empty(species(at1, :)), empty(mass(at1, :)))
+        at2 = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å", :Ar => [3.0, 3.0, 3.0]u"Å"], box, pbc))
+
+        @testset "helpers on empty systems and zero-count components" begin
+            comps = split_components(empty_at, [0])
+            @test length(comps) == 1
+            @test length(comps[1]) == 0
+            @test cell_vectors(comps[1]) == cell_vectors(empty_at)
+            @test periodicity(comps[1]) == periodicity(empty_at)
+
+            mixed = split_components(at2, [0, 2])
+            @test map(length, mixed) == [0, 2]
+            @test position(mixed[2], :) == position(at2, :)
+            @test species(mixed[2], :) == species(at2, :)
+
+            @test AbstractWalkers.split_components_by_chemical_species(empty_at) == FastSystem[]
+
+            list_num_par, sorted = sort_components_by_atomic_number(empty_at)
+            @test isempty(list_num_par)
+            @test length(sorted) == 0
+            @test cell_vectors(sorted) == cell_vectors(empty_at)
+
+            list_num_par_nm, sorted_nm = sort_components_by_atomic_number(empty_at, merge_same_species=false)
+            @test isempty(list_num_par_nm)
+            @test length(sorted_nm) == 0
+        end
+
+        @testset "nonempty outputs unchanged by the retyped helpers" begin
+            mixed_at = FastSystem(atomic_system([:H => [1.0, 1.0, 1.0]u"Å",
+                                                 :O => [2.0, 2.0, 2.0]u"Å",
+                                                 :H => [3.0, 3.0, 3.0]u"Å"], box, pbc))
+            comps = AbstractWalkers.split_components_by_chemical_species(mixed_at)
+            @test map(length, comps) == [2, 1]  # H (Z = 1) before O (Z = 8)
+            @test position(comps[1], 1) == position(mixed_at, 1)
+            @test position(comps[1], 2) == position(mixed_at, 3)
+            @test position(comps[2], 1) == position(mixed_at, 2)
+        end
+
+        @testset "zero-particle AtomWalker{1} round-trip" begin
+            w = AtomWalker{1}(empty_at)
+            @test w.list_num_par == [0]
+            @test w.frozen == [false]
+            lj = LJParameters()
+            @test interacting_energy(w.configuration, lj) == 0.0u"eV"
+            @test interacting_energy(w.configuration, lj, w.list_num_par, w.frozen) == 0.0u"eV"
+            @test frozen_energy(w.configuration, lj, w.list_num_par, [true]) == 0.0u"eV"
+        end
+
+        @testset "convenience constructor rejects empty input legibly" begin
+            @test_throws ArgumentError AtomWalker(empty_at)
+        end
+
+        @testset "liveset accepts a zero-particle walker" begin
+            w0 = AtomWalker{1}(empty_at)
+            w2 = AtomWalker{1}(at2)
+            ls = LJAtomWalkers([w0, w2], LJParameters())
+            @test length(ls.walkers) == 2
+            @test ls.walkers[1].energy == 0.0u"eV"
+            @test isfinite(ustrip(ls.walkers[2].energy))
+        end
+    end
+
 end

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -834,4 +834,21 @@
         end
     end
 
+    @testset "empty-configuration energy fast paths" begin
+        box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+        pbc = (true, true, true)
+        seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        empty_at = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                              empty(position(seed_at, :)), empty(species(seed_at, :)), empty(mass(seed_at, :)))
+        lj = LJParameters()
+        cps = CompositeParameterSets(2, [lj, lj, lj])
+
+        @test interacting_energy(empty_at, lj) == 0.0u"eV"
+        @test interacting_energy(empty_at, lj, [0], [false]) == 0.0u"eV"
+        @test interacting_energy(empty_at, cps, [0, 0], [false, false]) == 0.0u"eV"
+        @test interacting_energy(empty_at, cps, [0], [false], seed_at) == 0.0u"eV"
+        @test frozen_energy(empty_at, lj, [0], [true]) == 0.0u"eV"
+        @test frozen_energy(empty_at, cps, [0, 0], [true, true]) == 0.0u"eV"
+    end
+
 end


### PR DESCRIPTION
Implements #194, fix 1 (the preferred direction): empty-configuration support through the atomistic component helpers and the pairwise energy paths. Two commits: `Add empty-configuration support to the atomistic component helpers and pairwise energy paths.` (src) and `Test empty-configuration handling across walkers, component helpers, and pairwise energy paths.` (tests).

- Helper retypes: the three first-atom typing idioms (`split_components`, `split_components_by_chemical_species`, `sort_components_by_atomic_number`) build their work lists as `Pair{Symbol, eltype(position(at, :))}[]`, so an empty system no longer indexes `at[1]`. Behavior on nonempty systems is unchanged (the constructed element type is identical), locked by an element-for-element fixture comparison. The `merge_same_species=false` branch of `sort_components_by_atomic_number` gains the same empty guard its merge branch inherits structurally; both flags return an empty `list_num_par` and a zero-atom system on empty input.
- Energy fast paths: five, not the issue's estimated two, since the pairwise family has five members that traverse components: `length(at) == 0 && return 0.0u"eV"` on both `frozen_energy` methods and all three pairwise `interacting_energy` methods (single-component, composite, and composite-with-surface). Each sits after the argument validation, so malformed inputs still error identically.
- Convenience constructor: `AtomWalker(configuration)` on an empty configuration now throws a legible `ArgumentError` naming the supported route (`AtomWalker{1}(configuration)` for a zero-particle single-component walker) in place of the previous `BoundsError` from three layers down; the issue's Impact section asked for a legible error or a valid empty walker, and the component count of an empty system is genuinely ambiguous. The typed inner constructor accepted empty configurations before this change and still does.
- Docstring notes on the three helpers and the convenience constructor state the empty-input behavior.
- Tests: per-helper empty and mixed `[0, n]` regressions with cell and periodicity preservation; the zero-particle `AtomWalker{1}` round-trip (`list_num_par == [0]`, `frozen == [false]`, zero energies through the 2-argument and 4-argument routes, by value rather than bitwise, since signed zeros are legal); the convenience-constructor throw; a liveset containing a zero-particle walker constructing and assigning energies.

Adversarially reviewed pre-PR in three charters (issue-promise round-trip, independent-oracle physics, determinism and assertion-delta accounting); the docstring notes and the five-path scope were the round-trip charter's findings on this change, both applied. The full test suite passes on the shipped bytes: AbstractWalkers 365 (= dev 339 + 26) and Energy Evaluation 346 (= dev 340 + 6), reconciled against the new testsets' loop arithmetic, all other testsets at dev counts.
