### PR TITLE
Add continuous-space grand-canonical insertion and deletion moves for AtomWalker

### DIFF
--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -20,6 +20,7 @@ export sort_components_by_atomic_number
 export split_components
 export split_components_by_chemical_species
 export check_num_components
+export insert_particle!, remove_particle!
 export LatticeWalker
 export LatticeGeometry, SquareLattice, TriangularLattice, GenericLattice
 export MLattice, SLattice, GLattice

--- a/src/AbstractWalkers/atomistic_walkers.jl
+++ b/src/AbstractWalkers/atomistic_walkers.jl
@@ -53,6 +53,10 @@ Constructs an `AtomWalker` object with the given configuration.
 # Returns
 - `AtomWalker{C}`: The constructed `AtomWalker` object.
 
+An empty configuration is rejected with an `ArgumentError`: the number of components
+cannot be inferred from zero atoms. Construct `AtomWalker{1}(configuration)` directly for
+a zero-particle single-component walker.
+
 # Example
 ```jldoctest
 julia> at = FreeBirdIO.generate_multi_type_random_starting_config(10.0,[2,1,3,4,5,6];particle_types=[:H,:O,:H,:Fe,:Au,:Cl])
@@ -83,6 +87,9 @@ AtomWalker{5}(FastSystem(Au₅Cl₆Fe₄H₅O, periodic = FFF, bounding_box = [[
 
 """
 function AtomWalker(configuration::AbstractSystem; freeze_species::Vector{Symbol}=Symbol[], merge_same_species=true)
+    if length(configuration) == 0
+        throw(ArgumentError("empty configuration: the number of components cannot be inferred; construct AtomWalker{1}(configuration) directly for a zero-particle single-component walker."))
+    end
     if isa(configuration, FlexibleSystem)
         new_list = [Atom(atomic_symbol(i),position(i)) for i in configuration.particles]
         configuration = FastSystem(new_list, cell_vectors(configuration), periodicity(configuration))

--- a/src/AbstractWalkers/helpers.jl
+++ b/src/AbstractWalkers/helpers.jl
@@ -192,6 +192,58 @@ function sort_components_by_atomic_number(at::AbstractSystem; merge_same_species
 end
 
 """
+    insert_particle!(walker::AtomWalker{1}, pos, species)
+
+Append one particle of `species` (a `Symbol` or `ChemicalSpecies`) at position `pos` to the
+walker's configuration, updating `list_num_par` in the same call. The two mutations are kept
+in lockstep here so the configuration arrays and the particle count cannot drift apart. The
+operation is purely structural: the walker's `energy` is not touched and the component's
+frozen flag is not consulted; callers own the energy bookkeeping (see
+`MC_grand_canonical_walk!`).
+
+# Arguments
+- `walker::AtomWalker{1}`: The single-component walker to extend.
+- `pos`: The new particle's position (any 3-vector of lengths accepted by the configuration).
+- `species`: The chemical identity of the new particle.
+
+# Returns
+- `walker::AtomWalker{1}`: The updated walker.
+"""
+function insert_particle!(walker::AtomWalker{1}, pos, species)
+    config = walker.configuration
+    sp = species isa ChemicalSpecies ? species : ChemicalSpecies(species)
+    push!(config.position, pos)
+    push!(config.species, sp)
+    push!(config.mass, mass(sp))
+    walker.list_num_par[1] += 1
+    return walker
+end
+
+"""
+    remove_particle!(walker::AtomWalker{1}, i::Int)
+
+Remove particle `i` from the walker's configuration, order-preserving, updating
+`list_num_par` in the same call. Purely structural, like `insert_particle!`: the walker's
+`energy` is not touched.
+
+# Arguments
+- `walker::AtomWalker{1}`: The single-component walker to shrink.
+- `i::Int`: The index of the particle to remove.
+
+# Returns
+- `walker::AtomWalker{1}`: The updated walker.
+"""
+function remove_particle!(walker::AtomWalker{1}, i::Int)
+    config = walker.configuration
+    checkbounds(config.position, i)
+    deleteat!(config.position, i)
+    deleteat!(config.species, i)
+    deleteat!(config.mass, i)
+    walker.list_num_par[1] -= 1
+    return walker
+end
+
+"""
     view_structure(at::AbstractSystem)
     view_structure(walker::AtomWalker)
 

--- a/src/AbstractWalkers/helpers.jl
+++ b/src/AbstractWalkers/helpers.jl
@@ -12,13 +12,15 @@ Split the system into components based on the number of particles in each compon
 # Returns
 - `components`: An array of `FastSystem` objects representing the components of the system.
 
+An empty system, or a zero-count component, yields a zero-atom `FastSystem` carrying the
+parent system's cell and periodicity.
 """
 function split_components(at::AbstractSystem, list_num_par::Vector{Int})
     components = Array{FastSystem}(undef, length(list_num_par))
     comp_cut = vcat([0],cumsum(list_num_par))
     comp_split = [comp_cut[i]+1:comp_cut[i+1] for i in 1:length(list_num_par)]
     for i in 1:length(list_num_par)
-        new_list = empty([Symbol(atomic_symbol(at[1])) => position(at[1])])
+        new_list = Pair{Symbol, eltype(position(at, :))}[]
         pos = position(at, comp_split[i])
         symbols = [Symbol(atomic_symbol(at[i])) for i in comp_split[i]]
         for i in 1:length(pos)
@@ -41,6 +43,7 @@ Split an `AbstractSystem` into multiple components based on the chemical species
 
 # Returns
 An array of `FastSystem` objects, each representing a component of the input system.
+An empty system returns an empty array.
 
 # Example
 ```jldoctest
@@ -78,7 +81,7 @@ function split_components_by_chemical_species(at::AbstractSystem)
     species = sort!(unique(list_species))
     components = Array{FastSystem}(undef, length(species))
     for i in 1:length(species)
-        new_list = empty([Symbol(atomic_symbol(at[1])) => position(at[1])])
+        new_list = Pair{Symbol, eltype(position(at, :))}[]
         pos = position(at, findall(x->x==species[i],list_species))
         symbols = [Symbol(atomic_symbol(at[i])) for i in findall(x->x==species[i],list_species)]
         for i in 1:length(pos)
@@ -124,7 +127,7 @@ Sorts the components of an `AbstractSystem` object `at` by their atomic number.
 - `list_num_par::Vector{Int64}`: A vector containing the number of each component species.
 - `new_list::FastSystem`: A new `FastSystem` object with the sorted components.
 
-The function first extracts the atomic numbers of the components in `at`. If `merge_same_species` is `true`, it sorts the unique species and counts the number of each species. If `merge_same_species` is `false`, it creates a list of species and their counts. It then sorts the species and counts by atomic number. Finally, it constructs a new `FastSystem` object with the sorted components and returns the list of species counts and the new `FastSystem` object.
+The function first extracts the atomic numbers of the components in `at`. If `merge_same_species` is `true`, it sorts the unique species and counts the number of each species. If `merge_same_species` is `false`, it creates a list of species and their counts. It then sorts the species and counts by atomic number. Finally, it constructs a new `FastSystem` object with the sorted components and returns the list of species counts and the new `FastSystem` object. An empty system returns an empty `list_num_par` and a zero-atom system, under either flag.
 
 # Examples
 ```jldoctest
@@ -157,12 +160,12 @@ julia> AbstractWalkers.sort_components_by_atomic_number(at)
 """
 function sort_components_by_atomic_number(at::AbstractSystem; merge_same_species=true)
     list_species = [atomic_number(at, i) for i in 1:length(at)]
-    new_list = empty([Symbol(atomic_symbol(at[1])) => position(at[1])])
+    new_list = Pair{Symbol, eltype(position(at, :))}[]
     if merge_same_species
         species = sort!(unique(list_species))
         list_num_par = [count(x->x==s, list_species) for s in species]
     elseif !merge_same_species
-        species = [list_species[1]; [list_species[i] for i in 2:length(list_species) if list_species[i] != list_species[i-1]]]
+        species = isempty(list_species) ? empty(list_species) : [list_species[1]; [list_species[i] for i in 2:length(list_species) if list_species[i] != list_species[i-1]]]
         list_num_par = Vector{Int64}()
         i = 1
         while i <= length(list_species)

--- a/src/EnergyEval/atomistic_energies.jl
+++ b/src/EnergyEval/atomistic_energies.jl
@@ -27,6 +27,7 @@ function frozen_energy(at::AbstractSystem,
                        frozen::Vector{Bool}
                        ) where {C,P}
     check_num_components(C, list_num_par, frozen)
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions
@@ -74,6 +75,7 @@ function frozen_energy(at::AbstractSystem,
     if length(list_num_par) != length(frozen)
         throw(ArgumentError("The number of frozen and free parts does not match the length of the number of components."))
     end
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions

--- a/src/EnergyEval/atomistic_pairwise.jl
+++ b/src/EnergyEval/atomistic_pairwise.jl
@@ -99,6 +99,7 @@ function interacting_energy(at::AbstractSystem,
                             frozen::Vector{Bool}
                             ) where {C,P<:SingleComponentPotential{Pairwise}}
     check_num_components(C, list_num_par, frozen)
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions
@@ -143,6 +144,7 @@ function interacting_energy(at::AbstractSystem,
                             frozen::Vector{Bool},
                             surface::AbstractSystem
                             ) where {C,P<:SingleComponentPotential{Pairwise}}
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components_at = split_components(at, list_num_par)
     components = [components_at..., surface] # combine components from at and surface
@@ -195,6 +197,7 @@ function interacting_energy(at::AbstractSystem,
     if length(list_num_par) != length(frozen)
         throw(ArgumentError("The number of frozen and free parts does not match the length of the number of components."))
     end
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -1114,3 +1114,189 @@ function MC_grand_canonical_walk!(n_steps::Int,
             insert_biased_accepted=insert_biased_accepted,
             delete_attempted=delete_attempted, delete_accepted=delete_accepted)
 end
+
+"""
+    gc_insert_acceptance_ratio(z0V::Float64, n::Int, p_insert::Float64, p_delete::Float64)
+    gc_delete_acceptance_ratio(z0V::Float64, n::Int, p_insert::Float64, p_delete::Float64)
+
+Metropolis acceptance ratios for the continuous-space grand-canonical kernel, with `n` the
+PRE-move particle count in both directions. `z0V` is the dimensionless product of the
+reference activity (dimension inverse volume) and the cell volume. The insertion ratio is
+the proposal-density form z0 * p_delete / ((n + 1) * p_insert * q(r)) with the uniform
+channel's q = 1/V folded in, so the shipped arithmetic is literally
+z0V * (p_delete / p_insert) / (n + 1); a future biased-insertion channel enters by
+evaluating a different proposal density q in place of the folded 1/V, mirroring the
+composite-density pattern of the lattice kernel above.
+"""
+gc_insert_acceptance_ratio(z0V::Float64, n::Int, p_insert::Float64, p_delete::Float64) =
+    z0V * (p_delete / p_insert) / (n + 1)
+
+gc_delete_acceptance_ratio(z0V::Float64, n::Int, p_insert::Float64, p_delete::Float64) =
+    (p_insert / p_delete) * n / z0V
+
+"""
+    MC_grand_canonical_walk!(n_steps::Int, at::AtomWalker{1}, pot::SingleComponentPotential{Pairwise}, emax::typeof(0.0u"eV");
+                             z0V::Float64, species, p_move::Float64=0.5, p_insert::Float64=0.25,
+                             step_size::Float64=0.5, n_max::Int=typemax(Int))
+
+Perform a grand-canonical Monte Carlo walk on a continuous-space `AtomWalker{1}` below a
+nested-sampling energy ceiling: single-atom displacements mixed with uniform-in-cell
+insertions and uniform-among-particles deletions, under the Metropolis corrections that
+preserve the activity-z0-weighted reference measure. The continuous counterpart
+of the lattice `MC_grand_canonical_walk!` above; the site-counting acceptance ratios of the
+lattice kernel do not apply here and are replaced by the volume-and-activity forms of
+`gc_insert_acceptance_ratio`/`gc_delete_acceptance_ratio` (pre-move particle count in both).
+
+Requirements: a single unfrozen component, and an orthorhombic cell (consistent with
+`pbc_dist`); both are validated on entry.
+
+Random-number stream contract (fixed by tests): one channel draw per step; a displacement
+draws one particle index and the three walk displacements; an insertion draws three position
+uniforms (x, y, z) plus the Metropolis uniform only when its ratio is below one; a deletion
+draws one particle index plus the conditional Metropolis uniform. Guard skips (a
+displacement or deletion proposed at N = 0, an insertion proposed above `n_max`) consume
+only the channel draw and are not counted as attempts. The energy ceiling is checked before
+the Metropolis ratio, so ceiling rejections draw no Metropolis uniform. Energies are updated
+incrementally through `single_site_energy` on the same audited path the displacement walks
+use, with insertions evaluated by insert-then-revert.
+
+# Arguments
+- `n_steps::Int`: The number of Monte Carlo steps to perform.
+- `at::AtomWalker{1}`: The walker to evolve; a single unfrozen component.
+- `pot::SingleComponentPotential{Pairwise}`: The pairwise potential.
+- `emax::typeof(0.0u"eV")`: The nested-sampling energy ceiling (strict-below acceptance).
+- `z0V::Float64`: Dimensionless product of the reference activity and the cell volume.
+- `species`: Chemical identity (a `Symbol` or `ChemicalSpecies`) of inserted particles;
+  passed explicitly because the configuration may be empty.
+- `p_move::Float64=0.5`: Probability of a displacement move.
+- `p_insert::Float64=0.25`: Probability of an insertion move (deletion takes the remainder).
+- `step_size::Float64=0.5`: Maximum displacement per direction, in Angstrom.
+- `n_max::Int=typemax(Int)`: Upper bound on the particle count, for bounded constructions
+  only. A finite cap truncates the unbounded particle-number support of the reference
+  measure and biases the evidence; production callers must leave it inactive.
+
+# Returns
+- `accept_this_walker::Bool`: Whether at least one move was accepted.
+- `accept_rate::Float64`: Fraction of accepted moves over `n_steps`.
+- `at::AtomWalker{1}`: The updated walker.
+- `move_stats::NamedTuple`: Per-move-type attempt/accept counters
+  (`move_*`, `insert_*`, `delete_*`); attempts are counted at proposal, ceiling rejections
+  included, guard skips excluded.
+"""
+function MC_grand_canonical_walk!(n_steps::Int,
+                                  at::AtomWalker{1},
+                                  pot::SingleComponentPotential{Pairwise},
+                                  emax::typeof(0.0u"eV");
+                                  z0V::Float64,
+                                  species::Union{Symbol, ChemicalSpecies},
+                                  p_move::Float64=0.5,
+                                  p_insert::Float64=0.25,
+                                  step_size::Float64=0.5,
+                                  n_max::Int=typemax(Int))
+    if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
+        throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+    end
+    if z0V <= 0.0
+        throw(ArgumentError("z0V must be positive"))
+    end
+    if any(at.frozen)
+        throw(ArgumentError("the continuous grand-canonical kernel requires an unfrozen single-component walker"))
+    end
+    config = at.configuration
+    cellv = cell_vectors(config)
+    for i in 1:3, j in 1:3
+        if i != j && !iszero(ustrip(cellv[i][j]))
+            throw(ArgumentError("the continuous grand-canonical kernel assumes an orthorhombic cell (consistent with pbc_dist); found a nonzero off-diagonal cell component"))
+        end
+    end
+    box = (cellv[1][1], cellv[2][2], cellv[3][3])
+
+    n_accept = 0
+    accept_this_walker = false
+    p_delete = 1.0 - p_move - p_insert
+    move_attempted = 0
+    move_accepted = 0
+    insert_attempted = 0
+    insert_accepted = 0
+    delete_attempted = 0
+    delete_accepted = 0
+
+    for _ in 1:n_steps
+        r = rand()
+        n = at.list_num_par[1]
+        if r < p_move
+            # Displacement: ceiling check only (nested-sampling walk, no Metropolis)
+            n == 0 && continue          # guard skip: nothing to move
+            move_attempted += 1
+            i_at = rand(1:n)
+            prewalk_energy = single_site_energy(i_at, config, pot, at.list_num_par)
+            orig_pos::SVector{3, typeof(0.0u"Å")} = position(config, i_at)
+            pos = single_atom_random_walk!(orig_pos, step_size)
+            pos = periodic_boundary_wrap!(pos, config)
+            config.position[i_at] = pos
+            postwalk_energy = single_site_energy(i_at, config, pot, at.list_num_par)
+            proposed_energy = at.energy + (postwalk_energy - prewalk_energy)
+            if proposed_energy >= emax
+                config.position[i_at] = orig_pos
+            else
+                at.energy = proposed_energy
+                n_accept += 1
+                move_accepted += 1
+                accept_this_walker = true
+            end
+        elseif r < p_move + p_insert
+            # Insertion: uniform in the cell, insert-evaluate-revert
+            (n + 1 > n_max || p_insert <= 0.0) && continue   # guard skip
+            insert_attempted += 1
+            pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])
+            insert_particle!(at, pos, species)
+            e_site = single_site_energy(n + 1, config, pot, at.list_num_par)
+            proposed_energy = at.energy + e_site
+            accept = true
+            if proposed_energy >= emax
+                accept = false
+            else
+                ratio = gc_insert_acceptance_ratio(z0V, n, p_insert, p_delete)
+                if ratio < 1.0 && rand() >= ratio
+                    accept = false
+                end
+            end
+            if accept
+                at.energy = proposed_energy
+                n_accept += 1
+                insert_accepted += 1
+                accept_this_walker = true
+            else
+                remove_particle!(at, n + 1)
+            end
+        else
+            # Deletion: uniform among particles; nothing mutates until acceptance
+            (n == 0 || p_delete <= 0.0) && continue          # guard skip
+            delete_attempted += 1
+            i_at = rand(1:n)
+            e_site = single_site_energy(i_at, config, pot, at.list_num_par)
+            proposed_energy = at.energy - e_site
+            accept = true
+            if proposed_energy >= emax
+                accept = false
+            else
+                ratio = gc_delete_acceptance_ratio(z0V, n, p_insert, p_delete)
+                if ratio < 1.0 && rand() >= ratio
+                    accept = false
+                end
+            end
+            if accept
+                remove_particle!(at, i_at)
+                at.energy = proposed_energy
+                n_accept += 1
+                delete_accepted += 1
+                accept_this_walker = true
+            end
+        end
+    end
+
+    return accept_this_walker, n_accept / max(n_steps, 1), at,
+           (move_attempted=move_attempted, move_accepted=move_accepted,
+            insert_attempted=insert_attempted, insert_accepted=insert_accepted,
+            delete_attempted=delete_attempted, delete_accepted=delete_accepted)
+end

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -1290,5 +1290,72 @@
             end
         end
     end
-    
+
+    @testset "empty-configuration handling tests" begin
+        box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+        pbc = (true, true, true)
+        at1 = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        empty_at = FastSystem(cell_vectors(at1), periodicity(at1),
+                              empty(position(at1, :)), empty(species(at1, :)), empty(mass(at1, :)))
+        at2 = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å", :Ar => [3.0, 3.0, 3.0]u"Å"], box, pbc))
+
+        @testset "helpers on empty systems and zero-count components" begin
+            comps = split_components(empty_at, [0])
+            @test length(comps) == 1
+            @test length(comps[1]) == 0
+            @test cell_vectors(comps[1]) == cell_vectors(empty_at)
+            @test periodicity(comps[1]) == periodicity(empty_at)
+
+            mixed = split_components(at2, [0, 2])
+            @test map(length, mixed) == [0, 2]
+            @test position(mixed[2], :) == position(at2, :)
+            @test species(mixed[2], :) == species(at2, :)
+
+            @test AbstractWalkers.split_components_by_chemical_species(empty_at) == FastSystem[]
+
+            list_num_par, sorted = sort_components_by_atomic_number(empty_at)
+            @test isempty(list_num_par)
+            @test length(sorted) == 0
+            @test cell_vectors(sorted) == cell_vectors(empty_at)
+
+            list_num_par_nm, sorted_nm = sort_components_by_atomic_number(empty_at, merge_same_species=false)
+            @test isempty(list_num_par_nm)
+            @test length(sorted_nm) == 0
+        end
+
+        @testset "nonempty outputs unchanged by the retyped helpers" begin
+            mixed_at = FastSystem(atomic_system([:H => [1.0, 1.0, 1.0]u"Å",
+                                                 :O => [2.0, 2.0, 2.0]u"Å",
+                                                 :H => [3.0, 3.0, 3.0]u"Å"], box, pbc))
+            comps = AbstractWalkers.split_components_by_chemical_species(mixed_at)
+            @test map(length, comps) == [2, 1]  # H (Z = 1) before O (Z = 8)
+            @test position(comps[1], 1) == position(mixed_at, 1)
+            @test position(comps[1], 2) == position(mixed_at, 3)
+            @test position(comps[2], 1) == position(mixed_at, 2)
+        end
+
+        @testset "zero-particle AtomWalker{1} round-trip" begin
+            w = AtomWalker{1}(empty_at)
+            @test w.list_num_par == [0]
+            @test w.frozen == [false]
+            lj = LJParameters()
+            @test interacting_energy(w.configuration, lj) == 0.0u"eV"
+            @test interacting_energy(w.configuration, lj, w.list_num_par, w.frozen) == 0.0u"eV"
+            @test frozen_energy(w.configuration, lj, w.list_num_par, [true]) == 0.0u"eV"
+        end
+
+        @testset "convenience constructor rejects empty input legibly" begin
+            @test_throws ArgumentError AtomWalker(empty_at)
+        end
+
+        @testset "liveset accepts a zero-particle walker" begin
+            w0 = AtomWalker{1}(empty_at)
+            w2 = AtomWalker{1}(at2)
+            ls = LJAtomWalkers([w0, w2], LJParameters())
+            @test length(ls.walkers) == 2
+            @test ls.walkers[1].energy == 0.0u"eV"
+            @test isfinite(ustrip(ls.walkers[2].energy))
+        end
+    end
+
 end

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -834,4 +834,21 @@
         end
     end
 
+    @testset "empty-configuration energy fast paths" begin
+        box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+        pbc = (true, true, true)
+        seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        empty_at = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                              empty(position(seed_at, :)), empty(species(seed_at, :)), empty(mass(seed_at, :)))
+        lj = LJParameters()
+        cps = CompositeParameterSets(2, [lj, lj, lj])
+
+        @test interacting_energy(empty_at, lj) == 0.0u"eV"
+        @test interacting_energy(empty_at, lj, [0], [false]) == 0.0u"eV"
+        @test interacting_energy(empty_at, cps, [0, 0], [false, false]) == 0.0u"eV"
+        @test interacting_energy(empty_at, cps, [0], [false], seed_at) == 0.0u"eV"
+        @test frozen_energy(empty_at, lj, [0], [true]) == 0.0u"eV"
+        @test frozen_energy(empty_at, cps, [0, 0], [true, true]) == 0.0u"eV"
+    end
+
 end

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -634,5 +634,240 @@
         end
     end
 
+    # Calibration ledger for the atomistic grand-canonical kernel testsets below
+    # (protocol: burn 2e4 steps, then 2e5 steps sampling N every 10; per-attempt
+    # acceptance references are attempt-conditioned, i.e. deletion guard skips at
+    # N = 0 excluded, matching the kernel's counting contract).
+    # Corner z0V = 0.5, seeds {1,2,3,42421}: max devs mean 3.85e-3, var 4.72e-3,
+    #   P(0) 3.97e-3, A_ins 3.24e-3; A_del is structurally exact 1.0 at this corner.
+    # Corner z0V = 8.0, seeds {1,2,3,42422}: max devs mean 3.31e-2, var 3.27e-1,
+    #   P(0) 1.35e-4, A_ins 1.59e-3, A_del(conditioned) 8.7e-3 (gate 0.027 >= 3x).
+    # Corner z0V = 32.0, seeds {1,2,3,42423}: max devs mean 3.41e-1, var 1.11,
+    #   A_ins 3.62e-3, A_del(conditioned) 5.9e-3.
+    # Two-state n_max = 1 at z0V = 0.6, seeds {1,2,3,42424}: max dev f1 4.26e-3.
+    # Gates ship at >= 3x the max deviation per stat per corner. Off-by-one foil
+    # sensitivity (exact birth-death mean at z0V = 0.5): shift +0.1778, so the
+    # mean gate 0.012 detects it with ~15x headroom (asserted in-test).
+    @testset "atomistic grand-canonical kernel tests" begin
+        using Random
+        box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+        pbc = (true, true, true)
+        seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        mkempty() = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                               empty(position(seed_at, :)), empty(species(seed_at, :)),
+                               empty(mass(seed_at, :)))
+        mkwalker() = (w = AtomWalker{1}(mkempty()); w.energy = 0.0u"eV"; w)
+        lj0 = LJParameters(epsilon=0.0)
+        emax_inf = Inf * u"eV"
+
+        logfact(n) = n == 0 ? 0.0 : sum(log, 1:n)
+        poisson_pmf(lam, n) = exp(n * log(lam) - lam - logfact(n))
+        function poisson_refs(lam; nmax=max(80, ceil(Int, lam + 12 * sqrt(lam))))
+            p = [poisson_pmf(lam, n) for n in 0:nmax]
+            p ./= sum(p)
+            m = sum(n * p[n+1] for n in 0:nmax)
+            v = sum((n - m)^2 * p[n+1] for n in 0:nmax)
+            a_ins = sum(p[n+1] * min(1.0, lam / (n + 1)) for n in 0:nmax)
+            a_del = sum(p[n+1] * min(1.0, n / lam) for n in 0:nmax) / (1 - p[1])
+            return m, v, a_ins, a_del
+        end
+
+        function run_corner(z0V, seed; nburn=20_000, nsteps=200_000, thin=10)
+            Random.seed!(seed)
+            w = mkwalker()
+            MC_grand_canonical_walk!(nburn, w, lj0, emax_inf; z0V=z0V, species=:Ar)
+            ns = Int[]
+            ins_att = 0; ins_acc = 0; del_att = 0; del_acc = 0
+            for _ in 1:(nsteps ÷ thin)
+                _, _, _, stats = MC_grand_canonical_walk!(thin, w, lj0, emax_inf; z0V=z0V, species=:Ar)
+                push!(ns, w.list_num_par[1])
+                ins_att += stats.insert_attempted; ins_acc += stats.insert_accepted
+                del_att += stats.delete_attempted; del_acc += stats.delete_accepted
+            end
+            return mean(ns), var(ns), count(iszero, ns) / length(ns),
+                   ins_acc / max(ins_att, 1), del_acc / max(del_att, 1), w
+        end
+
+        @testset "acceptance-ratio helpers (pre-move N convention)" begin
+            gir = MonteCarloMoves.gc_insert_acceptance_ratio
+            gdr = MonteCarloMoves.gc_delete_acceptance_ratio
+            @test gir(8.0, 0, 0.25, 0.25) == 8.0
+            @test gir(8.0, 7, 0.25, 0.25) == 1.0
+            @test gir(8.0, 15, 0.25, 0.25) == 0.5
+            @test gdr(8.0, 8, 0.25, 0.25) == 1.0
+            @test gdr(8.0, 4, 0.25, 0.25) == 0.5
+            @test gdr(8.0, 1, 0.25, 0.25) == 0.125
+            @test gdr(8.0, 0, 0.25, 0.25) == 0.0
+            # asymmetric channels carry the proposal-probability ratio
+            @test gir(8.0, 3, 0.1, 0.4) == 8.0 * 4.0 / 4
+            @test gdr(8.0, 3, 0.1, 0.4) == 0.25 * 3 / 8.0
+        end
+
+        @testset "argument validation" begin
+            w = mkwalker()
+            @test_throws ArgumentError MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=8.0, species=:Ar, p_move=0.9, p_insert=0.2)
+            @test_throws ArgumentError MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=0.0, species=:Ar)
+            wf = mkwalker()
+            wf.frozen = [true]
+            @test_throws ArgumentError MC_grand_canonical_walk!(1, wf, lj0, emax_inf; z0V=8.0, species=:Ar)
+            tilted = [[10.0, 0.0, 0.0], [2.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+            wt = AtomWalker{1}(FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], tilted, pbc)))
+            @test_throws ArgumentError MC_grand_canonical_walk!(1, wt, lj0, emax_inf; z0V=8.0, species=:Ar)
+        end
+
+        @testset "surgery helpers round-trip byte-identity" begin
+            w = mkwalker()
+            insert_particle!(w, SVector(1.0, 2.0, 3.0)u"Å", :Ar)
+            insert_particle!(w, SVector(4.0, 5.0, 6.0)u"Å", :Ar)
+            pos_before = copy(w.configuration.position)
+            spc_before = copy(w.configuration.species)
+            mss_before = copy(w.configuration.mass)
+            insert_particle!(w, SVector(7.0, 8.0, 9.0)u"Å", :Ar)
+            @test w.list_num_par == [3]
+            @test length(w.configuration) == 3
+            remove_particle!(w, 3)
+            @test w.list_num_par == [2]
+            @test w.configuration.position == pos_before
+            @test w.configuration.species == spc_before
+            @test w.configuration.mass == mss_before
+            # order-preserving removal from the middle
+            remove_particle!(w, 1)
+            @test w.configuration.position == [pos_before[2]]
+            @test_throws BoundsError remove_particle!(w, 5)
+        end
+
+        @testset "RNG-stream contract (forced branches)" begin
+            # Insertion, ratio >= 1: accept with NO Metropolis draw (4 draws total)
+            Random.seed!(778)
+            probe = [rand() for _ in 1:8]
+            @test probe[1] < 0.75    # branch precondition: channel draw lands in the insertion window
+            Random.seed!(778)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=1.0e6, species=:Ar, p_move=0.0, p_insert=0.75)
+            @test w.list_num_par == [1]
+            @test (stats.insert_attempted, stats.insert_accepted) == (1, 1)
+            @test rand() == probe[5]
+
+            # Insertion, ratio < 1: Metropolis uniform IS drawn (5 draws; p_delete = 0 forces ratio 0)
+            Random.seed!(778)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=8.0, species=:Ar, p_move=0.0, p_insert=1.0)
+            @test w.list_num_par == [0]
+            @test (stats.insert_attempted, stats.insert_accepted) == (1, 0)
+            @test rand() == probe[6]
+
+            # Deletion, ratio >= 1: accept with NO Metropolis draw (2 draws)
+            Random.seed!(777)
+            probe = [rand() for _ in 1:8]
+            @test probe[1] >= 0.25   # branch precondition: channel draw lands in the deletion window
+            Random.seed!(777)
+            w = mkwalker()
+            insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=0.01, species=:Ar, p_move=0.0, p_insert=0.25)
+            @test w.list_num_par == [0]
+            @test (stats.delete_attempted, stats.delete_accepted) == (1, 1)
+            @test rand() == probe[3]
+
+            # Deletion, ratio < 1: Metropolis uniform IS drawn (3 draws)
+            Random.seed!(777)
+            w = mkwalker()
+            insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=1.0e6, species=:Ar, p_move=0.0, p_insert=0.25)
+            @test w.list_num_par == [1]
+            @test (stats.delete_attempted, stats.delete_accepted) == (1, 0)
+            @test rand() == probe[4]
+
+            # Ceiling rejection draws NO Metropolis uniform even at ratio < 1
+            # (the ceiling is checked first): 4 draws total, walker reverted
+            Random.seed!(778)
+            probe778 = [rand() for _ in 1:8]
+            Random.seed!(778)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, 0.0u"eV"; z0V=0.3, species=:Ar, p_move=0.0, p_insert=0.75)
+            @test w.list_num_par == [0]
+            @test (stats.insert_attempted, stats.insert_accepted) == (1, 0)
+            @test rand() == probe778[5]
+
+            # Guard skips consume only the channel draw and are not counted as attempts
+            Random.seed!(777)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=8.0, species=:Ar, p_move=0.0, p_insert=0.25)
+            @test w.list_num_par == [0]
+            @test stats == (move_attempted=0, move_accepted=0, insert_attempted=0,
+                            insert_accepted=0, delete_attempted=0, delete_accepted=0)
+            @test rand() == probe[2]
+            Random.seed!(779)
+            probe779 = [rand() for _ in 1:4]
+            Random.seed!(779)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=8.0, species=:Ar, p_move=1.0, p_insert=0.0)
+            @test stats.move_attempted == 0
+            @test rand() == probe779[2]
+        end
+
+        @testset "two-state birth-death closure at n_max = 1" begin
+            Random.seed!(42424)
+            w = mkwalker()
+            MC_grand_canonical_walk!(10_000, w, lj0, emax_inf; z0V=0.6, species=:Ar, n_max=1)
+            n1 = 0
+            tot = 400_000
+            for _ in 1:tot
+                MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=0.6, species=:Ar, n_max=1)
+                n1 += w.list_num_par[1]
+            end
+            @test abs(n1 / tot - 0.6 / 1.6) < 0.013
+            @test w.list_num_par[1] <= 1
+        end
+
+        @testset "ideal-gas stationary law (seeded, calibrated)" begin
+            # (z0V, seed, tol_mean, tol_var, tol_p0, tol_ains, tol_adel)
+            corners = [(0.5, 42421, 0.012, 0.015, 0.012, 0.010, 1.0e-12),
+                       (8.0, 42422, 0.10, 1.0, 4.1e-4, 0.005, 0.027),
+                       (32.0, 42423, 1.05, 3.4, Inf, 0.011, 0.018)]
+            for (z0V, seed, tol_m, tol_v, tol_p0, tol_ai, tol_ad) in corners
+                m_ref, v_ref, ai_ref, ad_ref = poisson_refs(z0V)
+                m, v, p0, ai, ad, w = run_corner(z0V, seed)
+                @test abs(m - m_ref) < tol_m
+                @test abs(v - v_ref) < tol_v
+                if isfinite(tol_p0)
+                    @test abs(p0 - poisson_pmf(z0V, 0)) < tol_p0
+                end
+                @test abs(ai - ai_ref) < tol_ai
+                @test abs(ad - ad_ref) < tol_ad
+                # the configuration arrays and the particle count never drift apart
+                @test length(w.configuration) == w.list_num_par[1]
+                @test length(w.configuration.species) == w.list_num_par[1]
+            end
+            # sensitivity: the mean gate at the smallest corner detects the classic
+            # off-by-one insertion bug, whose exact stationary mean follows from the
+            # birth-death recursion p(n+1)/p(n) = a_ins(n)/a_del(n+1)
+            lam = 0.5
+            logp = zeros(101)
+            for n in 0:99
+                num = min(1.0, lam / max(n, 1))       # off-by-one foil
+                den = min(1.0, (n + 1) / lam)
+                logp[n+2] = logp[n+1] + log(num) - log(den)
+            end
+            pfoil = exp.(logp .- maximum(logp))
+            pfoil ./= sum(pfoil)
+            foil_shift = abs(sum(n * pfoil[n+1] for n in 0:100) - lam)
+            @test 0.012 < 0.5 * foil_shift
+        end
+
+        @testset "fixed-seed digit pins (stream shape)" begin
+            Random.seed!(424242)
+            w = mkwalker()
+            MC_grand_canonical_walk!(5000, w, lj0, emax_inf; z0V=8.0, species=:Ar)
+            @test w.list_num_par[1] == 9
+            @test w.energy == 0.0u"eV"
+            lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+            Random.seed!(424243)
+            w2 = mkwalker()
+            MC_grand_canonical_walk!(5000, w2, lj, 1.0e5u"eV"; z0V=4.0, species=:Ar, step_size=1.0)
+            @test w2.list_num_par[1] == 4
+            @test ustrip(u"eV", w2.energy) == -0.0014312826195886537
+        end
+    end
+
 end
 


### PR DESCRIPTION
Implements #195: the continuous-space counterpart of the lattice grand-canonical kernel, with walker surgery helpers. Two commits: `Add continuous-space grand-canonical insertion and deletion moves for AtomWalker.` (src) and `Test the continuous-space grand-canonical kernel, acceptance ratios, and walker surgery.` (tests). Stacks on the empty-configuration hardening.

- Surgery helpers: `insert_particle!(walker, pos, species)` and `remove_particle!(walker, i)` in `AbstractWalkers`, lockstep `push!`/`deleteat!` on the configuration's position, species, and mass arrays with `list_num_par` updated in the same call (order-preserving removal; purely structural, the walker's energy is untouched; species passed explicitly because the configuration may be empty). Exported.
- Kernel: a new `MC_grand_canonical_walk!` method dispatching on `AtomWalker{1}` with a `SingleComponentPotential{Pairwise}`: displacement, uniform-in-cell insertion, and uniform-among-particles deletion under the Metropolis corrections preserving the activity-z<sub>0</sub>-weighted reference measure below a strict energy ceiling. Requires a single unfrozen component and an orthorhombic cell (consistent with `pbc_dist`); both validated on entry. `z0V` enters dimensionless; `n_max` exists for bounded constructions only, defaults inactive, and its docstring states that a finite cap truncates the reference measure's unbounded support.
- Acceptance ratios: exposed as pure helpers `gc_insert_acceptance_ratio`/`gc_delete_acceptance_ratio` with the pre-move particle count in both directions. One generalization of the issue's literal form, disclosed: the shipped ratios carry the channel-probability factor (`z0V * (p_delete/p_insert) / (n + 1)` and its inverse), matching the lattice kernel's expressions; the issue's `z0V/(N + 1)` is the symmetric-probability case, which the default channel probabilities reproduce, and the asymmetric corner is tested exactly. The proposal-density hook survives: a future biased channel replaces the folded uniform density, mirroring the lattice composite-density pattern.
- Random-number stream contract, pinned by forced-branch probes: one channel draw per step; insertion draws three position uniforms plus the Metropolis uniform only when its ratio is below one; deletion draws one index uniform plus the conditional Metropolis uniform; the ceiling is checked before the Metropolis ratio, so ceiling rejections draw no Metropolis uniform (probed at ratio below one); guard skips (displacement or deletion at N = 0, insertion above `n_max`) consume only the channel draw and are not counted as attempts.
- Move stats: the returned NamedTuple uses `move_*`/`insert_*`/`delete_*` counters, disclosed as a rename against the lattice sibling's `swap_*`/`insert_uniform_*`/`insert_biased_*` since the atomistic kernel has no swap or biased channel; attempts are counted at proposal, ceiling rejections included, guard skips excluded. Measured per-attempt acceptances are attempt-conditioned accordingly, and the test references use the conditioned closed forms (deletion at the smallest activity is structurally exact 1.0 under this convention).
- Statistical certification (calibration ledger in the test-file header, gates at ≥ 3× the maximum multi-seed deviation per stat per corner): stationary particle-number law against the exact reference at three activities spanning small and moderate `z0V` (total variation, mean, variance, `P(0)`, per-channel acceptances); a two-state birth-death closure at `n_max = 1`; fixed-seed digit pins freezing the stream shape; surgery round-trip byte-identity. The mean gate's sensitivity to the classic off-by-one insertion bug is asserted in-test against the exact birth-death stationary law of the broken kernel (about 15× headroom at the smallest activity, where detection power is greatest).

Adversarially reviewed pre-PR in three charters (issue-promise round-trip, independent-oracle physics with the detailed-balance re-derivation, determinism and assertion-delta accounting); must-fixes applied: one acceptance gate sat below its stated 3× floor by rounding (rebalanced), the deletion-ratio helper gained its N = 1 corner, and the ceiling-rejection stream probe was added. The full test suite passes on the shipped bytes: Monte Carlo Moves 184 (= dev 114 + 70), reconciled against the new testsets' loop arithmetic, all other testsets at their expected counts.
