### PR TITLE
Cross-architecture hardening for the continuous grand-canonical trajectory pins

### DIFF
--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -645,6 +645,10 @@
     # Corner z0V = 32.0, seeds {1,2,3,42423}: max devs mean 3.41e-1, var 1.11,
     #   A_ins 3.62e-3, A_del(conditioned) 5.9e-3.
     # Two-state n_max = 1 at z0V = 0.6, seeds {1,2,3,42424}: max dev f1 4.26e-3.
+    # The zero-interaction digit pin (seed 424242) is architecture-exact (every
+    # energy is exactly 0.0 eV, so no rounding enters the trajectory); the
+    # interacting pin (seed 424243) gates its energy at rtol 1e-12 to tolerate
+    # compiler-level rounding drift along the same trajectory.
     # Gates ship at >= 3x the max deviation per stat per corner. Off-by-one foil
     # sensitivity (exact birth-death mean at z0V = 0.5): shift +0.1778, so the
     # mean gate 0.012 detects it with ~15x headroom (asserted in-test).
@@ -865,7 +869,10 @@
             w2 = mkwalker()
             MC_grand_canonical_walk!(5000, w2, lj, 1.0e5u"eV"; z0V=4.0, species=:Ar, step_size=1.0)
             @test w2.list_num_par[1] == 4
-            @test ustrip(u"eV", w2.energy) == -0.0014312826195886537
+            # rtol 1e-12: tolerate compiler-level rounding drift along the same
+            # trajectory (observed stable across architectures at authoring); a
+            # stream or trajectory change fails loudly
+            @test isapprox(ustrip(u"eV", w2.energy), -0.0014312826195886537; rtol=1e-12)
         end
     end
 

--- a/test/test-SamplingSchemes/test-atomistic-gc-regressions.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gc-regressions.jl
@@ -2,11 +2,17 @@
 # grand-canonical route.
 #
 # Calibration ledger:
-# - (a) The canonical-ladder digit pins were recorded by running the identical
-#   fixture on dev @ 6b9d030 and on this change set's bytes: the two streams
-#   agree digit-for-digit (rows 60, last emax -0.024149711142342864 eV,
-#   live-energy sum -0.20617927437954883 eV, last log-compression
-#   -0.11778303565638351), so the pins lock the shared stream against drift.
+# - (a) The canonical-ladder pins were recorded by running the identical
+#   fixture on dev @ 6b9d030 and on that change set's bytes: the two streams
+#   agree digit-for-digit on one machine (rows 60, last emax
+#   -0.024149711142342864 eV, live-energy sum -0.20617927437954883 eV, last
+#   log-compression -0.11778303565638351). Across architectures and compiler
+#   versions the same trajectory reproduces these values only to the last one
+#   or two ulps (ubuntu-x64 under Julia 1.12 measured -0.024149711142342878
+#   against the macOS-aarch64 recording), so the pins gate at rtol 1e-12: a
+#   genuine stream change produces order-one deviations and still fails
+#   loudly, while compiler-level rounding drift along the same trajectory
+#   passes.
 # - (b) Ideal-gas pipeline (K = 512, z0V = 4, 50 requested steps stalling at 5,
 #   mu grid at target zV = {2.8, 4, 5.2}, seeds {1,2,3,81811}): per-point max
 #   devs logXi 0.063, mean_N {0.084, 0.139, 0.386}, var_N {0.142, 0.498, 1.518};
@@ -64,9 +70,11 @@
         df, lso, _ = nested_sampling(ls, p, 60, MCRandomWalkClone(), save)
         clean("ab")
         @test nrow(df) == 60
-        @test df.emax[end] == -0.024149711142342864
-        @test sum(ustrip(u"eV", w.energy) for w in lso.walkers) == -0.20617927437954883
-        @test df.log_compression[end] == -0.11778303565638351
+        # rtol 1e-12: tolerate compiler-level rounding drift along the same
+        # trajectory (see the calibration ledger); a stream change fails loudly
+        @test isapprox(df.emax[end], -0.024149711142342864; rtol=1e-12)
+        @test isapprox(sum(ustrip(u"eV", w.energy) for w in lso.walkers), -0.20617927437954883; rtol=1e-12)
+        @test isapprox(df.log_compression[end], -0.11778303565638351; rtol=1e-12)
     end
 
     @testset "end-to-end ideal-gas pipeline closes against the closed forms (seed 81811)" begin

--- a/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
@@ -4,12 +4,16 @@
 # - Initializer moments at K = 200, z0V = 3, seeds {1,2,3,52521}: max devs
 #   mean 0.25, var 0.339; gates ship at >= 3x (0.75 and 1.05).
 # - Tie-block fixture (seed 52530): eviction charges are DETERMINISTIC
-#   [log(5/6), log(4/5), log(3/4), log(2/3)] and the refilled live set is
-#   pinned to particle counts [2, 2, 2, 3, 3, 3]: the refill walks run the
-#   grand-canonical kernel, so refilled clones re-enter at different particle
-#   counts (the N-changing refill contract). Accepted clones are re-anchored
-#   by a from-scratch energy recompute, so refilled walkers carry genuinely
-#   negative energies (partial-well configurations), never rounding dust.
+#   [log(5/6), log(4/5), log(3/4), log(2/3)] (exact logs of integer ratios,
+#   architecture-exact). The refill outcome is trajectory-dependent and
+#   architecture-sensitive at the ulp level (macOS-aarch64 refilled to
+#   particle counts [2, 2, 2, 3, 3, 3]; ubuntu-x64 under Julia 1.12 to
+#   [2, 2, 2, 3, 4, 5]: rounding drift flips accept/reject decisions inside
+#   the refill walks), so the outcome asserts are trajectory-robust: the live
+#   set is restored to size, every walker sits genuinely below the plateau
+#   (negative energy, never rounding dust, thanks to the from-scratch
+#   re-anchoring of accepted clones), and at least one refilled clone
+#   re-entered at a different particle count (the N-changing refill contract).
 # - End-to-end determinism at K = 16, seed 52522: two runs digit-identical.
 @testset "atomistic ideal-gas-referenced GC-NS tests" begin
     using Random
@@ -125,8 +129,12 @@
         @test npars == [1, 1, 1, 1]
         @test length(ls.walkers) == 6
         @test params.plateau_refill_target == 0
-        @test sort([w.list_num_par[1] for w in ls.walkers]) == [2, 2, 2, 3, 3, 3]
+        # trajectory-robust refill asserts (the exact particle-count multiset is
+        # architecture-sensitive; see the calibration ledger)
         @test all(w.energy < 0.0u"eV" for w in ls.walkers)
+        @test any(w.list_num_par[1] != 2 for w in ls.walkers)
+        @test all(1 <= w.list_num_par[1] <= 8 for w in ls.walkers)
+        @test all(length(w.configuration) == w.list_num_par[1] for w in ls.walkers)
     end
 
     @testset "dilute interacting end-to-end with same-seed determinism" begin


### PR DESCRIPTION
Hardens the trajectory pins of the continuous grand-canonical round (#201, #203, #205) against cross-architecture floating-point drift, after the round's CI failed its ubuntu-x64 legs under Julia 1.12 and pre while passing macOS-aarch64 and LTS-x64. Test-only, one commit: `Cross-architecture hardening for the continuous grand-canonical trajectory pins.`

- Diagnosis: the pins were recorded on macOS-aarch64, and x64 code generation under Julia 1.12 reproduces the same trajectories only to the last one or two ulps (measured `-0.024149711142342878` against the recorded `-0.024149711142342864` on the canonical-ladder pin). Where the pinned quantity is a smooth accumulation, the drift stays in the last ulps; where it feeds accept/reject decisions, it cascades into a different but equally valid trajectory (the tie-block refill came out `[2, 2, 2, 3, 4, 5]` against the recorded `[2, 2, 2, 3, 3, 3]`).
- RNG-neutrality pins (the regression coverage): the three canonical-ladder value pins now gate at rtol 10<sup>−12</sup>, which tolerates compiler-level rounding drift along the same trajectory while a genuine stream change still fails by orders of magnitude; the row-count pin stays exact.
- Tie-block fixture (the ideal-gas-referenced sampler tests): the bit-exact eviction charge schedule and the per-eviction particle counts stay pinned exactly (exact logs of integer ratios, architecture-exact, and they passed on every CI leg); the refill-outcome multiset pin is replaced by trajectory-robust asserts, namely the live set restored to size, every walker genuinely below the plateau with negative energy, at least one refilled clone at a changed particle count (the N-changing refill contract), and configuration-count consistency.
- Kernel stream pins (the grand-canonical kernel tests): the zero-interaction pin is architecture-exact by construction (every energy is exactly zero, so no rounding enters the trajectory) and stays bitwise; the interacting pin's energy gates at rtol 10<sup>−12</sup> with its particle-count pin unchanged (observed stable across all CI legs at authoring).
- Nothing physics-bearing was touched: every statistical gate, closed-form weld, and calibration ledger is unchanged except for the recorded cross-architecture observations added to the three file headers.
- The concurrent docs-deploy failures on the round's PRs were a gh-pages push race between six simultaneous builds, not a content defect; the post-merge Documentation runs on dev succeeded.

The three touched testsets pass locally on the recording architecture (184, 47, and 25 assertions; the tie fixture gains two robust asserts); the decisive check is this PR's own ubuntu-x64 CI legs, which reproduce the environment the round failed on.
