### PR TITLE
Add a grand-canonical Metropolis sampling driver

### DIFF
--- a/src/AbstractPotentials/lennardjones.jl
+++ b/src/AbstractPotentials/lennardjones.jl
@@ -118,3 +118,19 @@ Compute the energy of a pair of particles separated by distance `r` using the Le
 
 """
 pair_energy(r::typeof(1.0u"Å"), lj::LJParameters) = lj_energy(r, lj)
+"""
+    _max_interaction_range(pot)
+
+Maximum pair-interaction range of a potential, as a Unitful length, for
+minimum-image sanity checks: `cutoff * sigma` for `LJParameters` (infinite for
+the untruncated default), the maximum over the entries of a
+`CompositeParameterSets`, and `missing` for potentials whose range the library
+cannot determine (the check is then skipped).
+"""
+_max_interaction_range(lj::LJParameters) = lj.cutoff * lj.sigma
+_max_interaction_range(::AbstractPotential) = missing
+function _max_interaction_range(cps::CompositeParameterSets)
+    ranges = [_max_interaction_range(p) for p in cps.param_sets]
+    any(r === missing for r in ranges) && return missing
+    return maximum(ranges)
+end

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -467,6 +467,11 @@ size `(length(μs), length(Ts))`, indexed `[i_μ, i_T]`:
   follows as `C = k_B β² (var_U − μ · cov_UN)`, matching the Ω-sorted
   `gc_thermodynamic_stats` formula.
 - `cov_UN`: Energy–particle-number covariance ⟨EN⟩ − ⟨E⟩⟨N⟩.
+- `p_N`: `Array{Float64,3}` indexed `[i_μ, i_T, i_N]`, the particle-number
+  distribution P(N | μ, T) over `N_support`; a support member no sample visited
+  carries exactly 0.0 (a convergence diagnostic, not physics).
+- `N_support`: `UnitRange{Int}` `0:N_max` over the union of dead rows and the
+  live tail, indexing the third axis of `p_N`.
 - `observables`: `Dict{Symbol,Matrix{Float64}}` mapping each requested
   column to its reweighted average ⟨A⟩(μ, T); empty when no columns are
   requested.
@@ -585,6 +590,12 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     E_shift = isempty(Es) ? 0.0 : minimum(Es)
     Es_c = Es .- E_shift
 
+    # Particle-number support for P(N | mu, T): a support member no sample
+    # visited keeps exactly 0.0 (a convergence diagnostic, not physics)
+    N_int_pn = Int.(Ns)
+    N_max_pn = isempty(N_int_pn) ? 0 : maximum(N_int_pn)
+    N_support = 0:N_max_pn
+
     log_prior_mass = n_sites * log1p(z0)
     log_z0 = log(z0)
 
@@ -599,6 +610,7 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     cov_UN = Matrix{Float64}(undef, n_mu, n_T)
     obs_out = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
+    p_N = Array{Float64,3}(undef, n_mu, n_T, N_max_pn + 1)
 
     Threads.@threads for j in 1:n_T
         β = 1.0 / (kb * Ts[j])
@@ -620,11 +632,17 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                 obs_out[col][i, j] = sum(ws .* As[col]) / sum_w
             end
             N_eff[i, j] = sum_w^2 / sum(abs2, ws)
+            acc_pn = zeros(Float64, N_max_pn + 1)
+            @inbounds for k_pn in eachindex(N_int_pn)
+                acc_pn[N_int_pn[k_pn] + 1] += ws[k_pn]
+            end
+            p_N[i, j, :] .= acc_pn ./ sum_w
         end
     end
 
     return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff,
-            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
+            var_U=var_U, cov_UN=cov_UN, p_N=p_N, N_support=N_support,
+            observables=obs_out)
 end
 
 
@@ -697,8 +715,10 @@ follow-up item and out of scope here.
 # Returns
 A `NamedTuple` with the same shape as the lattice method: `logXi`, `mean_N`, `var_N`,
 `mean_U`, `N_eff`, `var_U`, `cov_UN` (each a `Matrix{Float64}` of size
-`(length(μ_grid), length(T_grid))`, indexed `[i_μ, i_T]`), and `observables`
-(`Dict{Symbol,Matrix{Float64}}`). The returned moments are configurational: beyond the
+`(length(μ_grid), length(T_grid))`, indexed `[i_μ, i_T]`), `p_N` (an
+`Array{Float64,3}` indexed `[i_μ, i_T, i_N]`, the particle-number distribution
+P(N | μ, T) over `N_support::UnitRange{Int}`, with exactly 0.0 on support
+members no sample visited), and `observables` (`Dict{Symbol,Matrix{Float64}}`). The returned moments are configurational: beyond the
 Λ(T)³ activity conversion this reduction carries no momentum integral, so
 temperature-derivative observables built from it (heat capacities) must add the Λ(T)
 term explicitly, exactly as for `gc_thermodynamic_stats_fixed_N`.
@@ -812,6 +832,12 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     E_shift = isempty(Es) ? 0.0 : minimum(Es)
     Es_c = Es .- E_shift
 
+    # Particle-number support for P(N | mu, T): a support member no sample
+    # visited keeps exactly 0.0 (a convergence diagnostic, not physics)
+    N_int_pn = Int.(Ns)
+    N_max_pn = isempty(N_int_pn) ? 0 : maximum(N_int_pn)
+    N_support = 0:N_max_pn
+
     z0V = ustrip(Unitful.NoUnits, reference_activity * V)
     log_z0 = log(ustrip(u"Å^-3", reference_activity))
 
@@ -826,6 +852,7 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     cov_UN = Matrix{Float64}(undef, n_mu, n_T)
     obs_out = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
+    p_N = Array{Float64,3}(undef, n_mu, n_T, N_max_pn + 1)
 
     Threads.@threads for j in 1:n_T
         T_K = ustrip(u"K", T_grid[j])
@@ -850,11 +877,17 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                 obs_out[col][i, j] = sum(ws .* As[col]) / sum_w
             end
             N_eff[i, j] = sum_w^2 / sum(abs2, ws)
+            acc_pn = zeros(Float64, N_max_pn + 1)
+            @inbounds for k_pn in eachindex(N_int_pn)
+                acc_pn[N_int_pn[k_pn] + 1] += ws[k_pn]
+            end
+            p_N[i, j, :] .= acc_pn ./ sum_w
         end
     end
 
     return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff,
-            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
+            var_U=var_U, cov_UN=cov_UN, p_N=p_N, N_support=N_support,
+            observables=obs_out)
 end
 
 
@@ -1107,8 +1140,8 @@ does not cancel.
 
 # Returns
 A `NamedTuple` `(Xi, mean_N, var_N, mean_U, logXi, var_U, cov_UN, log_Z_N,
-N_values, observables)`; the first four fields keep their historical leading
-positions. `Xi`, `mean_N`, `var_N`, `mean_U`, `logXi`, `var_U`, and `cov_UN`
+N_values, p_N, N_support, observables)`; the first four fields keep their
+historical leading positions. `Xi`, `mean_N`, `var_N`, `mean_U`, `logXi`, `var_U`, and `cov_UN`
 are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))` indexed
 `[i_μ, i_T]`. `Xi` is the absolute grand partition function in linear space —
 `Inf` once `ln Ξ` exceeds ≈ 709; `logXi`, its log-space companion, stays
@@ -1129,7 +1162,10 @@ functions `log Z_N(T) = log Z_NS^{(N)}(β) + N·log(V/Λ³) − log N!` — the
 μ-independent evidence the assembly is built from — and `N_values` echoes the
 particle counts (as `Vector{Int}`) indexing its rows; the particle-number
 distribution follows as `P(N | μ, T) ∝ exp.(log_Z_N[:, j] .+ β .* μ .* N_values)`,
-normalized over the supplied sectors. `observables` is a
+normalized over the supplied sectors, and is returned ready-made as `p_N`
+(`Array{Float64,3}` indexed `[i_μ, i_T, i_N]`) over `N_support::Vector{Int}`,
+the sorted sector list (a vector, not a range: the fixed-N routes accept
+non-contiguous sectors). `observables` is a
 `Dict{Symbol,Matrix{Float64}}` mapping each requested column to ⟨A⟩(μ, T);
 empty when no columns are requested. No Kish effective sample size is
 returned: the fixed-`N` route introduces no importance reweighting (`μ`
@@ -1293,6 +1329,10 @@ function gc_thermodynamic_stats_fixed_N(
     obs_out = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
+    perm_pn = sortperm(N_int)
+    N_support = N_int[perm_pn]
+    p_N = Array{Float64,3}(undef, n_mu, n_T, length(N_int))
+
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
         Λ_val = ustrip(u"Å", _thermal_wavelength(atomic_mass, T))
@@ -1326,12 +1366,14 @@ function gc_thermodynamic_stats_fixed_N(
             for col in observable_cols
                 obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
             end
+            p_N[k, j, :] .= (ws ./ sum_w)[perm_pn]
         end
     end
 
     return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
             logXi=logXi, var_U=var_U, cov_UN=cov_UN,
-            log_Z_N=log_Z_N, N_values=N_int, observables=obs_out)
+            log_Z_N=log_Z_N, N_values=N_int, p_N=p_N, N_support=N_support,
+            observables=obs_out)
 end
 
 """
@@ -1427,7 +1469,9 @@ in length or convergence.
 
 # Returns
 A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values, var_U,
-cov_UN, observables)`. The first
+cov_UN, p_N, N_support, observables)`; `p_N` (`Array{Float64,3}` indexed
+`[i_μ, i_T, i_N]`) is the particle-number distribution over
+`N_support::Vector{Int}`, the sorted sector list. The first
 four fields are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))`
 indexed `[i_μ, i_T]`. `logXi` is the natural log of the absolute grand
 partition function — returned in log space (the atomistic method returns
@@ -1594,6 +1638,10 @@ function gc_thermodynamic_stats_fixed_N(
     obs_out = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
+    perm_pn = sortperm(N_int)
+    N_support = N_int[perm_pn]
+    p_N = Array{Float64,3}(undef, n_mu, n_T, length(N_int))
+
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
         for (k, μ) in enumerate(μ_grid)
@@ -1620,12 +1668,14 @@ function gc_thermodynamic_stats_fixed_N(
             for col in observable_cols
                 obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
             end
+            p_N[k, j, :] .= (ws ./ sum_w)[perm_pn]
         end
     end
 
     return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
             log_Z_N=log_Z_NS .+ log_binom, N_values=N_int,
-            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
+            var_U=var_U, cov_UN=cov_UN, p_N=p_N, N_support=N_support,
+            observables=obs_out)
 end
 
 

--- a/src/FreeBirdIO/FreeBirdIO.jl
+++ b/src/FreeBirdIO/FreeBirdIO.jl
@@ -352,27 +352,140 @@ function extract_free_par(walker::AtomWalker)
 end
 
 """
-    generate_random_starting_config(volume_per_particle::Float64, num_particle::Int; particle_type::Symbol=:H)
+    generate_random_starting_config(volume_per_particle::Float64, num_particle::Int;
+                                    particle_type::Symbol=:H,
+                                    periodicity::NTuple{3,Bool}=(false, false, false),
+                                    min_separation::Float64=0.0,
+                                    max_attempts::Int=1000)
 
 Generate a random starting configuration for a system of particles.
+
+Intended for Metropolis and grand-canonical Metropolis starting states and
+reference-run inputs. Nested-sampling live sets must remain i.i.d. draws from the
+sampling prior: a minimum-separation draw is not the uniform prior, and a
+non-prior initial live set biases the nested-sampling evidence (see the
+initialization note in `test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl`).
 
 # Arguments
 - `volume_per_particle::Float64`: The volume per particle.
 - `num_particle::Int`: The number of particles.
 - `particle_type::Symbol=:H`: The type of particle (default is hydrogen).
+- `periodicity::NTuple{3,Bool}=(false, false, false)`: Per-axis boundary
+  conditions of the generated system. The default keeps the historical
+  non-periodic behavior.
+- `min_separation::Float64=0.0`: Minimum pairwise separation in Å, enforced by
+  sequential insertion with per-particle retries. Distances are minimum-image on
+  periodic axes and plain Euclidean otherwise. The default performs no
+  separation screening and consumes exactly the historical random stream.
+- `max_attempts::Int=1000`: Retry budget per particle; exhaustion throws an
+  `ArgumentError` reporting the attempted packing fraction.
 
 # Returns
 - `FastSystem`: A FastSystem object representing the generated system.
 
 """
-function generate_random_starting_config(volume_per_particle::Float64, num_particle::Int; particle_type::Symbol=:H)
+function generate_random_starting_config(volume_per_particle::Float64, num_particle::Int;
+                                         particle_type::Symbol=:H,
+                                         periodicity::NTuple{3,Bool}=(false, false, false),
+                                         min_separation::Float64=0.0,
+                                         max_attempts::Int=1000)
     # generate random starting configuration
     total_volume = volume_per_particle * num_particle
     box_length = total_volume^(1/3)
     box = [[box_length, 0.0, 0.0], [0.0, box_length, 0.0], [0.0, 0.0, box_length]]u"Å"
-    boundary_conditions = (false, false, false)
-    list_of_atoms = [particle_type => [rand(), rand(), rand()] .* box_length * u"Å" for _ in 1:num_particle]
+    boundary_conditions = periodicity
+    placed = Vector{Vector{typeof(1.0u"Å")}}()
+    for _ in 1:num_particle
+        attempts = 0
+        while true
+            # Literal legacy draw: at min_separation = 0 the first candidate
+            # always passes, so the default path consumes exactly the
+            # historical stream and returns bit-identical configurations
+            candidate = [rand(), rand(), rand()] .* box_length * u"Å"
+            if min_separation <= 0.0 ||
+               _separation_ok(candidate, placed, box_length, periodicity, min_separation)
+                push!(placed, candidate)
+                break
+            end
+            attempts += 1
+            if attempts >= max_attempts
+                packing = (length(placed) + 1) * (π / 6) * min_separation^3 / total_volume
+                throw(ArgumentError(
+                    "sequential insertion failed after $max_attempts attempts at particle $(length(placed) + 1) of $num_particle " *
+                    "(attempted packing fraction $(round(packing; sigdigits=3)) at the $min_separation Å separation); " *
+                    "reduce min_separation or use generate_lattice_starting_config"))
+            end
+        end
+    end
+    list_of_atoms = [particle_type => placed[i] for i in 1:num_particle]
     system = atomic_system(list_of_atoms, box, boundary_conditions)
+    return FastSystem(system)
+end
+
+# Pairwise separation screen for sequential insertion: minimum-image on
+# periodic axes, plain Euclidean otherwise
+function _separation_ok(candidate, placed, box_length::Float64,
+                        periodicity::NTuple{3,Bool}, min_separation::Float64)
+    for p in placed
+        d2 = 0.0
+        for k in 1:3
+            δ = ustrip(u"Å", candidate[k] - p[k])
+            if periodicity[k]
+                δ -= box_length * round(δ / box_length)
+            end
+            d2 += δ^2
+        end
+        sqrt(d2) < min_separation && return false
+    end
+    return true
+end
+
+"""
+    generate_lattice_starting_config(box_length::Float64, num_particle::Int;
+                                     particle_type::Symbol=:H,
+                                     periodicity::NTuple{3,Bool}=(true, true, true),
+                                     jitter::Float64=0.0)
+
+Generate a starting configuration on a simple-cubic grid: the first
+`num_particle` cell-centered sites of the smallest grid containing them, with an
+optional uniform jitter of up to `jitter` Å per coordinate. Deterministic at
+`jitter = 0`. Covers densities beyond the sequential-insertion regime of
+`generate_random_starting_config` (dense-liquid and solid-like starts for
+Metropolis annealing); the pairwise separation is at least the grid spacing
+minus `2 √3 jitter`. The same nested-sampling scoping applies: this is not a
+prior draw and must not seed a nested-sampling live set.
+
+# Arguments
+- `box_length::Float64`: The cubic box edge in Å.
+- `num_particle::Int`: The number of particles.
+- `particle_type::Symbol=:H`: The type of particle.
+- `periodicity::NTuple{3,Bool}=(true, true, true)`: Per-axis boundary conditions.
+- `jitter::Float64=0.0`: Uniform per-coordinate displacement bound in Å.
+
+# Returns
+- `FastSystem`: A FastSystem object representing the generated system.
+
+"""
+function generate_lattice_starting_config(box_length::Float64, num_particle::Int;
+                                          particle_type::Symbol=:H,
+                                          periodicity::NTuple{3,Bool}=(true, true, true),
+                                          jitter::Float64=0.0)
+    num_particle > 0 || throw(ArgumentError("num_particle must be positive"))
+    box = [[box_length, 0.0, 0.0], [0.0, box_length, 0.0], [0.0, 0.0, box_length]]u"Å"
+    n_side = ceil(Int, cbrt(num_particle))
+    a = box_length / n_side
+    list_of_atoms = []
+    count = 0
+    for ix in 0:(n_side - 1), iy in 0:(n_side - 1), iz in 0:(n_side - 1)
+        count >= num_particle && break
+        pos = [(ix + 0.5) * a, (iy + 0.5) * a, (iz + 0.5) * a]
+        if jitter > 0.0
+            pos = pos .+ jitter .* (2 .* [rand(), rand(), rand()] .- 1)
+        end
+        push!(list_of_atoms, particle_type => pos .* u"Å")
+        count += 1
+    end
+    system = atomic_system(list_of_atoms, box, periodicity)
     return FastSystem(system)
 end
 

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -29,6 +29,7 @@ export random_microstate!
 export lattice_insert_particle!, lattice_delete_particle!
 export lattice_biased_sites
 export MC_grand_canonical_walk!
+export MC_muVT_walk!
 
 export free_component_index, free_par_index
 

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -1300,3 +1300,146 @@ function MC_grand_canonical_walk!(n_steps::Int,
             insert_attempted=insert_attempted, insert_accepted=insert_accepted,
             delete_attempted=delete_attempted, delete_accepted=delete_accepted)
 end
+"""
+    MC_muVT_walk!(n_steps::Int, at::AtomWalker{1}, pot::SingleComponentPotential{Pairwise},
+                  temperature::Float64;
+                  zV::Float64, species, p_move::Float64=0.5, p_insert::Float64=0.25,
+                  step_size::Float64=0.5, kb::Float64=8.617333262e-5)
+
+Perform a fixed-temperature grand-canonical (μVT) Metropolis walk on a continuous-space
+`AtomWalker{1}`: single-atom displacements under the Boltzmann acceptance
+min(1, e^(-βΔU)), mixed with uniform-in-cell insertions and uniform-among-particles
+deletions under min(1, ratio × e^(-βΔU)), where the ratio is the volume-and-activity
+form of `gc_insert_acceptance_ratio`/`gc_delete_acceptance_ratio` (pre-move particle
+count in both) and ΔU is the post-minus-pre energy change of the proposed move in every
+channel. The fixed-temperature sibling of the nested-sampling kernel above, sharing its
+entry validation, guard-skip discipline, incremental `single_site_energy` path,
+insert-evaluate-revert bookkeeping, and `move_stats` schema; the athermal energy ceiling
+is replaced by the Boltzmann factor, and the dimensionless activity-volume
+`zV = e^(βμ) V / Λ(T)^3` is folded by the caller, mirroring the z0V convention (the
+kernel itself never sees μ or Λ).
+
+Draw discipline: one channel draw per step; the Metropolis uniform is drawn only when
+the combined acceptance factor is below one (for displacements, only when ΔU > 0).
+An insertion landing exactly on a particle (a NaN pair energy) rejects without
+drawing; a +Inf overlap energy underflows the Boltzmann factor to a combined
+factor of exactly zero and rejects through the ordinary draw.
+
+# Arguments
+- `n_steps::Int`: The number of Monte Carlo steps to perform.
+- `at::AtomWalker{1}`: The walker to evolve; a single unfrozen component.
+- `pot::SingleComponentPotential{Pairwise}`: The pairwise potential.
+- `temperature::Float64`: The temperature in Kelvin; must be positive.
+- `zV::Float64`: Dimensionless product of the target activity and the cell volume.
+- `species`: Chemical identity (a `Symbol` or `ChemicalSpecies`) of inserted particles.
+- `p_move::Float64=0.5`: Probability of a displacement move.
+- `p_insert::Float64=0.25`: Probability of an insertion move (deletion takes the remainder).
+- `step_size::Float64=0.5`: Maximum displacement per direction, in Angstrom.
+- `kb::Float64=8.617333262e-5`: The Boltzmann constant in eV/K.
+
+# Returns
+- `at::AtomWalker{1}`: The updated walker.
+- `accept_rate::Float64`: Fraction of accepted moves over `n_steps`.
+- `move_stats::NamedTuple`: Per-move-type attempt/accept counters
+  (`move_*`, `insert_*`, `delete_*`); attempts are counted at proposal, guard skips
+  excluded.
+"""
+function MC_muVT_walk!(n_steps::Int,
+                       at::AtomWalker{1},
+                       pot::SingleComponentPotential{Pairwise},
+                       temperature::Float64;
+                       zV::Float64,
+                       species::Union{Symbol, ChemicalSpecies},
+                       p_move::Float64=0.5,
+                       p_insert::Float64=0.25,
+                       step_size::Float64=0.5,
+                       kb::Float64=8.617333262e-5)
+    if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
+        throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+    end
+    if zV <= 0.0
+        throw(ArgumentError("zV must be positive"))
+    end
+    if temperature <= 0.0
+        throw(ArgumentError("temperature must be positive"))
+    end
+    if any(at.frozen)
+        throw(ArgumentError("the muVT kernel requires an unfrozen single-component walker"))
+    end
+    config = at.configuration
+    cellv = cell_vectors(config)
+    for i in 1:3, j in 1:3
+        if i != j && !iszero(ustrip(cellv[i][j]))
+            throw(ArgumentError("the muVT kernel assumes an orthorhombic cell (consistent with pbc_dist); found a nonzero off-diagonal cell component"))
+        end
+    end
+    box = (cellv[1][1], cellv[2][2], cellv[3][3])
+
+    β = 1.0 / (kb * temperature)
+    n_accept = 0
+    p_delete = 1.0 - p_move - p_insert
+    move_attempted = 0
+    move_accepted = 0
+    insert_attempted = 0
+    insert_accepted = 0
+    delete_attempted = 0
+    delete_accepted = 0
+
+    for _ in 1:n_steps
+        r = rand()
+        n = at.list_num_par[1]
+        if r < p_move
+            # Displacement: Boltzmann acceptance; uniform drawn only for uphill moves
+            n == 0 && continue          # guard skip: nothing to move
+            move_attempted += 1
+            i_at = rand(1:n)
+            prewalk_energy = single_site_energy(i_at, config, pot, at.list_num_par)
+            orig_pos::SVector{3, typeof(0.0u"Å")} = position(config, i_at)
+            pos = single_atom_random_walk!(orig_pos, step_size)
+            pos = periodic_boundary_wrap!(pos, config)
+            config.position[i_at] = pos
+            dU = ustrip(u"eV", single_site_energy(i_at, config, pot, at.list_num_par) - prewalk_energy)
+            if dU <= 0.0 || (isfinite(dU) && rand() < exp(-β * dU))
+                at.energy = at.energy + dU * u"eV"
+                n_accept += 1
+                move_accepted += 1
+            else
+                config.position[i_at] = orig_pos
+            end
+        elseif r < p_move + p_insert
+            # Insertion: uniform in the cell, insert-evaluate-revert
+            p_insert <= 0.0 && continue   # guard skip
+            insert_attempted += 1
+            pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])
+            insert_particle!(at, pos, species)
+            e_site = ustrip(u"eV", single_site_energy(n + 1, config, pot, at.list_num_par))
+            combined = gc_insert_acceptance_ratio(zV, n, p_insert, p_delete) * exp(-β * e_site)
+            if combined >= 1.0 || (isfinite(combined) && rand() < combined)
+                at.energy = at.energy + e_site * u"eV"
+                n_accept += 1
+                insert_accepted += 1
+            else
+                remove_particle!(at, n + 1)
+            end
+        else
+            # Deletion: uniform among particles; nothing mutates until acceptance
+            (n == 0 || p_delete <= 0.0) && continue          # guard skip
+            delete_attempted += 1
+            i_at = rand(1:n)
+            e_site = ustrip(u"eV", single_site_energy(i_at, config, pot, at.list_num_par))
+            # ΔU = -e_site, so the Boltzmann factor is e^(+β e_site)
+            combined = gc_delete_acceptance_ratio(zV, n, p_insert, p_delete) * exp(β * e_site)
+            if combined >= 1.0 || (isfinite(combined) && rand() < combined)
+                remove_particle!(at, i_at)
+                at.energy = at.energy - e_site * u"eV"
+                n_accept += 1
+                delete_accepted += 1
+            end
+        end
+    end
+
+    return at, n_accept / max(n_steps, 1),
+           (move_attempted=move_attempted, move_accepted=move_accepted,
+            insert_attempted=insert_attempted, insert_accepted=insert_accepted,
+            delete_attempted=delete_attempted, delete_accepted=delete_accepted)
+end

--- a/src/SamplingSchemes/SamplingSchemes.jl
+++ b/src/SamplingSchemes/SamplingSchemes.jl
@@ -32,6 +32,7 @@ export NestedSamplingParameters
 export LatticeNestedSamplingParameters
 export WangLandauParameters
 export MetropolisMCParameters
+export MuVTMCParameters
 
 # nested sampling related functions
 export sort_by_energy!, nested_sampling_step!
@@ -72,6 +73,7 @@ include("nested_sampling.jl")
 include("exact_enumeration.jl")
 
 include("nvt_monte_carlo.jl")
+include("muvt_monte_carlo.jl")
 
 include("wang_landau.jl")
 

--- a/src/SamplingSchemes/muvt_monte_carlo.jl
+++ b/src/SamplingSchemes/muvt_monte_carlo.jl
@@ -1,0 +1,199 @@
+"""
+    MuVTMCParameters <: SamplingParameters
+
+Parameters for fixed-temperature grand-canonical (μVT) Metropolis sampling of
+continuous atomistic walkers through `MC_muVT_walk!`.
+
+# Fields
+- `temperatures::Vector{Float64}`: The temperature ladder, in Kelvin.
+- `activity_volumes::Vector{Float64}`: The dimensionless activity-volume zV per
+  temperature (`zV = e^(βμ) V / Λ(T)^3`, folded by the caller exactly as the
+  kernel documents; the driver never sees μ or Λ). Must match `temperatures` in
+  length: at fixed μ the activity is temperature-dependent, so each rung carries
+  its own value.
+- `equilibrium_steps::Int64`: Kernel steps of equilibration per temperature, run
+  in ten equal adaptation blocks (documented contract: step-size adjustment acts
+  between blocks on the displacement-only acceptance rate of the block).
+- `sampling_steps::Int64`: Kernel steps of production per temperature, with the
+  step size frozen (adapting during production breaks detailed balance).
+- `sampling_interval::Int64`: Kernel steps between recorded samples.
+- `step_size::Float64`: Displacement step size (Angstrom; mutable runtime state).
+- `step_size_lo::Float64`: Lower bound for the step-size adjustment.
+- `step_size_up::Float64`: Upper bound for the step-size adjustment.
+- `accept_range::Tuple{Float64,Float64}`: Acceptance window for the adjustment.
+- `random_seed::Int64`: Base seed. Temperature rung `i` seeds equilibration with
+  `random_seed + 2(i-1)` and production with `random_seed + 2(i-1) + 1`, so no
+  two phases share a random stream.
+"""
+mutable struct MuVTMCParameters <: SamplingParameters
+    temperatures::Vector{Float64}
+    activity_volumes::Vector{Float64}
+    equilibrium_steps::Int64
+    sampling_steps::Int64
+    sampling_interval::Int64
+    step_size::Float64
+    step_size_lo::Float64
+    step_size_up::Float64
+    accept_range::Tuple{Float64,Float64}
+    random_seed::Int64
+    function MuVTMCParameters(temperatures, activity_volumes;
+                              equilibrium_steps::Int64=10_000,
+                              sampling_steps::Int64=50_000,
+                              sampling_interval::Int64=10,
+                              step_size::Float64=0.5,
+                              step_size_lo::Float64=0.01,
+                              step_size_up::Float64=2.0,
+                              accept_range::Tuple{Float64,Float64}=(0.25, 0.75),
+                              random_seed::Int64=1234)
+        if length(temperatures) != length(activity_volumes)
+            throw(ArgumentError("temperatures and activity_volumes must have the same length"))
+        end
+        if any(t -> t <= 0.0, temperatures) || any(z -> z <= 0.0, activity_volumes)
+            throw(ArgumentError("temperatures and activity_volumes must be positive"))
+        end
+        if sampling_interval <= 0 || equilibrium_steps < 0 || sampling_steps <= 0
+            throw(ArgumentError("equilibrium_steps must be non-negative and sampling_steps, sampling_interval positive"))
+        end
+        new(collect(Float64, temperatures), collect(Float64, activity_volumes),
+            equilibrium_steps, sampling_steps, sampling_interval,
+            step_size, step_size_lo, step_size_up, accept_range, random_seed)
+    end
+end
+
+"""
+    monte_carlo_sampling(mc_routine::MCAtomGrandCanonicalMoves,
+                         at::AtomWalker{1},
+                         pot::SingleComponentPotential{Pairwise},
+                         mc_params::MuVTMCParameters;
+                         kb::Float64=8.617333262e-5)
+
+Fixed-temperature grand-canonical (μVT) Metropolis sampling over a temperature
+ladder, wrapping `MC_muVT_walk!`. The routine supplies the channel split
+(`p_move`, `p_insert`); its nested-sampling-only fields (`step_rate_source`,
+`mc_steps_per_particle`) are not consumed here. Per temperature rung:
+equilibration in ten adaptation blocks (step size adjusted between blocks on the
+displacement-only rate; a block that attempted no displacement skips the
+adjustment), then production with the step size frozen, recording the particle
+count every `sampling_interval` kernel steps and re-anchoring the walker's
+incremental energy with a from-scratch `interacting_energy` recompute every ten
+recorded samples. Phase seeding follows the documented per-rung law of
+`MuVTMCParameters.random_seed`. The final walker of each rung starts the next
+(sequential annealing over the ladder); the entry check warns once when the
+potential's finite interaction range exceeds half the smallest cell edge.
+
+# Returns
+A `NamedTuple` of per-temperature results:
+- `mean_N::Vector{Float64}`, `var_N::Vector{Float64}`: Particle-number moments.
+- `mean_U::Vector{Float64}`: Mean total interaction energy, in eV.
+- `p_N::Vector{Vector{Float64}}`, `N_support::Vector{UnitRange{Int}}`: The
+  recorded particle-number histogram per rung, normalized, over `0:N_max`.
+- `N_series::Vector{Vector{Int}}`: The recorded particle-number series per rung
+  (the cross-check artifact; its length is `sampling_steps ÷ sampling_interval`).
+- `acceptance::Vector{NamedTuple}`: Production per-channel attempt/accept
+  counters per rung (the kernel's `move_stats` schema).
+- `walkers::Vector{AtomWalker}`: An independent copy of the final walker per rung.
+"""
+function monte_carlo_sampling(mc_routine::MCAtomGrandCanonicalMoves,
+                              at::AtomWalker{1},
+                              pot::SingleComponentPotential{Pairwise},
+                              mc_params::MuVTMCParameters;
+                              kb::Float64=8.617333262e-5)
+    _warn_min_image_cutoff(pot, at.configuration)
+    sp = _walker_species(at)
+    n_T = length(mc_params.temperatures)
+    mean_N = Vector{Float64}(undef, n_T)
+    var_N = Vector{Float64}(undef, n_T)
+    mean_U = Vector{Float64}(undef, n_T)
+    p_N = Vector{Vector{Float64}}(undef, n_T)
+    N_support = Vector{UnitRange{Int}}(undef, n_T)
+    N_series = Vector{Vector{Int}}(undef, n_T)
+    acceptance = Vector{NamedTuple}(undef, n_T)
+    walkers = Vector{typeof(at)}(undef, n_T)
+
+    walker = deepcopy(at)
+    for (i, temp) in enumerate(mc_params.temperatures)
+        zV = mc_params.activity_volumes[i]
+        # Equilibration: ten adaptation blocks, displacement-only rate
+        Random.seed!(mc_params.random_seed + 2 * (i - 1))
+        block = mc_params.equilibrium_steps ÷ 10
+        for _ in 1:10
+            block == 0 && break
+            _, _, stats = MC_muVT_walk!(block, walker, pot, temp;
+                                        zV=zV, species=sp,
+                                        p_move=mc_routine.p_move,
+                                        p_insert=mc_routine.p_insert,
+                                        step_size=mc_params.step_size, kb=kb)
+            if stats.move_attempted > 0
+                adjust_step_size(mc_params, stats.move_accepted / stats.move_attempted;
+                                 range=mc_params.accept_range)
+            end
+        end
+        # Production: step size frozen, recording every sampling_interval steps
+        Random.seed!(mc_params.random_seed + 2 * (i - 1) + 1)
+        n_rec = mc_params.sampling_steps ÷ mc_params.sampling_interval
+        ns = Vector{Int}(undef, n_rec)
+        e_sum = 0.0
+        att = Dict{Symbol,Int}()
+        for k in 1:n_rec
+            _, _, stats = MC_muVT_walk!(mc_params.sampling_interval, walker, pot, temp;
+                                        zV=zV, species=sp,
+                                        p_move=mc_routine.p_move,
+                                        p_insert=mc_routine.p_insert,
+                                        step_size=mc_params.step_size, kb=kb)
+            ns[k] = walker.list_num_par[1]
+            e_sum += ustrip(u"eV", walker.energy)
+            for (key, val) in pairs(stats)
+                att[key] = get(att, key, 0) + val
+            end
+            if k % 10 == 0
+                # Re-anchor the incremental energy from scratch
+                walker.energy = interacting_energy(walker.configuration, pot,
+                    walker.list_num_par, walker.frozen) + walker.energy_frozen_part
+            end
+        end
+        mean_N[i] = mean(ns)
+        var_N[i] = var(ns)
+        mean_U[i] = e_sum / n_rec
+        n_max = maximum(ns)
+        hist = zeros(Float64, n_max + 1)
+        for n in ns
+            hist[n + 1] += 1.0
+        end
+        p_N[i] = hist ./ n_rec
+        N_support[i] = 0:n_max
+        N_series[i] = ns
+        acceptance[i] = (move_attempted=get(att, :move_attempted, 0),
+                        move_accepted=get(att, :move_accepted, 0),
+                        insert_attempted=get(att, :insert_attempted, 0),
+                        insert_accepted=get(att, :insert_accepted, 0),
+                        delete_attempted=get(att, :delete_attempted, 0),
+                        delete_accepted=get(att, :delete_accepted, 0))
+        walkers[i] = deepcopy(walker)
+        @info "muVT MC T = $temp K, zV = $zV: <N> = $(round(mean_N[i]; sigdigits=5)), var(N) = $(round(var_N[i]; sigdigits=5)), <U> = $(round(mean_U[i]; sigdigits=5)) eV, step size = $(round(mc_params.step_size; sigdigits=4))"
+    end
+
+    return (mean_N=mean_N, var_N=var_N, mean_U=mean_U, p_N=p_N,
+            N_support=N_support, N_series=N_series, acceptance=acceptance,
+            walkers=walkers)
+end
+
+# Chemical identity for insertions, resolved once at driver entry: an empty
+# single-component walker carries no species record, so sampling must start
+# from a non-empty walker (mid-run empty states are fine; the identity is
+# already fixed by then)
+function _walker_species(walker::AtomWalker{1})
+    if length(walker.configuration) == 0
+        throw(ArgumentError("muVT sampling requires a non-empty starting walker (an empty single-component walker carries no species record)"))
+    end
+    return species(walker.configuration, 1)
+end
+
+# Catch-all for the common mistake of omitting the routine, mirroring the
+# Metropolis guard (whose params annotation cannot fire for this params type)
+function monte_carlo_sampling(system, potential_or_hamiltonian, mc_params::MuVTMCParameters; kwargs...)
+    throw(ArgumentError(
+        "`monte_carlo_sampling` requires an `MCRoutine` as the first argument.\n" *
+        "For muVT sampling, use `MCAtomGrandCanonicalMoves()`.\n" *
+        "Example: monte_carlo_sampling(MCAtomGrandCanonicalMoves(), walker, potential, params)"
+    ))
+end

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -480,7 +480,9 @@ function update_iter!(liveset::AbstractLiveSet)
     end
 end
 
-const _RESERVED_LEDGER_COLUMNS = (:iter, :emax, :omega, :energy, :num_particles, :log_compression)
+const _RESERVED_LEDGER_COLUMNS = (:iter, :emax, :omega, :energy, :num_particles, :log_compression,
+                                  :move_attempted, :move_accepted, :insert_attempted,
+                                  :insert_accepted, :delete_attempted, :delete_accepted)
 
 """
     _validate_observables(observables, liveset::AbstractLiveSet)
@@ -2019,16 +2021,44 @@ are a known hazard class.
 # Fields
 - `p_move::Float64`: Probability of a displacement move.
 - `p_insert::Float64`: Probability of an insertion move (deletion takes the remainder).
+- `step_rate_source::Symbol`: Which acceptance rate drives the step-size
+  adjustment. `:mixed` (the default) keeps the historical behavior, adapting on
+  the kernel's combined rate over all three channels; `:move` adapts on the
+  displacement-only rate from the walk's per-channel counters, so a collapsing
+  insertion or deletion acceptance in a dense interacting system cannot drag the
+  displacement step size down against a healthy displacement channel (adjustment
+  is skipped when a walk attempted no displacement).
+- `mc_steps_per_particle::Float64`: Extra kernel steps per parent particle: a
+  decorrelation walk for a parent at particle count N runs
+  `mc_steps + round(Int, mc_steps_per_particle * N)` steps, restoring per-sweep
+  decorrelation as the count grows. The default 0.0 is draw-count identical to
+  the historical fixed-length walk.
 """
 struct MCAtomGrandCanonicalMoves <: MCRoutine
     p_move::Float64
     p_insert::Float64
-    function MCAtomGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25)
+    step_rate_source::Symbol
+    mc_steps_per_particle::Float64
+    function MCAtomGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25,
+                                       step_rate_source::Symbol=:mixed,
+                                       mc_steps_per_particle::Float64=0.0)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
         end
-        new(p_move, p_insert)
+        if !(step_rate_source in (:mixed, :move))
+            throw(ArgumentError("step_rate_source must be :mixed or :move"))
+        end
+        if !(mc_steps_per_particle >= 0.0)
+            throw(ArgumentError("mc_steps_per_particle must be non-negative"))
+        end
+        new(p_move, p_insert, step_rate_source, mc_steps_per_particle)
     end
+end
+
+# Number of kernel steps for a decorrelation walk whose parent carries n_par
+# particles (see `MCAtomGrandCanonicalMoves.mc_steps_per_particle`)
+function _gc_walk_length(params::SamplingParameters, mc_routine::MCAtomGrandCanonicalMoves, n_par::Int)
+    return params.mc_steps + round(Int, mc_routine.mc_steps_per_particle * n_par)
 end
 
 """
@@ -2053,11 +2083,19 @@ enter a run; both enter only in the post-run reduction to Ξ(μ, T).
   step-size adjustment.
 - `fail_count::Int64`: Consecutive failed replacements.
 - `allowed_fail_count::Int64`: Maximum consecutive failures before the driver's stall
-  contract fires (see `ideal_gas_referenced_nested_sampling`).
+  contract fires (see `ideal_gas_referenced_nested_sampling`). The default (100,
+  matching the canonical atomistic loop) suits interacting descents, where a run of
+  failed replacements is an ordinary sampling hiccup rather than a terminal state.
 - `plateau_refill_target::Int64`: Live-set size to restore after a plateau eviction
   block (mutable runtime state; reset at driver entry).
+- `refill_fail_budget::Int64`: Failure budget for one plateau-refill loop. The default
+  0 keeps the historical behavior of charging refill failures against
+  `allowed_fail_count` cumulatively; a positive value gives each refill loop its own
+  budget, so recovering from one difficult plateau block cannot permanently shrink
+  the live set within the stall budget.
 - `move_stats::Dict{Symbol,Int}`: Run-total per-move-type attempt/accept counters
-  accumulated from every decorrelation walk (cleared once at run start).
+  accumulated from every ordinary-cull decorrelation walk (cleared once at run
+  start; plateau-refill walks are not accumulated).
 
 Three fields carried by sibling parameter structs are deliberately absent. No `n_max`:
 the reference measure has unbounded particle-number support, and a cap silently
@@ -2080,6 +2118,7 @@ mutable struct AtomisticIGRefGCNSParameters <: SamplingParameters
     fail_count::Int64
     allowed_fail_count::Int64
     plateau_refill_target::Int64
+    refill_fail_budget::Int64
     move_stats::Dict{Symbol,Int}
 end
 
@@ -2087,8 +2126,8 @@ end
     AtomisticIGRefGCNSParameters(;
         mc_steps=100, reference_activity=0.01u"Å^-3", species=:H,
         initial_step_size=0.5, step_size=0.5, step_size_lo=0.01, step_size_up=2.0,
-        accept_range=(0.25, 0.75), fail_count=0, allowed_fail_count=10,
-        plateau_refill_target=0, move_stats=Dict{Symbol,Int}())
+        accept_range=(0.25, 0.75), fail_count=0, allowed_fail_count=100,
+        plateau_refill_target=0, refill_fail_budget=0, move_stats=Dict{Symbol,Int}())
 
 Convenience constructor for `AtomisticIGRefGCNSParameters`. `reference_activity` (z0)
 must be positive; choose it so z0V sits near the particle-number range of interest, as
@@ -2105,18 +2144,50 @@ function AtomisticIGRefGCNSParameters(;
     step_size_up::Float64=2.0,
     accept_range::Tuple{Float64,Float64}=(0.25, 0.75),
     fail_count::Int64=0,
-    allowed_fail_count::Int64=10,
+    allowed_fail_count::Int64=100,
     plateau_refill_target::Int64=0,
+    refill_fail_budget::Int64=0,
     move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
 )
     if reference_activity <= 0.0u"Å^-3"
         throw(ArgumentError("reference_activity must be positive"))
     end
+    if refill_fail_budget < 0
+        throw(ArgumentError("refill_fail_budget must be non-negative (0 charges refill failures against allowed_fail_count)"))
+    end
     AtomisticIGRefGCNSParameters(
         mc_steps, reference_activity, species,
         initial_step_size, step_size, step_size_lo, step_size_up, accept_range,
-        fail_count, allowed_fail_count, plateau_refill_target, move_stats,
+        fail_count, allowed_fail_count, plateau_refill_target, refill_fail_budget, move_stats,
     )
+end
+
+# Per-iteration acceptance-ledger columns (order matters: it is the ledger
+# schema order when `record_move_rates=true`)
+const _MOVE_RATE_COLUMNS = (:move_attempted, :move_accepted, :insert_attempted,
+                            :insert_accepted, :delete_attempted, :delete_accepted)
+
+_move_stats_snapshot(params::SamplingParameters) =
+    Tuple(get(params.move_stats, k, 0) for k in _MOVE_RATE_COLUMNS)
+
+"""
+    _warn_min_image_cutoff(pot, config)
+
+Warn once when a potential's finite interaction range exceeds half the smallest
+cell edge of `config`: minimum-image truncation is anisotropic in that regime.
+An infinite range never warns (an untruncated minimum-image Hamiltonian is a
+deliberate model choice), and potentials of undeterminable range are skipped.
+"""
+function _warn_min_image_cutoff(pot, config)
+    rng = AbstractPotentials._max_interaction_range(pot)
+    rng === missing && return nothing
+    isfinite(ustrip(rng)) || return nothing
+    cellv = cell_vectors(config)
+    L_min = min(ustrip(u"Å", cellv[1][1]), ustrip(u"Å", cellv[2][2]), ustrip(u"Å", cellv[3][3]))
+    if ustrip(u"Å", rng) > L_min / 2
+        @warn "The potential's interaction range ($(round(ustrip(u"Å", rng); sigdigits=4)) Å) exceeds half the smallest cell edge ($(round(L_min / 2; sigdigits=4)) Å): minimum-image truncation is anisotropic in this regime."
+    end
+    return nothing
 end
 
 """
@@ -2233,9 +2304,11 @@ function nested_sampling_step!(liveset::AtomWalkers,
             # decorrelating strictly below the plateau energy with the
             # grand-canonical kernel (volume-neutral; no ledger row).
             refill_fails = 0
-            while length(ats) < params.plateau_refill_target && refill_fails < params.allowed_fail_count
+            refill_budget = params.refill_fail_budget > 0 ? params.refill_fail_budget : params.allowed_fail_count
+            while length(ats) < params.plateau_refill_target && refill_fails < refill_budget
+                at_r = deepcopy(rand(ats))
                 accept_r, _, at_r, _ = MC_grand_canonical_walk!(
-                    params.mc_steps, deepcopy(rand(ats)), pot, emax;
+                    _gc_walk_length(params, mc_routine, at_r.list_num_par[1]), at_r, pot, emax;
                     z0V=z0V, species=params.species,
                     p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
                     step_size=params.step_size)
@@ -2256,6 +2329,9 @@ function nested_sampling_step!(liveset::AtomWalkers,
             length(ats) < params.plateau_refill_target && @warn "Plateau refill left the live set at $(length(ats)) of $(params.plateau_refill_target) walkers after $(refill_fails) failed decorrelation attempts; subsequent culls are charged with the actual live count."
             params.plateau_refill_target = 0
         end
+        # Step-size adaptation and move-stats accumulation stay off inside
+        # plateau blocks by design: refill walks run under a fixed plateau
+        # ceiling, and their acceptance is not representative of ordinary culls
         return iter, emax, num_particles, liveset, params, log_t
     end
     # Ordinary cull: strictly-below-ceiling parent selection, mirroring the
@@ -2264,7 +2340,7 @@ function nested_sampling_step!(liveset::AtomWalkers,
     parent_idx = isempty(eligible) ? rand(2:n_live) : rand(eligible)
     to_walk = deepcopy(ats[parent_idx])
     accept, rate, to_walk, move_stats = MC_grand_canonical_walk!(
-        params.mc_steps, to_walk, pot, emax;
+        _gc_walk_length(params, mc_routine, to_walk.list_num_par[1]), to_walk, pot, emax;
         z0V=z0V, species=params.species,
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         step_size=params.step_size)
@@ -2287,7 +2363,16 @@ function nested_sampling_step!(liveset::AtomWalkers,
         params.fail_count += 1
     end
     _accumulate_move_stats!(params, move_stats)
-    adjust_step_size(params, rate; range=params.accept_range)
+    if mc_routine.step_rate_source === :move
+        # Displacement-only adaptation: skip when the walk attempted no
+        # displacement (nothing to adapt on)
+        if move_stats.move_attempted > 0
+            adjust_step_size(params, move_stats.move_accepted / move_stats.move_attempted;
+                             range=params.accept_range)
+        end
+    else
+        adjust_step_size(params, rate; range=params.accept_range)
+    end
     return iter, emax, num_particles, liveset, params, log_t
 end
 
@@ -2316,14 +2401,28 @@ that cannot be accepted. A fully degenerate live set (every configuration at exa
 energy, the zero-interaction limit) is a legitimate terminal state whose entire prior
 mass sits in the live set; the subsequent ledger reduction is then exact. With
 `stop_on_stall=false` the driver keeps the warn-and-continue contract of the sibling
-loops (the failure counter is reset and the loop continues).
+loops (the failure counter is reset, the step size is reset to
+`params.initial_step_size` following the canonical loop's contract, and the loop
+continues).
+
+With `record_move_rates=true` the ledger gains the per-iteration acceptance columns
+`[:move_attempted, :move_accepted, :insert_attempted, :insert_accepted,
+:delete_attempted, :delete_accepted]`, recorded as the change in the run-total
+counters since the previous recorded row: the production diagnostic for how the
+per-channel acceptances evolve with descent depth. A recorded row therefore also
+carries the attempts of any failed replacements since the previous row;
+plateau-eviction rows run no decorrelation walk of their own, and refill-walk
+counters are deliberately not accumulated. The recorded columns sum exactly to
+the `move_stats` run totals accumulated through the last recorded row. The names are reserved ledger columns, rejected as
+observable names.
 
 Observable callbacks must handle empty configurations: under this construction a
 walker's particle count may be zero.
 
 # Returns
-- `df::DataFrame`: Columns `[:iter, :emax, :num_particles, :log_compression]`, plus one
-  column per requested observable. Zero-accept runs return the schema with no rows.
+- `df::DataFrame`: Columns `[:iter, :emax, :num_particles, :log_compression]`, plus the
+  acceptance columns when requested, plus one column per requested observable.
+  Zero-accept runs return the schema with no rows.
 - `liveset::AtomWalkers`: The final liveset (surviving walkers).
 - `params::AtomisticIGRefGCNSParameters`: Updated parameters.
 """
@@ -2334,8 +2433,10 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
                                               save_strategy::DataSavingStrategy;
                                               observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
                                               dead_point_callback::Union{Nothing,Function}=nothing,
-                                              stop_on_stall::Bool=true)
+                                              stop_on_stall::Bool=true,
+                                              record_move_rates::Bool=false)
     z0V = _atomistic_igref_z0V(liveset, params)
+    _warn_min_image_cutoff(liveset.potential, liveset.walkers[1].configuration)
     _init_atomistic_igref_walkers!(liveset, params, z0V)
 
     # Parameter-reuse hazards: runtime state never leaks between runs
@@ -2344,6 +2445,11 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
     empty!(params.move_stats)
 
     df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[], log_compression=Float64[])
+    if record_move_rates
+        for name in _MOVE_RATE_COLUMNS
+            df[!, name] = Int[]
+        end
+    end
     if observables !== nothing
         _validate_observables(observables, liveset)
         for (name, _) in observables
@@ -2352,6 +2458,7 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
     end
     culled = nothing
     empty_frame_warned = false
+    rate_prev = record_move_rates ? _move_stats_snapshot(params) : nothing
 
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
@@ -2382,8 +2489,9 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
                 @warn "Atomistic IG-ref GC-NS: $(params.allowed_fail_count) consecutive failed replacements; returning the partial ledger and the intact live set (stop_on_stall=true)."
                 break
             else
-                @warn "Atomistic IG-ref GC-NS: Failed $(params.allowed_fail_count) times in a row."
+                @warn "Atomistic IG-ref GC-NS: Failed $(params.allowed_fail_count) times in a row. Reset step size!"
                 params.fail_count = 0
+                params.step_size = params.initial_step_size
             end
         end
 
@@ -2394,10 +2502,17 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
                     "pairing lost (step culled a walker with energy $emax, " *
                     "but the pre-sorted worst walker had $(culled.energy))")
             end
-            if observables === nothing
-                push!(df, (iter, emax.val, n_par, log_t))
+            if record_move_rates
+                snap = _move_stats_snapshot(params)
+                rate_row = snap .- rate_prev
+                rate_prev = snap
             else
-                push!(df, (iter, emax.val, n_par, log_t,
+                rate_row = ()
+            end
+            if observables === nothing
+                push!(df, (iter, emax.val, n_par, log_t, rate_row...))
+            else
+                push!(df, (iter, emax.val, n_par, log_t, rate_row...,
                            (Float64(f(culled.configuration)) for (_, f) in observables)...))
             end
             dead_point_callback === nothing || dead_point_callback(iter, culled)

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -12,7 +12,9 @@ Parameters for the Metropolis Monte Carlo algorithm.
 - `step_size_up::Float64`: The upper bound of the step size.
 - `accept_range::Tuple{Float64, Float64}`: The range of acceptance rates for adjusting the step size.
 e.g. (0.25, 0.75) means that the step size will decrease if the acceptance rate is below 0.25 and increase if it is above 0.75.
-- `random_seed::Int64`: The seed for the random number generator.
+- `random_seed::Int64`: The seed for the random number generator. The `monte_carlo_sampling`
+drivers seed the equilibration phase with `random_seed` and the production phase with
+`random_seed + 1`, so the two phases never share a random stream.
 """
 mutable struct MetropolisMCParameters <: SamplingParameters
     temperatures::Vector{Float64}
@@ -173,7 +175,8 @@ function nvt_monte_carlo(
 
     current_walker = deepcopy(walker)
     current_energy = interacting_energy(current_walker.configuration, pot, current_walker.list_num_par, current_walker.frozen) + current_walker.energy_frozen_part
-    
+    current_walker.energy = current_energy
+
     for i in 1:num_steps
         proposed_walker = deepcopy(current_walker)
         # move the atoms by 1% of the average cell size
@@ -186,10 +189,15 @@ function nvt_monte_carlo(
         if ΔE < 0*e_unit || rand() < exp(-ΔE.val / (kb * temperature))
             current_walker.configuration = proposed_walker.configuration
             current_energy = proposed_energy
+            # Keep the walker's energy field in sync with the tracked energy,
+            # so stored snapshots carry the energy of their own configuration
+            current_walker.energy = current_energy
             accepted_steps += 1
         end
         energies[i] = current_energy
-        configurations[i] = current_walker
+        # Store an independent snapshot: storing the mutated walker itself
+        # would alias every recorded step to the final configuration
+        configurations[i] = deepcopy(current_walker)
     end
 
     return energies, configurations, accepted_steps
@@ -222,7 +230,10 @@ function nvt_monte_carlo(
         freq = [mc_routine.walks_freq, mc_routine.swaps_freq]
         swap_prob = freq[2] / sum(freq)
         proposed_walker = deepcopy(current_walker)
-        # Propose a move
+        # Propose a move: one channel draw per step, so every step performs
+        # exactly one move type (two independent draws would leave a
+        # walks_freq*swaps_freq-weighted channel where neither branch fires and
+        # the unchanged configuration is accepted at ΔE = 0 as a null move)
         if rand() > swap_prob
             config = proposed_walker.configuration
             free_index = free_par_index(proposed_walker)
@@ -233,7 +244,7 @@ function nvt_monte_carlo(
             pos = single_atom_random_walk!(pos, step_size)
             pos = periodic_boundary_wrap!(pos, config)
             config.position[i_at] = pos
-        elseif rand() <= swap_prob
+        else
             #println("Performing a swap move")
             config = proposed_walker.configuration
             free_comp = free_component_index(proposed_walker)
@@ -255,7 +266,9 @@ function nvt_monte_carlo(
             accepted_steps += 1
         end
         energies[i] = current_energy
-        configurations[i] = current_walker
+        # Store an independent snapshot: consecutive rejections would otherwise
+        # alias repeated entries to one mutable walker
+        configurations[i] = deepcopy(current_walker)
         # println(configurations[i])
     end
 
@@ -325,14 +338,16 @@ function monte_carlo_sampling(
         @info "Temperature: $temp K, Equilibration energy: $equi_mean, Variance: $(round(equi_var; sigdigits=4)), Acceptance rate: $(round(equi_rate; sigdigits=4))"
 
 
-        # Sample the lattice
+        # Sample the lattice. The production seed is derived from the
+        # equilibration seed (random_seed + 1): passing the same seed replays
+        # the equilibration random stream, correlating the two phases
         sampling_energies, sampling_configurations, sampling_accepted_steps = nvt_monte_carlo(
             mc_routine,
             equilibration_configurations[end],
             h,
             temp,
             mc_params.sampling_steps,
-            mc_params.random_seed
+            mc_params.random_seed + 1
         )
 
         # Compute the heat capacity
@@ -419,7 +434,9 @@ function monte_carlo_sampling(
 
         @info "Temperature: $temp K, Equilibration energy: $equi_mean, Variance: $(round(equi_var.val; sigdigits=4)), Acceptance rate: $(round(equi_rate; sigdigits=4)), Step size: $(round(mc_params.step_size; sigdigits=4))"
 
-        # Sample the lattice
+        # Sample the walker. The production seed is derived from the
+        # equilibration seed (random_seed + 1): passing the same seed replays
+        # the equilibration random stream, correlating the two phases
         sampling_energies, sampling_configurations, sampling_accepted_steps = nvt_monte_carlo(
             mc_routine,
             equilibration_configurations[end],
@@ -427,7 +444,7 @@ function monte_carlo_sampling(
             temp,
             mc_params.sampling_steps,
             mc_params.step_size,
-            mc_params.random_seed
+            mc_params.random_seed + 1
         )
 
         # Compute the heat capacity

--- a/test/test-FreeBirdIO.jl
+++ b/test/test-FreeBirdIO.jl
@@ -140,3 +140,84 @@
 
 
 end
+@testset "Overlap-aware periodic starting configurations" begin
+    # Minimum-image pairwise distance under the generated system's own metric
+    function _test_min_dist(sys)
+        L = ustrip(u"Å", cell_vectors(sys)[1][1])
+        pbc = periodicity(sys)
+        n = length(sys)
+        dmin = Inf
+        for i in 1:(n - 1), j in (i + 1):n
+            d2 = 0.0
+            for k in 1:3
+                δ = ustrip(u"Å", position(sys, i)[k] - position(sys, j)[k])
+                if pbc[k]
+                    δ -= L * round(δ / L)
+                end
+                d2 += δ^2
+            end
+            dmin = min(dmin, sqrt(d2))
+        end
+        return dmin
+    end
+
+    @testset "Default path is stream-neutral" begin
+        Random.seed!(31415)
+        sys_new = FreeBirdIO.generate_random_starting_config(100.0, 5)
+        Random.seed!(31415)
+        box_length = (100.0 * 5)^(1 / 3)
+        legacy_positions = [[rand(), rand(), rand()] .* box_length * u"Å" for _ in 1:5]
+        @test all(position(sys_new, i) == SVector{3}(legacy_positions[i]) for i in 1:5)
+        @test periodicity(sys_new) == (false, false, false)
+    end
+
+    @testset "Periodicity propagation" begin
+        sys = FreeBirdIO.generate_random_starting_config(100.0, 3; periodicity=(true, true, false))
+        @test periodicity(sys) == (true, true, false)
+        sys_p = FreeBirdIO.generate_random_starting_config(100.0, 3; periodicity=(true, true, true))
+        @test periodicity(sys_p) == (true, true, true)
+    end
+
+    @testset "Separation invariant at a dense point" begin
+        # 24 particles at 15.625 A^3 each (box 7.211 A): packing fraction 0.257
+        # at the 2.125 A separation, safely under the sequential-insertion regime
+        Random.seed!(2718)
+        sys = FreeBirdIO.generate_random_starting_config(15.625, 24;
+            periodicity=(true, true, true), min_separation=2.125, max_attempts=5000)
+        @test length(sys) == 24
+        @test _test_min_dist(sys) >= 2.125
+        Random.seed!(2718)
+        sys_m = FreeBirdIO.generate_random_starting_config(15.625, 24;
+            periodicity=(true, true, false), min_separation=2.125, max_attempts=5000)
+        @test _test_min_dist(sys_m) >= 2.125
+    end
+
+    @testset "Infeasible packing throws" begin
+        Random.seed!(1618)
+        @test_throws ArgumentError FreeBirdIO.generate_random_starting_config(15.625, 24;
+            periodicity=(true, true, true), min_separation=4.0, max_attempts=200)
+    end
+
+    @testset "Lattice starting configuration" begin
+        sys1 = FreeBirdIO.generate_lattice_starting_config(12.5, 100)
+        sys2 = FreeBirdIO.generate_lattice_starting_config(12.5, 100)
+        @test length(sys1) == 100
+        @test periodicity(sys1) == (true, true, true)
+        # deterministic at jitter = 0
+        @test all(position(sys1, i) == position(sys2, i) for i in 1:100)
+        # separation bound: at least the grid spacing (100 sites on a 5^3 grid)
+        @test _test_min_dist(sys1) >= 12.5 / 5 - 1e-9
+        # partial fill keeps the bound
+        sys3 = FreeBirdIO.generate_lattice_starting_config(12.5, 30)
+        @test length(sys3) == 30
+        @test _test_min_dist(sys3) >= 12.5 / ceil(Int, cbrt(30)) - 1e-9
+        # jitter: seeded reproducibility and the documented separation bound
+        Random.seed!(999)
+        sysj1 = FreeBirdIO.generate_lattice_starting_config(12.5, 100; jitter=0.2)
+        Random.seed!(999)
+        sysj2 = FreeBirdIO.generate_lattice_starting_config(12.5, 100; jitter=0.2)
+        @test all(position(sysj1, i) == position(sysj2, i) for i in 1:100)
+        @test _test_min_dist(sysj1) >= 12.5 / 5 - 2 * sqrt(3) * 0.2 - 1e-9
+        @test_throws ArgumentError FreeBirdIO.generate_lattice_starting_config(12.5, 0)
+    end
+end

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -878,3 +878,175 @@
 
 end
 
+
+@testset "atomistic muVT kernel tests" begin
+    using Random
+    # Calibration ledger (gates at >= 3x the max three-seed deviation, per stat):
+    # - Ideal-gas Poisson closure, zV = 3, T = 300 K, seeds 91001/91002/91003:
+    #   max devs mean 0.036, var 0.059, p0 0.0018; gates 0.11, 0.18, 0.0055.
+    # - Fixed-N pair-distance Boltzmann ratio (bins [2.5,2.9)/[3.3,3.7) A,
+    #   quadrature reference 0.7929), seeds 92001/92002/92003: max rel dev
+    #   0.0039; gate 0.012 relative.
+    box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+    pbc = (true, true, true)
+    seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+    mkempty() = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                           empty(position(seed_at, :)), empty(species(seed_at, :)),
+                           empty(mass(seed_at, :)))
+    mkwalker() = (w = AtomWalker{1}(mkempty()); w.energy = 0.0u"eV"; w)
+    lj0 = LJParameters(epsilon=0.0)
+    T300 = 300.0
+    logfact(n) = n == 0 ? 0.0 : sum(log, 1:n)
+    poisson_pmf(lam, n) = exp(n * log(lam) - lam - logfact(n))
+
+    @testset "argument validation" begin
+        w = mkwalker()
+        @test_throws ArgumentError MC_muVT_walk!(1, w, lj0, T300; zV=0.0, species=:Ar)
+        @test_throws ArgumentError MC_muVT_walk!(1, w, lj0, 0.0; zV=1.0, species=:Ar)
+        @test_throws ArgumentError MC_muVT_walk!(1, w, lj0, T300; zV=1.0, species=:Ar, p_move=0.7, p_insert=0.4)
+        frozen_w = AtomWalker(FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc));
+                              freeze_species=[:Ar])
+        @test_throws ArgumentError MC_muVT_walk!(1, frozen_w, lj0, T300; zV=1.0, species=:Ar)
+    end
+
+    @testset "RNG-stream contract (forced branches)" begin
+        # Insertion, combined ratio >= 1 (zV huge, zero-interaction): accept
+        # with NO Metropolis draw (channel + three position uniforms = 4)
+        Random.seed!(778)
+        probe = [rand() for _ in 1:8]
+        @test probe[1] < 0.75
+        Random.seed!(778)
+        w = mkwalker()
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=1.0e6, species=:Ar, p_move=0.0, p_insert=0.75)
+        @test w.list_num_par == [1]
+        @test (stats.insert_attempted, stats.insert_accepted) == (1, 1)
+        @test rand() == probe[5]
+
+        # Insertion, combined < 1: the Metropolis uniform IS drawn (5 draws;
+        # p_delete = 0 forces the ratio to zero)
+        Random.seed!(778)
+        w = mkwalker()
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=8.0, species=:Ar, p_move=0.0, p_insert=1.0)
+        @test w.list_num_par == [0]
+        @test (stats.insert_attempted, stats.insert_accepted) == (1, 0)
+        @test rand() == probe[6]
+
+        # Deletion, combined >= 1: accept with NO Metropolis draw (2 draws)
+        Random.seed!(777)
+        probe = [rand() for _ in 1:8]
+        @test probe[1] >= 0.25
+        Random.seed!(777)
+        w = mkwalker()
+        insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=0.01, species=:Ar, p_move=0.0, p_insert=0.25)
+        @test w.list_num_par == [0]
+        @test (stats.delete_attempted, stats.delete_accepted) == (1, 1)
+        @test rand() == probe[3]
+
+        # Deletion, combined < 1: the Metropolis uniform IS drawn (3 draws)
+        Random.seed!(777)
+        w = mkwalker()
+        insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=1.0e6, species=:Ar, p_move=0.0, p_insert=0.25)
+        @test w.list_num_par == [1]
+        @test (stats.delete_attempted, stats.delete_accepted) == (1, 0)
+        @test rand() == probe[4]
+
+        # Zero-interaction displacement: dU = 0 accepts downhill-style with NO
+        # Metropolis draw (channel + index + three walk displacements = 5)
+        Random.seed!(779)
+        probe779 = [rand() for _ in 1:8]
+        @test probe779[1] < 1.0
+        Random.seed!(779)
+        w = mkwalker()
+        insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=1.0, species=:Ar, p_move=1.0, p_insert=0.0)
+        @test (stats.move_attempted, stats.move_accepted) == (1, 1)
+        @test rand() == probe779[6]
+
+        # Uphill displacement from the exact pair minimum: any move raises the
+        # pair energy, so the Metropolis uniform IS drawn (6 draws)
+        lj_up = LJParameters(epsilon=0.05, sigma=2.5, cutoff=3.0, shift=true)
+        r0 = 2.5 * 2.0^(1 / 6)
+        Random.seed!(781)
+        probe781 = [rand() for _ in 1:8]
+        Random.seed!(781)
+        wp = AtomWalker(FastSystem(atomic_system(
+            [:Ar => [2.0, 5.0, 5.0]u"Å", :Ar => [2.0 + r0, 5.0, 5.0]u"Å"], box, pbc)))
+        wp.energy = interacting_energy(wp.configuration, lj_up, wp.list_num_par, wp.frozen)
+        _, _, stats = MC_muVT_walk!(1, wp, lj_up, T300; zV=1.0, species=:Ar,
+                                    p_move=1.0, p_insert=0.0, step_size=0.3)
+        @test stats.move_attempted == 1
+        @test rand() == probe781[7]
+
+        # Guard skips consume only the channel draw and count no attempt
+        Random.seed!(777)
+        w = mkwalker()
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=8.0, species=:Ar, p_move=0.0, p_insert=0.25)
+        @test stats == (move_attempted=0, move_accepted=0, insert_attempted=0,
+                        insert_accepted=0, delete_attempted=0, delete_accepted=0)
+        @test rand() == probe[2]
+    end
+
+    @testset "ideal-gas Poisson closure (seeded, calibrated)" begin
+        Random.seed!(91001)
+        w = mkwalker()
+        MC_muVT_walk!(20_000, w, lj0, T300; zV=3.0, species=:Ar)
+        ns = Int[]
+        for _ in 1:20_000
+            MC_muVT_walk!(10, w, lj0, T300; zV=3.0, species=:Ar)
+            push!(ns, w.list_num_par[1])
+        end
+        @test abs(mean(ns) - 3.0) < 0.11
+        @test abs(var(ns) - 3.0) < 0.18
+        @test abs(count(iszero, ns) / length(ns) - poisson_pmf(3.0, 0)) < 0.0055
+        @test length(w.configuration) == w.list_num_par[1]
+    end
+
+    @testset "fixed-N Boltzmann law for the pair distance (seeded, calibrated)" begin
+        lj = LJParameters(epsilon=0.02, sigma=2.5, cutoff=2.5, shift=true)
+        kb = 8.617333262e-5
+        β = 1 / (kb * T300)
+        u_of(r) = ustrip(u"eV", FreeBird.AbstractPotentials.lj_energy((r)u"Å", lj))
+        simpson(f, a, b; n=2000) = (h = (b - a) / n;
+            h / 3 * sum(k -> f(a + k * h) * (k == 0 || k == n ? 1 : (isodd(k) ? 4 : 2)), 0:n))
+        R_ref = simpson(r -> r^2 * exp(-β * u_of(r)), 2.5, 2.9) /
+                simpson(r -> r^2 * exp(-β * u_of(r)), 3.3, 3.7)
+        Random.seed!(92001)
+        w = AtomWalker(FastSystem(atomic_system(
+            [:Ar => [2.0, 5.0, 5.0]u"Å", :Ar => [4.8, 5.0, 5.0]u"Å"], box, pbc)))
+        w.energy = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen)
+        MC_muVT_walk!(50_000, w, lj, T300; zV=1.0, species=:Ar, p_move=1.0, p_insert=0.0, step_size=0.8)
+        c1 = 0; c2 = 0
+        for _ in 1:200_000
+            MC_muVT_walk!(5, w, lj, T300; zV=1.0, species=:Ar, p_move=1.0, p_insert=0.0, step_size=0.8)
+            d = ustrip(u"Å", FreeBird.EnergyEval.pbc_dist(position(w.configuration, 1),
+                                                          position(w.configuration, 2),
+                                                          w.configuration))
+            (2.5 <= d < 2.9) && (c1 += 1)
+            (3.3 <= d < 3.7) && (c2 += 1)
+        end
+        @test abs(c1 / c2 - R_ref) / R_ref < 0.012
+    end
+
+    @testset "incremental-energy drift audit" begin
+        lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5, shift=true)
+        Random.seed!(93001)
+        w = mkwalker()
+        MC_muVT_walk!(20_000, w, lj, T300; zV=6.0, species=:Ar, step_size=0.6)
+        E_re = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen) + w.energy_frozen_part
+        @test abs(ustrip(u"eV", w.energy - E_re)) < 5e-10
+        @test length(w.configuration) == w.list_num_par[1]
+    end
+
+    @testset "same-seed determinism" begin
+        lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5, shift=true)
+        outs = map(1:2) do _
+            Random.seed!(94001)
+            w = mkwalker()
+            _, rate, stats = MC_muVT_walk!(5_000, w, lj, T300; zV=4.0, species=:Ar)
+            (w.list_num_par[1], ustrip(u"eV", w.energy), rate, stats)
+        end
+        @test outs[1] == outs[2]
+    end
+end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -6,6 +6,7 @@
     include("test-nested_sampling.jl")
     # test NVT Monte Carlo
     include("test-nvt_monte_carlo.jl")
+include("test-muvt-monte-carlo.jl")
     # test Wang-Landau
     include("test-wang_landau.jl")
     # test grand-canonical nested sampling

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -511,7 +511,7 @@ end
             n_walkers=K, ω0=ω0_test, live_emax=live_all)
         @test propertynames(out) == (:Xi, :mean_N, :var_N, :mean_U, :logXi,
                                      :var_U, :cov_UN, :log_Z_N, :N_values,
-                                     :observables)
+                                     :p_N, :N_support, :observables)
         @test out[1] === out.Xi && out[2] === out.mean_N &&
               out[3] === out.var_N && out[4] === out.mean_U
         @test isempty(out.observables)

--- a/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
@@ -222,3 +222,165 @@
         @test seen_ns == df.num_particles
     end
 end
+
+@testset "Interacting-regime controls" begin
+    using Random
+    # Fixtures calibrated in-session; see the assertions for the measured
+    # separations. Bound-dimer walkers at slightly different separations give a
+    # continuous energy ladder with collapsed insertion/deletion acceptance at
+    # tiny z0V (Metropolis ratio z0V/(N+1)), while displacements stay healthy.
+    hard_L = 12.0
+    hard_box = [[hard_L * u"Å", 0u"Å", 0u"Å"],
+                [0u"Å", hard_L * u"Å", 0u"Å"],
+                [0u"Å", 0u"Å", hard_L * u"Å"]]
+    hard_lj = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.0, shift=true)
+    hard_pair(r) = AtomWalker(FastSystem(periodic_system(
+        [:Ar => [0.3, 0.5, 0.5], :Ar => [0.3 + r / hard_L, 0.5, 0.5]],
+        hard_box, fractional=true)))
+
+    @testset "Routine and parameter validation" begin
+        r = MCAtomGrandCanonicalMoves()
+        @test r.step_rate_source == :mixed
+        @test r.mc_steps_per_particle == 0.0
+        @test_throws ArgumentError MCAtomGrandCanonicalMoves(step_rate_source=:invalid)
+        @test_throws ArgumentError MCAtomGrandCanonicalMoves(mc_steps_per_particle=-1.0)
+        p = AtomisticIGRefGCNSParameters()
+        @test p.allowed_fail_count == 100
+        @test p.refill_fail_budget == 0
+        @test_throws ArgumentError AtomisticIGRefGCNSParameters(refill_fail_budget=-1)
+    end
+
+    @testset "Walk-length arithmetic" begin
+        p = AtomisticIGRefGCNSParameters(mc_steps=100)
+        @test FreeBird.SamplingSchemes._gc_walk_length(p, MCAtomGrandCanonicalMoves(), 50) == 100
+        @test FreeBird.SamplingSchemes._gc_walk_length(p, MCAtomGrandCanonicalMoves(mc_steps_per_particle=2.0), 50) == 200
+        @test FreeBird.SamplingSchemes._gc_walk_length(p, MCAtomGrandCanonicalMoves(mc_steps_per_particle=1.5), 2) == 103
+    end
+
+    @testset "Step-rate source A/B" begin
+        # Calibrated at seed 3000: the mixed rate ~ 0.3*A_move + 0.35*A_ins +
+        # 0.35*A_del sits below the 0.2 band edge (measured A_ins ~ A_del ~ 0.010,
+        # A_move 0.56-0.64),
+        # so :mixed shrinks the step (measured 0.028) while :move holds it
+        # inside the wide band (measured 0.104)
+        results = Dict{Symbol,Float64}()
+        stats = Dict{Symbol,Dict{Symbol,Int}}()
+        for src in (:mixed, :move)
+            Random.seed!(3000)
+            ls = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+            params = AtomisticIGRefGCNSParameters(mc_steps=100,
+                reference_activity=(0.05 / hard_L^3)u"Å^-3", species=:Ar,
+                step_size=0.1, accept_range=(0.2, 0.9), allowed_fail_count=100_000)
+            routine = MCAtomGrandCanonicalMoves(p_move=0.3, p_insert=0.35, step_rate_source=src)
+            z0V = FreeBird.SamplingSchemes._atomistic_igref_z0V(ls, params)
+            for i in 1:30
+                FreeBird.SamplingSchemes.nested_sampling_step!(ls, params, routine; ns_iteration=i, z0V=z0V)
+            end
+            results[src] = params.step_size
+            stats[src] = copy(params.move_stats)
+        end
+        for src in (:mixed, :move)
+            ms = stats[src]
+            @test ms[:move_accepted] / ms[:move_attempted] > 0.5
+            @test ms[:insert_accepted] / ms[:insert_attempted] < 0.05
+        end
+        @test results[:mixed] < 0.05
+        @test results[:move] > 0.09
+    end
+
+    @testset "Refill failure budget" begin
+        # Bit-exact duplicate dimers form a tie block above three slightly
+        # deeper dimers; five-step walks at step 1.5 rarely land below the tie
+        # energy, so the cumulative budget (allowed_fail_count = 2) abandons
+        # the refill where a dedicated budget completes it. Calibrated at
+        # seeds 4000/4001: n_live 3 vs 6 at both.
+        for (budget, expected) in ((0, 3), (300, 6))
+            Random.seed!(4000)
+            dup = hard_pair(2.90)
+            ls = LJAtomWalkers([deepcopy(dup), deepcopy(dup), deepcopy(dup),
+                                hard_pair(2.82), hard_pair(2.83), hard_pair(2.84)], hard_lj)
+            params = AtomisticIGRefGCNSParameters(mc_steps=5,
+                reference_activity=(0.05 / hard_L^3)u"Å^-3", species=:Ar,
+                step_size=1.5, allowed_fail_count=2, refill_fail_budget=budget)
+            routine = MCAtomGrandCanonicalMoves(p_move=0.6, p_insert=0.2)
+            z0V = FreeBird.SamplingSchemes._atomistic_igref_z0V(ls, params)
+            for i in 1:6
+                FreeBird.SamplingSchemes.nested_sampling_step!(ls, params, routine; ns_iteration=i, z0V=z0V)
+            end
+            @test length(ls.walkers) == expected
+        end
+    end
+
+    @testset "Stall-continue resets the step size" begin
+        # Zero-interaction degenerate live set: every replacement fails, and on
+        # the stop_on_stall=false branch the step size returns to initial
+        Random.seed!(5000)
+        seeds = [AtomWalker(FastSystem(periodic_system(
+            [:Ar => [0.5, 0.5, 0.5]], hard_box, fractional=true))) for _ in 1:4]
+        ls = GenericAtomWalkers(seeds, IdealGasParameters())
+        params = AtomisticIGRefGCNSParameters(mc_steps=10,
+            reference_activity=(2.0 / hard_L^3)u"Å^-3", species=:Ar,
+            initial_step_size=0.5, step_size=1.7, allowed_fail_count=3)
+        save = SaveEveryN(df_filename="_t_stall.csv", wk_filename="_t_stall.traj.extxyz",
+                          ls_filename="_t_stall.ls.extxyz",
+                          n_traj=10^7, n_snap=10^7, n_info=10^7)
+        df, ls, params = ideal_gas_referenced_nested_sampling(
+            ls, params, 3, MCAtomGrandCanonicalMoves(), save; stop_on_stall=false)
+        for f in ("_t_stall.csv", "_t_stall.traj.extxyz", "_t_stall.ls.extxyz")
+            rm(f, force=true)
+        end
+        @test params.step_size == params.initial_step_size
+        @test nrow(df) == 0
+    end
+
+    @testset "Per-iteration acceptance ledger" begin
+        Random.seed!(6000)
+        ls = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+        params = AtomisticIGRefGCNSParameters(mc_steps=60,
+            reference_activity=(6.0 / hard_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        save = SaveEveryN(df_filename="_t_rates.csv", wk_filename="_t_rates.traj.extxyz",
+                          ls_filename="_t_rates.ls.extxyz",
+                          n_traj=10^7, n_snap=10^7, n_info=10^7)
+        df, ls, params = ideal_gas_referenced_nested_sampling(
+            ls, params, 40, MCAtomGrandCanonicalMoves(), save; record_move_rates=true)
+        rate_names = ["move_attempted", "move_accepted", "insert_attempted",
+                      "insert_accepted", "delete_attempted", "delete_accepted"]
+        @test names(df) == vcat(["iter", "emax", "num_particles", "log_compression"], rate_names)
+        # Closure: recorded per-iteration deltas sum to the run totals
+        for name in rate_names
+            @test sum(df[!, name]) == get(params.move_stats, Symbol(name), 0)
+        end
+        # The default keeps the shipped four-column schema
+        Random.seed!(6000)
+        ls2 = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+        params2 = AtomisticIGRefGCNSParameters(mc_steps=60,
+            reference_activity=(6.0 / hard_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        save2 = SaveEveryN(df_filename="_t_rates.csv", wk_filename="_t_rates.traj.extxyz",
+                           ls_filename="_t_rates.ls.extxyz",
+                           n_traj=10^7, n_snap=10^7, n_info=10^7)
+        df2, _, _ = ideal_gas_referenced_nested_sampling(
+            ls2, params2, 40, MCAtomGrandCanonicalMoves(), save2)
+        @test names(df2) == ["iter", "emax", "num_particles", "log_compression"]
+        # Same seed, recording on or off: identical sampling trajectory
+        @test df2.emax == df.emax
+        for f in ("_t_rates.csv", "_t_rates.traj.extxyz", "_t_rates.ls.extxyz")
+            rm(f, force=true)
+        end
+        # The rate columns are reserved: observables cannot collide with them
+        @test_throws ArgumentError FreeBird.SamplingSchemes._validate_observables(
+            [:insert_accepted => cfg -> 0.0], ls)
+    end
+
+    @testset "Minimum-image cutoff guard" begin
+        cfg = hard_pair(2.9).configuration
+        over = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.5, shift=true)   # 6.25 > 6.0
+        under = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.0, shift=true)  # 5.0 <= 6.0
+        untr = LJParameters(epsilon=0.05, sigma=2.5)                           # Inf: never warns
+        @test_logs (:warn, r"minimum-image") FreeBird.SamplingSchemes._warn_min_image_cutoff(over, cfg)
+        @test_logs FreeBird.SamplingSchemes._warn_min_image_cutoff(under, cfg)
+        @test_logs FreeBird.SamplingSchemes._warn_min_image_cutoff(untr, cfg)
+        @test SamplingSchemes.AbstractPotentials._max_interaction_range(IdealGasParameters()) === missing
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-stats.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-stats.jl
@@ -202,3 +202,131 @@
         end
     end
 end
+
+@testset "particle-number distributions from the reductions" begin
+    kb = 8.617333262e-5
+    Vq = 1000.0u"Å^3"
+    V = 1000.0
+    mass_ar = 39.948u"u"
+    lam(T) = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass_ar, T * u"K"))
+    mu_for(zV, T) = (kb * T * (log(zV / V) + 3 * log(lam(T)))) * u"eV"
+    logfact(n) = n == 0 ? 0.0 : sum(log, 1:n)
+    poisson_pmf(lam0, n) = exp(n * log(lam0) - lam0 - logfact(n))
+    function poisson_ledger(z0V; nmax=60)
+        p = [poisson_pmf(z0V, n) for n in 0:nmax]
+        remainder = max(1.0 - sum(p), 1.0e-300)
+        masses = vcat(p, remainder)
+        X = reverse(cumsum(reverse(masses)))
+        lc = [log(X[j+1] / X[j]) for j in 1:nmax+1]
+        df = DataFrame(iter=collect(1:nmax+1), emax=zeros(nmax + 1),
+                       num_particles=collect(0:nmax), log_compression=lc)
+        return df, [0.0], [nmax + 1]
+    end
+
+    @testset "exact Poisson closure of p_N" begin
+        z0V = 3.0
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = poisson_ledger(z0V)
+        T = 300.0
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0,
+            [mu_for(2.0, T), mu_for(5.0, T)], [T]u"K";
+            live_emax=live_e, live_numbers=live_n)
+        @test stats.N_support == 0:61
+        @test size(stats.p_N) == (2, 1, 62)
+        for (i, zV) in enumerate([2.0, 5.0])
+            for n in 0:15
+                @test abs(stats.p_N[i, 1, n + 1] - poisson_pmf(zV, n)) < 1e-11
+            end
+            @test abs(sum(stats.p_N[i, 1, :]) - 1.0) < 1e-12
+        end
+    end
+
+    @testset "moment identities per grid point" begin
+        z0V = 4.0
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = poisson_ledger(z0V; nmax=40)
+        Ts = [250.0, 350.0]
+        mus = [mu_for(1.5, 300.0), mu_for(4.0, 300.0)]
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, Ts * u"K";
+            live_emax=live_e, live_numbers=live_n)
+        Ns = collect(stats.N_support)
+        for i in 1:2, j in 1:2
+            m1 = sum(stats.p_N[i, j, :] .* Ns)
+            m2 = sum(stats.p_N[i, j, :] .* Ns .^ 2)
+            @test isapprox(m1, stats.mean_N[i, j]; rtol=1e-12)
+            # The two routes reassociate m2 - m1^2 differently, so the identity
+            # carries an eps*m2 cancellation floor where the variance collapses
+            @test isapprox(m2 - m1^2, stats.var_N[i, j]; rtol=1e-11,
+                           atol=1e-11 * max(1.0, m2))
+        end
+    end
+
+    @testset "live-tail mixture weld, bit-for-bit" begin
+        z0V = 2.5
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = poisson_ledger(z0V; nmax=8)
+        T = 300.0
+        mu = mu_for(3.0, T)
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, [mu], [T]u"K";
+            live_emax=live_e, live_numbers=live_n)
+        # hand assembly replicating the source arithmetic exactly
+        lc = Vector{Float64}(df.log_compression)
+        cs = cumsum(lc)
+        log_w0 = vcat(0.0 .+ vcat(0.0, cs[1:end-1]) .+ log.(-expm1.(lc)),
+                      [cs[end] - log(1)])
+        Es = vcat(zeros(9), live_e)
+        Nsamp = vcat(Vector{Float64}(df.num_particles), Float64.(live_n))
+        β = 1.0 / (kb * T)
+        s = β * ustrip(u"eV", mu) - 3.0 * log(lam(T)) - log(ustrip(u"Å^-3", z0))
+        log_w = log_w0 .+ s .* Nsamp .- β .* Es
+        max_log = maximum(log_w)
+        ws = exp.(log_w .- max_log)
+        sum_w = sum(ws)
+        acc = zeros(Float64, maximum(Int.(Nsamp)) + 1)
+        for k in eachindex(ws)
+            acc[Int(Nsamp[k]) + 1] += ws[k]
+        end
+        @test stats.p_N[1, 1, :] == acc ./ sum_w
+    end
+
+    @testset "support holes stay exactly zero" begin
+        # masses on N in {0, 2} only, live tail at N = 4: N = 1 and N = 3 are
+        # in-support holes that must carry exactly 0.0
+        masses = [0.4, 0.35, 0.25]
+        X = reverse(cumsum(reverse(masses)))
+        lc = [log(X[j+1] / X[j]) for j in 1:2]
+        df = DataFrame(iter=[1, 2], emax=zeros(2), num_particles=[0, 2],
+                       log_compression=lc)
+        T = 300.0
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, (2.0 / V)u"Å^-3",
+            [mu_for(2.0, T)], [T]u"K"; live_emax=[0.0], live_numbers=[4])
+        @test stats.N_support == 0:4
+        @test stats.p_N[1, 1, 2] == 0.0
+        @test stats.p_N[1, 1, 4] == 0.0
+        @test abs(sum(stats.p_N[1, 1, :]) - 1.0) < 1e-12
+    end
+
+    @testset "fixed-N parity with the documented recipe" begin
+        N_values = [0, 1, 2]
+        ns_outputs = [DataFrame(iter=Int[], emax=Float64[]),
+                      DataFrame(iter=collect(1:50), emax=zeros(50)),
+                      DataFrame(iter=collect(1:60),
+                                emax=collect(range(-0.010, -0.020, length=60)))]
+        live_all = [Float64[], zeros(8), fill(-0.0201, 8)]
+        T = 300.0
+        mus = [mu_for(1.0, T), mu_for(3.0, T)]
+        out = gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, Vq, mass_ar,
+            mus, [T]u"K"; n_walkers=8, live_emax=live_all)
+        @test out.N_support == [0, 1, 2]
+        @test size(out.p_N) == (2, 1, 3)
+        β = 1.0 / (kb * T)
+        for (k, mu) in enumerate(mus)
+            w = out.log_Z_N[:, 1] .+ β * ustrip(u"eV", mu) .* N_values
+            w .-= maximum(w)
+            pw = exp.(w) ./ sum(exp.(w))
+            for n_idx in 1:3
+                @test isapprox(out.p_N[k, 1, n_idx], pw[n_idx]; rtol=1e-12, atol=1e-15)
+            end
+        end
+    end
+end

--- a/test/test-SamplingSchemes/test-muvt-monte-carlo.jl
+++ b/test/test-SamplingSchemes/test-muvt-monte-carlo.jl
@@ -1,0 +1,141 @@
+# Fixed-temperature grand-canonical (muVT) Metropolis sampling driver.
+#
+# Calibration ledger (gates at >= 3x the max three-seed deviation, per stat):
+# - Ideal-gas closure, T = [300, 400] K, zV = [3, 5], seeds 95001/95002/95003:
+#   max devs mean 0.0411, var 0.1479; gates 0.13 and 0.45.
+# - Dilute-LJ second-virial mean gate (epsilon = 0.01 eV, sigma = 2.0 A,
+#   cutoff 2.5 so r_c = 5.0 A = L/2, guard-clean; b2 = +1.2458 A^3 at 300 K,
+#   N_ref = 0.80159 at zV = 0.8), seeds 96001/96002/96003: max dev 0.00968;
+#   gate 0.03.
+@testset "muVT Metropolis sampling driver" begin
+    using Random
+
+    box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+    pbc = (true, true, true)
+    mk1() = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"], box, pbc)))
+    lj0 = LJParameters(epsilon=0.0)
+
+    @testset "parameter and entry validation" begin
+        @test_throws ArgumentError MuVTMCParameters([300.0], [1.0, 2.0])
+        @test_throws ArgumentError MuVTMCParameters([300.0], [-1.0])
+        @test_throws ArgumentError MuVTMCParameters([300.0], [1.0]; sampling_interval=0)
+        params = MuVTMCParameters([300.0], [1.0])
+        # omitting the routine hits the muVT catch-all, not a bare MethodError
+        @test_throws ArgumentError monte_carlo_sampling(mk1(), lj0, params)
+        # an empty starting walker carries no species record
+        empty_sys = FastSystem(cell_vectors(mk1().configuration), pbc,
+                               empty(position(mk1().configuration, :)),
+                               empty(species(mk1().configuration, :)),
+                               empty(mass(mk1().configuration, :)))
+        w_empty = AtomWalker{1}(empty_sys)
+        @test_throws ArgumentError monte_carlo_sampling(MCAtomGrandCanonicalMoves(),
+            w_empty, lj0, params)
+    end
+
+    @testset "ideal-gas closure over a temperature ladder (seeded, calibrated)" begin
+        params = MuVTMCParameters([300.0, 400.0], [3.0, 5.0];
+            equilibrium_steps=20_000, sampling_steps=200_000, sampling_interval=10,
+            random_seed=95001)
+        w = mk1(); w.energy = 0.0u"eV"
+        out = monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, lj0, params)
+        for (i, zV) in enumerate([3.0, 5.0])
+            @test abs(out.mean_N[i] - zV) < 0.13
+            @test abs(out.var_N[i] - zV) < 0.45
+            @test abs(sum(out.p_N[i]) - 1.0) < 1e-12
+            @test length(out.N_series[i]) == 200_000 ÷ 10
+            @test out.N_support[i] == 0:maximum(out.N_series[i])
+        end
+        @test all(out.mean_U .== 0.0)
+    end
+
+    @testset "dilute-LJ second-virial mean gate (seeded, calibrated)" begin
+        lj = LJParameters(epsilon=0.01, sigma=2.0, cutoff=2.5, shift=true)
+        kb = 8.617333262e-5
+        T = 300.0
+        β = 1 / (kb * T)
+        u_of(r) = ustrip(u"eV", FreeBird.AbstractPotentials.lj_energy((r)u"Å", lj))
+        simpson(f, a, b; n=4000) = (h = (b - a) / n;
+            h / 3 * sum(k -> f(a + k * h) * (k == 0 || k == n ? 1 : (isodd(k) ? 4 : 2)), 0:n))
+        b2 = 2π * simpson(r -> (exp(-β * u_of(r)) - 1) * r^2, 1.0e-6, 5.0)
+        zV = 0.8
+        N_ref = zV + 2 * zV^2 * b2 / 1000.0
+        params = MuVTMCParameters([T], [zV];
+            equilibrium_steps=20_000, sampling_steps=400_000, sampling_interval=10,
+            random_seed=96001)
+        w = mk1(); w.energy = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen)
+        out = monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, lj, params)
+        @test abs(out.mean_N[1] - N_ref) < 0.03
+        # production acceptance counters are populated and channel-consistent
+        acc = out.acceptance[1]
+        @test acc.insert_attempted > 0 && acc.delete_attempted > 0
+        @test acc.insert_accepted <= acc.insert_attempted
+        @test acc.delete_accepted <= acc.delete_attempted
+        # the returned walker's incremental energy stays anchored
+        wf = out.walkers[1]
+        E_re = interacting_energy(wf.configuration, lj, wf.list_num_par, wf.frozen) +
+               wf.energy_frozen_part
+        @test abs(ustrip(u"eV", wf.energy - E_re)) < 5e-10
+    end
+
+    @testset "phase seeding and frozen production (contract emulation)" begin
+        # The driver's documented contract: equilibration seeded random_seed in
+        # ten adaptation blocks on the displacement-only rate; production seeded
+        # random_seed + 1 with the step size frozen. An independent emulation of
+        # that contract must reproduce the recorded series exactly.
+        lj = LJParameters(epsilon=0.01, sigma=2.0, cutoff=2.5, shift=true)
+        seed = 97001
+        params = MuVTMCParameters([300.0], [2.0];
+            equilibrium_steps=2_000, sampling_steps=8_000, sampling_interval=20,
+            random_seed=seed)
+        w = mk1(); w.energy = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen)
+        out = monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, lj, params)
+
+        emu_params = MuVTMCParameters([300.0], [2.0];
+            equilibrium_steps=2_000, sampling_steps=8_000, sampling_interval=20,
+            random_seed=seed)
+        we = mk1(); we.energy = interacting_energy(we.configuration, lj, we.list_num_par, we.frozen)
+        sp_e = species(we.configuration, 1)
+        Random.seed!(seed)
+        for _ in 1:10
+            _, _, stats = MC_muVT_walk!(200, we, lj, 300.0; zV=2.0, species=sp_e,
+                                        step_size=emu_params.step_size)
+            if stats.move_attempted > 0
+                FreeBird.SamplingSchemes.adjust_step_size(emu_params,
+                    stats.move_accepted / stats.move_attempted; range=emu_params.accept_range)
+            end
+        end
+        Random.seed!(seed + 1)
+        ns_emu = Int[]
+        for _ in 1:(8_000 ÷ 20)
+            MC_muVT_walk!(20, we, lj, 300.0; zV=2.0, species=sp_e,
+                          step_size=emu_params.step_size)
+            push!(ns_emu, we.list_num_par[1])
+        end
+        @test out.N_series[1] == ns_emu
+        @test out.mean_N[1] == mean(ns_emu)
+    end
+
+    @testset "same-seed determinism" begin
+        lj = LJParameters(epsilon=0.01, sigma=2.0, cutoff=2.5, shift=true)
+        outs = map(1:2) do _
+            params = MuVTMCParameters([300.0, 350.0], [1.0, 2.0];
+                equilibrium_steps=1_000, sampling_steps=5_000, sampling_interval=10,
+                random_seed=98001)
+            w = mk1(); w.energy = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen)
+            monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, lj, params)
+        end
+        @test outs[1].mean_N == outs[2].mean_N
+        @test outs[1].N_series == outs[2].N_series
+        @test outs[1].acceptance == outs[2].acceptance
+    end
+
+    @testset "cutoff guard at driver entry" begin
+        over = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5, shift=true)   # 6.25 > 5.0
+        params = MuVTMCParameters([300.0], [1.0];
+            equilibrium_steps=100, sampling_steps=200, sampling_interval=10)
+        w = mk1(); w.energy = interacting_energy(w.configuration, over, w.list_num_par, w.frozen)
+        @test_logs (:warn, r"minimum-image") match_mode = :any begin
+            monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, over, params)
+        end
+    end
+end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -800,7 +800,7 @@
         stats3 = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K)
         @test isempty(stats3.observables)
         @test keys(stats3) == (:logXi, :mean_N, :var_N, :mean_U, :N_eff,
-                               :var_U, :cov_UN, :observables)
+                               :var_U, :cov_UN, :p_N, :N_support, :observables)
         lX, mN, vN, mU, Ne = stats3
         @test lX == stats3.logXi && Ne == stats3.N_eff
 
@@ -917,7 +917,7 @@
             n_walkers=K, ω0=ω0, live_emax=live_E)
         @test keys(stats_nc) == (:logXi, :mean_N, :var_N, :mean_U,
                                  :log_Z_N, :N_values, :var_U, :cov_UN,
-                                 :observables)
+                                 :p_N, :N_support, :observables)
         @test isempty(stats_nc.observables)
         @test stats_nc.logXi ≈ stats.logXi rtol = 1e-14
 

--- a/test/test-SamplingSchemes/test-nvt_monte_carlo.jl
+++ b/test/test-SamplingSchemes/test-nvt_monte_carlo.jl
@@ -157,3 +157,97 @@ end
 
     end
 end
+@testset "NVT MC loop hardening (aliasing, null moves, phase seeding)" begin
+    # Shared fixture: a 4-atom periodic LJ walker in a 10 A cubic box.
+    # Calibration ledger: null-move surplus (accepted - changepoints)/n on
+    #   MCMixedMoves(5, 1), n = 2000, T = 300 K, seeds 777/778/779: measured
+    #   0.0435, 0.0380, 0.0435 (accepted identity swaps only; expectation
+    #   (1/6)*(1/4) ~ 0.042, binomial sigma ~ 0.0045). The historical
+    #   double-draw loop adds null moves at 5/36 ~ 0.139 on top, landing near
+    #   0.146. Gate: surplus <= 0.09, over 10 sigma above the measured band's
+    #   ceiling and over 12 sigma below the defect value.
+    hardening_box = [[10.0u"Å", 0u"Å", 0u"Å"],
+                     [0u"Å", 10.0u"Å", 0u"Å"],
+                     [0u"Å", 0u"Å", 10.0u"Å"]]
+    hardening_coords = [:H => [0.2, 0.2, 0.2], :H => [0.7, 0.3, 0.4],
+                        :H => [0.3, 0.7, 0.6], :H => [0.6, 0.6, 0.3]]
+    hardening_at = AtomWalker(FastSystem(periodic_system(hardening_coords, hardening_box, fractional=true)))
+    hardening_lj = LJParameters(epsilon=0.1, sigma=2.5, cutoff=3.0, shift=true)
+
+    # State-changing acceptances, counted from the stored snapshots
+    function count_changepoints(configs, at_start)
+        prev = at_start.configuration.position
+        n = 0
+        for c in configs
+            if c.configuration.position != prev
+                n += 1
+            end
+            prev = c.configuration.position
+        end
+        return n
+    end
+
+    @testset "Stored trajectory snapshots are independent (MCRandomWalkMaxE)" begin
+        energies, configs, accepted = nvt_monte_carlo(
+            MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, 300.0, 200, 0.4, 4242)
+        @test 0 < accepted < 200
+        # Distinct objects, not one aliased walker repeated
+        @test all(configs[i] !== configs[j] for i in 1:20 for j in (i + 1):20)
+        # The stored trajectory actually varies
+        @test any(configs[i].configuration.position != configs[end].configuration.position for i in 1:199)
+        # Each snapshot's energy field matches a from-scratch recompute of its
+        # own configuration (incremental-accumulation drift class)
+        for i in (1, 50, 100, 150, 200)
+            E_re = interacting_energy(configs[i].configuration, hardening_lj,
+                                      configs[i].list_num_par, configs[i].frozen) +
+                   configs[i].energy_frozen_part
+            @test isapprox(configs[i].energy, E_re; atol=1e-9u"eV")
+            @test configs[i].energy == energies[i]
+        end
+        # Walk-only path: every acceptance changes the configuration, exactly
+        @test accepted == count_changepoints(configs, hardening_at)
+    end
+
+    @testset "Null-move accounting (MCMixedMoves single channel draw)" begin
+        n_steps = 2000
+        energies, configs, accepted = nvt_monte_carlo(
+            MCMixedMoves(5, 1), deepcopy(hardening_at), hardening_lj, 300.0, n_steps, 0.4, 777)
+        # Accepted identity swaps (same atom drawn twice in the swap channel)
+        # are the only legal accepted-without-change steps; the historical
+        # double-draw loop added a 5/36 null-move channel on top. See the
+        # calibration ledger above.
+        surplus = (accepted - count_changepoints(configs, hardening_at)) / n_steps
+        @test 0.0 <= surplus <= 0.09
+        @test all(configs[i] !== configs[j] for i in 1:20 for j in (i + 1):20)
+        for i in (1, 1000, 2000)
+            @test configs[i].energy == energies[i]
+        end
+    end
+
+    @testset "Equilibration and production streams are independent" begin
+        # Lattice driver wiring: the production leg must reproduce an explicit
+        # nvt_monte_carlo call seeded with random_seed + 1 from the
+        # equilibration end configuration
+        lattice = SLattice{SquareLattice}(supercell_dimensions=(2, 2, 1), components=[[1, 2]])
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        seed = 4242
+        params = MetropolisMCParameters([300.0];
+            equilibrium_steps=60, sampling_steps=80, random_seed=seed)
+        d_energies, d_configs, d_cvs, d_rates = monte_carlo_sampling(MCNewSample(), lattice, ham, params)
+        eq_e, eq_c, eq_acc = nvt_monte_carlo(MCNewSample(), lattice, ham, 300.0, 60, seed)
+        pr_e, pr_c, pr_acc = nvt_monte_carlo(MCNewSample(), eq_c[end], ham, 300.0, 80, seed + 1)
+        @test d_energies[1] == mean(pr_e)
+        @test d_rates[1] == pr_acc / 80
+        # Atomistic driver: same-seed reproducibility end to end
+        p1 = MetropolisMCParameters([500.0];
+            equilibrium_steps=100, sampling_steps=100, step_size=0.3, random_seed=99)
+        p2 = MetropolisMCParameters([500.0];
+            equilibrium_steps=100, sampling_steps=100, step_size=0.3, random_seed=99)
+        e1, ls1, cv1, r1 = monte_carlo_sampling(MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, p1)
+        e2, ls2, cv2, r2 = monte_carlo_sampling(MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, p2)
+        @test e1 == e2
+        @test cv1 == cv2
+        @test r1 == r2
+        @test ls1.walkers[1].configuration.position == ls2.walkers[1].configuration.position
+    end
+end


### PR DESCRIPTION
Implements #212. Stacks on the muVT kernel and the interacting-regime controls of this round (the entry check reuses the cutoff-range helper); the overlap-aware starting configurations of this round supply dense-start fixtures.

- New `MuVTMCParameters` (temperature ladder with a per-rung dimensionless activity-volume, equilibration and production budgets, recording cadence, step-size block, base seed) and a `monte_carlo_sampling` method on `MCAtomGrandCanonicalMoves` wrapping `MC_muVT_walk!`.
- Documented contracts, each tested: equilibration runs in ten adaptation blocks on the displacement-only acceptance; production runs with the step size frozen (adapting during production breaks detailed balance); rung i seeds equilibration with base + 2(i-1) and production with base + 2(i-1) + 1; the walker's incremental energy is re-anchored from scratch every ten recorded samples; the insertion species is resolved once at entry (mid-run empty states are legal).
- Returns per rung: particle-number moments, mean energy, normalized histograms with support, the recorded particle-number series (the cross-check artifact whose length pins the recording cadence), per-channel acceptance counters, and an independent final-walker copy.
- Calibrated gates: ideal-gas ladder closure (mean gate 0.13, variance gate 0.45); a dilute-LJ mean gate against the second-virial closed form on a guard-clean geometry (gate 0.03 against the quadrature reference); a contract emulation reproducing the recorded series exactly; same-seed determinism; the entry cutoff warning.
- Disclosure: driver-level closure gates are moment-only (the kernel's P(0) pin and the regression coverage's total-variation cross-route gate carry the distributional end), and the re-anchor check is a final-walker drift audit because the driver returns reductions, not an energy series.

Adversarially reviewed (issue-promise round-trip, independent-oracle physics, determinism and assertion accounting), and the full suite passes on the shipped bytes.
