### PR TITLE
RNG-neutrality and closed-form regression coverage for the continuous-space grand-canonical route

### DIFF
--- a/src/AbstractLiveSets/AbstractLiveSets.jl
+++ b/src/AbstractLiveSets/AbstractLiveSets.jl
@@ -22,6 +22,7 @@ export LJAtomWalkers, LatticeGasWalkers
 export LJSurfaceWalkers
 export MLIPAtomWalkers
 export GuptaAtomWalkers
+export GenericAtomWalkers
 export assign_energy!
 
 abstract type AbstractLiveSet end

--- a/src/AbstractLiveSets/atomistic_livesets.jl
+++ b/src/AbstractLiveSets/atomistic_livesets.jl
@@ -164,6 +164,42 @@ end
 
 AtomWalkers(walkers::Vector{AtomWalker{C}}, potential::PyMLPotential; assign_energy=true) where C = MLIPAtomWalkers(walkers, potential; assign_energy=assign_energy)
 
+"""
+    struct GenericAtomWalkers{P<:AbstractPotential} <: AtomWalkers
+
+The `GenericAtomWalkers` struct represents a collection of atom walkers interacting through
+any `AbstractPotential`, for potential types that have no dedicated walker collection
+(for example the analytic reference potential `IdealGasParameters`).
+
+# Fields
+- `walkers::Vector{AtomWalker{C}}`: A vector of atom walkers, where `C` is the number of components.
+- `potential::P`: The potential.
+
+# Constructor
+- `GenericAtomWalkers(walkers::Vector{AtomWalker{C}}, pot::P; assign_energy=true)`:
+    Constructs a new `GenericAtomWalkers` object with the given walkers and potential.
+    If `assign_energy=true`, each walker's frozen-part and total energies are assigned
+    through the single-walker `assign_frozen_energy!` and `assign_energy!` paths, honoring
+    `list_num_par` and `frozen`.
+
+Initial scope: no constant-frozen-part caching (each walker's frozen part is computed
+individually), and canonical nested sampling flows through the generic `AbstractPotential`
+fallback of `MC_random_walk!` (full-energy evaluation per step), a performance note rather
+than a defect.
+"""
+struct GenericAtomWalkers{P<:AbstractPotential} <: AtomWalkers
+    walkers::Vector{AtomWalker{C}} where C
+    potential::P
+    function GenericAtomWalkers(walkers::Vector{AtomWalker{C}}, pot::P; assign_energy=true) where {C, P<:AbstractPotential}
+        if assign_energy
+            for walker in walkers
+                assign_frozen_energy!(walker, pot)
+                assign_energy!(walker, pot)
+            end
+        end
+        return new{P}(walkers, pot)
+    end
+end
 
 """
     struct LJSurfaceWalkers <: AtomWalkers

--- a/src/AbstractLiveSets/shows.jl
+++ b/src/AbstractLiveSets/shows.jl
@@ -16,6 +16,25 @@ function Base.show(io::IO, walkers::LJAtomWalkers)
     println(io, walkers.potential)
 end
 
+
+function Base.show(io::IO, walkers::GenericAtomWalkers)
+    println(io, "GenericAtomWalkers($(eltype(walkers.walkers)), $(typeof(walkers.potential))):")
+    if length(walkers.walkers) > 10
+        for i in 1:5
+            println(io, "[$i] ", walkers.walkers[i])
+        end
+        println(io, "⋮\nOmitted ", length(walkers.walkers)-10, " walkers\n⋮\n")
+        for i in length(walkers.walkers)-4:length(walkers.walkers)
+            println(io, "[$i] ", walkers.walkers[i])
+        end
+    else
+        for (ind, w) in enumerate(walkers.walkers)
+            println(io, "[$ind] ", w)
+        end
+    end
+    println(io, walkers.potential)
+end
+
 function Base.show(io::IO, walkers::LJSurfaceWalkers)
     println(io, "LJSurfaceWalkers($(eltype(walkers.walkers)), $(typeof(walkers.potential))):")
     if length(walkers.walkers) > 10

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -20,6 +20,7 @@ export sort_components_by_atomic_number
 export split_components
 export split_components_by_chemical_species
 export check_num_components
+export insert_particle!, remove_particle!
 export LatticeWalker
 export LatticeGeometry, SquareLattice, TriangularLattice, GenericLattice
 export MLattice, SLattice, GLattice

--- a/src/AbstractWalkers/atomistic_walkers.jl
+++ b/src/AbstractWalkers/atomistic_walkers.jl
@@ -53,6 +53,10 @@ Constructs an `AtomWalker` object with the given configuration.
 # Returns
 - `AtomWalker{C}`: The constructed `AtomWalker` object.
 
+An empty configuration is rejected with an `ArgumentError`: the number of components
+cannot be inferred from zero atoms. Construct `AtomWalker{1}(configuration)` directly for
+a zero-particle single-component walker.
+
 # Example
 ```jldoctest
 julia> at = FreeBirdIO.generate_multi_type_random_starting_config(10.0,[2,1,3,4,5,6];particle_types=[:H,:O,:H,:Fe,:Au,:Cl])
@@ -83,6 +87,9 @@ AtomWalker{5}(FastSystem(Au₅Cl₆Fe₄H₅O, periodic = FFF, bounding_box = [[
 
 """
 function AtomWalker(configuration::AbstractSystem; freeze_species::Vector{Symbol}=Symbol[], merge_same_species=true)
+    if length(configuration) == 0
+        throw(ArgumentError("empty configuration: the number of components cannot be inferred; construct AtomWalker{1}(configuration) directly for a zero-particle single-component walker."))
+    end
     if isa(configuration, FlexibleSystem)
         new_list = [Atom(atomic_symbol(i),position(i)) for i in configuration.particles]
         configuration = FastSystem(new_list, cell_vectors(configuration), periodicity(configuration))

--- a/src/AbstractWalkers/helpers.jl
+++ b/src/AbstractWalkers/helpers.jl
@@ -192,6 +192,58 @@ function sort_components_by_atomic_number(at::AbstractSystem; merge_same_species
 end
 
 """
+    insert_particle!(walker::AtomWalker{1}, pos, species)
+
+Append one particle of `species` (a `Symbol` or `ChemicalSpecies`) at position `pos` to the
+walker's configuration, updating `list_num_par` in the same call. The two mutations are kept
+in lockstep here so the configuration arrays and the particle count cannot drift apart. The
+operation is purely structural: the walker's `energy` is not touched and the component's
+frozen flag is not consulted; callers own the energy bookkeeping (see
+`MC_grand_canonical_walk!`).
+
+# Arguments
+- `walker::AtomWalker{1}`: The single-component walker to extend.
+- `pos`: The new particle's position (any 3-vector of lengths accepted by the configuration).
+- `species`: The chemical identity of the new particle.
+
+# Returns
+- `walker::AtomWalker{1}`: The updated walker.
+"""
+function insert_particle!(walker::AtomWalker{1}, pos, species)
+    config = walker.configuration
+    sp = species isa ChemicalSpecies ? species : ChemicalSpecies(species)
+    push!(config.position, pos)
+    push!(config.species, sp)
+    push!(config.mass, mass(sp))
+    walker.list_num_par[1] += 1
+    return walker
+end
+
+"""
+    remove_particle!(walker::AtomWalker{1}, i::Int)
+
+Remove particle `i` from the walker's configuration, order-preserving, updating
+`list_num_par` in the same call. Purely structural, like `insert_particle!`: the walker's
+`energy` is not touched.
+
+# Arguments
+- `walker::AtomWalker{1}`: The single-component walker to shrink.
+- `i::Int`: The index of the particle to remove.
+
+# Returns
+- `walker::AtomWalker{1}`: The updated walker.
+"""
+function remove_particle!(walker::AtomWalker{1}, i::Int)
+    config = walker.configuration
+    checkbounds(config.position, i)
+    deleteat!(config.position, i)
+    deleteat!(config.species, i)
+    deleteat!(config.mass, i)
+    walker.list_num_par[1] -= 1
+    return walker
+end
+
+"""
     view_structure(at::AbstractSystem)
     view_structure(walker::AtomWalker)
 

--- a/src/AbstractWalkers/helpers.jl
+++ b/src/AbstractWalkers/helpers.jl
@@ -12,13 +12,15 @@ Split the system into components based on the number of particles in each compon
 # Returns
 - `components`: An array of `FastSystem` objects representing the components of the system.
 
+An empty system, or a zero-count component, yields a zero-atom `FastSystem` carrying the
+parent system's cell and periodicity.
 """
 function split_components(at::AbstractSystem, list_num_par::Vector{Int})
     components = Array{FastSystem}(undef, length(list_num_par))
     comp_cut = vcat([0],cumsum(list_num_par))
     comp_split = [comp_cut[i]+1:comp_cut[i+1] for i in 1:length(list_num_par)]
     for i in 1:length(list_num_par)
-        new_list = empty([Symbol(atomic_symbol(at[1])) => position(at[1])])
+        new_list = Pair{Symbol, eltype(position(at, :))}[]
         pos = position(at, comp_split[i])
         symbols = [Symbol(atomic_symbol(at[i])) for i in comp_split[i]]
         for i in 1:length(pos)
@@ -41,6 +43,7 @@ Split an `AbstractSystem` into multiple components based on the chemical species
 
 # Returns
 An array of `FastSystem` objects, each representing a component of the input system.
+An empty system returns an empty array.
 
 # Example
 ```jldoctest
@@ -78,7 +81,7 @@ function split_components_by_chemical_species(at::AbstractSystem)
     species = sort!(unique(list_species))
     components = Array{FastSystem}(undef, length(species))
     for i in 1:length(species)
-        new_list = empty([Symbol(atomic_symbol(at[1])) => position(at[1])])
+        new_list = Pair{Symbol, eltype(position(at, :))}[]
         pos = position(at, findall(x->x==species[i],list_species))
         symbols = [Symbol(atomic_symbol(at[i])) for i in findall(x->x==species[i],list_species)]
         for i in 1:length(pos)
@@ -124,7 +127,7 @@ Sorts the components of an `AbstractSystem` object `at` by their atomic number.
 - `list_num_par::Vector{Int64}`: A vector containing the number of each component species.
 - `new_list::FastSystem`: A new `FastSystem` object with the sorted components.
 
-The function first extracts the atomic numbers of the components in `at`. If `merge_same_species` is `true`, it sorts the unique species and counts the number of each species. If `merge_same_species` is `false`, it creates a list of species and their counts. It then sorts the species and counts by atomic number. Finally, it constructs a new `FastSystem` object with the sorted components and returns the list of species counts and the new `FastSystem` object.
+The function first extracts the atomic numbers of the components in `at`. If `merge_same_species` is `true`, it sorts the unique species and counts the number of each species. If `merge_same_species` is `false`, it creates a list of species and their counts. It then sorts the species and counts by atomic number. Finally, it constructs a new `FastSystem` object with the sorted components and returns the list of species counts and the new `FastSystem` object. An empty system returns an empty `list_num_par` and a zero-atom system, under either flag.
 
 # Examples
 ```jldoctest
@@ -157,12 +160,12 @@ julia> AbstractWalkers.sort_components_by_atomic_number(at)
 """
 function sort_components_by_atomic_number(at::AbstractSystem; merge_same_species=true)
     list_species = [atomic_number(at, i) for i in 1:length(at)]
-    new_list = empty([Symbol(atomic_symbol(at[1])) => position(at[1])])
+    new_list = Pair{Symbol, eltype(position(at, :))}[]
     if merge_same_species
         species = sort!(unique(list_species))
         list_num_par = [count(x->x==s, list_species) for s in species]
     elseif !merge_same_species
-        species = [list_species[1]; [list_species[i] for i in 2:length(list_species) if list_species[i] != list_species[i-1]]]
+        species = isempty(list_species) ? empty(list_species) : [list_species[1]; [list_species[i] for i in 2:length(list_species) if list_species[i] != list_species[i-1]]]
         list_num_par = Vector{Int64}()
         i = 1
         while i <= length(list_species)

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -628,6 +628,236 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
 end
 
 
+
+
+"""
+    gc_thermodynamic_stats_ideal_ref(df::DataFrame,
+                                     V::typeof(1.0u"Å^3"),
+                                     atomic_mass::typeof(1.0u"u"),
+                                     reference_activity::typeof(1.0u"Å^-3"),
+                                     μ_grid::AbstractVector{<:typeof(1.0u"eV")},
+                                     T_grid::AbstractVector{<:Unitful.Temperature};
+                                     ω0=1.0, live_emax=nothing, live_numbers=nothing,
+                                     observable_cols=Symbol[], live_observables=nothing,
+                                     kb=8.617333262e-5)
+
+Reduce an atomistic energy-sorted ideal-gas-referenced grand-canonical ledger (see the
+`AtomisticIGRefGCNSParameters` method of `ideal_gas_referenced_nested_sampling`) to
+Ξ(μ, T) on an arbitrary (μ, T) grid. The assembly is
+
+```math
+\\log \\Xi(\\mu, T) = z_0 V + \\mathrm{logsumexp}_j\\left[\\log \\omega_j + N_j \\log(z/z_0) - E_j/k_B T\\right]
+```
+
+with `z = exp(μ/kT)/Λ(T)³` the target activity, `z0` the run's reference activity, and
+`e^{z0V}` the reference measure's total mass. The thermal wavelength and the volume enter
+only here: the sampler is athermal and its ledger is reduced, never re-run.
+
+Three conventions are fixed by measurement and documented here:
+- Shell weights follow the log-compression convention of `ωᵢ(log_compression; ω0=1.0)`,
+  evaluated in log space (`log ω_j = log X_{j-1} + log(1 - t_j)`) so deep ladders cannot
+  underflow (the same rationale as the iteration-based assembly above). The
+  `ω0 = (K+1)/K` convention of the iteration-based route must not be applied to
+  compression ledgers: it inflates the total prior mass by exactly `1/K`.
+- The live-set tail carries the mass `ω0·exp(Σ log_compression)` split over
+  `length(live_emax)`, never over the nominal walker count: a run that ends inside a
+  plateau eviction block has fewer live walkers than it started with, and splitting over
+  the nominal count loses `(1 - live/K)` of the terminal mass.
+- A ledger with zero rows is a legal input, produced by zero-accept runs (see the
+  driver's stall contract): the entire prior mass then sits in the live set, which is
+  the exact reduction for a fully degenerate landscape. A ledger that has rows but no
+  `:log_compression` column is rejected: its compression cannot be reconstructed here.
+
+Convention differences among the grand-canonical stats functions: this method and the
+lattice `gc_thermodynamic_stats_ideal_ref` reduce one variable-N ledger against their
+reference measures (`e^{z0V}` here, `(1+z0)^M` there); `gc_thermodynamic_stats_fixed_N`
+stitches per-N canonical ledgers with `(zV)^N/N!` (continuous) or binomial (lattice)
+prefactors; the Ω-sorted `gc_thermodynamic_stats` reweights an Ω-ladder at its run
+chemical potential. Reconciling the ω0/tail conventions across them is a recorded
+follow-up item and out of scope here.
+
+# Arguments
+- `df::DataFrame`: NS output with columns `[:iter, :emax, :num_particles, :log_compression]`.
+- `V::typeof(1.0u"Å^3")`: The cell volume.
+- `atomic_mass::typeof(1.0u"u")`: The particle mass entering Λ(T).
+- `reference_activity::typeof(1.0u"Å^-3")`: The run's reference activity z0 (must match!).
+- `μ_grid::AbstractVector{<:typeof(1.0u"eV")}`: Chemical potential grid (Unitful, eV),
+  matching the atomistic `gc_thermodynamic_stats_fixed_N` convention.
+- `T_grid::AbstractVector{<:Unitful.Temperature}`: Temperature grid (Unitful).
+- `ω0::Float64=1.0`: Total prior mass before the first cull. Leave at 1.0 for ledgers
+  produced by the driver; do not pass the iteration-based route's `(K+1)/K`.
+- `live_emax::Union{Nothing,Vector{Float64}}=nothing`: Energies of the surviving live walkers.
+- `live_numbers::Union{Nothing,Vector{Int}}=nothing`: Particle counts of the surviving live walkers.
+- `observable_cols::AbstractVector{Symbol}=Symbol[]`: Names of extra per-dead-point `df`
+  columns whose reweighted averages are returned in `observables`.
+- `live_observables=nothing`: Required whenever `observable_cols` is non-empty and a
+  live-set tail is supplied; same contract as the lattice method above.
+- `kb::Float64`: Boltzmann constant (default: eV/K).
+
+# Returns
+A `NamedTuple` with the same shape as the lattice method: `logXi`, `mean_N`, `var_N`,
+`mean_U`, `N_eff`, `var_U`, `cov_UN` (each a `Matrix{Float64}` of size
+`(length(μ_grid), length(T_grid))`, indexed `[i_μ, i_T]`), and `observables`
+(`Dict{Symbol,Matrix{Float64}}`). The returned moments are configurational: beyond the
+Λ(T)³ activity conversion this reduction carries no momentum integral, so
+temperature-derivative observables built from it (heat capacities) must add the Λ(T)
+term explicitly, exactly as for `gc_thermodynamic_stats_fixed_N`.
+"""
+function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
+                                          V::typeof(1.0u"Å^3"),
+                                          atomic_mass::typeof(1.0u"u"),
+                                          reference_activity::typeof(1.0u"Å^-3"),
+                                          μ_grid::AbstractVector{<:typeof(1.0u"eV")},
+                                          T_grid::AbstractVector{<:Unitful.Temperature};
+                                          ω0::Float64=1.0,
+                                          live_emax::Union{Nothing,Vector{Float64}}=nothing,
+                                          live_numbers::Union{Nothing,Vector{Int}}=nothing,
+                                          observable_cols::AbstractVector{Symbol}=Symbol[],
+                                          live_observables::Union{Nothing,AbstractDict{Symbol}}=nothing,
+                                          kb::Float64=8.617333262e-5)
+    if reference_activity <= 0.0u"Å^-3"
+        throw(ArgumentError("reference_activity must be positive"))
+    end
+    if V <= 0.0u"Å^3"
+        throw(ArgumentError("V must be positive"))
+    end
+    if (live_emax === nothing) != (live_numbers === nothing)
+        throw(ArgumentError("live_emax and live_numbers must be provided together"))
+    end
+    if live_emax !== nothing && length(live_emax) != length(live_numbers)
+        throw(DimensionMismatch("live_emax and live_numbers must have the same length"))
+    end
+    n_dead = nrow(df)
+    if n_dead == 0 && (live_emax === nothing || isempty(live_emax))
+        throw(ArgumentError("df is empty and no live walkers were provided"))
+    end
+    allunique(observable_cols) || throw(ArgumentError(
+        "observable_cols must not contain duplicate entries"))
+    if n_dead > 0
+        hasproperty(df, :log_compression) || throw(ArgumentError(
+            "the ledger has rows but no :log_compression column, so its compression " *
+            "cannot be reconstructed; only zero-accept (empty) ledgers may omit it"))
+        for col in observable_cols
+            hasproperty(df, col) || throw(ArgumentError(
+                "observable_cols: df has no column :$col"))
+            any(ismissing, df[!, col]) && throw(ArgumentError(
+                "observable_cols: df column :$col contains missing values"))
+        end
+    end
+    if live_observables !== nothing && live_emax === nothing
+        throw(ArgumentError(
+            "live_observables requires live_emax/live_numbers (the live-set tail)"))
+    end
+    if live_observables !== nothing && isempty(observable_cols)
+        throw(ArgumentError(
+            "live_observables was given but observable_cols is empty"))
+    end
+    if !isempty(observable_cols) && live_emax !== nothing
+        if live_observables === nothing
+            throw(ArgumentError(
+                "observable_cols with a live-set tail requires live_observables " *
+                "(the per-column values of the surviving live walkers)"))
+        end
+        if Set(keys(live_observables)) != Set(observable_cols)
+            throw(ArgumentError(
+                "live_observables keys must match observable_cols exactly"))
+        end
+        for col in observable_cols
+            v = live_observables[col]
+            (v isa AbstractVector && all(x -> x isa Real, v)) || throw(ArgumentError(
+                "live_observables[:$col] must be a vector of Real values"))
+            if length(v) != length(live_emax)
+                throw(DimensionMismatch(
+                    "live_observables[:$col] must have one entry per live " *
+                    "walker (length(live_emax) = $(length(live_emax)))"))
+            end
+        end
+    end
+
+    lc = n_dead > 0 ? Vector{Float64}(df.log_compression) : Float64[]
+    if any(x -> !isfinite(x) || x >= 0.0, lc)
+        throw(ArgumentError(
+            "corrupted :log_compression column: every entry must be finite and negative"))
+    end
+
+    # Per-shell log prior-volume weights built directly in log space:
+    # log ω_j = log X_{j-1} + log(1 - t_j), X_j = ω0 Π t_j. The linear shells
+    # underflow on deep ladders, exactly as for the iteration-based assembly.
+    cs = cumsum(lc)
+    log_w0 = n_dead > 0 ?
+        (log(ω0) .+ vcat(0.0, cs[1:end-1]) .+ log.(-expm1.(lc))) : Float64[]
+    Es = n_dead > 0 ? Vector{Float64}(df.emax) : Float64[]
+    Ns = n_dead > 0 ? Vector{Float64}(df.num_particles) : Float64[]
+
+    if live_emax !== nothing && !isempty(live_emax)
+        # Residual prior volume after the last recorded cull, split uniformly
+        # over the SURVIVING walkers (a run ended inside an eviction block has
+        # fewer live walkers than its nominal count)
+        log_tail = log(ω0) + (n_dead > 0 ? cs[end] : 0.0) - log(length(live_emax))
+        log_w0 = vcat(log_w0, fill(log_tail, length(live_emax)))
+        Es = vcat(Es, live_emax)
+        Ns = vcat(Ns, Float64.(live_numbers))
+    end
+
+    As = Dict{Symbol,Vector{Float64}}()
+    for col in observable_cols
+        A = n_dead > 0 ? Vector{Float64}(df[!, col]) : Float64[]
+        if live_emax !== nothing && !isempty(live_emax)
+            A = vcat(A, Vector{Float64}(live_observables[col]))
+        end
+        As[col] = A
+    end
+
+    # Second moments on shifted energies (see the lattice method above)
+    E_shift = isempty(Es) ? 0.0 : minimum(Es)
+    Es_c = Es .- E_shift
+
+    z0V = ustrip(Unitful.NoUnits, reference_activity * V)
+    log_z0 = log(ustrip(u"Å^-3", reference_activity))
+
+    n_mu = length(μ_grid)
+    n_T = length(T_grid)
+    logXi = Matrix{Float64}(undef, n_mu, n_T)
+    mean_N = Matrix{Float64}(undef, n_mu, n_T)
+    var_N = Matrix{Float64}(undef, n_mu, n_T)
+    mean_U = Matrix{Float64}(undef, n_mu, n_T)
+    N_eff = Matrix{Float64}(undef, n_mu, n_T)
+    var_U = Matrix{Float64}(undef, n_mu, n_T)
+    cov_UN = Matrix{Float64}(undef, n_mu, n_T)
+    obs_out = Dict{Symbol,Matrix{Float64}}(
+        col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
+
+    Threads.@threads for j in 1:n_T
+        T_K = ustrip(u"K", T_grid[j])
+        β = 1.0 / (kb * T_K)
+        logΛ = log(ustrip(u"Å", _thermal_wavelength(atomic_mass, T_grid[j])))
+        for i in 1:n_mu
+            # log z = βμ - 3 log Λ; the reweighting exponent is N log(z/z0) - βE
+            s = β * ustrip(u"eV", μ_grid[i]) - 3.0 * logΛ - log_z0
+            log_w = log_w0 .+ s .* Ns .- β .* Es
+            max_log = maximum(log_w)
+            ws = exp.(log_w .- max_log)
+            sum_w = sum(ws)
+            logXi[i, j] = z0V + max_log + log(sum_w)
+            n_avg = sum(ws .* Ns) / sum_w
+            mean_N[i, j] = n_avg
+            var_N[i, j] = sum(ws .* Ns .^ 2) / sum_w - n_avg^2
+            u_c = sum(ws .* Es_c) / sum_w
+            mean_U[i, j] = u_c + E_shift
+            var_U[i, j] = sum(ws .* Es_c .^ 2) / sum_w - u_c^2
+            cov_UN[i, j] = sum(ws .* Es_c .* Ns) / sum_w - u_c * n_avg
+            for col in observable_cols
+                obs_out[col][i, j] = sum(ws .* As[col]) / sum_w
+            end
+            N_eff[i, j] = sum_w^2 / sum(abs2, ws)
+        end
+    end
+
+    return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff,
+            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
+end
+
+
 """
     _thermal_wavelength(atomic_mass::typeof(1.0u"u"), T::Unitful.Temperature) -> typeof(1.0u"Å")
 

--- a/src/EnergyEval/atomistic_energies.jl
+++ b/src/EnergyEval/atomistic_energies.jl
@@ -27,6 +27,7 @@ function frozen_energy(at::AbstractSystem,
                        frozen::Vector{Bool}
                        ) where {C,P}
     check_num_components(C, list_num_par, frozen)
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions
@@ -74,6 +75,7 @@ function frozen_energy(at::AbstractSystem,
     if length(list_num_par) != length(frozen)
         throw(ArgumentError("The number of frozen and free parts does not match the length of the number of components."))
     end
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions

--- a/src/EnergyEval/atomistic_pairwise.jl
+++ b/src/EnergyEval/atomistic_pairwise.jl
@@ -99,6 +99,7 @@ function interacting_energy(at::AbstractSystem,
                             frozen::Vector{Bool}
                             ) where {C,P<:SingleComponentPotential{Pairwise}}
     check_num_components(C, list_num_par, frozen)
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions
@@ -143,6 +144,7 @@ function interacting_energy(at::AbstractSystem,
                             frozen::Vector{Bool},
                             surface::AbstractSystem
                             ) where {C,P<:SingleComponentPotential{Pairwise}}
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components_at = split_components(at, list_num_par)
     components = [components_at..., surface] # combine components from at and surface
@@ -195,6 +197,7 @@ function interacting_energy(at::AbstractSystem,
     if length(list_num_par) != length(frozen)
         throw(ArgumentError("The number of frozen and free parts does not match the length of the number of components."))
     end
+    length(at) == 0 && return 0.0u"eV"
     energy = 0.0u"eV"
     components = split_components(at, list_num_par)
     # intra-component interactions

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -1114,3 +1114,189 @@ function MC_grand_canonical_walk!(n_steps::Int,
             insert_biased_accepted=insert_biased_accepted,
             delete_attempted=delete_attempted, delete_accepted=delete_accepted)
 end
+
+"""
+    gc_insert_acceptance_ratio(z0V::Float64, n::Int, p_insert::Float64, p_delete::Float64)
+    gc_delete_acceptance_ratio(z0V::Float64, n::Int, p_insert::Float64, p_delete::Float64)
+
+Metropolis acceptance ratios for the continuous-space grand-canonical kernel, with `n` the
+PRE-move particle count in both directions. `z0V` is the dimensionless product of the
+reference activity (dimension inverse volume) and the cell volume. The insertion ratio is
+the proposal-density form z0 * p_delete / ((n + 1) * p_insert * q(r)) with the uniform
+channel's q = 1/V folded in, so the shipped arithmetic is literally
+z0V * (p_delete / p_insert) / (n + 1); a future biased-insertion channel enters by
+evaluating a different proposal density q in place of the folded 1/V, mirroring the
+composite-density pattern of the lattice kernel above.
+"""
+gc_insert_acceptance_ratio(z0V::Float64, n::Int, p_insert::Float64, p_delete::Float64) =
+    z0V * (p_delete / p_insert) / (n + 1)
+
+gc_delete_acceptance_ratio(z0V::Float64, n::Int, p_insert::Float64, p_delete::Float64) =
+    (p_insert / p_delete) * n / z0V
+
+"""
+    MC_grand_canonical_walk!(n_steps::Int, at::AtomWalker{1}, pot::SingleComponentPotential{Pairwise}, emax::typeof(0.0u"eV");
+                             z0V::Float64, species, p_move::Float64=0.5, p_insert::Float64=0.25,
+                             step_size::Float64=0.5, n_max::Int=typemax(Int))
+
+Perform a grand-canonical Monte Carlo walk on a continuous-space `AtomWalker{1}` below a
+nested-sampling energy ceiling: single-atom displacements mixed with uniform-in-cell
+insertions and uniform-among-particles deletions, under the Metropolis corrections that
+preserve the activity-z0-weighted reference measure. The continuous counterpart
+of the lattice `MC_grand_canonical_walk!` above; the site-counting acceptance ratios of the
+lattice kernel do not apply here and are replaced by the volume-and-activity forms of
+`gc_insert_acceptance_ratio`/`gc_delete_acceptance_ratio` (pre-move particle count in both).
+
+Requirements: a single unfrozen component, and an orthorhombic cell (consistent with
+`pbc_dist`); both are validated on entry.
+
+Random-number stream contract (fixed by tests): one channel draw per step; a displacement
+draws one particle index and the three walk displacements; an insertion draws three position
+uniforms (x, y, z) plus the Metropolis uniform only when its ratio is below one; a deletion
+draws one particle index plus the conditional Metropolis uniform. Guard skips (a
+displacement or deletion proposed at N = 0, an insertion proposed above `n_max`) consume
+only the channel draw and are not counted as attempts. The energy ceiling is checked before
+the Metropolis ratio, so ceiling rejections draw no Metropolis uniform. Energies are updated
+incrementally through `single_site_energy` on the same audited path the displacement walks
+use, with insertions evaluated by insert-then-revert.
+
+# Arguments
+- `n_steps::Int`: The number of Monte Carlo steps to perform.
+- `at::AtomWalker{1}`: The walker to evolve; a single unfrozen component.
+- `pot::SingleComponentPotential{Pairwise}`: The pairwise potential.
+- `emax::typeof(0.0u"eV")`: The nested-sampling energy ceiling (strict-below acceptance).
+- `z0V::Float64`: Dimensionless product of the reference activity and the cell volume.
+- `species`: Chemical identity (a `Symbol` or `ChemicalSpecies`) of inserted particles;
+  passed explicitly because the configuration may be empty.
+- `p_move::Float64=0.5`: Probability of a displacement move.
+- `p_insert::Float64=0.25`: Probability of an insertion move (deletion takes the remainder).
+- `step_size::Float64=0.5`: Maximum displacement per direction, in Angstrom.
+- `n_max::Int=typemax(Int)`: Upper bound on the particle count, for bounded constructions
+  only. A finite cap truncates the unbounded particle-number support of the reference
+  measure and biases the evidence; production callers must leave it inactive.
+
+# Returns
+- `accept_this_walker::Bool`: Whether at least one move was accepted.
+- `accept_rate::Float64`: Fraction of accepted moves over `n_steps`.
+- `at::AtomWalker{1}`: The updated walker.
+- `move_stats::NamedTuple`: Per-move-type attempt/accept counters
+  (`move_*`, `insert_*`, `delete_*`); attempts are counted at proposal, ceiling rejections
+  included, guard skips excluded.
+"""
+function MC_grand_canonical_walk!(n_steps::Int,
+                                  at::AtomWalker{1},
+                                  pot::SingleComponentPotential{Pairwise},
+                                  emax::typeof(0.0u"eV");
+                                  z0V::Float64,
+                                  species::Union{Symbol, ChemicalSpecies},
+                                  p_move::Float64=0.5,
+                                  p_insert::Float64=0.25,
+                                  step_size::Float64=0.5,
+                                  n_max::Int=typemax(Int))
+    if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
+        throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+    end
+    if z0V <= 0.0
+        throw(ArgumentError("z0V must be positive"))
+    end
+    if any(at.frozen)
+        throw(ArgumentError("the continuous grand-canonical kernel requires an unfrozen single-component walker"))
+    end
+    config = at.configuration
+    cellv = cell_vectors(config)
+    for i in 1:3, j in 1:3
+        if i != j && !iszero(ustrip(cellv[i][j]))
+            throw(ArgumentError("the continuous grand-canonical kernel assumes an orthorhombic cell (consistent with pbc_dist); found a nonzero off-diagonal cell component"))
+        end
+    end
+    box = (cellv[1][1], cellv[2][2], cellv[3][3])
+
+    n_accept = 0
+    accept_this_walker = false
+    p_delete = 1.0 - p_move - p_insert
+    move_attempted = 0
+    move_accepted = 0
+    insert_attempted = 0
+    insert_accepted = 0
+    delete_attempted = 0
+    delete_accepted = 0
+
+    for _ in 1:n_steps
+        r = rand()
+        n = at.list_num_par[1]
+        if r < p_move
+            # Displacement: ceiling check only (nested-sampling walk, no Metropolis)
+            n == 0 && continue          # guard skip: nothing to move
+            move_attempted += 1
+            i_at = rand(1:n)
+            prewalk_energy = single_site_energy(i_at, config, pot, at.list_num_par)
+            orig_pos::SVector{3, typeof(0.0u"Å")} = position(config, i_at)
+            pos = single_atom_random_walk!(orig_pos, step_size)
+            pos = periodic_boundary_wrap!(pos, config)
+            config.position[i_at] = pos
+            postwalk_energy = single_site_energy(i_at, config, pot, at.list_num_par)
+            proposed_energy = at.energy + (postwalk_energy - prewalk_energy)
+            if proposed_energy >= emax
+                config.position[i_at] = orig_pos
+            else
+                at.energy = proposed_energy
+                n_accept += 1
+                move_accepted += 1
+                accept_this_walker = true
+            end
+        elseif r < p_move + p_insert
+            # Insertion: uniform in the cell, insert-evaluate-revert
+            (n + 1 > n_max || p_insert <= 0.0) && continue   # guard skip
+            insert_attempted += 1
+            pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])
+            insert_particle!(at, pos, species)
+            e_site = single_site_energy(n + 1, config, pot, at.list_num_par)
+            proposed_energy = at.energy + e_site
+            accept = true
+            if proposed_energy >= emax
+                accept = false
+            else
+                ratio = gc_insert_acceptance_ratio(z0V, n, p_insert, p_delete)
+                if ratio < 1.0 && rand() >= ratio
+                    accept = false
+                end
+            end
+            if accept
+                at.energy = proposed_energy
+                n_accept += 1
+                insert_accepted += 1
+                accept_this_walker = true
+            else
+                remove_particle!(at, n + 1)
+            end
+        else
+            # Deletion: uniform among particles; nothing mutates until acceptance
+            (n == 0 || p_delete <= 0.0) && continue          # guard skip
+            delete_attempted += 1
+            i_at = rand(1:n)
+            e_site = single_site_energy(i_at, config, pot, at.list_num_par)
+            proposed_energy = at.energy - e_site
+            accept = true
+            if proposed_energy >= emax
+                accept = false
+            else
+                ratio = gc_delete_acceptance_ratio(z0V, n, p_insert, p_delete)
+                if ratio < 1.0 && rand() >= ratio
+                    accept = false
+                end
+            end
+            if accept
+                remove_particle!(at, i_at)
+                at.energy = proposed_energy
+                n_accept += 1
+                delete_accepted += 1
+                accept_this_walker = true
+            end
+        end
+    end
+
+    return accept_this_walker, n_accept / max(n_steps, 1), at,
+           (move_attempted=move_attempted, move_accepted=move_accepted,
+            insert_attempted=insert_attempted, insert_accepted=insert_accepted,
+            delete_attempted=delete_attempted, delete_accepted=delete_accepted)
+end

--- a/src/SamplingSchemes/SamplingSchemes.jl
+++ b/src/SamplingSchemes/SamplingSchemes.jl
@@ -49,6 +49,9 @@ export grand_canonical_nested_sampling
 export IdealGasReferencedGCNSParameters
 export ideal_gas_referenced_nested_sampling
 
+export AtomisticIGRefGCNSParameters
+export MCAtomGrandCanonicalMoves
+
 # other sampling schemes
 export exact_enumeration
 export wang_landau

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -2006,3 +2006,417 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
 
     return df, liveset, params
 end
+"""
+    struct MCAtomGrandCanonicalMoves <: MCRoutine
+
+Move routine for atomistic ideal-gas-referenced grand-canonical nested sampling:
+single-atom displacements mixed with continuous-space insertions and deletions through
+the atomistic `MC_grand_canonical_walk!` kernel. Deliberately lean: the lattice
+`MCGrandCanonicalMoves` carries cluster and biased-insertion configuration that has no
+continuous-space counterpart yet, and silently ignored fields on a mismatched routine
+are a known hazard class.
+
+# Fields
+- `p_move::Float64`: Probability of a displacement move.
+- `p_insert::Float64`: Probability of an insertion move (deletion takes the remainder).
+"""
+struct MCAtomGrandCanonicalMoves <: MCRoutine
+    p_move::Float64
+    p_insert::Float64
+    function MCAtomGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25)
+        if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
+            throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+        end
+        new(p_move, p_insert)
+    end
+end
+
+"""
+    mutable struct AtomisticIGRefGCNSParameters <: SamplingParameters
+
+Parameters for atomistic energy-sorted ideal-gas-referenced grand-canonical nested
+sampling. The sampler is athermal: the chemical potential and the temperature never
+enter a run; both enter only in the post-run reduction to Ξ(μ, T).
+
+# Fields
+- `mc_steps::Int64`: MCMC steps per replacement walker.
+- `reference_activity::typeof(1.0u"Å^-3")`: The reference activity z0 (dimension inverse
+  volume). The driver folds the dimensionless z0V once from the walkers' shared
+  orthorhombic cell.
+- `species::Symbol`: Chemical identity of inserted particles, passed explicitly because
+  a walker's configuration may be empty.
+- `initial_step_size::Float64`: Initial displacement step size (Angstrom).
+- `step_size::Float64`: Current displacement step size (mutable runtime state).
+- `step_size_lo::Float64`: Lower bound for the step-size adjustment.
+- `step_size_up::Float64`: Upper bound for the step-size adjustment.
+- `accept_range::Tuple{Float64,Float64}`: Acceptance-rate window forwarded to the
+  step-size adjustment.
+- `fail_count::Int64`: Consecutive failed replacements.
+- `allowed_fail_count::Int64`: Maximum consecutive failures before the driver's stall
+  contract fires (see `ideal_gas_referenced_nested_sampling`).
+- `plateau_refill_target::Int64`: Live-set size to restore after a plateau eviction
+  block (mutable runtime state; reset at driver entry).
+- `move_stats::Dict{Symbol,Int}`: Run-total per-move-type attempt/accept counters
+  accumulated from every decorrelation walk (cleared once at run start).
+
+Three fields carried by sibling parameter structs are deliberately absent. No `n_max`:
+the reference measure has unbounded particle-number support, and a cap silently
+truncates its mass and biases the evidence (the kernel's keyword exists for bounded
+constructions only; this sampler never sets it). No `energy_perturbation`: exact energy
+ties are handled by the plateau-aware eviction machinery, and perturbing recorded
+energies would break the exactly-zero closed-form checks this construction is validated
+against. No `random_seed`: the lattice ideal-gas-referenced sibling documents its field
+as not consumed by the sampling loop; seed the global RNG before the run instead.
+"""
+mutable struct AtomisticIGRefGCNSParameters <: SamplingParameters
+    mc_steps::Int64
+    reference_activity::typeof(1.0u"Å^-3")
+    species::Symbol
+    initial_step_size::Float64
+    step_size::Float64
+    step_size_lo::Float64
+    step_size_up::Float64
+    accept_range::Tuple{Float64,Float64}
+    fail_count::Int64
+    allowed_fail_count::Int64
+    plateau_refill_target::Int64
+    move_stats::Dict{Symbol,Int}
+end
+
+"""
+    AtomisticIGRefGCNSParameters(;
+        mc_steps=100, reference_activity=0.01u"Å^-3", species=:H,
+        initial_step_size=0.5, step_size=0.5, step_size_lo=0.01, step_size_up=2.0,
+        accept_range=(0.25, 0.75), fail_count=0, allowed_fail_count=10,
+        plateau_refill_target=0, move_stats=Dict{Symbol,Int}())
+
+Convenience constructor for `AtomisticIGRefGCNSParameters`. `reference_activity` (z0)
+must be positive; choose it so z0V sits near the particle-number range of interest, as
+post-run reweighting to a target (μ, T) carries a factor `(z/z0)^N` per sample whose
+effective sample size degrades away from the reference.
+"""
+function AtomisticIGRefGCNSParameters(;
+    mc_steps::Int64=100,
+    reference_activity::typeof(1.0u"Å^-3")=0.01u"Å^-3",
+    species::Symbol=:H,
+    initial_step_size::Float64=0.5,
+    step_size::Float64=0.5,
+    step_size_lo::Float64=0.01,
+    step_size_up::Float64=2.0,
+    accept_range::Tuple{Float64,Float64}=(0.25, 0.75),
+    fail_count::Int64=0,
+    allowed_fail_count::Int64=10,
+    plateau_refill_target::Int64=0,
+    move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
+)
+    if reference_activity <= 0.0u"Å^-3"
+        throw(ArgumentError("reference_activity must be positive"))
+    end
+    AtomisticIGRefGCNSParameters(
+        mc_steps, reference_activity, species,
+        initial_step_size, step_size, step_size_lo, step_size_up, accept_range,
+        fail_count, allowed_fail_count, plateau_refill_target, move_stats,
+    )
+end
+
+"""
+    _atomistic_igref_z0V(liveset::AtomWalkers, params::AtomisticIGRefGCNSParameters)
+
+Validate the liveset for the atomistic ideal-gas-referenced construction (single
+unfrozen component per walker, one shared orthorhombic cell) and return the
+dimensionless product of the reference activity and the cell volume.
+"""
+function _atomistic_igref_z0V(liveset::AtomWalkers, params::AtomisticIGRefGCNSParameters)
+    isempty(liveset.walkers) && throw(ArgumentError("the liveset carries no walkers"))
+    cellv = cell_vectors(liveset.walkers[1].configuration)
+    for i in 1:3, j in 1:3
+        if i != j && !iszero(ustrip(cellv[i][j]))
+            throw(ArgumentError("the atomistic ideal-gas-referenced construction assumes an orthorhombic cell (consistent with pbc_dist); found a nonzero off-diagonal cell component"))
+        end
+    end
+    for walker in liveset.walkers
+        walker isa AtomWalker{1} || throw(ArgumentError("every walker must be a single-component AtomWalker{1}"))
+        any(walker.frozen) && throw(ArgumentError("the atomistic ideal-gas-referenced construction requires unfrozen walkers"))
+        cell_vectors(walker.configuration) == cellv || throw(ArgumentError("all walkers must share one cell"))
+    end
+    V = cellv[1][1] * cellv[2][2] * cellv[3][3]
+    return ustrip(Unitful.NoUnits, params.reference_activity * V)
+end
+
+"""
+    _init_atomistic_igref_walkers!(liveset::AtomWalkers,
+                                   params::AtomisticIGRefGCNSParameters,
+                                   z0V::Float64)
+
+Initialize walkers as exact i.i.d. draws from the continuous ideal-gas prior at the
+reference activity: each walker's particle count is Poisson(z0V) and its positions are
+uniform in the cell.
+"""
+function _init_atomistic_igref_walkers!(liveset::AtomWalkers,
+                                        params::AtomisticIGRefGCNSParameters,
+                                        z0V::Float64)
+    pot = liveset.potential
+    cellv = cell_vectors(liveset.walkers[1].configuration)
+    box = (cellv[1][1], cellv[2][2], cellv[3][3])
+    for walker in liveset.walkers
+        while walker.list_num_par[1] > 0
+            remove_particle!(walker, walker.list_num_par[1])
+        end
+        n = rand(Poisson(z0V))
+        for _ in 1:n
+            pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])
+            insert_particle!(walker, pos, params.species)
+        end
+        AbstractLiveSets.assign_frozen_energy!(walker, pot)
+        assign_energy!(walker, pot)
+        # Reset the iteration counter: a stale counter from a reused liveset
+        # corrupts the prior-volume bookkeeping
+        walker.iter = 0
+    end
+    return liveset
+end
+
+"""
+    nested_sampling_step!(liveset::AtomWalkers,
+                          params::AtomisticIGRefGCNSParameters,
+                          mc_routine::MCAtomGrandCanonicalMoves;
+                          ns_iteration::Int=0, z0V::Union{Nothing,Float64}=nothing)
+
+Perform one step of atomistic energy-sorted ideal-gas-referenced grand-canonical nested
+sampling: sort by energy (descending), handle exact ceiling ties with the plateau-aware
+eviction machinery of the canonical atomistic steps (refill walks run the grand-canonical
+kernel, so refilled clones may re-enter at a different particle count; the compression
+bookkeeping counts walkers, not particle-number sectors), otherwise cull the worst walker
+and decorrelate a strictly-below-ceiling clone through `MC_grand_canonical_walk!` under
+the z0-weighted prior. Accepted clones (cull and refill alike) have their energies
+re-anchored by a from-scratch `interacting_energy` recompute and are re-checked against
+the ceiling before entering the live set: the kernel's incremental bookkeeping leaves
+rounding dust that would otherwise fragment bit-exact energy plateaus into artificial
+sub-levels and admit clones whose true energy sits on, not below, the ceiling.
+
+# Returns
+- `iter`: Iteration number (or `missing` if the step failed).
+- `emax`: The energy of the culled walker (with units; `missing` on failure).
+- `num_particles`: The particle count of the culled walker (`missing` on failure).
+- `liveset`: The updated liveset.
+- `params`: The updated parameters.
+- `log_t`: The log prior-volume compression charged for this cull (`missing` on failure).
+"""
+function nested_sampling_step!(liveset::AtomWalkers,
+                               params::AtomisticIGRefGCNSParameters,
+                               mc_routine::MCAtomGrandCanonicalMoves;
+                               ns_iteration::Int=0,
+                               z0V::Union{Nothing,Float64}=nothing)
+    z0V === nothing && (z0V = _atomistic_igref_z0V(liveset, params))
+    sort_by_energy!(liveset)
+    ats = liveset.walkers
+    pot = liveset.potential
+    iter::Union{Missing,Int} = missing
+    emax::Union{Missing,typeof(0.0u"eV")} = ats[1].energy
+    num_particles::Union{Missing,Int} = ats[1].list_num_par[1]
+    log_t::Union{Missing,Float64} = missing
+    n_live = length(ats)
+    n_tied = _tie_block_length(ats)
+    if (n_tied >= 2 || params.plateau_refill_target != 0) && n_tied < n_live
+        # Plateau block: evict the worst tied walker without replacement
+        # (Fowlie-Handley-Su), charging (n_live - 1)/n_live with the shrinking
+        # live count; see the canonical atomistic step for the full contract.
+        if params.plateau_refill_target == 0
+            params.plateau_refill_target = n_live
+        end
+        popfirst!(ats)
+        update_iter!(liveset)
+        iter = liveset.walkers[1].iter
+        log_t = log((n_live - 1) / n_live)
+        if n_tied == 1
+            # The plateau is exhausted: refill by cloning survivors and
+            # decorrelating strictly below the plateau energy with the
+            # grand-canonical kernel (volume-neutral; no ledger row).
+            refill_fails = 0
+            while length(ats) < params.plateau_refill_target && refill_fails < params.allowed_fail_count
+                accept_r, _, at_r, _ = MC_grand_canonical_walk!(
+                    params.mc_steps, deepcopy(rand(ats)), pot, emax;
+                    z0V=z0V, species=params.species,
+                    p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
+                    step_size=params.step_size)
+                if accept_r
+                    # Re-anchor the clone's energy from scratch: the kernel's
+                    # incremental bookkeeping leaves dust that would fragment
+                    # bit-exact plateaus and admit sub-ceiling dust crossings
+                    at_r.energy = interacting_energy(at_r.configuration, pot,
+                        at_r.list_num_par, at_r.frozen) + at_r.energy_frozen_part
+                    accept_r = at_r.energy < emax
+                end
+                if accept_r
+                    push!(ats, at_r)
+                else
+                    refill_fails += 1
+                end
+            end
+            length(ats) < params.plateau_refill_target && @warn "Plateau refill left the live set at $(length(ats)) of $(params.plateau_refill_target) walkers after $(refill_fails) failed decorrelation attempts; subsequent culls are charged with the actual live count."
+            params.plateau_refill_target = 0
+        end
+        return iter, emax, num_particles, liveset, params, log_t
+    end
+    # Ordinary cull: strictly-below-ceiling parent selection, mirroring the
+    # lattice ideal-gas-referenced step
+    eligible = [k for k in 2:n_live if ats[k].energy < emax]
+    parent_idx = isempty(eligible) ? rand(2:n_live) : rand(eligible)
+    to_walk = deepcopy(ats[parent_idx])
+    accept, rate, to_walk, move_stats = MC_grand_canonical_walk!(
+        params.mc_steps, to_walk, pot, emax;
+        z0V=z0V, species=params.species,
+        p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
+        step_size=params.step_size)
+    if accept
+        # Re-anchor the clone's energy from scratch (see the refill branch)
+        to_walk.energy = interacting_energy(to_walk.configuration, pot,
+            to_walk.list_num_par, to_walk.frozen) + to_walk.energy_frozen_part
+        accept = to_walk.energy < emax
+    end
+    if accept
+        push!(ats, to_walk)
+        popfirst!(ats)
+        update_iter!(liveset)
+        params.fail_count = 0
+        iter = liveset.walkers[1].iter
+        log_t = log(n_live / (n_live + 1))
+    else
+        emax = missing
+        num_particles = missing
+        params.fail_count += 1
+    end
+    _accumulate_move_stats!(params, move_stats)
+    adjust_step_size(params, rate; range=params.accept_range)
+    return iter, emax, num_particles, liveset, params, log_t
+end
+
+"""
+    ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
+                                         params::AtomisticIGRefGCNSParameters,
+                                         n_steps::Int64,
+                                         mc_routine::MCAtomGrandCanonicalMoves,
+                                         save_strategy::DataSavingStrategy;
+                                         observables=nothing,
+                                         dead_point_callback=nothing,
+                                         stop_on_stall::Bool=true)
+
+Run the atomistic energy-sorted ideal-gas-referenced grand-canonical nested sampling
+loop. Walkers are initialized as exact i.i.d. draws from the continuous ideal-gas prior
+at the reference activity (particle counts Poisson(z0V), positions uniform in the cell),
+then the loop iterates: remove the highest-energy walker, record (E, N, log-compression),
+replace with a strictly-below-ceiling clone decorrelated by the grand-canonical kernel
+under the z0-weighted prior. Exact ceiling ties are handled by the plateau-aware
+eviction machinery. Neither the chemical potential nor the temperature enters the run.
+
+Stall contract: when `params.fail_count` reaches `params.allowed_fail_count`, the driver
+warns once and, with `stop_on_stall=true` (the default), returns the partial ledger and
+the intact live set instead of consuming the remaining iteration budget on proposals
+that cannot be accepted. A fully degenerate live set (every configuration at exactly one
+energy, the zero-interaction limit) is a legitimate terminal state whose entire prior
+mass sits in the live set; the subsequent ledger reduction is then exact. With
+`stop_on_stall=false` the driver keeps the warn-and-continue contract of the sibling
+loops (the failure counter is reset and the loop continues).
+
+Observable callbacks must handle empty configurations: under this construction a
+walker's particle count may be zero.
+
+# Returns
+- `df::DataFrame`: Columns `[:iter, :emax, :num_particles, :log_compression]`, plus one
+  column per requested observable. Zero-accept runs return the schema with no rows.
+- `liveset::AtomWalkers`: The final liveset (surviving walkers).
+- `params::AtomisticIGRefGCNSParameters`: Updated parameters.
+"""
+function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
+                                              params::AtomisticIGRefGCNSParameters,
+                                              n_steps::Int64,
+                                              mc_routine::MCAtomGrandCanonicalMoves,
+                                              save_strategy::DataSavingStrategy;
+                                              observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
+                                              dead_point_callback::Union{Nothing,Function}=nothing,
+                                              stop_on_stall::Bool=true)
+    z0V = _atomistic_igref_z0V(liveset, params)
+    _init_atomistic_igref_walkers!(liveset, params, z0V)
+
+    # Parameter-reuse hazards: runtime state never leaks between runs
+    params.plateau_refill_target = 0
+    params.fail_count = 0
+    empty!(params.move_stats)
+
+    df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[], log_compression=Float64[])
+    if observables !== nothing
+        _validate_observables(observables, liveset)
+        for (name, _) in observables
+            df[!, name] = Float64[]
+        end
+    end
+    culled = nothing
+    empty_frame_warned = false
+
+    for i in 1:n_steps
+        print_info = i % save_strategy.n_info == 0
+        # The save layer cannot represent a zero-atom frame, and this
+        # construction produces empty walkers by design (the reference measure
+        # puts mass e^{-z0V} on N = 0): skip those writes with one warning
+        if length(liveset.walkers[1].configuration) > 0
+            write_walker_every_n(liveset.walkers[1], i, save_strategy)
+        elseif !empty_frame_warned
+            @warn "Skipping trajectory/live-set writes that would contain a zero-atom frame: the save layer cannot represent one."
+            empty_frame_warned = true
+        end
+
+        if observables !== nothing || dead_point_callback !== nothing
+            # Pre-sort with the step's own comparator (energy, descending)
+            # and hold the walker the step will cull; see `nested_sampling`.
+            sort_by_energy!(liveset)
+            culled = liveset.walkers[1]
+        end
+
+        iter, emax, n_par, liveset, params, log_t = nested_sampling_step!(
+            liveset, params, mc_routine; ns_iteration=i, z0V=z0V)
+
+        @debug "Atomistic IG-ref GC-NS step $i, iter: $iter, emax: $emax, N: $n_par"
+
+        if params.fail_count >= params.allowed_fail_count
+            if stop_on_stall
+                @warn "Atomistic IG-ref GC-NS: $(params.allowed_fail_count) consecutive failed replacements; returning the partial ledger and the intact live set (stop_on_stall=true)."
+                break
+            else
+                @warn "Atomistic IG-ref GC-NS: Failed $(params.allowed_fail_count) times in a row."
+                params.fail_count = 0
+            end
+        end
+
+        if !(iter isa typeof(missing))
+            if culled !== nothing
+                emax == culled.energy || error(
+                    "Atomistic IG-ref GC-NS observable recording: dead-point/observable " *
+                    "pairing lost (step culled a walker with energy $emax, " *
+                    "but the pre-sorted worst walker had $(culled.energy))")
+            end
+            if observables === nothing
+                push!(df, (iter, emax.val, n_par, log_t))
+            else
+                push!(df, (iter, emax.val, n_par, log_t,
+                           (Float64(f(culled.configuration)) for (_, f) in observables)...))
+            end
+            dead_point_callback === nothing || dead_point_callback(iter, culled)
+        end
+
+        if print_info && !(iter isa typeof(missing))
+            @info "Atomistic IG-ref GC-NS iter: $(iter), E: $(emax), N: $(n_par)"
+        elseif print_info && iter isa typeof(missing)
+            @info "Atomistic IG-ref GC-NS MC move failed, step: $(i)"
+        end
+
+        write_df_every_n(df, i, save_strategy)
+        if all(w -> length(w.configuration) > 0, liveset.walkers)
+            write_ls_every_n(liveset, i, save_strategy)
+        elseif !empty_frame_warned
+            @warn "Skipping trajectory/live-set writes that would contain a zero-atom frame: the save layer cannot represent one."
+            empty_frame_warned = true
+        end
+    end
+
+    return df, liveset, params
+end

--- a/test/test-AbstractLiveSets.jl
+++ b/test/test-AbstractLiveSets.jl
@@ -662,4 +662,83 @@ FreeBird.EnergyEval.interacting_energy(lattice::SLattice, h::ExtBadHam) = 1.6
         @test liveS == liveD
     end
 
+    @testset "GenericAtomWalkers tests" begin
+        using Random
+        box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+        pbc = (true, true, true)
+        mkconfig(coords) = FastSystem(atomic_system([:Ar => SVector{3}(c)u"Å" for c in coords], box, pbc))
+
+        @testset "IdealGasParameters construction assigns exact zeros" begin
+            # the zero-particle liveset case is owned by the empty-configuration
+            # hardening's tests and the regression coverage's pipeline lock
+            overlap = AtomWalker{1}(mkconfig([[5.0, 5.0, 5.0], [5.05, 5.0, 5.0], [5.0, 5.05, 5.0]]))
+            spread = AtomWalker{1}(mkconfig([[1.0, 1.0, 1.0], [8.0, 8.0, 8.0]]))
+            ls = GenericAtomWalkers([overlap, spread], IdealGasParameters())
+            @test ls isa GenericAtomWalkers{IdealGasParameters}
+            @test ls isa AtomWalkers
+            @test all(w.energy == 0.0u"eV" for w in ls.walkers)
+            @test all(w.energy_frozen_part == 0.0u"eV" for w in ls.walkers)
+        end
+
+        @testset "digit identity against LJAtomWalkers" begin
+            lj = LJParameters(epsilon=0.05, sigma=2.5, cutoff=4.0)
+            coords = [[[1.0, 1.0, 1.0], [3.5, 1.0, 1.0], [1.0, 4.0, 1.0]],
+                      [[2.0, 2.0, 2.0], [4.5, 2.0, 2.0], [2.0, 2.0, 6.0]]]
+            ws_g = [AtomWalker{1}(mkconfig(c)) for c in coords]
+            ws_l = [AtomWalker{1}(mkconfig(c)) for c in coords]
+            ls_g = GenericAtomWalkers(ws_g, lj)
+            ls_l = LJAtomWalkers(ws_l, lj)
+            @test all(ls_g.walkers[i].energy == ls_l.walkers[i].energy for i in eachindex(coords))
+            # frozen-bearing walker: per-walker frozen part matches the LJ path's value
+            mixed = FastSystem(atomic_system([:H => [1.0, 1.0, 1.0]u"Å", :H => [2.6, 1.0, 1.0]u"Å",
+                                              :Ar => [5.0, 5.0, 5.0]u"Å"], box, pbc))
+            wf_g = AtomWalker(mixed; freeze_species=[:H])
+            wf_l = AtomWalker(mixed; freeze_species=[:H])
+            lsf_g = GenericAtomWalkers([wf_g], lj)
+            lsf_l = LJAtomWalkers([wf_l], lj; const_frozen_part=false)
+            @test lsf_g.walkers[1].energy == lsf_l.walkers[1].energy
+            @test lsf_g.walkers[1].energy_frozen_part == lsf_l.walkers[1].energy_frozen_part
+        end
+
+        @testset "serial canonical nested sampling completes with the full schema" begin
+            Random.seed!(53531)
+            lj = LJParameters(epsilon=0.01, sigma=2.5)
+            walkers = AtomWalker{1}[]
+            for _ in 1:8
+                coords = [[rand() * 10.0, rand() * 10.0, rand() * 10.0] for _ in 1:3]
+                push!(walkers, AtomWalker{1}(mkconfig(coords)))
+            end
+            ls = GenericAtomWalkers(walkers, lj)
+            ns_params = NestedSamplingParameters(mc_steps=40, initial_step_size=0.5,
+                                                 step_size=0.5, step_size_lo=0.01,
+                                                 step_size_up=2.0, allowed_fail_count=1000)
+            save_strategy = SaveEveryN(df_filename="_test_generic_ns.csv",
+                                       wk_filename="_test_generic_ns.traj.extxyz",
+                                       ls_filename="_test_generic_ns.ls.extxyz",
+                                       n_traj=100_000, n_snap=100_000, n_info=100_000)
+            df, ls_out, _ = nested_sampling(ls, ns_params, 60, MCRandomWalkClone(), save_strategy)
+            rm("_test_generic_ns.csv", force=true)
+            rm("_test_generic_ns.traj.extxyz", force=true)
+            rm("_test_generic_ns.ls.extxyz", force=true)
+            @test nrow(df) > 0
+            @test "iter" in names(df) && "emax" in names(df)
+            @test "log_compression" in names(df)
+            @test all(df.log_compression .< 0.0)
+            @test issorted(df.emax, rev=true)
+            @test length(ls_out.walkers) == 8
+        end
+
+        @testset "dispatch remains unambiguous for the concrete livesets" begin
+            lj = LJParameters()
+            ws = [AtomWalker{1}(mkconfig([[1.0, 1.0, 1.0], [4.0, 4.0, 4.0]]))]
+            @test AtomWalkers(ws, lj) isa LJAtomWalkers
+            @test GenericAtomWalkers(ws, lj) isa GenericAtomWalkers{LJParameters}
+            surf = AtomWalker(FastSystem(atomic_system([:Pt => [5.0, 5.0, 5.0]u"Å"], box, pbc));
+                              freeze_species=[:Pt])
+            cps = CompositeParameterSets(2, [lj, lj, lj])
+            ws_surf = [AtomWalker{1}(mkconfig([[1.0, 1.0, 1.0]]))]
+            @test LJSurfaceWalkers(ws_surf, cps, surf; compute_frozen_energy=true) isa LJSurfaceWalkers
+        end
+    end
+
 end

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -1290,5 +1290,72 @@
             end
         end
     end
-    
+
+    @testset "empty-configuration handling tests" begin
+        box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+        pbc = (true, true, true)
+        at1 = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        empty_at = FastSystem(cell_vectors(at1), periodicity(at1),
+                              empty(position(at1, :)), empty(species(at1, :)), empty(mass(at1, :)))
+        at2 = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å", :Ar => [3.0, 3.0, 3.0]u"Å"], box, pbc))
+
+        @testset "helpers on empty systems and zero-count components" begin
+            comps = split_components(empty_at, [0])
+            @test length(comps) == 1
+            @test length(comps[1]) == 0
+            @test cell_vectors(comps[1]) == cell_vectors(empty_at)
+            @test periodicity(comps[1]) == periodicity(empty_at)
+
+            mixed = split_components(at2, [0, 2])
+            @test map(length, mixed) == [0, 2]
+            @test position(mixed[2], :) == position(at2, :)
+            @test species(mixed[2], :) == species(at2, :)
+
+            @test AbstractWalkers.split_components_by_chemical_species(empty_at) == FastSystem[]
+
+            list_num_par, sorted = sort_components_by_atomic_number(empty_at)
+            @test isempty(list_num_par)
+            @test length(sorted) == 0
+            @test cell_vectors(sorted) == cell_vectors(empty_at)
+
+            list_num_par_nm, sorted_nm = sort_components_by_atomic_number(empty_at, merge_same_species=false)
+            @test isempty(list_num_par_nm)
+            @test length(sorted_nm) == 0
+        end
+
+        @testset "nonempty outputs unchanged by the retyped helpers" begin
+            mixed_at = FastSystem(atomic_system([:H => [1.0, 1.0, 1.0]u"Å",
+                                                 :O => [2.0, 2.0, 2.0]u"Å",
+                                                 :H => [3.0, 3.0, 3.0]u"Å"], box, pbc))
+            comps = AbstractWalkers.split_components_by_chemical_species(mixed_at)
+            @test map(length, comps) == [2, 1]  # H (Z = 1) before O (Z = 8)
+            @test position(comps[1], 1) == position(mixed_at, 1)
+            @test position(comps[1], 2) == position(mixed_at, 3)
+            @test position(comps[2], 1) == position(mixed_at, 2)
+        end
+
+        @testset "zero-particle AtomWalker{1} round-trip" begin
+            w = AtomWalker{1}(empty_at)
+            @test w.list_num_par == [0]
+            @test w.frozen == [false]
+            lj = LJParameters()
+            @test interacting_energy(w.configuration, lj) == 0.0u"eV"
+            @test interacting_energy(w.configuration, lj, w.list_num_par, w.frozen) == 0.0u"eV"
+            @test frozen_energy(w.configuration, lj, w.list_num_par, [true]) == 0.0u"eV"
+        end
+
+        @testset "convenience constructor rejects empty input legibly" begin
+            @test_throws ArgumentError AtomWalker(empty_at)
+        end
+
+        @testset "liveset accepts a zero-particle walker" begin
+            w0 = AtomWalker{1}(empty_at)
+            w2 = AtomWalker{1}(at2)
+            ls = LJAtomWalkers([w0, w2], LJParameters())
+            @test length(ls.walkers) == 2
+            @test ls.walkers[1].energy == 0.0u"eV"
+            @test isfinite(ustrip(ls.walkers[2].energy))
+        end
+    end
+
 end

--- a/test/test-EnergyEval.jl
+++ b/test/test-EnergyEval.jl
@@ -834,4 +834,21 @@
         end
     end
 
+    @testset "empty-configuration energy fast paths" begin
+        box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+        pbc = (true, true, true)
+        seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        empty_at = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                              empty(position(seed_at, :)), empty(species(seed_at, :)), empty(mass(seed_at, :)))
+        lj = LJParameters()
+        cps = CompositeParameterSets(2, [lj, lj, lj])
+
+        @test interacting_energy(empty_at, lj) == 0.0u"eV"
+        @test interacting_energy(empty_at, lj, [0], [false]) == 0.0u"eV"
+        @test interacting_energy(empty_at, cps, [0, 0], [false, false]) == 0.0u"eV"
+        @test interacting_energy(empty_at, cps, [0], [false], seed_at) == 0.0u"eV"
+        @test frozen_energy(empty_at, lj, [0], [true]) == 0.0u"eV"
+        @test frozen_energy(empty_at, cps, [0, 0], [true, true]) == 0.0u"eV"
+    end
+
 end

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -634,5 +634,240 @@
         end
     end
 
+    # Calibration ledger for the atomistic grand-canonical kernel testsets below
+    # (protocol: burn 2e4 steps, then 2e5 steps sampling N every 10; per-attempt
+    # acceptance references are attempt-conditioned, i.e. deletion guard skips at
+    # N = 0 excluded, matching the kernel's counting contract).
+    # Corner z0V = 0.5, seeds {1,2,3,42421}: max devs mean 3.85e-3, var 4.72e-3,
+    #   P(0) 3.97e-3, A_ins 3.24e-3; A_del is structurally exact 1.0 at this corner.
+    # Corner z0V = 8.0, seeds {1,2,3,42422}: max devs mean 3.31e-2, var 3.27e-1,
+    #   P(0) 1.35e-4, A_ins 1.59e-3, A_del(conditioned) 8.7e-3 (gate 0.027 >= 3x).
+    # Corner z0V = 32.0, seeds {1,2,3,42423}: max devs mean 3.41e-1, var 1.11,
+    #   A_ins 3.62e-3, A_del(conditioned) 5.9e-3.
+    # Two-state n_max = 1 at z0V = 0.6, seeds {1,2,3,42424}: max dev f1 4.26e-3.
+    # Gates ship at >= 3x the max deviation per stat per corner. Off-by-one foil
+    # sensitivity (exact birth-death mean at z0V = 0.5): shift +0.1778, so the
+    # mean gate 0.012 detects it with ~15x headroom (asserted in-test).
+    @testset "atomistic grand-canonical kernel tests" begin
+        using Random
+        box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+        pbc = (true, true, true)
+        seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        mkempty() = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                               empty(position(seed_at, :)), empty(species(seed_at, :)),
+                               empty(mass(seed_at, :)))
+        mkwalker() = (w = AtomWalker{1}(mkempty()); w.energy = 0.0u"eV"; w)
+        lj0 = LJParameters(epsilon=0.0)
+        emax_inf = Inf * u"eV"
+
+        logfact(n) = n == 0 ? 0.0 : sum(log, 1:n)
+        poisson_pmf(lam, n) = exp(n * log(lam) - lam - logfact(n))
+        function poisson_refs(lam; nmax=max(80, ceil(Int, lam + 12 * sqrt(lam))))
+            p = [poisson_pmf(lam, n) for n in 0:nmax]
+            p ./= sum(p)
+            m = sum(n * p[n+1] for n in 0:nmax)
+            v = sum((n - m)^2 * p[n+1] for n in 0:nmax)
+            a_ins = sum(p[n+1] * min(1.0, lam / (n + 1)) for n in 0:nmax)
+            a_del = sum(p[n+1] * min(1.0, n / lam) for n in 0:nmax) / (1 - p[1])
+            return m, v, a_ins, a_del
+        end
+
+        function run_corner(z0V, seed; nburn=20_000, nsteps=200_000, thin=10)
+            Random.seed!(seed)
+            w = mkwalker()
+            MC_grand_canonical_walk!(nburn, w, lj0, emax_inf; z0V=z0V, species=:Ar)
+            ns = Int[]
+            ins_att = 0; ins_acc = 0; del_att = 0; del_acc = 0
+            for _ in 1:(nsteps ÷ thin)
+                _, _, _, stats = MC_grand_canonical_walk!(thin, w, lj0, emax_inf; z0V=z0V, species=:Ar)
+                push!(ns, w.list_num_par[1])
+                ins_att += stats.insert_attempted; ins_acc += stats.insert_accepted
+                del_att += stats.delete_attempted; del_acc += stats.delete_accepted
+            end
+            return mean(ns), var(ns), count(iszero, ns) / length(ns),
+                   ins_acc / max(ins_att, 1), del_acc / max(del_att, 1), w
+        end
+
+        @testset "acceptance-ratio helpers (pre-move N convention)" begin
+            gir = MonteCarloMoves.gc_insert_acceptance_ratio
+            gdr = MonteCarloMoves.gc_delete_acceptance_ratio
+            @test gir(8.0, 0, 0.25, 0.25) == 8.0
+            @test gir(8.0, 7, 0.25, 0.25) == 1.0
+            @test gir(8.0, 15, 0.25, 0.25) == 0.5
+            @test gdr(8.0, 8, 0.25, 0.25) == 1.0
+            @test gdr(8.0, 4, 0.25, 0.25) == 0.5
+            @test gdr(8.0, 1, 0.25, 0.25) == 0.125
+            @test gdr(8.0, 0, 0.25, 0.25) == 0.0
+            # asymmetric channels carry the proposal-probability ratio
+            @test gir(8.0, 3, 0.1, 0.4) == 8.0 * 4.0 / 4
+            @test gdr(8.0, 3, 0.1, 0.4) == 0.25 * 3 / 8.0
+        end
+
+        @testset "argument validation" begin
+            w = mkwalker()
+            @test_throws ArgumentError MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=8.0, species=:Ar, p_move=0.9, p_insert=0.2)
+            @test_throws ArgumentError MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=0.0, species=:Ar)
+            wf = mkwalker()
+            wf.frozen = [true]
+            @test_throws ArgumentError MC_grand_canonical_walk!(1, wf, lj0, emax_inf; z0V=8.0, species=:Ar)
+            tilted = [[10.0, 0.0, 0.0], [2.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+            wt = AtomWalker{1}(FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], tilted, pbc)))
+            @test_throws ArgumentError MC_grand_canonical_walk!(1, wt, lj0, emax_inf; z0V=8.0, species=:Ar)
+        end
+
+        @testset "surgery helpers round-trip byte-identity" begin
+            w = mkwalker()
+            insert_particle!(w, SVector(1.0, 2.0, 3.0)u"Å", :Ar)
+            insert_particle!(w, SVector(4.0, 5.0, 6.0)u"Å", :Ar)
+            pos_before = copy(w.configuration.position)
+            spc_before = copy(w.configuration.species)
+            mss_before = copy(w.configuration.mass)
+            insert_particle!(w, SVector(7.0, 8.0, 9.0)u"Å", :Ar)
+            @test w.list_num_par == [3]
+            @test length(w.configuration) == 3
+            remove_particle!(w, 3)
+            @test w.list_num_par == [2]
+            @test w.configuration.position == pos_before
+            @test w.configuration.species == spc_before
+            @test w.configuration.mass == mss_before
+            # order-preserving removal from the middle
+            remove_particle!(w, 1)
+            @test w.configuration.position == [pos_before[2]]
+            @test_throws BoundsError remove_particle!(w, 5)
+        end
+
+        @testset "RNG-stream contract (forced branches)" begin
+            # Insertion, ratio >= 1: accept with NO Metropolis draw (4 draws total)
+            Random.seed!(778)
+            probe = [rand() for _ in 1:8]
+            @test probe[1] < 0.75    # branch precondition: channel draw lands in the insertion window
+            Random.seed!(778)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=1.0e6, species=:Ar, p_move=0.0, p_insert=0.75)
+            @test w.list_num_par == [1]
+            @test (stats.insert_attempted, stats.insert_accepted) == (1, 1)
+            @test rand() == probe[5]
+
+            # Insertion, ratio < 1: Metropolis uniform IS drawn (5 draws; p_delete = 0 forces ratio 0)
+            Random.seed!(778)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=8.0, species=:Ar, p_move=0.0, p_insert=1.0)
+            @test w.list_num_par == [0]
+            @test (stats.insert_attempted, stats.insert_accepted) == (1, 0)
+            @test rand() == probe[6]
+
+            # Deletion, ratio >= 1: accept with NO Metropolis draw (2 draws)
+            Random.seed!(777)
+            probe = [rand() for _ in 1:8]
+            @test probe[1] >= 0.25   # branch precondition: channel draw lands in the deletion window
+            Random.seed!(777)
+            w = mkwalker()
+            insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=0.01, species=:Ar, p_move=0.0, p_insert=0.25)
+            @test w.list_num_par == [0]
+            @test (stats.delete_attempted, stats.delete_accepted) == (1, 1)
+            @test rand() == probe[3]
+
+            # Deletion, ratio < 1: Metropolis uniform IS drawn (3 draws)
+            Random.seed!(777)
+            w = mkwalker()
+            insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=1.0e6, species=:Ar, p_move=0.0, p_insert=0.25)
+            @test w.list_num_par == [1]
+            @test (stats.delete_attempted, stats.delete_accepted) == (1, 0)
+            @test rand() == probe[4]
+
+            # Ceiling rejection draws NO Metropolis uniform even at ratio < 1
+            # (the ceiling is checked first): 4 draws total, walker reverted
+            Random.seed!(778)
+            probe778 = [rand() for _ in 1:8]
+            Random.seed!(778)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, 0.0u"eV"; z0V=0.3, species=:Ar, p_move=0.0, p_insert=0.75)
+            @test w.list_num_par == [0]
+            @test (stats.insert_attempted, stats.insert_accepted) == (1, 0)
+            @test rand() == probe778[5]
+
+            # Guard skips consume only the channel draw and are not counted as attempts
+            Random.seed!(777)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=8.0, species=:Ar, p_move=0.0, p_insert=0.25)
+            @test w.list_num_par == [0]
+            @test stats == (move_attempted=0, move_accepted=0, insert_attempted=0,
+                            insert_accepted=0, delete_attempted=0, delete_accepted=0)
+            @test rand() == probe[2]
+            Random.seed!(779)
+            probe779 = [rand() for _ in 1:4]
+            Random.seed!(779)
+            w = mkwalker()
+            _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=8.0, species=:Ar, p_move=1.0, p_insert=0.0)
+            @test stats.move_attempted == 0
+            @test rand() == probe779[2]
+        end
+
+        @testset "two-state birth-death closure at n_max = 1" begin
+            Random.seed!(42424)
+            w = mkwalker()
+            MC_grand_canonical_walk!(10_000, w, lj0, emax_inf; z0V=0.6, species=:Ar, n_max=1)
+            n1 = 0
+            tot = 400_000
+            for _ in 1:tot
+                MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=0.6, species=:Ar, n_max=1)
+                n1 += w.list_num_par[1]
+            end
+            @test abs(n1 / tot - 0.6 / 1.6) < 0.013
+            @test w.list_num_par[1] <= 1
+        end
+
+        @testset "ideal-gas stationary law (seeded, calibrated)" begin
+            # (z0V, seed, tol_mean, tol_var, tol_p0, tol_ains, tol_adel)
+            corners = [(0.5, 42421, 0.012, 0.015, 0.012, 0.010, 1.0e-12),
+                       (8.0, 42422, 0.10, 1.0, 4.1e-4, 0.005, 0.027),
+                       (32.0, 42423, 1.05, 3.4, Inf, 0.011, 0.018)]
+            for (z0V, seed, tol_m, tol_v, tol_p0, tol_ai, tol_ad) in corners
+                m_ref, v_ref, ai_ref, ad_ref = poisson_refs(z0V)
+                m, v, p0, ai, ad, w = run_corner(z0V, seed)
+                @test abs(m - m_ref) < tol_m
+                @test abs(v - v_ref) < tol_v
+                if isfinite(tol_p0)
+                    @test abs(p0 - poisson_pmf(z0V, 0)) < tol_p0
+                end
+                @test abs(ai - ai_ref) < tol_ai
+                @test abs(ad - ad_ref) < tol_ad
+                # the configuration arrays and the particle count never drift apart
+                @test length(w.configuration) == w.list_num_par[1]
+                @test length(w.configuration.species) == w.list_num_par[1]
+            end
+            # sensitivity: the mean gate at the smallest corner detects the classic
+            # off-by-one insertion bug, whose exact stationary mean follows from the
+            # birth-death recursion p(n+1)/p(n) = a_ins(n)/a_del(n+1)
+            lam = 0.5
+            logp = zeros(101)
+            for n in 0:99
+                num = min(1.0, lam / max(n, 1))       # off-by-one foil
+                den = min(1.0, (n + 1) / lam)
+                logp[n+2] = logp[n+1] + log(num) - log(den)
+            end
+            pfoil = exp.(logp .- maximum(logp))
+            pfoil ./= sum(pfoil)
+            foil_shift = abs(sum(n * pfoil[n+1] for n in 0:100) - lam)
+            @test 0.012 < 0.5 * foil_shift
+        end
+
+        @testset "fixed-seed digit pins (stream shape)" begin
+            Random.seed!(424242)
+            w = mkwalker()
+            MC_grand_canonical_walk!(5000, w, lj0, emax_inf; z0V=8.0, species=:Ar)
+            @test w.list_num_par[1] == 9
+            @test w.energy == 0.0u"eV"
+            lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+            Random.seed!(424243)
+            w2 = mkwalker()
+            MC_grand_canonical_walk!(5000, w2, lj, 1.0e5u"eV"; z0V=4.0, species=:Ar, step_size=1.0)
+            @test w2.list_num_par[1] == 4
+            @test ustrip(u"eV", w2.energy) == -0.0014312826195886537
+        end
+    end
+
 end
 

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -16,6 +16,8 @@
     include("test-atomistic-igref-gcns.jl")
     # test the atomistic ideal-gas-referenced ledger assembly
     include("test-atomistic-igref-stats.jl")
+    # regression coverage for the continuous-space grand-canonical route
+    include("test-atomistic-gc-regressions.jl")
     # test atomistic GC-NS fixed-N post-processing (ideal gas reference)
     include("test-atomistic-gcns-fixed-n.jl")
     # test lattice GC-NS fixed-N post-processing

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -14,6 +14,8 @@
     include("test-ideal-gas-ref-gcns.jl")
     # test atomistic ideal-gas-referenced grand-canonical nested sampling
     include("test-atomistic-igref-gcns.jl")
+    # test the atomistic ideal-gas-referenced ledger assembly
+    include("test-atomistic-igref-stats.jl")
     # test atomistic GC-NS fixed-N post-processing (ideal gas reference)
     include("test-atomistic-gcns-fixed-n.jl")
     # test lattice GC-NS fixed-N post-processing

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -12,6 +12,8 @@
     include("test-grand_canonical_ns.jl")
     # test ideal-gas-referenced grand-canonical nested sampling
     include("test-ideal-gas-ref-gcns.jl")
+    # test atomistic ideal-gas-referenced grand-canonical nested sampling
+    include("test-atomistic-igref-gcns.jl")
     # test atomistic GC-NS fixed-N post-processing (ideal gas reference)
     include("test-atomistic-gcns-fixed-n.jl")
     # test lattice GC-NS fixed-N post-processing

--- a/test/test-SamplingSchemes/test-atomistic-gc-regressions.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gc-regressions.jl
@@ -1,0 +1,151 @@
+# RNG-neutrality and closed-form regression coverage for the continuous-space
+# grand-canonical route.
+#
+# Calibration ledger:
+# - (a) The canonical-ladder digit pins were recorded by running the identical
+#   fixture on dev @ 6b9d030 and on this change set's bytes: the two streams
+#   agree digit-for-digit (rows 60, last emax -0.024149711142342864 eV,
+#   live-energy sum -0.20617927437954883 eV, last log-compression
+#   -0.11778303565638351), so the pins lock the shared stream against drift.
+# - (b) Ideal-gas pipeline (K = 512, z0V = 4, 50 requested steps stalling at 5,
+#   mu grid at target zV = {2.8, 4, 5.2}, seeds {1,2,3,81811}): per-point max
+#   devs logXi 0.063, mean_N {0.084, 0.139, 0.386}, var_N {0.142, 0.498, 1.518};
+#   gates ship at >= 3x per point (logXi 0.2; mean_N 0.25, 0.45, 1.2; var_N
+#   0.45, 1.5, 4.6). Observed N_eff floor 361 behind the > 100 assertion. At
+#   the reference activity the assembled logXi equals z0V exactly (the
+#   reference-mass prefactor and the tail normalization cancel bitwise);
+#   observed deviation 0.0 on every seed.
+# - (c) Kernel energy drift over 2e4 insert/delete/move steps on a dilute
+#   interacting gas (seeds {1,2,3,81812}): max 3.1e-11 eV; bound ships at 5e-10.
+# - (d) Cap-inactivity run (K = 16, z0V = 6, 120 steps, dilute interacting gas,
+#   seeds {1,2,3,81813}): observed max particle count 15 (ledger and live set
+#   alike) against the 50 bound, a 3x-plus margin on the support edge.
+# - (e) The save layer cannot currently persist a zero-atom frame (the ExtXYZ
+#   writer fails converting an empty species table); the testset pins that
+#   failure as the documented disclosure, so a future ExtXYZ that learns to
+#   write empty frames surfaces here and the persistence testset can be added.
+@testset "atomistic grand-canonical regression coverage" begin
+    using Random
+
+    box12 = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+    box10 = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+    pbc = (true, true, true)
+    seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box12, pbc))
+    mkempty() = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                           empty(position(seed_at, :)), empty(species(seed_at, :)),
+                           empty(mass(seed_at, :)))
+    V = 1728.0
+    Vq = 1728.0u"Å^3"
+    mass_ar = 39.948u"u"
+    kb = 8.617333262e-5
+    lam(T) = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass_ar, T * u"K"))
+    mu_for(zV, T) = (kb * T * (log(zV / V) + 3 * log(lam(T)))) * u"eV"
+    mksave(tag; n_snap=10^7) = SaveEveryN(df_filename="_gcreg_$(tag).csv",
+                                          wk_filename="_gcreg_$(tag).traj.extxyz",
+                                          ls_filename="_gcreg_$(tag).ls.extxyz",
+                                          n_traj=10^7, n_snap=n_snap, n_info=10^7)
+    clean(tag) = for f in ["_gcreg_$(tag).csv", "_gcreg_$(tag).traj.extxyz", "_gcreg_$(tag).ls.extxyz"]
+        rm(f, force=true)
+    end
+
+    @testset "RNG-stream neutrality: canonical-ladder digit pins" begin
+        Random.seed!(71711)
+        walkers = AtomWalker{1}[]
+        for _ in 1:8
+            coords = [[rand() * 10.0, rand() * 10.0, rand() * 10.0] for _ in 1:3]
+            push!(walkers, AtomWalker{1}(FastSystem(atomic_system(
+                [:Ar => SVector{3}(c)u"Å" for c in coords], box10, pbc))))
+        end
+        ls = LJAtomWalkers(walkers, LJParameters(epsilon=0.01, sigma=2.5))
+        p = NestedSamplingParameters(mc_steps=40, initial_step_size=0.5, step_size=0.5,
+                                     step_size_lo=0.01, step_size_up=2.0,
+                                     allowed_fail_count=1000)
+        save = mksave("ab")
+        df, lso, _ = nested_sampling(ls, p, 60, MCRandomWalkClone(), save)
+        clean("ab")
+        @test nrow(df) == 60
+        @test df.emax[end] == -0.024149711142342864
+        @test sum(ustrip(u"eV", w.energy) for w in lso.walkers) == -0.20617927437954883
+        @test df.log_compression[end] == -0.11778303565638351
+    end
+
+    @testset "end-to-end ideal-gas pipeline closes against the closed forms (seed 81811)" begin
+        z0V = 4.0
+        z0 = (z0V / V)u"Å^-3"
+        T = 300.0
+        Random.seed!(81811)
+        ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:512], IdealGasParameters())
+        params = AtomisticIGRefGCNSParameters(mc_steps=10, reference_activity=z0,
+                                              species=:Ar, allowed_fail_count=5)
+        save = mksave("pipe")
+        df, lso, _ = @test_logs (:warn, r"stop_on_stall") match_mode=:any begin
+            ideal_gas_referenced_nested_sampling(ls, params, 50, MCAtomGrandCanonicalMoves(), save)
+        end
+        clean("pipe")
+        @test nrow(df) == 0
+        @test names(df) == ["iter", "emax", "num_particles", "log_compression"]
+        live_e = [ustrip(u"eV", w.energy) for w in lso.walkers]
+        live_n = [w.list_num_par[1] for w in lso.walkers]
+        @test all(iszero, live_e)
+        mus = [mu_for(0.7 * z0V, T), mu_for(z0V, T), mu_for(1.3 * z0V, T)]
+        st = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, [T]u"K";
+                                              live_emax=live_e, live_numbers=live_n)
+        # at the reference activity the reference-mass prefactor and the tail
+        # normalization cancel, so the assembled logXi equals z0V up to rounding
+        @test abs(st.logXi[2, 1] - z0V) < 1e-12
+        # the activity-linearity identity logXi(z) = zV, one gate testing the
+        # prefactor, the reweighting factor, and the 1/N! bookkeeping together
+        @test abs(st.logXi[1, 1] - 0.7 * z0V) < 0.2
+        @test abs(st.logXi[3, 1] - 1.3 * z0V) < 0.2
+        # occupation mean and variance close on every grid point (per-point gates)
+        @test abs(st.mean_N[1, 1] - 0.7 * z0V) < 0.25
+        @test abs(st.mean_N[2, 1] - z0V) < 0.45
+        @test abs(st.mean_N[3, 1] - 1.3 * z0V) < 1.2
+        @test abs(st.var_N[1, 1] - 0.7 * z0V) < 0.45
+        @test abs(st.var_N[2, 1] - z0V) < 1.5
+        @test abs(st.var_N[3, 1] - 1.3 * z0V) < 4.6
+        @test all(st.mean_U .== 0.0)
+        @test minimum(st.N_eff) > 100.0
+    end
+
+    @testset "kernel incremental-energy drift pin (seed 81812)" begin
+        lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+        Random.seed!(81812)
+        w = AtomWalker{1}(mkempty())
+        w.energy = 0.0u"eV"
+        MC_grand_canonical_walk!(20000, w, lj, 1.0e5u"eV"; z0V=4.0, species=:Ar, step_size=1.0)
+        recomputed = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen)
+        @test abs(ustrip(u"eV", w.energy - recomputed)) < 5.0e-10
+        @test length(w.configuration) == w.list_num_par[1]
+    end
+
+    @testset "particle-number cap stays structurally inactive" begin
+        # the sampler's parameter struct carries no cap at all: a cap would
+        # silently truncate the reference measure's unbounded support
+        @test !hasfield(AtomisticIGRefGCNSParameters, :n_max)
+        Random.seed!(81813)
+        ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:16],
+                                LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5))
+        params = AtomisticIGRefGCNSParameters(mc_steps=60, reference_activity=(6.0 / V)u"Å^-3",
+                                              species=:Ar, allowed_fail_count=50)
+        save = mksave("cap")
+        df, lso, _ = ideal_gas_referenced_nested_sampling(ls, params, 120,
+                                                          MCAtomGrandCanonicalMoves(), save)
+        clean("cap")
+        @test maximum(df.num_particles) < 50
+        @test maximum(w.list_num_par[1] for w in lso.walkers) < 50
+    end
+
+    @testset "empty-walker persistence: documented save-layer limitation" begin
+        ws = [AtomWalker{1}(mkempty()),
+              AtomWalker{1}(FastSystem(atomic_system([:Ar => [2.0, 2.0, 2.0]u"Å"], box12, pbc)))]
+        ls = GenericAtomWalkers(ws, LJParameters(epsilon=0.0))
+        save = mksave("io"; n_snap=1)
+        # DISCLOSURE: the ExtXYZ-backed save layer cannot represent a zero-atom
+        # frame today (species-table conversion fails). This pin keeps the
+        # limitation documented; when it stops throwing, replace it with a
+        # write-and-read-back persistence testset.
+        @test_throws MethodError FreeBird.FreeBirdIO.write_ls_every_n(ls, 1, save)
+        clean("io")
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
@@ -1,0 +1,216 @@
+# Atomistic energy-sorted ideal-gas-referenced grand-canonical nested sampling.
+#
+# Calibration ledger (protocol identical to the shipped testsets):
+# - Initializer moments at K = 200, z0V = 3, seeds {1,2,3,52521}: max devs
+#   mean 0.25, var 0.339; gates ship at >= 3x (0.75 and 1.05).
+# - Tie-block fixture (seed 52530): eviction charges are DETERMINISTIC
+#   [log(5/6), log(4/5), log(3/4), log(2/3)] and the refilled live set is
+#   pinned to particle counts [2, 2, 2, 3, 3, 3]: the refill walks run the
+#   grand-canonical kernel, so refilled clones re-enter at different particle
+#   counts (the N-changing refill contract). Accepted clones are re-anchored
+#   by a from-scratch energy recompute, so refilled walkers carry genuinely
+#   negative energies (partial-well configurations), never rounding dust.
+# - End-to-end determinism at K = 16, seed 52522: two runs digit-identical.
+@testset "atomistic ideal-gas-referenced GC-NS tests" begin
+    using Random
+
+    box = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+    pbc = (true, true, true)
+    seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+    mkempty() = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                           empty(position(seed_at, :)), empty(species(seed_at, :)),
+                           empty(mass(seed_at, :)))
+    mkat(coords) = AtomWalker{1}(FastSystem(atomic_system([:Ar => SVector{3}(c)u"Å" for c in coords], box, pbc)))
+    V = 1728.0
+    lj0 = LJParameters(epsilon=0.0)
+    routine = MCAtomGrandCanonicalMoves()
+    mksave(tag) = SaveEveryN(df_filename="_igref_at_$(tag).csv",
+                             wk_filename="_igref_at_$(tag).traj.extxyz",
+                             ls_filename="_igref_at_$(tag).ls.extxyz",
+                             n_traj=10^7, n_snap=10^7, n_info=10^7)
+    clean(tag) = for f in ["_igref_at_$(tag).csv", "_igref_at_$(tag).traj.extxyz", "_igref_at_$(tag).ls.extxyz"]
+        rm(f, force=true)
+    end
+
+    @testset "routine and parameter validation" begin
+        @test_throws ArgumentError MCAtomGrandCanonicalMoves(p_move=0.9, p_insert=0.2)
+        @test_throws ArgumentError AtomisticIGRefGCNSParameters(reference_activity=0.0u"Å^-3")
+        params = AtomisticIGRefGCNSParameters(reference_activity=(2.0 / V)u"Å^-3", species=:Ar)
+        wf = AtomWalker{1}(mkempty())
+        wf.frozen = [true]
+        lsf = GenericAtomWalkers([wf], lj0; assign_energy=false)
+        @test_throws ArgumentError FreeBird.SamplingSchemes._atomistic_igref_z0V(lsf, params)
+        tilted = [[12.0, 0.0, 0.0], [2.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+        wt = AtomWalker{1}(FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], tilted, pbc)))
+        lst = GenericAtomWalkers([wt], lj0)
+        @test_throws ArgumentError FreeBird.SamplingSchemes._atomistic_igref_z0V(lst, params)
+        small = [[6.0, 0.0, 0.0], [0.0, 6.0, 0.0], [0.0, 0.0, 6.0]]u"Å"
+        wm = AtomWalker{1}(FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], small, pbc)))
+        lsm = GenericAtomWalkers([AtomWalker{1}(mkempty()), wm], lj0)
+        @test_throws ArgumentError FreeBird.SamplingSchemes._atomistic_igref_z0V(lsm, params)
+        # z0V folds the activity against the cell volume
+        @test FreeBird.SamplingSchemes._atomistic_igref_z0V(
+            GenericAtomWalkers([AtomWalker{1}(mkempty())], lj0), params) ≈ 2.0 atol=1e-12
+    end
+
+    @testset "initializer draws the reference law (seeded, calibrated)" begin
+        Random.seed!(52521)
+        ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:200], lj0)
+        for w in ls.walkers
+            w.iter = 99
+        end
+        params = AtomisticIGRefGCNSParameters(reference_activity=(3.0 / V)u"Å^-3", species=:Ar)
+        z0V = FreeBird.SamplingSchemes._atomistic_igref_z0V(ls, params)
+        FreeBird.SamplingSchemes._init_atomistic_igref_walkers!(ls, params, z0V)
+        ns = [w.list_num_par[1] for w in ls.walkers]
+        @test abs(mean(ns) - 3.0) < 0.75
+        @test abs(var(ns) - 3.0) < 1.05
+        @test all(w.iter == 0 for w in ls.walkers)
+        @test all(length(w.configuration) == w.list_num_par[1] for w in ls.walkers)
+        @test all(w.energy == 0.0u"eV" for w in ls.walkers)
+    end
+
+    @testset "stall contract on an exactly degenerate liveset (deterministic)" begin
+        Random.seed!(31312)
+        ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:8], lj0)
+        params = AtomisticIGRefGCNSParameters(mc_steps=20, reference_activity=(4.0 / V)u"Å^-3",
+                                              species=:Ar, allowed_fail_count=7)
+        save = mksave("stall")
+        df, ls_out, params_out = @test_logs (:warn, r"stop_on_stall") match_mode=:any begin
+            ideal_gas_referenced_nested_sampling(ls, params, 500, routine, save)
+        end
+        clean("stall")
+        @test nrow(df) == 0
+        @test names(df) == ["iter", "emax", "num_particles", "log_compression"]
+        @test length(ls_out.walkers) == 8
+        @test all(w.energy == 0.0u"eV" for w in ls_out.walkers)
+        @test params_out.fail_count == 7
+        # warn-and-continue keeps the sibling contract: the loop runs its full budget
+        Random.seed!(31313)
+        ls2 = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:8], lj0)
+        params2 = AtomisticIGRefGCNSParameters(mc_steps=20, reference_activity=(4.0 / V)u"Å^-3",
+                                               species=:Ar, allowed_fail_count=7)
+        save2 = mksave("stall2")
+        df2, _, params2_out = @test_logs (:warn, r"Failed 7 times") match_mode=:any begin
+            ideal_gas_referenced_nested_sampling(ls2, params2, 30, routine, save2; stop_on_stall=false)
+        end
+        clean("stall2")
+        @test nrow(df2) == 0
+        @test params2_out.fail_count < 7
+    end
+
+    @testset "plateau tie block: bit-exact charges and N-changing refill (seed 52530)" begin
+        lj = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.5)
+        rmin = 2.0^(1 / 6) * 2.5
+        walkers = AtomWalker{1}[]
+        push!(walkers, mkat([[1.0, 1.0, 1.0]]))
+        push!(walkers, mkat([[1.0, 6.0, 1.0]]))
+        push!(walkers, mkat([[6.0, 1.0, 1.0]]))
+        push!(walkers, mkat([[6.0, 6.0, 6.0]]))
+        push!(walkers, mkat([[3.0, 3.0, 3.0], [3.0 + rmin, 3.0, 3.0]]))
+        push!(walkers, mkat([[9.0, 9.0, 9.0], [9.0 - rmin, 9.0, 9.0]]))
+        ls = GenericAtomWalkers(walkers, lj)
+        @test FreeBird.SamplingSchemes._tie_block_length(sort(ls.walkers, by=w -> w.energy, rev=true)) == 4
+        Random.seed!(52530)
+        params = AtomisticIGRefGCNSParameters(mc_steps=100, reference_activity=(2.0 / V)u"Å^-3",
+                                              species=:Ar, allowed_fail_count=200, step_size=0.5)
+        charges = Float64[]
+        npars = Int[]
+        for _ in 1:4
+            iter, emax, n_par, ls, params, log_t = FreeBird.SamplingSchemes.nested_sampling_step!(ls, params, routine)
+            push!(charges, log_t)
+            push!(npars, n_par)
+        end
+        @test charges == [log(5 / 6), log(4 / 5), log(3 / 4), log(2 / 3)]
+        @test npars == [1, 1, 1, 1]
+        @test length(ls.walkers) == 6
+        @test params.plateau_refill_target == 0
+        @test sort([w.list_num_par[1] for w in ls.walkers]) == [2, 2, 2, 3, 3, 3]
+        @test all(w.energy < 0.0u"eV" for w in ls.walkers)
+    end
+
+    @testset "dilute interacting end-to-end with same-seed determinism" begin
+        function run_e2e(seed)
+            Random.seed!(seed)
+            ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:16],
+                                    LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5))
+            params = AtomisticIGRefGCNSParameters(mc_steps=60, reference_activity=(6.0 / V)u"Å^-3",
+                                                  species=:Ar, allowed_fail_count=50)
+            save = mksave("e2e")
+            df, lso, pout = ideal_gas_referenced_nested_sampling(ls, params, 120, routine, save)
+            clean("e2e")
+            return df, [ustrip(u"eV", w.energy) for w in lso.walkers], pout
+        end
+        df1, live1, pout1 = run_e2e(52522)
+        df2, live2, _ = run_e2e(52522)
+        @test df1 == df2
+        @test live1 == live2
+        @test nrow(df1) == 120
+        @test names(df1) == ["iter", "emax", "num_particles", "log_compression"]
+        @test issorted(df1.emax, rev=true)
+        @test all(df1.log_compression .< 0.0)
+        @test all(df1.num_particles .>= 0)
+        @test haskey(pout1.move_stats, :insert_attempted)
+        @test haskey(pout1.move_stats, :delete_attempted)
+        @test pout1.plateau_refill_target == 0
+    end
+
+    @testset "parameter reuse: dirty runtime state cannot leak into a run" begin
+        function run_with(params_init)
+            Random.seed!(52523)
+            ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:8],
+                                    LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5))
+            save = mksave("reuse")
+            df, lso, pout = ideal_gas_referenced_nested_sampling(ls, params_init, 60, routine, save)
+            clean("reuse")
+            return df, [ustrip(u"eV", w.energy) for w in lso.walkers], pout
+        end
+        clean_params() = AtomisticIGRefGCNSParameters(mc_steps=40, reference_activity=(4.0 / V)u"Å^-3",
+                                                      species=:Ar, allowed_fail_count=50)
+        dirty = clean_params()
+        dirty.plateau_refill_target = 3
+        dirty.fail_count = 5
+        dirty.move_stats[:stale] = 99
+        df_c, live_c, _ = run_with(clean_params())
+        df_d, live_d, pout_d = run_with(dirty)
+        @test df_c == df_d
+        @test live_c == live_d
+        @test !haskey(pout_d.move_stats, :stale)
+    end
+
+    @testset "default-cadence saves skip zero-atom frames instead of crashing" begin
+        Random.seed!(52541)
+        ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:8], LJParameters(epsilon=0.0))
+        params = AtomisticIGRefGCNSParameters(mc_steps=10, reference_activity=(0.5 / V)u"Å^-3",
+                                              species=:Ar, allowed_fail_count=5)
+        save = SaveEveryN(df_filename="_igref_at_guard.csv",
+                          wk_filename="_igref_at_guard.traj.extxyz",
+                          ls_filename="_igref_at_guard.ls.extxyz",
+                          n_traj=1, n_snap=1, n_info=10^7)
+        df, lso, _ = @test_logs (:warn, r"zero-atom frame") match_mode=:any begin
+            ideal_gas_referenced_nested_sampling(ls, params, 20, routine, save)
+        end
+        for f in ["_igref_at_guard.csv", "_igref_at_guard.traj.extxyz", "_igref_at_guard.ls.extxyz"]
+            rm(f, force=true)
+        end
+        @test length(lso.walkers) == 8
+    end
+
+    @testset "observables and dead-point callback handle variable N" begin
+        Random.seed!(52540)
+        ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:8],
+                                LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5))
+        params = AtomisticIGRefGCNSParameters(mc_steps=40, reference_activity=(4.0 / V)u"Å^-3",
+                                              species=:Ar, allowed_fail_count=50)
+        save = mksave("obs")
+        seen_ns = Int[]
+        df, _, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, 40, routine, save;
+            observables=[:n_obs => cfg -> Float64(length(cfg))],
+            dead_point_callback=(iter, walker) -> push!(seen_ns, walker.list_num_par[1]))
+        clean("obs")
+        @test "n_obs" in names(df)
+        @test df.n_obs == Float64.(df.num_particles)
+        @test seen_ns == df.num_particles
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-stats.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-stats.jl
@@ -1,0 +1,204 @@
+# Atomistic ledger assembly for ideal-gas-referenced grand-canonical runs.
+#
+# Calibration ledger:
+# - Cross-route agreement (igref reduction vs fixed-N stitching, dilute LJ gas,
+#   K = 24, per-T μ grids solved from target zV in {4, 6}; igref seeds
+#   {1,2,3,62621} against fixed-N stitching seeds {1001,1002,1003,63621}):
+#   max devs logXi 0.341, mean_N 0.636, N_eff floor observed 17.3; gates ship at
+#   >= 3x (1.05 and 2.0) with an N_eff floor assertion at 10.
+# - The exact-closure testset needs no calibration: the compression ledger is
+#   CONSTRUCTED to encode the truncated Poisson prior exactly, so every
+#   grand-canonical identity is a floating-point weld, gated at 1e-11 relative.
+@testset "atomistic ideal-gas-referenced ledger assembly tests" begin
+    using Random
+
+    kb = 8.617333262e-5
+    Vq = 1000.0u"Å^3"
+    V = 1000.0
+    mass_ar = 39.948u"u"
+    lam(T) = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass_ar, T * u"K"))
+    mu_for(zV, T) = (kb * T * (log(zV / V) + 3 * log(lam(T)))) * u"eV"
+
+    logfact(n) = n == 0 ? 0.0 : sum(log, 1:n)
+    poisson_pmf(lam0, n) = exp(n * log(lam0) - lam0 - logfact(n))
+
+    # A compression ledger that ENCODES the truncated Poisson(z0V) prior exactly:
+    # shell j carries mass p(N = j - 1) at energy zero, the tail walker carries
+    # the (negligible) truncation remainder
+    function poisson_ledger(z0V; nmax=60)
+        p = [poisson_pmf(z0V, n) for n in 0:nmax]
+        remainder = max(1.0 - sum(p), 1.0e-300)
+        masses = vcat(p, remainder)
+        # X[j] = prior mass from shell j onward, positive by construction
+        # (a forward 1 - cumsum cancels to negative dust at deep truncation)
+        X = reverse(cumsum(reverse(masses)))
+        lc = [log(X[j+1] / X[j]) for j in 1:nmax+1]
+        df = DataFrame(iter=collect(1:nmax+1), emax=zeros(nmax + 1),
+                       num_particles=collect(0:nmax), log_compression=lc)
+        return df, [0.0], [nmax + 1]     # live tail: the truncation remainder
+    end
+
+    @testset "exact closure: the assembly reproduces the grand-canonical closed forms" begin
+        z0V = 3.0
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = poisson_ledger(z0V)
+        Ts = [250.0, 300.0, 400.0]
+        for T in Ts
+            mus = [mu_for(1.0, T), mu_for(3.0, T), mu_for(7.0, T)]
+            stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, [T]u"K";
+                                                     live_emax=live_e, live_numbers=live_n)
+            for (i, zV) in enumerate([1.0, 3.0, 7.0])
+                @test abs(stats.logXi[i, 1] - zV) < 1e-11 * max(zV, 1.0)
+                @test abs(stats.mean_N[i, 1] - zV) < 1e-11 * zV
+                @test abs(stats.var_N[i, 1] - zV) < 1e-10 * zV
+                @test abs(stats.mean_U[i, 1]) < 1e-14
+            end
+        end
+    end
+
+    @testset "shell weld against the exported ωᵢ decode" begin
+        z0V = 3.0
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = poisson_ledger(z0V; nmax=20)
+        T = 300.0
+        mus = [mu_for(2.0, T)]
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, [T]u"K";
+                                                 live_emax=live_e, live_numbers=live_n)
+        # independent hand assembly through the exported linear-space decode
+        w = ωᵢ(Vector{Float64}(df.log_compression); ω0=1.0)
+        tail = exp(sum(df.log_compression)) / length(live_e)
+        s = 2.0 / z0V
+        hand = z0V + log(sum(w .* s .^ df.num_particles) + tail * s^live_n[1])
+        @test abs(stats.logXi[1, 1] - hand) < 1e-12
+    end
+
+    @testset "reweighting window collapse is visible in N_eff" begin
+        z0V = 3.0
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = poisson_ledger(z0V)
+        T = 300.0
+        # zV = 200 sits far beyond the ledger's N <= 60 support, so the reweighted
+        # mass concentrates on the last rows; within the support (zV = 3) the exact
+        # ledger reweights with a healthy effective sample size
+        mus = [mu_for(3.0, T), mu_for(200.0, T)]
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, [T]u"K";
+                                                 live_emax=live_e, live_numbers=live_n)
+        @test stats.N_eff[1, 1] > 5.0
+        @test stats.N_eff[2, 1] < 2.5
+        @test stats.N_eff[1, 1] / stats.N_eff[2, 1] > 2.0
+    end
+
+    @testset "ledger-shape hardening" begin
+        z0 = (3.0 / V)u"Å^-3"
+        T = [300.0]u"K"
+        mus = [mu_for(3.0, 300.0)]
+        # ended-mid-eviction ledger: tail splits over the SURVIVING count
+        lc = [log(8 / 9), log(8 / 9), log(8 / 9), log(7 / 8), log(6 / 7)]
+        df = DataFrame(iter=1:5, emax=zeros(5), num_particles=[3, 2, 4, 3, 2],
+                       log_compression=lc)
+        live_e = zeros(6)
+        live_n = [2, 3, 1, 4, 2, 3]
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, T;
+                                                 live_emax=live_e, live_numbers=live_n)
+        w = ωᵢ(lc; ω0=1.0)
+        tail_each = exp(sum(lc)) / 6
+        s = 3.0 / 3.0
+        hand = 3.0 + log(sum(w .* s .^ df.num_particles) + tail_each * sum(s .^ live_n))
+        @test abs(stats.logXi[1, 1] - hand) < 1e-12
+        # total prior mass closes: shells + tail account for exactly 1
+        @test abs(sum(w) + tail_each * 6 - 1.0) < 1e-14
+        # a ledger with rows but no compression column is rejected
+        df_bad = DataFrame(iter=1:2, emax=zeros(2), num_particles=[1, 2])
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_bad, Vq, mass_ar, z0, mus, T; live_emax=live_e, live_numbers=live_n)
+        # a corrupted compression column (positive entry) is rejected
+        df_pos = DataFrame(iter=1:2, emax=zeros(2), num_particles=[1, 2],
+                           log_compression=[log(0.9), 0.1])
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_pos, Vq, mass_ar, z0, mus, T; live_emax=live_e, live_numbers=live_n)
+        # zero-accept run: empty ledger with a live-set-only reduction is exact
+        df_empty = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[],
+                             log_compression=Float64[])
+        stats_live = gc_thermodynamic_stats_ideal_ref(df_empty, Vq, mass_ar, z0, mus, T;
+                                                      live_emax=zeros(4),
+                                                      live_numbers=[2, 3, 3, 4])
+        hand_live = 3.0 + log(sum((1.0) .^ [2, 3, 3, 4]) / 4)
+        @test abs(stats_live.logXi[1, 1] - hand_live) < 1e-12
+        # empty ledger with no live walkers is rejected
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_empty, Vq, mass_ar, z0, mus, T)
+        # mismatched live vectors are rejected
+        @test_throws DimensionMismatch gc_thermodynamic_stats_ideal_ref(
+            df_empty, Vq, mass_ar, z0, mus, T; live_emax=zeros(3), live_numbers=[1, 2])
+    end
+
+    @testset "cross-route agreement on a dilute interacting gas (seed 62621)" begin
+        box = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+        pbc = (true, true, true)
+        seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        mkempty() = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                               empty(position(seed_at, :)), empty(species(seed_at, :)),
+                               empty(mass(seed_at, :)))
+        V12 = 1728.0
+        Vq12 = 1728.0u"Å^3"
+        lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+        z0 = (6.0 / V12)u"Å^-3"
+        mu12(zV, T) = (kb * T * (log(zV / V12) + 3 * log(lam(T)))) * u"eV"
+        Ts = [300.0, 400.0]
+        mugrids = [[mu12(4.0, T), mu12(6.0, T)] for T in Ts]
+        mksave(tag) = SaveEveryN(df_filename="_igstats_$(tag).csv",
+                                 wk_filename="_igstats_$(tag).traj.extxyz",
+                                 ls_filename="_igstats_$(tag).ls.extxyz",
+                                 n_traj=10^7, n_snap=10^7, n_info=10^7)
+        clean(tag) = for f in ["_igstats_$(tag).csv", "_igstats_$(tag).traj.extxyz", "_igstats_$(tag).ls.extxyz"]
+            rm(f, force=true)
+        end
+
+        Random.seed!(62621)
+        ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:24], lj)
+        params = AtomisticIGRefGCNSParameters(mc_steps=60, reference_activity=z0,
+                                              species=:Ar, allowed_fail_count=100)
+        df, lso, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, 300, MCAtomGrandCanonicalMoves(), mksave("ig"))
+        clean("ig")
+        live_e = [ustrip(u"eV", w.energy) for w in lso.walkers]
+        live_n = [w.list_num_par[1] for w in lso.walkers]
+
+        Random.seed!(63621)
+        Nmax = 12
+        dfs = DataFrame[]
+        lives = Vector{Float64}[]
+        for N in 0:Nmax
+            if N == 0
+                push!(dfs, DataFrame(iter=Int[], emax=Float64[]))
+                push!(lives, zeros(8))
+                continue
+            end
+            walkers = AtomWalker{1}[]
+            for _ in 1:24
+                coords = [[rand() * 12.0, rand() * 12.0, rand() * 12.0] for _ in 1:N]
+                push!(walkers, AtomWalker{1}(FastSystem(atomic_system(
+                    [:Ar => SVector{3}(c)u"Å" for c in coords], box, pbc))))
+            end
+            lsN = GenericAtomWalkers(walkers, lj)
+            p = NestedSamplingParameters(mc_steps=60, initial_step_size=0.5, step_size=0.5,
+                                         step_size_lo=0.01, step_size_up=2.0,
+                                         allowed_fail_count=1000)
+            dfN, lsoN, _ = nested_sampling(lsN, p, 150, MCRandomWalkClone(), mksave("fx$N"))
+            clean("fx$N")
+            push!(dfs, dfN)
+            push!(lives, [ustrip(u"eV", w.energy) for w in lsoN.walkers])
+        end
+
+        for k in 1:2
+            ig = gc_thermodynamic_stats_ideal_ref(df, Vq12, mass_ar, z0, mugrids[k], [Ts[k]]u"K";
+                                                  live_emax=live_e, live_numbers=live_n)
+            fx = gc_thermodynamic_stats_fixed_N(dfs, collect(0:Nmax), Vq12, mass_ar,
+                                                mugrids[k], [Ts[k]]u"K";
+                                                n_walkers=24, live_emax=lives)
+            @test maximum(abs.(ig.logXi .- fx.logXi)) < 1.05
+            @test maximum(abs.(ig.mean_N .- fx.mean_N)) < 2.0
+            @test minimum(ig.N_eff) > 10.0
+        end
+    end
+end


### PR DESCRIPTION
Implements #199: RNG-neutrality and closed-form regression coverage for the continuous-space grand-canonical route. One commit: `RNG-neutrality and closed-form regression coverage for the continuous-space grand-canonical route.` Lands after the five changes filed alongside merge.

- (a) RNG-stream neutrality: a seeded canonical-ladder fixture whose digit pins were recorded by running the identical fixture on `dev` and on this change set's bytes, agreeing digit-for-digit (final ceiling, live-energy sum, final log-compression), so the pins lock the shared stream against future drift.
- (b) End-to-end closed-form pipeline: the generic liveset with the analytic reference potential, the ideal-gas-referenced sampler, and the atomistic ledger assembly composed on a periodic box. The run stalls by design (an exactly degenerate landscape), returning the full schema with zero rows and the entire prior mass in the live set; the assembly then closes against the grand-canonical closed forms with per-point gates at ≥ 3× the four-seed spread: the activity-linearity identity `log Ξ(z) = zV` (its value at the reference activity is exact by construction, the reference-mass prefactor and tail normalization cancel bitwise, observed deviation 0.0 on every calibration seed), and occupation mean and variance against `zV` on every grid point. The observed effective-sample-size floor sits at 361 behind the asserted 100.
- (c) Kernel energy-drift pin: a long insertion-deletion-displacement sequence on a dilute interacting gas, incremental energies against a from-scratch recompute at a bound calibrated above the measured residue (maximum 3.1×10<sup>−11</sup> eV over 2×10<sup>4</sup> steps across four seeds; bound 5×10<sup>−10</sup>).
- (d) Cap inactivity: structural (`AtomisticIGRefGCNSParameters` carries no cap field at all) and observational (maximum recorded and live particle counts far below any bound on a seeded dilute run; observed maximum 15 against the asserted 50 across the calibration seeds).
- (e) Empty-walker persistence, shipped as the issue's documented-disclosure contingency: the save layer cannot represent a zero-atom frame (its writer fails converting an empty species table), pinned with a `@test_throws` so a save layer that learns empty frames surfaces here and the persistence testset can replace the pin.
- Every calibration protocol, seed set, and observed deviation is stated in the test-file header at the granularity the gates use.

Adversarially reviewed pre-PR in three charters (issue-promise round-trip, independent-oracle physics, determinism and assertion-delta accounting); must-fixes applied: the per-grid-point occupation gates the issue promised were added with per-point calibration, and the header ledger gained the cap-inactivity and effective-sample-size entries. The full test suite passes on the shipped bytes: the new testset adds 25 assertions to SamplingSchemes, reconciled against its loop arithmetic; suite-wide, AbstractWalkers 365, Energy Evaluation 346, Monte Carlo Moves 184, AbstractLiveSets 162, SamplingSchemes 7926, all other testsets at dev counts.
