### PR TITLE
Add overlap-aware periodic starting configurations

### DIFF
--- a/src/FreeBirdIO/FreeBirdIO.jl
+++ b/src/FreeBirdIO/FreeBirdIO.jl
@@ -352,27 +352,140 @@ function extract_free_par(walker::AtomWalker)
 end
 
 """
-    generate_random_starting_config(volume_per_particle::Float64, num_particle::Int; particle_type::Symbol=:H)
+    generate_random_starting_config(volume_per_particle::Float64, num_particle::Int;
+                                    particle_type::Symbol=:H,
+                                    periodicity::NTuple{3,Bool}=(false, false, false),
+                                    min_separation::Float64=0.0,
+                                    max_attempts::Int=1000)
 
 Generate a random starting configuration for a system of particles.
+
+Intended for Metropolis and grand-canonical Metropolis starting states and
+reference-run inputs. Nested-sampling live sets must remain i.i.d. draws from the
+sampling prior: a minimum-separation draw is not the uniform prior, and a
+non-prior initial live set biases the nested-sampling evidence (see the
+initialization note in `test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl`).
 
 # Arguments
 - `volume_per_particle::Float64`: The volume per particle.
 - `num_particle::Int`: The number of particles.
 - `particle_type::Symbol=:H`: The type of particle (default is hydrogen).
+- `periodicity::NTuple{3,Bool}=(false, false, false)`: Per-axis boundary
+  conditions of the generated system. The default keeps the historical
+  non-periodic behavior.
+- `min_separation::Float64=0.0`: Minimum pairwise separation in Å, enforced by
+  sequential insertion with per-particle retries. Distances are minimum-image on
+  periodic axes and plain Euclidean otherwise. The default performs no
+  separation screening and consumes exactly the historical random stream.
+- `max_attempts::Int=1000`: Retry budget per particle; exhaustion throws an
+  `ArgumentError` reporting the attempted packing fraction.
 
 # Returns
 - `FastSystem`: A FastSystem object representing the generated system.
 
 """
-function generate_random_starting_config(volume_per_particle::Float64, num_particle::Int; particle_type::Symbol=:H)
+function generate_random_starting_config(volume_per_particle::Float64, num_particle::Int;
+                                         particle_type::Symbol=:H,
+                                         periodicity::NTuple{3,Bool}=(false, false, false),
+                                         min_separation::Float64=0.0,
+                                         max_attempts::Int=1000)
     # generate random starting configuration
     total_volume = volume_per_particle * num_particle
     box_length = total_volume^(1/3)
     box = [[box_length, 0.0, 0.0], [0.0, box_length, 0.0], [0.0, 0.0, box_length]]u"Å"
-    boundary_conditions = (false, false, false)
-    list_of_atoms = [particle_type => [rand(), rand(), rand()] .* box_length * u"Å" for _ in 1:num_particle]
+    boundary_conditions = periodicity
+    placed = Vector{Vector{typeof(1.0u"Å")}}()
+    for _ in 1:num_particle
+        attempts = 0
+        while true
+            # Literal legacy draw: at min_separation = 0 the first candidate
+            # always passes, so the default path consumes exactly the
+            # historical stream and returns bit-identical configurations
+            candidate = [rand(), rand(), rand()] .* box_length * u"Å"
+            if min_separation <= 0.0 ||
+               _separation_ok(candidate, placed, box_length, periodicity, min_separation)
+                push!(placed, candidate)
+                break
+            end
+            attempts += 1
+            if attempts >= max_attempts
+                packing = (length(placed) + 1) * (π / 6) * min_separation^3 / total_volume
+                throw(ArgumentError(
+                    "sequential insertion failed after $max_attempts attempts at particle $(length(placed) + 1) of $num_particle " *
+                    "(attempted packing fraction $(round(packing; sigdigits=3)) at the $min_separation Å separation); " *
+                    "reduce min_separation or use generate_lattice_starting_config"))
+            end
+        end
+    end
+    list_of_atoms = [particle_type => placed[i] for i in 1:num_particle]
     system = atomic_system(list_of_atoms, box, boundary_conditions)
+    return FastSystem(system)
+end
+
+# Pairwise separation screen for sequential insertion: minimum-image on
+# periodic axes, plain Euclidean otherwise
+function _separation_ok(candidate, placed, box_length::Float64,
+                        periodicity::NTuple{3,Bool}, min_separation::Float64)
+    for p in placed
+        d2 = 0.0
+        for k in 1:3
+            δ = ustrip(u"Å", candidate[k] - p[k])
+            if periodicity[k]
+                δ -= box_length * round(δ / box_length)
+            end
+            d2 += δ^2
+        end
+        sqrt(d2) < min_separation && return false
+    end
+    return true
+end
+
+"""
+    generate_lattice_starting_config(box_length::Float64, num_particle::Int;
+                                     particle_type::Symbol=:H,
+                                     periodicity::NTuple{3,Bool}=(true, true, true),
+                                     jitter::Float64=0.0)
+
+Generate a starting configuration on a simple-cubic grid: the first
+`num_particle` cell-centered sites of the smallest grid containing them, with an
+optional uniform jitter of up to `jitter` Å per coordinate. Deterministic at
+`jitter = 0`. Covers densities beyond the sequential-insertion regime of
+`generate_random_starting_config` (dense-liquid and solid-like starts for
+Metropolis annealing); the pairwise separation is at least the grid spacing
+minus `2 √3 jitter`. The same nested-sampling scoping applies: this is not a
+prior draw and must not seed a nested-sampling live set.
+
+# Arguments
+- `box_length::Float64`: The cubic box edge in Å.
+- `num_particle::Int`: The number of particles.
+- `particle_type::Symbol=:H`: The type of particle.
+- `periodicity::NTuple{3,Bool}=(true, true, true)`: Per-axis boundary conditions.
+- `jitter::Float64=0.0`: Uniform per-coordinate displacement bound in Å.
+
+# Returns
+- `FastSystem`: A FastSystem object representing the generated system.
+
+"""
+function generate_lattice_starting_config(box_length::Float64, num_particle::Int;
+                                          particle_type::Symbol=:H,
+                                          periodicity::NTuple{3,Bool}=(true, true, true),
+                                          jitter::Float64=0.0)
+    num_particle > 0 || throw(ArgumentError("num_particle must be positive"))
+    box = [[box_length, 0.0, 0.0], [0.0, box_length, 0.0], [0.0, 0.0, box_length]]u"Å"
+    n_side = ceil(Int, cbrt(num_particle))
+    a = box_length / n_side
+    list_of_atoms = []
+    count = 0
+    for ix in 0:(n_side - 1), iy in 0:(n_side - 1), iz in 0:(n_side - 1)
+        count >= num_particle && break
+        pos = [(ix + 0.5) * a, (iy + 0.5) * a, (iz + 0.5) * a]
+        if jitter > 0.0
+            pos = pos .+ jitter .* (2 .* [rand(), rand(), rand()] .- 1)
+        end
+        push!(list_of_atoms, particle_type => pos .* u"Å")
+        count += 1
+    end
+    system = atomic_system(list_of_atoms, box, periodicity)
     return FastSystem(system)
 end
 

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -12,7 +12,9 @@ Parameters for the Metropolis Monte Carlo algorithm.
 - `step_size_up::Float64`: The upper bound of the step size.
 - `accept_range::Tuple{Float64, Float64}`: The range of acceptance rates for adjusting the step size.
 e.g. (0.25, 0.75) means that the step size will decrease if the acceptance rate is below 0.25 and increase if it is above 0.75.
-- `random_seed::Int64`: The seed for the random number generator.
+- `random_seed::Int64`: The seed for the random number generator. The `monte_carlo_sampling`
+drivers seed the equilibration phase with `random_seed` and the production phase with
+`random_seed + 1`, so the two phases never share a random stream.
 """
 mutable struct MetropolisMCParameters <: SamplingParameters
     temperatures::Vector{Float64}
@@ -173,7 +175,8 @@ function nvt_monte_carlo(
 
     current_walker = deepcopy(walker)
     current_energy = interacting_energy(current_walker.configuration, pot, current_walker.list_num_par, current_walker.frozen) + current_walker.energy_frozen_part
-    
+    current_walker.energy = current_energy
+
     for i in 1:num_steps
         proposed_walker = deepcopy(current_walker)
         # move the atoms by 1% of the average cell size
@@ -186,10 +189,15 @@ function nvt_monte_carlo(
         if ΔE < 0*e_unit || rand() < exp(-ΔE.val / (kb * temperature))
             current_walker.configuration = proposed_walker.configuration
             current_energy = proposed_energy
+            # Keep the walker's energy field in sync with the tracked energy,
+            # so stored snapshots carry the energy of their own configuration
+            current_walker.energy = current_energy
             accepted_steps += 1
         end
         energies[i] = current_energy
-        configurations[i] = current_walker
+        # Store an independent snapshot: storing the mutated walker itself
+        # would alias every recorded step to the final configuration
+        configurations[i] = deepcopy(current_walker)
     end
 
     return energies, configurations, accepted_steps
@@ -222,7 +230,10 @@ function nvt_monte_carlo(
         freq = [mc_routine.walks_freq, mc_routine.swaps_freq]
         swap_prob = freq[2] / sum(freq)
         proposed_walker = deepcopy(current_walker)
-        # Propose a move
+        # Propose a move: one channel draw per step, so every step performs
+        # exactly one move type (two independent draws would leave a
+        # walks_freq*swaps_freq-weighted channel where neither branch fires and
+        # the unchanged configuration is accepted at ΔE = 0 as a null move)
         if rand() > swap_prob
             config = proposed_walker.configuration
             free_index = free_par_index(proposed_walker)
@@ -233,7 +244,7 @@ function nvt_monte_carlo(
             pos = single_atom_random_walk!(pos, step_size)
             pos = periodic_boundary_wrap!(pos, config)
             config.position[i_at] = pos
-        elseif rand() <= swap_prob
+        else
             #println("Performing a swap move")
             config = proposed_walker.configuration
             free_comp = free_component_index(proposed_walker)
@@ -255,7 +266,9 @@ function nvt_monte_carlo(
             accepted_steps += 1
         end
         energies[i] = current_energy
-        configurations[i] = current_walker
+        # Store an independent snapshot: consecutive rejections would otherwise
+        # alias repeated entries to one mutable walker
+        configurations[i] = deepcopy(current_walker)
         # println(configurations[i])
     end
 
@@ -325,14 +338,16 @@ function monte_carlo_sampling(
         @info "Temperature: $temp K, Equilibration energy: $equi_mean, Variance: $(round(equi_var; sigdigits=4)), Acceptance rate: $(round(equi_rate; sigdigits=4))"
 
 
-        # Sample the lattice
+        # Sample the lattice. The production seed is derived from the
+        # equilibration seed (random_seed + 1): passing the same seed replays
+        # the equilibration random stream, correlating the two phases
         sampling_energies, sampling_configurations, sampling_accepted_steps = nvt_monte_carlo(
             mc_routine,
             equilibration_configurations[end],
             h,
             temp,
             mc_params.sampling_steps,
-            mc_params.random_seed
+            mc_params.random_seed + 1
         )
 
         # Compute the heat capacity
@@ -419,7 +434,9 @@ function monte_carlo_sampling(
 
         @info "Temperature: $temp K, Equilibration energy: $equi_mean, Variance: $(round(equi_var.val; sigdigits=4)), Acceptance rate: $(round(equi_rate; sigdigits=4)), Step size: $(round(mc_params.step_size; sigdigits=4))"
 
-        # Sample the lattice
+        # Sample the walker. The production seed is derived from the
+        # equilibration seed (random_seed + 1): passing the same seed replays
+        # the equilibration random stream, correlating the two phases
         sampling_energies, sampling_configurations, sampling_accepted_steps = nvt_monte_carlo(
             mc_routine,
             equilibration_configurations[end],
@@ -427,7 +444,7 @@ function monte_carlo_sampling(
             temp,
             mc_params.sampling_steps,
             mc_params.step_size,
-            mc_params.random_seed
+            mc_params.random_seed + 1
         )
 
         # Compute the heat capacity

--- a/test/test-FreeBirdIO.jl
+++ b/test/test-FreeBirdIO.jl
@@ -140,3 +140,84 @@
 
 
 end
+@testset "Overlap-aware periodic starting configurations" begin
+    # Minimum-image pairwise distance under the generated system's own metric
+    function _test_min_dist(sys)
+        L = ustrip(u"Å", cell_vectors(sys)[1][1])
+        pbc = periodicity(sys)
+        n = length(sys)
+        dmin = Inf
+        for i in 1:(n - 1), j in (i + 1):n
+            d2 = 0.0
+            for k in 1:3
+                δ = ustrip(u"Å", position(sys, i)[k] - position(sys, j)[k])
+                if pbc[k]
+                    δ -= L * round(δ / L)
+                end
+                d2 += δ^2
+            end
+            dmin = min(dmin, sqrt(d2))
+        end
+        return dmin
+    end
+
+    @testset "Default path is stream-neutral" begin
+        Random.seed!(31415)
+        sys_new = FreeBirdIO.generate_random_starting_config(100.0, 5)
+        Random.seed!(31415)
+        box_length = (100.0 * 5)^(1 / 3)
+        legacy_positions = [[rand(), rand(), rand()] .* box_length * u"Å" for _ in 1:5]
+        @test all(position(sys_new, i) == SVector{3}(legacy_positions[i]) for i in 1:5)
+        @test periodicity(sys_new) == (false, false, false)
+    end
+
+    @testset "Periodicity propagation" begin
+        sys = FreeBirdIO.generate_random_starting_config(100.0, 3; periodicity=(true, true, false))
+        @test periodicity(sys) == (true, true, false)
+        sys_p = FreeBirdIO.generate_random_starting_config(100.0, 3; periodicity=(true, true, true))
+        @test periodicity(sys_p) == (true, true, true)
+    end
+
+    @testset "Separation invariant at a dense point" begin
+        # 24 particles at 15.625 A^3 each (box 7.211 A): packing fraction 0.257
+        # at the 2.125 A separation, safely under the sequential-insertion regime
+        Random.seed!(2718)
+        sys = FreeBirdIO.generate_random_starting_config(15.625, 24;
+            periodicity=(true, true, true), min_separation=2.125, max_attempts=5000)
+        @test length(sys) == 24
+        @test _test_min_dist(sys) >= 2.125
+        Random.seed!(2718)
+        sys_m = FreeBirdIO.generate_random_starting_config(15.625, 24;
+            periodicity=(true, true, false), min_separation=2.125, max_attempts=5000)
+        @test _test_min_dist(sys_m) >= 2.125
+    end
+
+    @testset "Infeasible packing throws" begin
+        Random.seed!(1618)
+        @test_throws ArgumentError FreeBirdIO.generate_random_starting_config(15.625, 24;
+            periodicity=(true, true, true), min_separation=4.0, max_attempts=200)
+    end
+
+    @testset "Lattice starting configuration" begin
+        sys1 = FreeBirdIO.generate_lattice_starting_config(12.5, 100)
+        sys2 = FreeBirdIO.generate_lattice_starting_config(12.5, 100)
+        @test length(sys1) == 100
+        @test periodicity(sys1) == (true, true, true)
+        # deterministic at jitter = 0
+        @test all(position(sys1, i) == position(sys2, i) for i in 1:100)
+        # separation bound: at least the grid spacing (100 sites on a 5^3 grid)
+        @test _test_min_dist(sys1) >= 12.5 / 5 - 1e-9
+        # partial fill keeps the bound
+        sys3 = FreeBirdIO.generate_lattice_starting_config(12.5, 30)
+        @test length(sys3) == 30
+        @test _test_min_dist(sys3) >= 12.5 / ceil(Int, cbrt(30)) - 1e-9
+        # jitter: seeded reproducibility and the documented separation bound
+        Random.seed!(999)
+        sysj1 = FreeBirdIO.generate_lattice_starting_config(12.5, 100; jitter=0.2)
+        Random.seed!(999)
+        sysj2 = FreeBirdIO.generate_lattice_starting_config(12.5, 100; jitter=0.2)
+        @test all(position(sysj1, i) == position(sysj2, i) for i in 1:100)
+        @test _test_min_dist(sysj1) >= 12.5 / 5 - 2 * sqrt(3) * 0.2 - 1e-9
+        @test_throws ArgumentError FreeBirdIO.generate_lattice_starting_config(12.5, 0)
+    end
+end

--- a/test/test-SamplingSchemes/test-nvt_monte_carlo.jl
+++ b/test/test-SamplingSchemes/test-nvt_monte_carlo.jl
@@ -157,3 +157,97 @@ end
 
     end
 end
+@testset "NVT MC loop hardening (aliasing, null moves, phase seeding)" begin
+    # Shared fixture: a 4-atom periodic LJ walker in a 10 A cubic box.
+    # Calibration ledger: null-move surplus (accepted - changepoints)/n on
+    #   MCMixedMoves(5, 1), n = 2000, T = 300 K, seeds 777/778/779: measured
+    #   0.0435, 0.0380, 0.0435 (accepted identity swaps only; expectation
+    #   (1/6)*(1/4) ~ 0.042, binomial sigma ~ 0.0045). The historical
+    #   double-draw loop adds null moves at 5/36 ~ 0.139 on top, landing near
+    #   0.146. Gate: surplus <= 0.09, over 10 sigma above the measured band's
+    #   ceiling and over 12 sigma below the defect value.
+    hardening_box = [[10.0u"Å", 0u"Å", 0u"Å"],
+                     [0u"Å", 10.0u"Å", 0u"Å"],
+                     [0u"Å", 0u"Å", 10.0u"Å"]]
+    hardening_coords = [:H => [0.2, 0.2, 0.2], :H => [0.7, 0.3, 0.4],
+                        :H => [0.3, 0.7, 0.6], :H => [0.6, 0.6, 0.3]]
+    hardening_at = AtomWalker(FastSystem(periodic_system(hardening_coords, hardening_box, fractional=true)))
+    hardening_lj = LJParameters(epsilon=0.1, sigma=2.5, cutoff=3.0, shift=true)
+
+    # State-changing acceptances, counted from the stored snapshots
+    function count_changepoints(configs, at_start)
+        prev = at_start.configuration.position
+        n = 0
+        for c in configs
+            if c.configuration.position != prev
+                n += 1
+            end
+            prev = c.configuration.position
+        end
+        return n
+    end
+
+    @testset "Stored trajectory snapshots are independent (MCRandomWalkMaxE)" begin
+        energies, configs, accepted = nvt_monte_carlo(
+            MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, 300.0, 200, 0.4, 4242)
+        @test 0 < accepted < 200
+        # Distinct objects, not one aliased walker repeated
+        @test all(configs[i] !== configs[j] for i in 1:20 for j in (i + 1):20)
+        # The stored trajectory actually varies
+        @test any(configs[i].configuration.position != configs[end].configuration.position for i in 1:199)
+        # Each snapshot's energy field matches a from-scratch recompute of its
+        # own configuration (incremental-accumulation drift class)
+        for i in (1, 50, 100, 150, 200)
+            E_re = interacting_energy(configs[i].configuration, hardening_lj,
+                                      configs[i].list_num_par, configs[i].frozen) +
+                   configs[i].energy_frozen_part
+            @test isapprox(configs[i].energy, E_re; atol=1e-9u"eV")
+            @test configs[i].energy == energies[i]
+        end
+        # Walk-only path: every acceptance changes the configuration, exactly
+        @test accepted == count_changepoints(configs, hardening_at)
+    end
+
+    @testset "Null-move accounting (MCMixedMoves single channel draw)" begin
+        n_steps = 2000
+        energies, configs, accepted = nvt_monte_carlo(
+            MCMixedMoves(5, 1), deepcopy(hardening_at), hardening_lj, 300.0, n_steps, 0.4, 777)
+        # Accepted identity swaps (same atom drawn twice in the swap channel)
+        # are the only legal accepted-without-change steps; the historical
+        # double-draw loop added a 5/36 null-move channel on top. See the
+        # calibration ledger above.
+        surplus = (accepted - count_changepoints(configs, hardening_at)) / n_steps
+        @test 0.0 <= surplus <= 0.09
+        @test all(configs[i] !== configs[j] for i in 1:20 for j in (i + 1):20)
+        for i in (1, 1000, 2000)
+            @test configs[i].energy == energies[i]
+        end
+    end
+
+    @testset "Equilibration and production streams are independent" begin
+        # Lattice driver wiring: the production leg must reproduce an explicit
+        # nvt_monte_carlo call seeded with random_seed + 1 from the
+        # equilibration end configuration
+        lattice = SLattice{SquareLattice}(supercell_dimensions=(2, 2, 1), components=[[1, 2]])
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        seed = 4242
+        params = MetropolisMCParameters([300.0];
+            equilibrium_steps=60, sampling_steps=80, random_seed=seed)
+        d_energies, d_configs, d_cvs, d_rates = monte_carlo_sampling(MCNewSample(), lattice, ham, params)
+        eq_e, eq_c, eq_acc = nvt_monte_carlo(MCNewSample(), lattice, ham, 300.0, 60, seed)
+        pr_e, pr_c, pr_acc = nvt_monte_carlo(MCNewSample(), eq_c[end], ham, 300.0, 80, seed + 1)
+        @test d_energies[1] == mean(pr_e)
+        @test d_rates[1] == pr_acc / 80
+        # Atomistic driver: same-seed reproducibility end to end
+        p1 = MetropolisMCParameters([500.0];
+            equilibrium_steps=100, sampling_steps=100, step_size=0.3, random_seed=99)
+        p2 = MetropolisMCParameters([500.0];
+            equilibrium_steps=100, sampling_steps=100, step_size=0.3, random_seed=99)
+        e1, ls1, cv1, r1 = monte_carlo_sampling(MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, p1)
+        e2, ls2, cv2, r2 = monte_carlo_sampling(MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, p2)
+        @test e1 == e2
+        @test cv1 == cv2
+        @test r1 == r2
+        @test ls1.walkers[1].configuration.position == ls2.walkers[1].configuration.position
+    end
+end


### PR DESCRIPTION
Implements #208.

- `generate_random_starting_config` gains `periodicity`, `min_separation`, and `max_attempts` keywords: sequential insertion with a per-particle retry against a minimum-image (periodic axes) or Euclidean (open axes) separation screen, throwing an `ArgumentError` that reports the attempted packing fraction on exhaustion.
- The default path keeps the literal legacy draw expression and consumes exactly the historical random stream, returning bit-identical configurations (asserted against a seeded hand-rolled replica).
- New sibling `generate_lattice_starting_config`: the first N cell-centered sites of the smallest simple-cubic grid, optional uniform jitter, deterministic at zero jitter, for densities beyond the sequential-insertion regime.
- Both docstrings scope the generators to Metropolis and grand-canonical Metropolis starts and reference runs: nested-sampling live sets must remain i.i.d. prior draws, and a minimum-separation draw is not the uniform prior.

Adversarially reviewed (issue-promise round-trip, independent-oracle physics, determinism and assertion accounting), and the full suite passes on the shipped bytes.
