### PR TITLE
Fix trajectory aliasing, null-move accounting, and phase seeding in the fixed-temperature Metropolis loops

### DIFF
--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -12,7 +12,9 @@ Parameters for the Metropolis Monte Carlo algorithm.
 - `step_size_up::Float64`: The upper bound of the step size.
 - `accept_range::Tuple{Float64, Float64}`: The range of acceptance rates for adjusting the step size.
 e.g. (0.25, 0.75) means that the step size will decrease if the acceptance rate is below 0.25 and increase if it is above 0.75.
-- `random_seed::Int64`: The seed for the random number generator.
+- `random_seed::Int64`: The seed for the random number generator. The `monte_carlo_sampling`
+drivers seed the equilibration phase with `random_seed` and the production phase with
+`random_seed + 1`, so the two phases never share a random stream.
 """
 mutable struct MetropolisMCParameters <: SamplingParameters
     temperatures::Vector{Float64}
@@ -173,7 +175,8 @@ function nvt_monte_carlo(
 
     current_walker = deepcopy(walker)
     current_energy = interacting_energy(current_walker.configuration, pot, current_walker.list_num_par, current_walker.frozen) + current_walker.energy_frozen_part
-    
+    current_walker.energy = current_energy
+
     for i in 1:num_steps
         proposed_walker = deepcopy(current_walker)
         # move the atoms by 1% of the average cell size
@@ -186,10 +189,15 @@ function nvt_monte_carlo(
         if ΔE < 0*e_unit || rand() < exp(-ΔE.val / (kb * temperature))
             current_walker.configuration = proposed_walker.configuration
             current_energy = proposed_energy
+            # Keep the walker's energy field in sync with the tracked energy,
+            # so stored snapshots carry the energy of their own configuration
+            current_walker.energy = current_energy
             accepted_steps += 1
         end
         energies[i] = current_energy
-        configurations[i] = current_walker
+        # Store an independent snapshot: storing the mutated walker itself
+        # would alias every recorded step to the final configuration
+        configurations[i] = deepcopy(current_walker)
     end
 
     return energies, configurations, accepted_steps
@@ -222,7 +230,10 @@ function nvt_monte_carlo(
         freq = [mc_routine.walks_freq, mc_routine.swaps_freq]
         swap_prob = freq[2] / sum(freq)
         proposed_walker = deepcopy(current_walker)
-        # Propose a move
+        # Propose a move: one channel draw per step, so every step performs
+        # exactly one move type (two independent draws would leave a
+        # walks_freq*swaps_freq-weighted channel where neither branch fires and
+        # the unchanged configuration is accepted at ΔE = 0 as a null move)
         if rand() > swap_prob
             config = proposed_walker.configuration
             free_index = free_par_index(proposed_walker)
@@ -233,7 +244,7 @@ function nvt_monte_carlo(
             pos = single_atom_random_walk!(pos, step_size)
             pos = periodic_boundary_wrap!(pos, config)
             config.position[i_at] = pos
-        elseif rand() <= swap_prob
+        else
             #println("Performing a swap move")
             config = proposed_walker.configuration
             free_comp = free_component_index(proposed_walker)
@@ -255,7 +266,9 @@ function nvt_monte_carlo(
             accepted_steps += 1
         end
         energies[i] = current_energy
-        configurations[i] = current_walker
+        # Store an independent snapshot: consecutive rejections would otherwise
+        # alias repeated entries to one mutable walker
+        configurations[i] = deepcopy(current_walker)
         # println(configurations[i])
     end
 
@@ -325,14 +338,16 @@ function monte_carlo_sampling(
         @info "Temperature: $temp K, Equilibration energy: $equi_mean, Variance: $(round(equi_var; sigdigits=4)), Acceptance rate: $(round(equi_rate; sigdigits=4))"
 
 
-        # Sample the lattice
+        # Sample the lattice. The production seed is derived from the
+        # equilibration seed (random_seed + 1): passing the same seed replays
+        # the equilibration random stream, correlating the two phases
         sampling_energies, sampling_configurations, sampling_accepted_steps = nvt_monte_carlo(
             mc_routine,
             equilibration_configurations[end],
             h,
             temp,
             mc_params.sampling_steps,
-            mc_params.random_seed
+            mc_params.random_seed + 1
         )
 
         # Compute the heat capacity
@@ -419,7 +434,9 @@ function monte_carlo_sampling(
 
         @info "Temperature: $temp K, Equilibration energy: $equi_mean, Variance: $(round(equi_var.val; sigdigits=4)), Acceptance rate: $(round(equi_rate; sigdigits=4)), Step size: $(round(mc_params.step_size; sigdigits=4))"
 
-        # Sample the lattice
+        # Sample the walker. The production seed is derived from the
+        # equilibration seed (random_seed + 1): passing the same seed replays
+        # the equilibration random stream, correlating the two phases
         sampling_energies, sampling_configurations, sampling_accepted_steps = nvt_monte_carlo(
             mc_routine,
             equilibration_configurations[end],
@@ -427,7 +444,7 @@ function monte_carlo_sampling(
             temp,
             mc_params.sampling_steps,
             mc_params.step_size,
-            mc_params.random_seed
+            mc_params.random_seed + 1
         )
 
         # Compute the heat capacity

--- a/test/test-SamplingSchemes/test-nvt_monte_carlo.jl
+++ b/test/test-SamplingSchemes/test-nvt_monte_carlo.jl
@@ -157,3 +157,97 @@ end
 
     end
 end
+@testset "NVT MC loop hardening (aliasing, null moves, phase seeding)" begin
+    # Shared fixture: a 4-atom periodic LJ walker in a 10 A cubic box.
+    # Calibration ledger: null-move surplus (accepted - changepoints)/n on
+    #   MCMixedMoves(5, 1), n = 2000, T = 300 K, seeds 777/778/779: measured
+    #   0.0435, 0.0380, 0.0435 (accepted identity swaps only; expectation
+    #   (1/6)*(1/4) ~ 0.042, binomial sigma ~ 0.0045). The historical
+    #   double-draw loop adds null moves at 5/36 ~ 0.139 on top, landing near
+    #   0.146. Gate: surplus <= 0.09, over 10 sigma above the measured band's
+    #   ceiling and over 12 sigma below the defect value.
+    hardening_box = [[10.0u"Å", 0u"Å", 0u"Å"],
+                     [0u"Å", 10.0u"Å", 0u"Å"],
+                     [0u"Å", 0u"Å", 10.0u"Å"]]
+    hardening_coords = [:H => [0.2, 0.2, 0.2], :H => [0.7, 0.3, 0.4],
+                        :H => [0.3, 0.7, 0.6], :H => [0.6, 0.6, 0.3]]
+    hardening_at = AtomWalker(FastSystem(periodic_system(hardening_coords, hardening_box, fractional=true)))
+    hardening_lj = LJParameters(epsilon=0.1, sigma=2.5, cutoff=3.0, shift=true)
+
+    # State-changing acceptances, counted from the stored snapshots
+    function count_changepoints(configs, at_start)
+        prev = at_start.configuration.position
+        n = 0
+        for c in configs
+            if c.configuration.position != prev
+                n += 1
+            end
+            prev = c.configuration.position
+        end
+        return n
+    end
+
+    @testset "Stored trajectory snapshots are independent (MCRandomWalkMaxE)" begin
+        energies, configs, accepted = nvt_monte_carlo(
+            MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, 300.0, 200, 0.4, 4242)
+        @test 0 < accepted < 200
+        # Distinct objects, not one aliased walker repeated
+        @test all(configs[i] !== configs[j] for i in 1:20 for j in (i + 1):20)
+        # The stored trajectory actually varies
+        @test any(configs[i].configuration.position != configs[end].configuration.position for i in 1:199)
+        # Each snapshot's energy field matches a from-scratch recompute of its
+        # own configuration (incremental-accumulation drift class)
+        for i in (1, 50, 100, 150, 200)
+            E_re = interacting_energy(configs[i].configuration, hardening_lj,
+                                      configs[i].list_num_par, configs[i].frozen) +
+                   configs[i].energy_frozen_part
+            @test isapprox(configs[i].energy, E_re; atol=1e-9u"eV")
+            @test configs[i].energy == energies[i]
+        end
+        # Walk-only path: every acceptance changes the configuration, exactly
+        @test accepted == count_changepoints(configs, hardening_at)
+    end
+
+    @testset "Null-move accounting (MCMixedMoves single channel draw)" begin
+        n_steps = 2000
+        energies, configs, accepted = nvt_monte_carlo(
+            MCMixedMoves(5, 1), deepcopy(hardening_at), hardening_lj, 300.0, n_steps, 0.4, 777)
+        # Accepted identity swaps (same atom drawn twice in the swap channel)
+        # are the only legal accepted-without-change steps; the historical
+        # double-draw loop added a 5/36 null-move channel on top. See the
+        # calibration ledger above.
+        surplus = (accepted - count_changepoints(configs, hardening_at)) / n_steps
+        @test 0.0 <= surplus <= 0.09
+        @test all(configs[i] !== configs[j] for i in 1:20 for j in (i + 1):20)
+        for i in (1, 1000, 2000)
+            @test configs[i].energy == energies[i]
+        end
+    end
+
+    @testset "Equilibration and production streams are independent" begin
+        # Lattice driver wiring: the production leg must reproduce an explicit
+        # nvt_monte_carlo call seeded with random_seed + 1 from the
+        # equilibration end configuration
+        lattice = SLattice{SquareLattice}(supercell_dimensions=(2, 2, 1), components=[[1, 2]])
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        seed = 4242
+        params = MetropolisMCParameters([300.0];
+            equilibrium_steps=60, sampling_steps=80, random_seed=seed)
+        d_energies, d_configs, d_cvs, d_rates = monte_carlo_sampling(MCNewSample(), lattice, ham, params)
+        eq_e, eq_c, eq_acc = nvt_monte_carlo(MCNewSample(), lattice, ham, 300.0, 60, seed)
+        pr_e, pr_c, pr_acc = nvt_monte_carlo(MCNewSample(), eq_c[end], ham, 300.0, 80, seed + 1)
+        @test d_energies[1] == mean(pr_e)
+        @test d_rates[1] == pr_acc / 80
+        # Atomistic driver: same-seed reproducibility end to end
+        p1 = MetropolisMCParameters([500.0];
+            equilibrium_steps=100, sampling_steps=100, step_size=0.3, random_seed=99)
+        p2 = MetropolisMCParameters([500.0];
+            equilibrium_steps=100, sampling_steps=100, step_size=0.3, random_seed=99)
+        e1, ls1, cv1, r1 = monte_carlo_sampling(MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, p1)
+        e2, ls2, cv2, r2 = monte_carlo_sampling(MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, p2)
+        @test e1 == e2
+        @test cv1 == cv2
+        @test r1 == r2
+        @test ls1.walkers[1].configuration.position == ls2.walkers[1].configuration.position
+    end
+end


### PR DESCRIPTION
Implements #207.

- Syncs the walker's energy field with the tracked energy and stores an independent snapshot per recorded step on both atomistic Metropolis paths, so the returned trajectory is a real trajectory rather than N references to the final configuration.
- Replaces the `MCMixedMoves` double channel draw with a single draw, so every step runs exactly one move type; the historical loop counted a walks_freq x swaps_freq weighted fraction of steps (about 13.9% at the documented `MCMixedMoves(5, 1)` construction) as accepted null moves.
- Seeds the production phase with `random_seed + 1` in both `monte_carlo_sampling` drivers, so production no longer replays the equilibration stream; documented on `MetropolisMCParameters`.
- Disclosure: the `MCMixedMoves` random stream changes; no digit pins exist on any fixed-temperature path (the suite gates same-seed A/B equality and structural properties only).
- Disclosure: the issue's instrumented-rerun equality is delivered as an exact changepoint equality on the walk-only path plus a calibrated changepoint-surplus gate on the mixed path (seeds 777/778/779, measured surplus 0.0435/0.0380/0.0435 against the defect value near 0.146, gate 0.09): accepted same-index swaps are legal accepted-without-change steps inherent to the shipped swap draw, so the surplus bounds them rather than eliminating them, and the promised low-temperature fixture is replaced by this sharper accounting identity.

Adversarially reviewed (issue-promise round-trip, independent-oracle physics, determinism and assertion accounting), and the full suite passes on the shipped bytes.
