### PR TITLE
Interacting-regime regression coverage for the continuous grand-canonical constructions

### DIFF
--- a/src/AbstractPotentials/lennardjones.jl
+++ b/src/AbstractPotentials/lennardjones.jl
@@ -118,3 +118,19 @@ Compute the energy of a pair of particles separated by distance `r` using the Le
 
 """
 pair_energy(r::typeof(1.0u"Å"), lj::LJParameters) = lj_energy(r, lj)
+"""
+    _max_interaction_range(pot)
+
+Maximum pair-interaction range of a potential, as a Unitful length, for
+minimum-image sanity checks: `cutoff * sigma` for `LJParameters` (infinite for
+the untruncated default), the maximum over the entries of a
+`CompositeParameterSets`, and `missing` for potentials whose range the library
+cannot determine (the check is then skipped).
+"""
+_max_interaction_range(lj::LJParameters) = lj.cutoff * lj.sigma
+_max_interaction_range(::AbstractPotential) = missing
+function _max_interaction_range(cps::CompositeParameterSets)
+    ranges = [_max_interaction_range(p) for p in cps.param_sets]
+    any(r === missing for r in ranges) && return missing
+    return maximum(ranges)
+end

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -467,6 +467,11 @@ size `(length(μs), length(Ts))`, indexed `[i_μ, i_T]`:
   follows as `C = k_B β² (var_U − μ · cov_UN)`, matching the Ω-sorted
   `gc_thermodynamic_stats` formula.
 - `cov_UN`: Energy–particle-number covariance ⟨EN⟩ − ⟨E⟩⟨N⟩.
+- `p_N`: `Array{Float64,3}` indexed `[i_μ, i_T, i_N]`, the particle-number
+  distribution P(N | μ, T) over `N_support`; a support member no sample visited
+  carries exactly 0.0 (a convergence diagnostic, not physics).
+- `N_support`: `UnitRange{Int}` `0:N_max` over the union of dead rows and the
+  live tail, indexing the third axis of `p_N`.
 - `observables`: `Dict{Symbol,Matrix{Float64}}` mapping each requested
   column to its reweighted average ⟨A⟩(μ, T); empty when no columns are
   requested.
@@ -585,6 +590,12 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     E_shift = isempty(Es) ? 0.0 : minimum(Es)
     Es_c = Es .- E_shift
 
+    # Particle-number support for P(N | mu, T): a support member no sample
+    # visited keeps exactly 0.0 (a convergence diagnostic, not physics)
+    N_int_pn = Int.(Ns)
+    N_max_pn = isempty(N_int_pn) ? 0 : maximum(N_int_pn)
+    N_support = 0:N_max_pn
+
     log_prior_mass = n_sites * log1p(z0)
     log_z0 = log(z0)
 
@@ -599,6 +610,7 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     cov_UN = Matrix{Float64}(undef, n_mu, n_T)
     obs_out = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
+    p_N = Array{Float64,3}(undef, n_mu, n_T, N_max_pn + 1)
 
     Threads.@threads for j in 1:n_T
         β = 1.0 / (kb * Ts[j])
@@ -620,11 +632,17 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                 obs_out[col][i, j] = sum(ws .* As[col]) / sum_w
             end
             N_eff[i, j] = sum_w^2 / sum(abs2, ws)
+            acc_pn = zeros(Float64, N_max_pn + 1)
+            @inbounds for k_pn in eachindex(N_int_pn)
+                acc_pn[N_int_pn[k_pn] + 1] += ws[k_pn]
+            end
+            p_N[i, j, :] .= acc_pn ./ sum_w
         end
     end
 
     return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff,
-            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
+            var_U=var_U, cov_UN=cov_UN, p_N=p_N, N_support=N_support,
+            observables=obs_out)
 end
 
 
@@ -697,8 +715,10 @@ follow-up item and out of scope here.
 # Returns
 A `NamedTuple` with the same shape as the lattice method: `logXi`, `mean_N`, `var_N`,
 `mean_U`, `N_eff`, `var_U`, `cov_UN` (each a `Matrix{Float64}` of size
-`(length(μ_grid), length(T_grid))`, indexed `[i_μ, i_T]`), and `observables`
-(`Dict{Symbol,Matrix{Float64}}`). The returned moments are configurational: beyond the
+`(length(μ_grid), length(T_grid))`, indexed `[i_μ, i_T]`), `p_N` (an
+`Array{Float64,3}` indexed `[i_μ, i_T, i_N]`, the particle-number distribution
+P(N | μ, T) over `N_support::UnitRange{Int}`, with exactly 0.0 on support
+members no sample visited), and `observables` (`Dict{Symbol,Matrix{Float64}}`). The returned moments are configurational: beyond the
 Λ(T)³ activity conversion this reduction carries no momentum integral, so
 temperature-derivative observables built from it (heat capacities) must add the Λ(T)
 term explicitly, exactly as for `gc_thermodynamic_stats_fixed_N`.
@@ -812,6 +832,12 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     E_shift = isempty(Es) ? 0.0 : minimum(Es)
     Es_c = Es .- E_shift
 
+    # Particle-number support for P(N | mu, T): a support member no sample
+    # visited keeps exactly 0.0 (a convergence diagnostic, not physics)
+    N_int_pn = Int.(Ns)
+    N_max_pn = isempty(N_int_pn) ? 0 : maximum(N_int_pn)
+    N_support = 0:N_max_pn
+
     z0V = ustrip(Unitful.NoUnits, reference_activity * V)
     log_z0 = log(ustrip(u"Å^-3", reference_activity))
 
@@ -826,6 +852,7 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     cov_UN = Matrix{Float64}(undef, n_mu, n_T)
     obs_out = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
+    p_N = Array{Float64,3}(undef, n_mu, n_T, N_max_pn + 1)
 
     Threads.@threads for j in 1:n_T
         T_K = ustrip(u"K", T_grid[j])
@@ -850,11 +877,17 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                 obs_out[col][i, j] = sum(ws .* As[col]) / sum_w
             end
             N_eff[i, j] = sum_w^2 / sum(abs2, ws)
+            acc_pn = zeros(Float64, N_max_pn + 1)
+            @inbounds for k_pn in eachindex(N_int_pn)
+                acc_pn[N_int_pn[k_pn] + 1] += ws[k_pn]
+            end
+            p_N[i, j, :] .= acc_pn ./ sum_w
         end
     end
 
     return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff,
-            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
+            var_U=var_U, cov_UN=cov_UN, p_N=p_N, N_support=N_support,
+            observables=obs_out)
 end
 
 
@@ -1107,8 +1140,8 @@ does not cancel.
 
 # Returns
 A `NamedTuple` `(Xi, mean_N, var_N, mean_U, logXi, var_U, cov_UN, log_Z_N,
-N_values, observables)`; the first four fields keep their historical leading
-positions. `Xi`, `mean_N`, `var_N`, `mean_U`, `logXi`, `var_U`, and `cov_UN`
+N_values, p_N, N_support, observables)`; the first four fields keep their
+historical leading positions. `Xi`, `mean_N`, `var_N`, `mean_U`, `logXi`, `var_U`, and `cov_UN`
 are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))` indexed
 `[i_μ, i_T]`. `Xi` is the absolute grand partition function in linear space —
 `Inf` once `ln Ξ` exceeds ≈ 709; `logXi`, its log-space companion, stays
@@ -1129,7 +1162,10 @@ functions `log Z_N(T) = log Z_NS^{(N)}(β) + N·log(V/Λ³) − log N!` — the
 μ-independent evidence the assembly is built from — and `N_values` echoes the
 particle counts (as `Vector{Int}`) indexing its rows; the particle-number
 distribution follows as `P(N | μ, T) ∝ exp.(log_Z_N[:, j] .+ β .* μ .* N_values)`,
-normalized over the supplied sectors. `observables` is a
+normalized over the supplied sectors, and is returned ready-made as `p_N`
+(`Array{Float64,3}` indexed `[i_μ, i_T, i_N]`) over `N_support::Vector{Int}`,
+the sorted sector list (a vector, not a range: the fixed-N routes accept
+non-contiguous sectors). `observables` is a
 `Dict{Symbol,Matrix{Float64}}` mapping each requested column to ⟨A⟩(μ, T);
 empty when no columns are requested. No Kish effective sample size is
 returned: the fixed-`N` route introduces no importance reweighting (`μ`
@@ -1293,6 +1329,10 @@ function gc_thermodynamic_stats_fixed_N(
     obs_out = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
+    perm_pn = sortperm(N_int)
+    N_support = N_int[perm_pn]
+    p_N = Array{Float64,3}(undef, n_mu, n_T, length(N_int))
+
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
         Λ_val = ustrip(u"Å", _thermal_wavelength(atomic_mass, T))
@@ -1326,12 +1366,14 @@ function gc_thermodynamic_stats_fixed_N(
             for col in observable_cols
                 obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
             end
+            p_N[k, j, :] .= (ws ./ sum_w)[perm_pn]
         end
     end
 
     return (Xi=Xi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
             logXi=logXi, var_U=var_U, cov_UN=cov_UN,
-            log_Z_N=log_Z_N, N_values=N_int, observables=obs_out)
+            log_Z_N=log_Z_N, N_values=N_int, p_N=p_N, N_support=N_support,
+            observables=obs_out)
 end
 
 """
@@ -1427,7 +1469,9 @@ in length or convergence.
 
 # Returns
 A `NamedTuple` `(logXi, mean_N, var_N, mean_U, log_Z_N, N_values, var_U,
-cov_UN, observables)`. The first
+cov_UN, p_N, N_support, observables)`; `p_N` (`Array{Float64,3}` indexed
+`[i_μ, i_T, i_N]`) is the particle-number distribution over
+`N_support::Vector{Int}`, the sorted sector list. The first
 four fields are `Matrix{Float64}` of size `(length(μ_grid), length(T_grid))`
 indexed `[i_μ, i_T]`. `logXi` is the natural log of the absolute grand
 partition function — returned in log space (the atomistic method returns
@@ -1594,6 +1638,10 @@ function gc_thermodynamic_stats_fixed_N(
     obs_out = Dict{Symbol,Matrix{Float64}}(
         col => Matrix{Float64}(undef, n_mu, n_T) for col in observable_cols)
 
+    perm_pn = sortperm(N_int)
+    N_support = N_int[perm_pn]
+    p_N = Array{Float64,3}(undef, n_mu, n_T, length(N_int))
+
     for (j, T) in enumerate(T_grid)
         β = 1.0 / (kb * ustrip(u"K", T))
         for (k, μ) in enumerate(μ_grid)
@@ -1620,12 +1668,14 @@ function gc_thermodynamic_stats_fixed_N(
             for col in observable_cols
                 obs_out[col][k, j] = sum(ws .* view(obs_N[col], :, j)) / sum_w
             end
+            p_N[k, j, :] .= (ws ./ sum_w)[perm_pn]
         end
     end
 
     return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U,
             log_Z_N=log_Z_NS .+ log_binom, N_values=N_int,
-            var_U=var_U, cov_UN=cov_UN, observables=obs_out)
+            var_U=var_U, cov_UN=cov_UN, p_N=p_N, N_support=N_support,
+            observables=obs_out)
 end
 
 

--- a/src/EnergyEval/EnergyEval.jl
+++ b/src/EnergyEval/EnergyEval.jl
@@ -13,9 +13,10 @@ using ..AbstractPotentials
 using ..AbstractHamiltonians
 using AtomsCalculators
 
-export pbc_dist
+export pbc_dist, pbc_displacement
 export interacting_energy, frozen_energy
 export single_site_energy
+export pair_force, interacting_gradient
 
 # definitions of frozen_energy and interacting_energy
 include("atomistic_energies.jl")
@@ -28,6 +29,9 @@ include("atomistic_pairwise.jl")
 
 # definitions of single_site_energy for computing a site energy using a pairwise potential
 include("atomistic_single_site.jl")
+
+# definitions of pairwise forces and gradients
+include("atomistic_forces.jl")
 
 # definitions of interacting_energy for many-body potentials
 include("atomistic_many_body.jl")

--- a/src/EnergyEval/atomistic_forces.jl
+++ b/src/EnergyEval/atomistic_forces.jl
@@ -1,0 +1,105 @@
+"""
+    pbc_displacement(pos1, pos2, at::AbstractSystem)
+
+Minimum-image displacement vector from `pos2` to `pos1` (`pos1 - pos2`,
+min-imaged per axis), sharing `pbc_dist`'s per-axis periodicity switch and its
+orthorhombic scope; its norm matches `pbc_dist(pos1, pos2, at)` on every axis
+combination. Positions are assumed wrapped into the cell, the storage
+convention of the walk kernels.
+
+# Arguments
+- `pos1`, `pos2`: The two positions (Unitful, Å components).
+- `at::AbstractSystem`: The system carrying the cell and boundary conditions.
+
+# Returns
+- `SVector{3}`: The minimum-image displacement vector, in Å.
+"""
+function pbc_displacement(pos1, pos2, at::AbstractSystem)
+    cellv = cell_vectors(at)
+    pbc = periodicity(at)
+    δx = pos1[1] - pos2[1]
+    δy = pos1[2] - pos2[2]
+    δz = pos1[3] - pos2[3]
+    if pbc[1]
+        L = cellv[1][1]
+        δx -= L * round(δx / L)
+    end
+    if pbc[2]
+        L = cellv[2][2]
+        δy -= L * round(δy / L)
+    end
+    if pbc[3]
+        L = cellv[3][3]
+        δz -= L * round(δz / L)
+    end
+    return SVector(δx, δy, δz)
+end
+
+"""
+    pair_force(r::typeof(1.0u"Å"), pot::SingleComponentPotential{Pairwise})
+    pair_force(r::typeof(1.0u"Å"), lj::LJParameters)
+
+The scalar radial force -du/dr of a pairwise potential at separation `r`, in
+eV/Å. The generic method is a two-sided central finite difference of
+`pair_energy` at a machine-scaled step, safe for any smooth pairwise potential;
+`LJParameters` carries the analytic override
+F(r) = 24 ε (2 (σ/r)¹² − (σ/r)⁶) / r for r ≤ r_c σ and exactly zero beyond:
+plainly truncated, so the force is discontinuous at the cutoff (the stored
+`shift` field shifts the energy only and never enters the derivative). In an
+indicator-acceptance reflective walk the force enters only through the
+reflection direction, where any deterministic position-dependent direction
+preserves the stationary measure, so the finite-difference fallback degrades
+mixing at worst, never sampled averages.
+"""
+function pair_force(r::typeof(1.0u"Å"), pot::SingleComponentPotential{Pairwise})
+    h = (cbrt(eps(Float64)) * max(ustrip(u"Å", r), 1.0)) * u"Å"
+    return (pair_energy(r - h, pot) - pair_energy(r + h, pot)) / (2 * h)
+end
+
+function pair_force(r::typeof(1.0u"Å"), lj::LJParameters)
+    r > lj.cutoff * lj.sigma && return 0.0u"eV/Å"
+    r6 = (lj.sigma / r)^6
+    r12 = r6^2
+    return 24 * lj.epsilon * (2 * r12 - r6) / r
+end
+
+"""
+    interacting_gradient(at::AbstractSystem, pot::SingleComponentPotential{Pairwise},
+                         list_num_par::Vector{Int}, frozen::Vector{Bool})
+
+The per-particle gradient of the interacting energy, `∇ᵢU`, as a vector of
+`SVector{3}` in eV/Å, over the same pair split as the matching
+`interacting_energy` method: free-free and free-frozen pairs contribute,
+frozen-frozen pairs are skipped, and frozen particles carry exactly zero
+entries (they are never displaced; they still exert forces on free particles).
+O(N²) serial accumulation through `pbc_dist`-consistent minimum-image
+displacements; a collective move consumes the full gradient, so there is no
+single-site variant to prefer. Empty and single-particle systems short-circuit
+to zero entries.
+"""
+function interacting_gradient(at::AbstractSystem, pot::SingleComponentPotential{Pairwise},
+                              list_num_par::Vector{Int}, frozen::Vector{Bool})
+    n = length(at)
+    zero_g = SVector(0.0u"eV/Å", 0.0u"eV/Å", 0.0u"eV/Å")
+    grad = fill(zero_g, n)
+    n <= 1 && return grad
+    # Per-particle frozen status from the per-component flags
+    bounds = cumsum(list_num_par)
+    comp_of = [searchsortedfirst(bounds, i) for i in 1:n]
+    part_frozen = [frozen[comp_of[i]] for i in 1:n]
+    for i in 1:(n - 1)
+        pos_i = position(at, i)
+        for j in (i + 1):n
+            (part_frozen[i] && part_frozen[j]) && continue
+            disp = pbc_displacement(pos_i, position(at, j), at)
+            r = sqrt(disp[1]^2 + disp[2]^2 + disp[3]^2)
+            f = pair_force(r, pot)
+            iszero(ustrip(f)) && continue
+            # ∇ᵢU = (du/dr) r̂ᵢⱼ = -F(r) (posᵢ - posⱼ)/r
+            g = (-f / r) * disp
+            part_frozen[i] || (grad[i] += g)
+            part_frozen[j] || (grad[j] -= g)
+        end
+    end
+    return grad
+end

--- a/src/FreeBirdIO/FreeBirdIO.jl
+++ b/src/FreeBirdIO/FreeBirdIO.jl
@@ -352,27 +352,140 @@ function extract_free_par(walker::AtomWalker)
 end
 
 """
-    generate_random_starting_config(volume_per_particle::Float64, num_particle::Int; particle_type::Symbol=:H)
+    generate_random_starting_config(volume_per_particle::Float64, num_particle::Int;
+                                    particle_type::Symbol=:H,
+                                    periodicity::NTuple{3,Bool}=(false, false, false),
+                                    min_separation::Float64=0.0,
+                                    max_attempts::Int=1000)
 
 Generate a random starting configuration for a system of particles.
+
+Intended for Metropolis and grand-canonical Metropolis starting states and
+reference-run inputs. Nested-sampling live sets must remain i.i.d. draws from the
+sampling prior: a minimum-separation draw is not the uniform prior, and a
+non-prior initial live set biases the nested-sampling evidence (see the
+initialization note in `test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl`).
 
 # Arguments
 - `volume_per_particle::Float64`: The volume per particle.
 - `num_particle::Int`: The number of particles.
 - `particle_type::Symbol=:H`: The type of particle (default is hydrogen).
+- `periodicity::NTuple{3,Bool}=(false, false, false)`: Per-axis boundary
+  conditions of the generated system. The default keeps the historical
+  non-periodic behavior.
+- `min_separation::Float64=0.0`: Minimum pairwise separation in Å, enforced by
+  sequential insertion with per-particle retries. Distances are minimum-image on
+  periodic axes and plain Euclidean otherwise. The default performs no
+  separation screening and consumes exactly the historical random stream.
+- `max_attempts::Int=1000`: Retry budget per particle; exhaustion throws an
+  `ArgumentError` reporting the attempted packing fraction.
 
 # Returns
 - `FastSystem`: A FastSystem object representing the generated system.
 
 """
-function generate_random_starting_config(volume_per_particle::Float64, num_particle::Int; particle_type::Symbol=:H)
+function generate_random_starting_config(volume_per_particle::Float64, num_particle::Int;
+                                         particle_type::Symbol=:H,
+                                         periodicity::NTuple{3,Bool}=(false, false, false),
+                                         min_separation::Float64=0.0,
+                                         max_attempts::Int=1000)
     # generate random starting configuration
     total_volume = volume_per_particle * num_particle
     box_length = total_volume^(1/3)
     box = [[box_length, 0.0, 0.0], [0.0, box_length, 0.0], [0.0, 0.0, box_length]]u"Å"
-    boundary_conditions = (false, false, false)
-    list_of_atoms = [particle_type => [rand(), rand(), rand()] .* box_length * u"Å" for _ in 1:num_particle]
+    boundary_conditions = periodicity
+    placed = Vector{Vector{typeof(1.0u"Å")}}()
+    for _ in 1:num_particle
+        attempts = 0
+        while true
+            # Literal legacy draw: at min_separation = 0 the first candidate
+            # always passes, so the default path consumes exactly the
+            # historical stream and returns bit-identical configurations
+            candidate = [rand(), rand(), rand()] .* box_length * u"Å"
+            if min_separation <= 0.0 ||
+               _separation_ok(candidate, placed, box_length, periodicity, min_separation)
+                push!(placed, candidate)
+                break
+            end
+            attempts += 1
+            if attempts >= max_attempts
+                packing = (length(placed) + 1) * (π / 6) * min_separation^3 / total_volume
+                throw(ArgumentError(
+                    "sequential insertion failed after $max_attempts attempts at particle $(length(placed) + 1) of $num_particle " *
+                    "(attempted packing fraction $(round(packing; sigdigits=3)) at the $min_separation Å separation); " *
+                    "reduce min_separation or use generate_lattice_starting_config"))
+            end
+        end
+    end
+    list_of_atoms = [particle_type => placed[i] for i in 1:num_particle]
     system = atomic_system(list_of_atoms, box, boundary_conditions)
+    return FastSystem(system)
+end
+
+# Pairwise separation screen for sequential insertion: minimum-image on
+# periodic axes, plain Euclidean otherwise
+function _separation_ok(candidate, placed, box_length::Float64,
+                        periodicity::NTuple{3,Bool}, min_separation::Float64)
+    for p in placed
+        d2 = 0.0
+        for k in 1:3
+            δ = ustrip(u"Å", candidate[k] - p[k])
+            if periodicity[k]
+                δ -= box_length * round(δ / box_length)
+            end
+            d2 += δ^2
+        end
+        sqrt(d2) < min_separation && return false
+    end
+    return true
+end
+
+"""
+    generate_lattice_starting_config(box_length::Float64, num_particle::Int;
+                                     particle_type::Symbol=:H,
+                                     periodicity::NTuple{3,Bool}=(true, true, true),
+                                     jitter::Float64=0.0)
+
+Generate a starting configuration on a simple-cubic grid: the first
+`num_particle` cell-centered sites of the smallest grid containing them, with an
+optional uniform jitter of up to `jitter` Å per coordinate. Deterministic at
+`jitter = 0`. Covers densities beyond the sequential-insertion regime of
+`generate_random_starting_config` (dense-liquid and solid-like starts for
+Metropolis annealing); the pairwise separation is at least the grid spacing
+minus `2 √3 jitter`. The same nested-sampling scoping applies: this is not a
+prior draw and must not seed a nested-sampling live set.
+
+# Arguments
+- `box_length::Float64`: The cubic box edge in Å.
+- `num_particle::Int`: The number of particles.
+- `particle_type::Symbol=:H`: The type of particle.
+- `periodicity::NTuple{3,Bool}=(true, true, true)`: Per-axis boundary conditions.
+- `jitter::Float64=0.0`: Uniform per-coordinate displacement bound in Å.
+
+# Returns
+- `FastSystem`: A FastSystem object representing the generated system.
+
+"""
+function generate_lattice_starting_config(box_length::Float64, num_particle::Int;
+                                          particle_type::Symbol=:H,
+                                          periodicity::NTuple{3,Bool}=(true, true, true),
+                                          jitter::Float64=0.0)
+    num_particle > 0 || throw(ArgumentError("num_particle must be positive"))
+    box = [[box_length, 0.0, 0.0], [0.0, box_length, 0.0], [0.0, 0.0, box_length]]u"Å"
+    n_side = ceil(Int, cbrt(num_particle))
+    a = box_length / n_side
+    list_of_atoms = []
+    count = 0
+    for ix in 0:(n_side - 1), iy in 0:(n_side - 1), iz in 0:(n_side - 1)
+        count >= num_particle && break
+        pos = [(ix + 0.5) * a, (iy + 0.5) * a, (iz + 0.5) * a]
+        if jitter > 0.0
+            pos = pos .+ jitter .* (2 .* [rand(), rand(), rand()] .- 1)
+        end
+        push!(list_of_atoms, particle_type => pos .* u"Å")
+        count += 1
+    end
+    system = atomic_system(list_of_atoms, box, periodicity)
     return FastSystem(system)
 end
 

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -29,6 +29,7 @@ export random_microstate!
 export lattice_insert_particle!, lattice_delete_particle!
 export lattice_biased_sites
 export MC_grand_canonical_walk!
+export MC_muVT_walk!
 
 export free_component_index, free_par_index
 

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -31,6 +31,7 @@ export lattice_biased_sites
 export MC_grand_canonical_walk!
 export MC_muVT_walk!
 export MC_galilean_walk!
+export continuous_cavity_cells
 
 export free_component_index, free_par_index
 

--- a/src/MonteCarloMoves/MonteCarloMoves.jl
+++ b/src/MonteCarloMoves/MonteCarloMoves.jl
@@ -30,6 +30,7 @@ export lattice_insert_particle!, lattice_delete_particle!
 export lattice_biased_sites
 export MC_grand_canonical_walk!
 export MC_muVT_walk!
+export MC_galilean_walk!
 
 export free_component_index, free_par_index
 

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -1192,12 +1192,24 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   p_move::Float64=0.5,
                                   p_insert::Float64=0.25,
                                   step_size::Float64=0.5,
-                                  n_max::Int=typemax(Int))
+                                  n_max::Int=typemax(Int),
+                                  p_bias::Float64=0.0,
+                                  bias_radius::Float64=0.0,
+                                  bias_grid::Int=0)
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
     if z0V <= 0.0
         throw(ArgumentError("z0V must be positive"))
+    end
+    if p_bias < 0.0 || p_bias > 1.0
+        throw(ArgumentError("p_bias must lie in [0, 1]"))
+    end
+    if p_bias > 0.0 && (bias_radius <= 0.0 || bias_grid < 1)
+        throw(ArgumentError("a biased insertion channel (p_bias > 0) requires bias_radius > 0 and bias_grid >= 1"))
+    end
+    if p_bias == 1.0
+        @warn "p_bias = 1: any deletion whose vacated cell is not a post-deletion cavity cell auto-rejects, which can freeze dense states; a mixed channel (p_bias < 1) keeps the chain irreducible." maxlog=1
     end
     if any(at.frozen)
         throw(ArgumentError("the continuous grand-canonical kernel requires an unfrozen single-component walker"))
@@ -1218,6 +1230,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
     move_accepted = 0
     insert_attempted = 0
     insert_accepted = 0
+    insert_biased_attempted = 0
+    insert_biased_accepted = 0
     delete_attempted = 0
     delete_accepted = 0
 
@@ -1245,10 +1259,30 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 accept_this_walker = true
             end
         elseif r < p_move + p_insert
-            # Insertion: uniform in the cell, insert-evaluate-revert
+            # Insertion: uniform in the cell (optionally cavity-biased),
+            # insert-evaluate-revert. The p_bias = 0 path keeps the shipped
+            # expressions literally and draws behind p_bias > 0 guards only.
             (n + 1 > n_max || p_insert <= 0.0) && continue   # guard skip
             insert_attempted += 1
-            pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])
+            biased_draw = false
+            q_fwd = 1.0
+            if p_bias > 0.0
+                cav = continuous_cavity_cells(config, box, bias_grid, bias_radius)
+                biased_draw = rand() < p_bias
+                if biased_draw
+                    insert_biased_attempted += 1
+                    if isempty(cav)
+                        # Null proposal: counted as attempted, no further draws
+                        continue
+                    end
+                    pos = _cavity_cell_draw(cav[rand(1:length(cav))], box, bias_grid)
+                else
+                    pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])
+                end
+                q_fwd = _composite_cavity_density(pos, cav, box, bias_grid, p_bias)
+            else
+                pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])
+            end
             insert_particle!(at, pos, species)
             e_site = single_site_energy(n + 1, config, pot, at.list_num_par)
             proposed_energy = at.energy + e_site
@@ -1256,7 +1290,11 @@ function MC_grand_canonical_walk!(n_steps::Int,
             if proposed_energy >= emax
                 accept = false
             else
-                ratio = gc_insert_acceptance_ratio(z0V, n, p_insert, p_delete)
+                if p_bias > 0.0
+                    ratio = gc_insert_acceptance_ratio(z0V, n, p_insert, p_delete) / q_fwd
+                else
+                    ratio = gc_insert_acceptance_ratio(z0V, n, p_insert, p_delete)
+                end
                 if ratio < 1.0 && rand() >= ratio
                     accept = false
                 end
@@ -1265,6 +1303,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 at.energy = proposed_energy
                 n_accept += 1
                 insert_accepted += 1
+                biased_draw && (insert_biased_accepted += 1)
                 accept_this_walker = true
             else
                 remove_particle!(at, n + 1)
@@ -1280,9 +1319,25 @@ function MC_grand_canonical_walk!(n_steps::Int,
             if proposed_energy >= emax
                 accept = false
             else
-                ratio = gc_delete_acceptance_ratio(z0V, n, p_insert, p_delete)
-                if ratio < 1.0 && rand() >= ratio
-                    accept = false
+                if p_bias > 0.0
+                    # Reverse density on the post-deletion configuration; a zero
+                    # reverse density rejects without a Metropolis draw
+                    cav_post = continuous_cavity_cells(config, box, bias_grid, bias_radius; skip=i_at)
+                    q_rev = _composite_cavity_density(position(config, i_at), cav_post,
+                                                      box, bias_grid, p_bias)
+                    if q_rev == 0.0
+                        accept = false
+                    else
+                        ratio = gc_delete_acceptance_ratio(z0V, n, p_insert, p_delete) * q_rev
+                        if ratio < 1.0 && rand() >= ratio
+                            accept = false
+                        end
+                    end
+                else
+                    ratio = gc_delete_acceptance_ratio(z0V, n, p_insert, p_delete)
+                    if ratio < 1.0 && rand() >= ratio
+                        accept = false
+                    end
                 end
             end
             if accept
@@ -1298,6 +1353,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
     return accept_this_walker, n_accept / max(n_steps, 1), at,
            (move_attempted=move_attempted, move_accepted=move_accepted,
             insert_attempted=insert_attempted, insert_accepted=insert_accepted,
+            insert_biased_attempted=insert_biased_attempted,
+            insert_biased_accepted=insert_biased_accepted,
             delete_attempted=delete_attempted, delete_accepted=delete_accepted)
 end
 """
@@ -1576,4 +1633,97 @@ function MC_galilean_walk!(n_steps::Int,
         total_inside += n_inside
     end
     return total_inside > 0, total_inside / (n_steps * n_refresh), at
+end
+
+"""
+    continuous_cavity_cells(config::AbstractSystem, box, grid::Int, r_cavity::Float64;
+                            skip::Int=0)
+
+The cavity cells of a continuous configuration: the sorted linear indices (of
+the `grid`³ overlay, column-major) of cells whose centers clear the
+minimum-image distance test r ≥ `r_cavity` against every particle. `skip`
+excludes one particle index, evaluating the post-deletion cavity set without
+mutating (the deletion channel's mutate-nothing-until-accepted convention).
+The indicator is a deterministic function of the configuration, evaluated
+identically in the biased draw, the forward proposal density, and the reverse
+density; a stochastic cavity-volume estimate has no Metropolis-Hastings
+exactness result and is deliberately not offered. Marks cells by particle,
+O(grid³ + N (r_cavity/h)³) with h the cell edge.
+"""
+function continuous_cavity_cells(config::AbstractSystem, box, grid::Int, r_cavity::Float64;
+                                 skip::Int=0)
+    n = length(config)
+    occupied = falses(grid, grid, grid)
+    L = (ustrip(u"Å", box[1]), ustrip(u"Å", box[2]), ustrip(u"Å", box[3]))
+    h = (L[1] / grid, L[2] / grid, L[3] / grid)
+    pbc = periodicity(config)
+    li = LinearIndices((grid, grid, grid))
+    for p_idx in 1:n
+        p_idx == skip && continue
+        pos = (ustrip(u"Å", position(config, p_idx)[1]),
+               ustrip(u"Å", position(config, p_idx)[2]),
+               ustrip(u"Å", position(config, p_idx)[3]))
+        base = (floor(Int, pos[1] / h[1]), floor(Int, pos[2] / h[2]), floor(Int, pos[3] / h[3]))
+        reach = (ceil(Int, r_cavity / h[1]) + 1, ceil(Int, r_cavity / h[2]) + 1,
+                 ceil(Int, r_cavity / h[3]) + 1)
+        for dx in -reach[1]:reach[1], dy in -reach[2]:reach[2], dz in -reach[3]:reach[3]
+            ix, iy, iz = base[1] + dx, base[2] + dy, base[3] + dz
+            if pbc[1]
+                ix = mod(ix, grid)
+            elseif ix < 0 || ix >= grid
+                continue
+            end
+            if pbc[2]
+                iy = mod(iy, grid)
+            elseif iy < 0 || iy >= grid
+                continue
+            end
+            if pbc[3]
+                iz = mod(iz, grid)
+            elseif iz < 0 || iz >= grid
+                continue
+            end
+            occupied[ix + 1, iy + 1, iz + 1] && continue
+            cx, cy, cz = (ix + 0.5) * h[1], (iy + 0.5) * h[2], (iz + 0.5) * h[3]
+            δx = cx - pos[1]
+            pbc[1] && (δx -= L[1] * round(δx / L[1]))
+            δy = cy - pos[2]
+            pbc[2] && (δy -= L[2] * round(δy / L[2]))
+            δz = cz - pos[3]
+            pbc[3] && (δz -= L[3] * round(δz / L[3]))
+            if δx^2 + δy^2 + δz^2 < r_cavity^2
+                occupied[ix + 1, iy + 1, iz + 1] = true
+            end
+        end
+    end
+    return findall(!, vec(occupied))
+end
+
+# Column-major linear cell index of a position under the grid overlay, matching
+# `continuous_cavity_cells` (cells located by floor on wrapped coordinates)
+function _cavity_cell_index(pos, box, grid::Int)
+    ix = min(floor(Int, ustrip(u"Å", pos[1]) / (ustrip(u"Å", box[1]) / grid)), grid - 1)
+    iy = min(floor(Int, ustrip(u"Å", pos[2]) / (ustrip(u"Å", box[2]) / grid)), grid - 1)
+    iz = min(floor(Int, ustrip(u"Å", pos[3]) / (ustrip(u"Å", box[3]) / grid)), grid - 1)
+    return LinearIndices((grid, grid, grid))[max(ix, 0) + 1, max(iy, 0) + 1, max(iz, 0) + 1]
+end
+
+# Composite proposal density at a point, in units of the uniform density:
+# p_bias (grid³/n_cav) 1{cell ∈ cavity} + (1 − p_bias). Membership is evaluated
+# at the CELL level in both directions (a point-level test disagrees with the
+# cell-level draw on boundary cells and breaks the density bookkeeping).
+function _composite_cavity_density(pos, cav::Vector{Int}, box, grid::Int, p_bias::Float64)
+    isempty(cav) && return 1.0 - p_bias
+    in_cav = insorted(_cavity_cell_index(pos, box, grid), cav)
+    return p_bias * (grid^3 / length(cav)) * (in_cav ? 1.0 : 0.0) + (1.0 - p_bias)
+end
+
+# Uniform draw within one cavity cell: the cell origin plus per-axis jitter
+function _cavity_cell_draw(cell::Int, box, grid::Int)
+    ci = CartesianIndices((grid, grid, grid))[cell]
+    h1 = box[1] / grid
+    h2 = box[2] / grid
+    h3 = box[3] / grid
+    return SVector((ci[1] - 1 + rand()) * h1, (ci[2] - 1 + rand()) * h2,
+                   (ci[3] - 1 + rand()) * h3)
 end

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -1300,3 +1300,146 @@ function MC_grand_canonical_walk!(n_steps::Int,
             insert_attempted=insert_attempted, insert_accepted=insert_accepted,
             delete_attempted=delete_attempted, delete_accepted=delete_accepted)
 end
+"""
+    MC_muVT_walk!(n_steps::Int, at::AtomWalker{1}, pot::SingleComponentPotential{Pairwise},
+                  temperature::Float64;
+                  zV::Float64, species, p_move::Float64=0.5, p_insert::Float64=0.25,
+                  step_size::Float64=0.5, kb::Float64=8.617333262e-5)
+
+Perform a fixed-temperature grand-canonical (μVT) Metropolis walk on a continuous-space
+`AtomWalker{1}`: single-atom displacements under the Boltzmann acceptance
+min(1, e^(-βΔU)), mixed with uniform-in-cell insertions and uniform-among-particles
+deletions under min(1, ratio × e^(-βΔU)), where the ratio is the volume-and-activity
+form of `gc_insert_acceptance_ratio`/`gc_delete_acceptance_ratio` (pre-move particle
+count in both) and ΔU is the post-minus-pre energy change of the proposed move in every
+channel. The fixed-temperature sibling of the nested-sampling kernel above, sharing its
+entry validation, guard-skip discipline, incremental `single_site_energy` path,
+insert-evaluate-revert bookkeeping, and `move_stats` schema; the athermal energy ceiling
+is replaced by the Boltzmann factor, and the dimensionless activity-volume
+`zV = e^(βμ) V / Λ(T)^3` is folded by the caller, mirroring the z0V convention (the
+kernel itself never sees μ or Λ).
+
+Draw discipline: one channel draw per step; the Metropolis uniform is drawn only when
+the combined acceptance factor is below one (for displacements, only when ΔU > 0).
+An insertion landing exactly on a particle (a NaN pair energy) rejects without
+drawing; a +Inf overlap energy underflows the Boltzmann factor to a combined
+factor of exactly zero and rejects through the ordinary draw.
+
+# Arguments
+- `n_steps::Int`: The number of Monte Carlo steps to perform.
+- `at::AtomWalker{1}`: The walker to evolve; a single unfrozen component.
+- `pot::SingleComponentPotential{Pairwise}`: The pairwise potential.
+- `temperature::Float64`: The temperature in Kelvin; must be positive.
+- `zV::Float64`: Dimensionless product of the target activity and the cell volume.
+- `species`: Chemical identity (a `Symbol` or `ChemicalSpecies`) of inserted particles.
+- `p_move::Float64=0.5`: Probability of a displacement move.
+- `p_insert::Float64=0.25`: Probability of an insertion move (deletion takes the remainder).
+- `step_size::Float64=0.5`: Maximum displacement per direction, in Angstrom.
+- `kb::Float64=8.617333262e-5`: The Boltzmann constant in eV/K.
+
+# Returns
+- `at::AtomWalker{1}`: The updated walker.
+- `accept_rate::Float64`: Fraction of accepted moves over `n_steps`.
+- `move_stats::NamedTuple`: Per-move-type attempt/accept counters
+  (`move_*`, `insert_*`, `delete_*`); attempts are counted at proposal, guard skips
+  excluded.
+"""
+function MC_muVT_walk!(n_steps::Int,
+                       at::AtomWalker{1},
+                       pot::SingleComponentPotential{Pairwise},
+                       temperature::Float64;
+                       zV::Float64,
+                       species::Union{Symbol, ChemicalSpecies},
+                       p_move::Float64=0.5,
+                       p_insert::Float64=0.25,
+                       step_size::Float64=0.5,
+                       kb::Float64=8.617333262e-5)
+    if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
+        throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+    end
+    if zV <= 0.0
+        throw(ArgumentError("zV must be positive"))
+    end
+    if temperature <= 0.0
+        throw(ArgumentError("temperature must be positive"))
+    end
+    if any(at.frozen)
+        throw(ArgumentError("the muVT kernel requires an unfrozen single-component walker"))
+    end
+    config = at.configuration
+    cellv = cell_vectors(config)
+    for i in 1:3, j in 1:3
+        if i != j && !iszero(ustrip(cellv[i][j]))
+            throw(ArgumentError("the muVT kernel assumes an orthorhombic cell (consistent with pbc_dist); found a nonzero off-diagonal cell component"))
+        end
+    end
+    box = (cellv[1][1], cellv[2][2], cellv[3][3])
+
+    β = 1.0 / (kb * temperature)
+    n_accept = 0
+    p_delete = 1.0 - p_move - p_insert
+    move_attempted = 0
+    move_accepted = 0
+    insert_attempted = 0
+    insert_accepted = 0
+    delete_attempted = 0
+    delete_accepted = 0
+
+    for _ in 1:n_steps
+        r = rand()
+        n = at.list_num_par[1]
+        if r < p_move
+            # Displacement: Boltzmann acceptance; uniform drawn only for uphill moves
+            n == 0 && continue          # guard skip: nothing to move
+            move_attempted += 1
+            i_at = rand(1:n)
+            prewalk_energy = single_site_energy(i_at, config, pot, at.list_num_par)
+            orig_pos::SVector{3, typeof(0.0u"Å")} = position(config, i_at)
+            pos = single_atom_random_walk!(orig_pos, step_size)
+            pos = periodic_boundary_wrap!(pos, config)
+            config.position[i_at] = pos
+            dU = ustrip(u"eV", single_site_energy(i_at, config, pot, at.list_num_par) - prewalk_energy)
+            if dU <= 0.0 || (isfinite(dU) && rand() < exp(-β * dU))
+                at.energy = at.energy + dU * u"eV"
+                n_accept += 1
+                move_accepted += 1
+            else
+                config.position[i_at] = orig_pos
+            end
+        elseif r < p_move + p_insert
+            # Insertion: uniform in the cell, insert-evaluate-revert
+            p_insert <= 0.0 && continue   # guard skip
+            insert_attempted += 1
+            pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])
+            insert_particle!(at, pos, species)
+            e_site = ustrip(u"eV", single_site_energy(n + 1, config, pot, at.list_num_par))
+            combined = gc_insert_acceptance_ratio(zV, n, p_insert, p_delete) * exp(-β * e_site)
+            if combined >= 1.0 || (isfinite(combined) && rand() < combined)
+                at.energy = at.energy + e_site * u"eV"
+                n_accept += 1
+                insert_accepted += 1
+            else
+                remove_particle!(at, n + 1)
+            end
+        else
+            # Deletion: uniform among particles; nothing mutates until acceptance
+            (n == 0 || p_delete <= 0.0) && continue          # guard skip
+            delete_attempted += 1
+            i_at = rand(1:n)
+            e_site = ustrip(u"eV", single_site_energy(i_at, config, pot, at.list_num_par))
+            # ΔU = -e_site, so the Boltzmann factor is e^(+β e_site)
+            combined = gc_delete_acceptance_ratio(zV, n, p_insert, p_delete) * exp(β * e_site)
+            if combined >= 1.0 || (isfinite(combined) && rand() < combined)
+                remove_particle!(at, i_at)
+                at.energy = at.energy - e_site * u"eV"
+                n_accept += 1
+                delete_accepted += 1
+            end
+        end
+    end
+
+    return at, n_accept / max(n_steps, 1),
+           (move_attempted=move_attempted, move_accepted=move_accepted,
+            insert_attempted=insert_attempted, insert_accepted=insert_accepted,
+            delete_attempted=delete_attempted, delete_accepted=delete_accepted)
+end

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -1443,3 +1443,137 @@ function MC_muVT_walk!(n_steps::Int,
             insert_attempted=insert_attempted, insert_accepted=insert_accepted,
             delete_attempted=delete_attempted, delete_accepted=delete_accepted)
 end
+
+# Householder reflection of the 3N-space velocity off the constraint boundary:
+# v' = v - 2 (v·ĝ) ĝ with ĝ the normalized energy gradient. Norm-preserving and
+# an involution; both properties are pinned in the tests.
+function _galilean_reflect(v::Vector{SVector{3,Float64}}, grad)
+    gn2 = 0.0
+    for gi in grad
+        gn2 += ustrip(u"eV/Å", gi[1])^2 + ustrip(u"eV/Å", gi[2])^2 + ustrip(u"eV/Å", gi[3])^2
+    end
+    gn2 <= 0.0 && return v, false
+    gn = sqrt(gn2)
+    vg = 0.0
+    for i in eachindex(v)
+        vg += v[i][1] * ustrip(u"eV/Å", grad[i][1]) +
+              v[i][2] * ustrip(u"eV/Å", grad[i][2]) +
+              v[i][3] * ustrip(u"eV/Å", grad[i][3])
+    end
+    vg /= gn
+    return [v[i] - (2 * vg / gn) * SVector(ustrip(u"eV/Å", grad[i][1]),
+                                           ustrip(u"eV/Å", grad[i][2]),
+                                           ustrip(u"eV/Å", grad[i][3])) for i in eachindex(v)], true
+end
+
+# One Galilean trajectory of n_refresh segments: straight-line motion, specular
+# reflection at the first rejected trial with continuation THROUGH it, velocity
+# reversal when the reflected trial also fails (continuing from the rejected
+# trial, never retrying from the segment start, is what makes the segment
+# retrace exactly under velocity reversal). Mutates the walker; returns the
+# final velocity and the number of segments that ended inside the constraint.
+function _galilean_trajectory!(at::AtomWalker{1},
+                               pot::SingleComponentPotential{Pairwise},
+                               emax::typeof(0.0u"eV"),
+                               v::Vector{SVector{3,Float64}},
+                               n_refresh::Int,
+                               step_size::Float64)
+    config = at.configuration
+    n = at.list_num_par[1]
+    n_inside = 0
+    current_E = at.energy
+    for _ in 1:n_refresh
+        saved = copy(config.position)
+        saved_E = current_E
+        for i in 1:n
+            pos = config.position[i] + (step_size * v[i]) * u"Å"
+            config.position[i] = periodic_boundary_wrap!(pos, config)
+        end
+        E1 = interacting_energy(config, pot, at.list_num_par, at.frozen) + at.energy_frozen_part
+        if E1 < emax
+            current_E = E1
+            n_inside += 1
+            continue
+        end
+        grad = interacting_gradient(config, pot, at.list_num_par, at.frozen)
+        v_r, ok = _galilean_reflect(v, grad)
+        if ok
+            for i in 1:n
+                pos = config.position[i] + (step_size * v_r[i]) * u"Å"
+                config.position[i] = periodic_boundary_wrap!(pos, config)
+            end
+            E2 = interacting_energy(config, pot, at.list_num_par, at.frozen) + at.energy_frozen_part
+            if E2 < emax
+                current_E = E2
+                n_inside += 1
+                v = v_r
+                continue
+            end
+        end
+        copyto!(config.position, saved)
+        current_E = saved_E
+        v = [-vi for vi in v]
+    end
+    at.energy = current_E
+    return v, n_inside
+end
+
+"""
+    MC_galilean_walk!(n_steps::Int, at::AtomWalker{1}, pot::SingleComponentPotential{Pairwise},
+                      emax::typeof(0.0u"eV"); step_size::Float64, n_refresh::Int=8)
+
+Perform a Galilean (reflective) Monte Carlo walk under a nested-sampling energy
+ceiling: `n_steps` trajectories, each drawing a fresh velocity uniformly on the
+3N-sphere and running `n_refresh` straight-line segments of 3N-space length
+`step_size` (per-atom displacement scales as `step_size`/sqrt(3N)), reflecting
+specularly off the constraint boundary through the energy gradient at the first
+rejected trial and continuing through it, with velocity reversal when the
+reflected trial also fails. All free particles move collectively; segment
+energies are full `interacting_energy` recomputes (a collective move has no
+incremental path), so the walker's energy never accumulates drift. The gradient
+enters only through the reflection direction, so an inaccurate force degrades
+mixing but cannot bias the stationary measure.
+
+Requirements: a single unfrozen component and a fully periodic orthorhombic cell
+(the position wrap mirrors coordinates at non-periodic walls without reversing
+the velocity, which would break reversibility); an empty walker returns unchanged.
+
+# Returns
+- `accept_this_walker::Bool`: Whether any segment ended inside the constraint.
+- `accept_rate::Float64`: Fraction of segments ending inside the constraint.
+- `at::AtomWalker{1}`: The updated walker.
+"""
+function MC_galilean_walk!(n_steps::Int,
+                           at::AtomWalker{1},
+                           pot::SingleComponentPotential{Pairwise},
+                           emax::typeof(0.0u"eV");
+                           step_size::Float64,
+                           n_refresh::Int=8)
+    if step_size <= 0.0 || n_refresh <= 0
+        throw(ArgumentError("step_size and n_refresh must be positive"))
+    end
+    if any(at.frozen)
+        throw(ArgumentError("the Galilean walk kernel requires an unfrozen single-component walker"))
+    end
+    if !all(periodicity(at.configuration))
+        throw(ArgumentError("the Galilean walk kernel requires fully periodic boundary conditions: the position wrap mirrors coordinates at non-periodic walls without reversing the velocity, which breaks the reflective walk's reversibility"))
+    end
+    cellv = cell_vectors(at.configuration)
+    for i in 1:3, j in 1:3
+        if i != j && !iszero(ustrip(cellv[i][j]))
+            throw(ArgumentError("the Galilean walk kernel assumes an orthorhombic cell (consistent with pbc_dist); found a nonzero off-diagonal cell component"))
+        end
+    end
+    n = at.list_num_par[1]
+    n == 0 && return false, 0.0, at
+
+    total_inside = 0
+    for _ in 1:n_steps
+        raw = [SVector(randn(), randn(), randn()) for _ in 1:n]
+        nrm = sqrt(sum(vi -> vi[1]^2 + vi[2]^2 + vi[3]^2, raw))
+        v = [vi / nrm for vi in raw]
+        _, n_inside = _galilean_trajectory!(at, pot, emax, v, n_refresh, step_size)
+        total_inside += n_inside
+    end
+    return total_inside > 0, total_inside / (n_steps * n_refresh), at
+end

--- a/src/SamplingSchemes/SamplingSchemes.jl
+++ b/src/SamplingSchemes/SamplingSchemes.jl
@@ -52,6 +52,7 @@ export ideal_gas_referenced_nested_sampling
 
 export AtomisticIGRefGCNSParameters
 export MCAtomGrandCanonicalMoves
+export MCGalileanWalk
 
 # other sampling schemes
 export exact_enumeration

--- a/src/SamplingSchemes/SamplingSchemes.jl
+++ b/src/SamplingSchemes/SamplingSchemes.jl
@@ -32,6 +32,7 @@ export NestedSamplingParameters
 export LatticeNestedSamplingParameters
 export WangLandauParameters
 export MetropolisMCParameters
+export MuVTMCParameters
 
 # nested sampling related functions
 export sort_by_energy!, nested_sampling_step!
@@ -72,6 +73,7 @@ include("nested_sampling.jl")
 include("exact_enumeration.jl")
 
 include("nvt_monte_carlo.jl")
+include("muvt_monte_carlo.jl")
 
 include("wang_landau.jl")
 

--- a/src/SamplingSchemes/muvt_monte_carlo.jl
+++ b/src/SamplingSchemes/muvt_monte_carlo.jl
@@ -1,0 +1,199 @@
+"""
+    MuVTMCParameters <: SamplingParameters
+
+Parameters for fixed-temperature grand-canonical (μVT) Metropolis sampling of
+continuous atomistic walkers through `MC_muVT_walk!`.
+
+# Fields
+- `temperatures::Vector{Float64}`: The temperature ladder, in Kelvin.
+- `activity_volumes::Vector{Float64}`: The dimensionless activity-volume zV per
+  temperature (`zV = e^(βμ) V / Λ(T)^3`, folded by the caller exactly as the
+  kernel documents; the driver never sees μ or Λ). Must match `temperatures` in
+  length: at fixed μ the activity is temperature-dependent, so each rung carries
+  its own value.
+- `equilibrium_steps::Int64`: Kernel steps of equilibration per temperature, run
+  in ten equal adaptation blocks (documented contract: step-size adjustment acts
+  between blocks on the displacement-only acceptance rate of the block).
+- `sampling_steps::Int64`: Kernel steps of production per temperature, with the
+  step size frozen (adapting during production breaks detailed balance).
+- `sampling_interval::Int64`: Kernel steps between recorded samples.
+- `step_size::Float64`: Displacement step size (Angstrom; mutable runtime state).
+- `step_size_lo::Float64`: Lower bound for the step-size adjustment.
+- `step_size_up::Float64`: Upper bound for the step-size adjustment.
+- `accept_range::Tuple{Float64,Float64}`: Acceptance window for the adjustment.
+- `random_seed::Int64`: Base seed. Temperature rung `i` seeds equilibration with
+  `random_seed + 2(i-1)` and production with `random_seed + 2(i-1) + 1`, so no
+  two phases share a random stream.
+"""
+mutable struct MuVTMCParameters <: SamplingParameters
+    temperatures::Vector{Float64}
+    activity_volumes::Vector{Float64}
+    equilibrium_steps::Int64
+    sampling_steps::Int64
+    sampling_interval::Int64
+    step_size::Float64
+    step_size_lo::Float64
+    step_size_up::Float64
+    accept_range::Tuple{Float64,Float64}
+    random_seed::Int64
+    function MuVTMCParameters(temperatures, activity_volumes;
+                              equilibrium_steps::Int64=10_000,
+                              sampling_steps::Int64=50_000,
+                              sampling_interval::Int64=10,
+                              step_size::Float64=0.5,
+                              step_size_lo::Float64=0.01,
+                              step_size_up::Float64=2.0,
+                              accept_range::Tuple{Float64,Float64}=(0.25, 0.75),
+                              random_seed::Int64=1234)
+        if length(temperatures) != length(activity_volumes)
+            throw(ArgumentError("temperatures and activity_volumes must have the same length"))
+        end
+        if any(t -> t <= 0.0, temperatures) || any(z -> z <= 0.0, activity_volumes)
+            throw(ArgumentError("temperatures and activity_volumes must be positive"))
+        end
+        if sampling_interval <= 0 || equilibrium_steps < 0 || sampling_steps <= 0
+            throw(ArgumentError("equilibrium_steps must be non-negative and sampling_steps, sampling_interval positive"))
+        end
+        new(collect(Float64, temperatures), collect(Float64, activity_volumes),
+            equilibrium_steps, sampling_steps, sampling_interval,
+            step_size, step_size_lo, step_size_up, accept_range, random_seed)
+    end
+end
+
+"""
+    monte_carlo_sampling(mc_routine::MCAtomGrandCanonicalMoves,
+                         at::AtomWalker{1},
+                         pot::SingleComponentPotential{Pairwise},
+                         mc_params::MuVTMCParameters;
+                         kb::Float64=8.617333262e-5)
+
+Fixed-temperature grand-canonical (μVT) Metropolis sampling over a temperature
+ladder, wrapping `MC_muVT_walk!`. The routine supplies the channel split
+(`p_move`, `p_insert`); its nested-sampling-only fields (`step_rate_source`,
+`mc_steps_per_particle`) are not consumed here. Per temperature rung:
+equilibration in ten adaptation blocks (step size adjusted between blocks on the
+displacement-only rate; a block that attempted no displacement skips the
+adjustment), then production with the step size frozen, recording the particle
+count every `sampling_interval` kernel steps and re-anchoring the walker's
+incremental energy with a from-scratch `interacting_energy` recompute every ten
+recorded samples. Phase seeding follows the documented per-rung law of
+`MuVTMCParameters.random_seed`. The final walker of each rung starts the next
+(sequential annealing over the ladder); the entry check warns once when the
+potential's finite interaction range exceeds half the smallest cell edge.
+
+# Returns
+A `NamedTuple` of per-temperature results:
+- `mean_N::Vector{Float64}`, `var_N::Vector{Float64}`: Particle-number moments.
+- `mean_U::Vector{Float64}`: Mean total interaction energy, in eV.
+- `p_N::Vector{Vector{Float64}}`, `N_support::Vector{UnitRange{Int}}`: The
+  recorded particle-number histogram per rung, normalized, over `0:N_max`.
+- `N_series::Vector{Vector{Int}}`: The recorded particle-number series per rung
+  (the cross-check artifact; its length is `sampling_steps ÷ sampling_interval`).
+- `acceptance::Vector{NamedTuple}`: Production per-channel attempt/accept
+  counters per rung (the kernel's `move_stats` schema).
+- `walkers::Vector{AtomWalker}`: An independent copy of the final walker per rung.
+"""
+function monte_carlo_sampling(mc_routine::MCAtomGrandCanonicalMoves,
+                              at::AtomWalker{1},
+                              pot::SingleComponentPotential{Pairwise},
+                              mc_params::MuVTMCParameters;
+                              kb::Float64=8.617333262e-5)
+    _warn_min_image_cutoff(pot, at.configuration)
+    sp = _walker_species(at)
+    n_T = length(mc_params.temperatures)
+    mean_N = Vector{Float64}(undef, n_T)
+    var_N = Vector{Float64}(undef, n_T)
+    mean_U = Vector{Float64}(undef, n_T)
+    p_N = Vector{Vector{Float64}}(undef, n_T)
+    N_support = Vector{UnitRange{Int}}(undef, n_T)
+    N_series = Vector{Vector{Int}}(undef, n_T)
+    acceptance = Vector{NamedTuple}(undef, n_T)
+    walkers = Vector{typeof(at)}(undef, n_T)
+
+    walker = deepcopy(at)
+    for (i, temp) in enumerate(mc_params.temperatures)
+        zV = mc_params.activity_volumes[i]
+        # Equilibration: ten adaptation blocks, displacement-only rate
+        Random.seed!(mc_params.random_seed + 2 * (i - 1))
+        block = mc_params.equilibrium_steps ÷ 10
+        for _ in 1:10
+            block == 0 && break
+            _, _, stats = MC_muVT_walk!(block, walker, pot, temp;
+                                        zV=zV, species=sp,
+                                        p_move=mc_routine.p_move,
+                                        p_insert=mc_routine.p_insert,
+                                        step_size=mc_params.step_size, kb=kb)
+            if stats.move_attempted > 0
+                adjust_step_size(mc_params, stats.move_accepted / stats.move_attempted;
+                                 range=mc_params.accept_range)
+            end
+        end
+        # Production: step size frozen, recording every sampling_interval steps
+        Random.seed!(mc_params.random_seed + 2 * (i - 1) + 1)
+        n_rec = mc_params.sampling_steps ÷ mc_params.sampling_interval
+        ns = Vector{Int}(undef, n_rec)
+        e_sum = 0.0
+        att = Dict{Symbol,Int}()
+        for k in 1:n_rec
+            _, _, stats = MC_muVT_walk!(mc_params.sampling_interval, walker, pot, temp;
+                                        zV=zV, species=sp,
+                                        p_move=mc_routine.p_move,
+                                        p_insert=mc_routine.p_insert,
+                                        step_size=mc_params.step_size, kb=kb)
+            ns[k] = walker.list_num_par[1]
+            e_sum += ustrip(u"eV", walker.energy)
+            for (key, val) in pairs(stats)
+                att[key] = get(att, key, 0) + val
+            end
+            if k % 10 == 0
+                # Re-anchor the incremental energy from scratch
+                walker.energy = interacting_energy(walker.configuration, pot,
+                    walker.list_num_par, walker.frozen) + walker.energy_frozen_part
+            end
+        end
+        mean_N[i] = mean(ns)
+        var_N[i] = var(ns)
+        mean_U[i] = e_sum / n_rec
+        n_max = maximum(ns)
+        hist = zeros(Float64, n_max + 1)
+        for n in ns
+            hist[n + 1] += 1.0
+        end
+        p_N[i] = hist ./ n_rec
+        N_support[i] = 0:n_max
+        N_series[i] = ns
+        acceptance[i] = (move_attempted=get(att, :move_attempted, 0),
+                        move_accepted=get(att, :move_accepted, 0),
+                        insert_attempted=get(att, :insert_attempted, 0),
+                        insert_accepted=get(att, :insert_accepted, 0),
+                        delete_attempted=get(att, :delete_attempted, 0),
+                        delete_accepted=get(att, :delete_accepted, 0))
+        walkers[i] = deepcopy(walker)
+        @info "muVT MC T = $temp K, zV = $zV: <N> = $(round(mean_N[i]; sigdigits=5)), var(N) = $(round(var_N[i]; sigdigits=5)), <U> = $(round(mean_U[i]; sigdigits=5)) eV, step size = $(round(mc_params.step_size; sigdigits=4))"
+    end
+
+    return (mean_N=mean_N, var_N=var_N, mean_U=mean_U, p_N=p_N,
+            N_support=N_support, N_series=N_series, acceptance=acceptance,
+            walkers=walkers)
+end
+
+# Chemical identity for insertions, resolved once at driver entry: an empty
+# single-component walker carries no species record, so sampling must start
+# from a non-empty walker (mid-run empty states are fine; the identity is
+# already fixed by then)
+function _walker_species(walker::AtomWalker{1})
+    if length(walker.configuration) == 0
+        throw(ArgumentError("muVT sampling requires a non-empty starting walker (an empty single-component walker carries no species record)"))
+    end
+    return species(walker.configuration, 1)
+end
+
+# Catch-all for the common mistake of omitting the routine, mirroring the
+# Metropolis guard (whose params annotation cannot fire for this params type)
+function monte_carlo_sampling(system, potential_or_hamiltonian, mc_params::MuVTMCParameters; kwargs...)
+    throw(ArgumentError(
+        "`monte_carlo_sampling` requires an `MCRoutine` as the first argument.\n" *
+        "For muVT sampling, use `MCAtomGrandCanonicalMoves()`.\n" *
+        "Example: monte_carlo_sampling(MCAtomGrandCanonicalMoves(), walker, potential, params)"
+    ))
+end

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -480,7 +480,9 @@ function update_iter!(liveset::AbstractLiveSet)
     end
 end
 
-const _RESERVED_LEDGER_COLUMNS = (:iter, :emax, :omega, :energy, :num_particles, :log_compression)
+const _RESERVED_LEDGER_COLUMNS = (:iter, :emax, :omega, :energy, :num_particles, :log_compression,
+                                  :move_attempted, :move_accepted, :insert_attempted,
+                                  :insert_accepted, :delete_attempted, :delete_accepted)
 
 """
     _validate_observables(observables, liveset::AbstractLiveSet)
@@ -2019,16 +2021,44 @@ are a known hazard class.
 # Fields
 - `p_move::Float64`: Probability of a displacement move.
 - `p_insert::Float64`: Probability of an insertion move (deletion takes the remainder).
+- `step_rate_source::Symbol`: Which acceptance rate drives the step-size
+  adjustment. `:mixed` (the default) keeps the historical behavior, adapting on
+  the kernel's combined rate over all three channels; `:move` adapts on the
+  displacement-only rate from the walk's per-channel counters, so a collapsing
+  insertion or deletion acceptance in a dense interacting system cannot drag the
+  displacement step size down against a healthy displacement channel (adjustment
+  is skipped when a walk attempted no displacement).
+- `mc_steps_per_particle::Float64`: Extra kernel steps per parent particle: a
+  decorrelation walk for a parent at particle count N runs
+  `mc_steps + round(Int, mc_steps_per_particle * N)` steps, restoring per-sweep
+  decorrelation as the count grows. The default 0.0 is draw-count identical to
+  the historical fixed-length walk.
 """
 struct MCAtomGrandCanonicalMoves <: MCRoutine
     p_move::Float64
     p_insert::Float64
-    function MCAtomGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25)
+    step_rate_source::Symbol
+    mc_steps_per_particle::Float64
+    function MCAtomGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25,
+                                       step_rate_source::Symbol=:mixed,
+                                       mc_steps_per_particle::Float64=0.0)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
         end
-        new(p_move, p_insert)
+        if !(step_rate_source in (:mixed, :move))
+            throw(ArgumentError("step_rate_source must be :mixed or :move"))
+        end
+        if !(mc_steps_per_particle >= 0.0)
+            throw(ArgumentError("mc_steps_per_particle must be non-negative"))
+        end
+        new(p_move, p_insert, step_rate_source, mc_steps_per_particle)
     end
+end
+
+# Number of kernel steps for a decorrelation walk whose parent carries n_par
+# particles (see `MCAtomGrandCanonicalMoves.mc_steps_per_particle`)
+function _gc_walk_length(params::SamplingParameters, mc_routine::MCAtomGrandCanonicalMoves, n_par::Int)
+    return params.mc_steps + round(Int, mc_routine.mc_steps_per_particle * n_par)
 end
 
 """
@@ -2053,11 +2083,19 @@ enter a run; both enter only in the post-run reduction to Ξ(μ, T).
   step-size adjustment.
 - `fail_count::Int64`: Consecutive failed replacements.
 - `allowed_fail_count::Int64`: Maximum consecutive failures before the driver's stall
-  contract fires (see `ideal_gas_referenced_nested_sampling`).
+  contract fires (see `ideal_gas_referenced_nested_sampling`). The default (100,
+  matching the canonical atomistic loop) suits interacting descents, where a run of
+  failed replacements is an ordinary sampling hiccup rather than a terminal state.
 - `plateau_refill_target::Int64`: Live-set size to restore after a plateau eviction
   block (mutable runtime state; reset at driver entry).
+- `refill_fail_budget::Int64`: Failure budget for one plateau-refill loop. The default
+  0 keeps the historical behavior of charging refill failures against
+  `allowed_fail_count` cumulatively; a positive value gives each refill loop its own
+  budget, so recovering from one difficult plateau block cannot permanently shrink
+  the live set within the stall budget.
 - `move_stats::Dict{Symbol,Int}`: Run-total per-move-type attempt/accept counters
-  accumulated from every decorrelation walk (cleared once at run start).
+  accumulated from every ordinary-cull decorrelation walk (cleared once at run
+  start; plateau-refill walks are not accumulated).
 
 Three fields carried by sibling parameter structs are deliberately absent. No `n_max`:
 the reference measure has unbounded particle-number support, and a cap silently
@@ -2080,6 +2118,7 @@ mutable struct AtomisticIGRefGCNSParameters <: SamplingParameters
     fail_count::Int64
     allowed_fail_count::Int64
     plateau_refill_target::Int64
+    refill_fail_budget::Int64
     move_stats::Dict{Symbol,Int}
 end
 
@@ -2087,8 +2126,8 @@ end
     AtomisticIGRefGCNSParameters(;
         mc_steps=100, reference_activity=0.01u"Å^-3", species=:H,
         initial_step_size=0.5, step_size=0.5, step_size_lo=0.01, step_size_up=2.0,
-        accept_range=(0.25, 0.75), fail_count=0, allowed_fail_count=10,
-        plateau_refill_target=0, move_stats=Dict{Symbol,Int}())
+        accept_range=(0.25, 0.75), fail_count=0, allowed_fail_count=100,
+        plateau_refill_target=0, refill_fail_budget=0, move_stats=Dict{Symbol,Int}())
 
 Convenience constructor for `AtomisticIGRefGCNSParameters`. `reference_activity` (z0)
 must be positive; choose it so z0V sits near the particle-number range of interest, as
@@ -2105,18 +2144,50 @@ function AtomisticIGRefGCNSParameters(;
     step_size_up::Float64=2.0,
     accept_range::Tuple{Float64,Float64}=(0.25, 0.75),
     fail_count::Int64=0,
-    allowed_fail_count::Int64=10,
+    allowed_fail_count::Int64=100,
     plateau_refill_target::Int64=0,
+    refill_fail_budget::Int64=0,
     move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
 )
     if reference_activity <= 0.0u"Å^-3"
         throw(ArgumentError("reference_activity must be positive"))
     end
+    if refill_fail_budget < 0
+        throw(ArgumentError("refill_fail_budget must be non-negative (0 charges refill failures against allowed_fail_count)"))
+    end
     AtomisticIGRefGCNSParameters(
         mc_steps, reference_activity, species,
         initial_step_size, step_size, step_size_lo, step_size_up, accept_range,
-        fail_count, allowed_fail_count, plateau_refill_target, move_stats,
+        fail_count, allowed_fail_count, plateau_refill_target, refill_fail_budget, move_stats,
     )
+end
+
+# Per-iteration acceptance-ledger columns (order matters: it is the ledger
+# schema order when `record_move_rates=true`)
+const _MOVE_RATE_COLUMNS = (:move_attempted, :move_accepted, :insert_attempted,
+                            :insert_accepted, :delete_attempted, :delete_accepted)
+
+_move_stats_snapshot(params::SamplingParameters) =
+    Tuple(get(params.move_stats, k, 0) for k in _MOVE_RATE_COLUMNS)
+
+"""
+    _warn_min_image_cutoff(pot, config)
+
+Warn once when a potential's finite interaction range exceeds half the smallest
+cell edge of `config`: minimum-image truncation is anisotropic in that regime.
+An infinite range never warns (an untruncated minimum-image Hamiltonian is a
+deliberate model choice), and potentials of undeterminable range are skipped.
+"""
+function _warn_min_image_cutoff(pot, config)
+    rng = AbstractPotentials._max_interaction_range(pot)
+    rng === missing && return nothing
+    isfinite(ustrip(rng)) || return nothing
+    cellv = cell_vectors(config)
+    L_min = min(ustrip(u"Å", cellv[1][1]), ustrip(u"Å", cellv[2][2]), ustrip(u"Å", cellv[3][3]))
+    if ustrip(u"Å", rng) > L_min / 2
+        @warn "The potential's interaction range ($(round(ustrip(u"Å", rng); sigdigits=4)) Å) exceeds half the smallest cell edge ($(round(L_min / 2; sigdigits=4)) Å): minimum-image truncation is anisotropic in this regime."
+    end
+    return nothing
 end
 
 """
@@ -2233,9 +2304,11 @@ function nested_sampling_step!(liveset::AtomWalkers,
             # decorrelating strictly below the plateau energy with the
             # grand-canonical kernel (volume-neutral; no ledger row).
             refill_fails = 0
-            while length(ats) < params.plateau_refill_target && refill_fails < params.allowed_fail_count
+            refill_budget = params.refill_fail_budget > 0 ? params.refill_fail_budget : params.allowed_fail_count
+            while length(ats) < params.plateau_refill_target && refill_fails < refill_budget
+                at_r = deepcopy(rand(ats))
                 accept_r, _, at_r, _ = MC_grand_canonical_walk!(
-                    params.mc_steps, deepcopy(rand(ats)), pot, emax;
+                    _gc_walk_length(params, mc_routine, at_r.list_num_par[1]), at_r, pot, emax;
                     z0V=z0V, species=params.species,
                     p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
                     step_size=params.step_size)
@@ -2256,6 +2329,9 @@ function nested_sampling_step!(liveset::AtomWalkers,
             length(ats) < params.plateau_refill_target && @warn "Plateau refill left the live set at $(length(ats)) of $(params.plateau_refill_target) walkers after $(refill_fails) failed decorrelation attempts; subsequent culls are charged with the actual live count."
             params.plateau_refill_target = 0
         end
+        # Step-size adaptation and move-stats accumulation stay off inside
+        # plateau blocks by design: refill walks run under a fixed plateau
+        # ceiling, and their acceptance is not representative of ordinary culls
         return iter, emax, num_particles, liveset, params, log_t
     end
     # Ordinary cull: strictly-below-ceiling parent selection, mirroring the
@@ -2264,7 +2340,7 @@ function nested_sampling_step!(liveset::AtomWalkers,
     parent_idx = isempty(eligible) ? rand(2:n_live) : rand(eligible)
     to_walk = deepcopy(ats[parent_idx])
     accept, rate, to_walk, move_stats = MC_grand_canonical_walk!(
-        params.mc_steps, to_walk, pot, emax;
+        _gc_walk_length(params, mc_routine, to_walk.list_num_par[1]), to_walk, pot, emax;
         z0V=z0V, species=params.species,
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         step_size=params.step_size)
@@ -2287,7 +2363,16 @@ function nested_sampling_step!(liveset::AtomWalkers,
         params.fail_count += 1
     end
     _accumulate_move_stats!(params, move_stats)
-    adjust_step_size(params, rate; range=params.accept_range)
+    if mc_routine.step_rate_source === :move
+        # Displacement-only adaptation: skip when the walk attempted no
+        # displacement (nothing to adapt on)
+        if move_stats.move_attempted > 0
+            adjust_step_size(params, move_stats.move_accepted / move_stats.move_attempted;
+                             range=params.accept_range)
+        end
+    else
+        adjust_step_size(params, rate; range=params.accept_range)
+    end
     return iter, emax, num_particles, liveset, params, log_t
 end
 
@@ -2316,14 +2401,28 @@ that cannot be accepted. A fully degenerate live set (every configuration at exa
 energy, the zero-interaction limit) is a legitimate terminal state whose entire prior
 mass sits in the live set; the subsequent ledger reduction is then exact. With
 `stop_on_stall=false` the driver keeps the warn-and-continue contract of the sibling
-loops (the failure counter is reset and the loop continues).
+loops (the failure counter is reset, the step size is reset to
+`params.initial_step_size` following the canonical loop's contract, and the loop
+continues).
+
+With `record_move_rates=true` the ledger gains the per-iteration acceptance columns
+`[:move_attempted, :move_accepted, :insert_attempted, :insert_accepted,
+:delete_attempted, :delete_accepted]`, recorded as the change in the run-total
+counters since the previous recorded row: the production diagnostic for how the
+per-channel acceptances evolve with descent depth. A recorded row therefore also
+carries the attempts of any failed replacements since the previous row;
+plateau-eviction rows run no decorrelation walk of their own, and refill-walk
+counters are deliberately not accumulated. The recorded columns sum exactly to
+the `move_stats` run totals accumulated through the last recorded row. The names are reserved ledger columns, rejected as
+observable names.
 
 Observable callbacks must handle empty configurations: under this construction a
 walker's particle count may be zero.
 
 # Returns
-- `df::DataFrame`: Columns `[:iter, :emax, :num_particles, :log_compression]`, plus one
-  column per requested observable. Zero-accept runs return the schema with no rows.
+- `df::DataFrame`: Columns `[:iter, :emax, :num_particles, :log_compression]`, plus the
+  acceptance columns when requested, plus one column per requested observable.
+  Zero-accept runs return the schema with no rows.
 - `liveset::AtomWalkers`: The final liveset (surviving walkers).
 - `params::AtomisticIGRefGCNSParameters`: Updated parameters.
 """
@@ -2334,8 +2433,10 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
                                               save_strategy::DataSavingStrategy;
                                               observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
                                               dead_point_callback::Union{Nothing,Function}=nothing,
-                                              stop_on_stall::Bool=true)
+                                              stop_on_stall::Bool=true,
+                                              record_move_rates::Bool=false)
     z0V = _atomistic_igref_z0V(liveset, params)
+    _warn_min_image_cutoff(liveset.potential, liveset.walkers[1].configuration)
     _init_atomistic_igref_walkers!(liveset, params, z0V)
 
     # Parameter-reuse hazards: runtime state never leaks between runs
@@ -2344,6 +2445,11 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
     empty!(params.move_stats)
 
     df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[], log_compression=Float64[])
+    if record_move_rates
+        for name in _MOVE_RATE_COLUMNS
+            df[!, name] = Int[]
+        end
+    end
     if observables !== nothing
         _validate_observables(observables, liveset)
         for (name, _) in observables
@@ -2352,6 +2458,7 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
     end
     culled = nothing
     empty_frame_warned = false
+    rate_prev = record_move_rates ? _move_stats_snapshot(params) : nothing
 
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
@@ -2382,8 +2489,9 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
                 @warn "Atomistic IG-ref GC-NS: $(params.allowed_fail_count) consecutive failed replacements; returning the partial ledger and the intact live set (stop_on_stall=true)."
                 break
             else
-                @warn "Atomistic IG-ref GC-NS: Failed $(params.allowed_fail_count) times in a row."
+                @warn "Atomistic IG-ref GC-NS: Failed $(params.allowed_fail_count) times in a row. Reset step size!"
                 params.fail_count = 0
+                params.step_size = params.initial_step_size
             end
         end
 
@@ -2394,10 +2502,17 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
                     "pairing lost (step culled a walker with energy $emax, " *
                     "but the pre-sorted worst walker had $(culled.energy))")
             end
-            if observables === nothing
-                push!(df, (iter, emax.val, n_par, log_t))
+            if record_move_rates
+                snap = _move_stats_snapshot(params)
+                rate_row = snap .- rate_prev
+                rate_prev = snap
             else
-                push!(df, (iter, emax.val, n_par, log_t,
+                rate_row = ()
+            end
+            if observables === nothing
+                push!(df, (iter, emax.val, n_par, log_t, rate_row...))
+            else
+                push!(df, (iter, emax.val, n_par, log_t, rate_row...,
                            (Float64(f(culled.configuration)) for (_, f) in observables)...))
             end
             dead_point_callback === nothing || dead_point_callback(iter, culled)

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -2009,6 +2009,93 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
     return df, liveset, params
 end
 """
+    struct MCGalileanWalk <: MCRoutine
+
+Move routine for canonical atomistic nested sampling through the Galilean
+reflective walk kernel `MC_galilean_walk!`: all free particles move
+collectively along straight lines, reflecting off the constraint boundary
+through the energy gradient. Clone semantics (a random survivor is cloned and
+decorrelated); three-dimensional only. `ns_params.mc_steps` sets the number of
+trajectories per replacement and `ns_params.step_size` the 3N-space segment
+length, adapted through the standard step-size machinery on the segment rate.
+
+# Fields
+- `n_refresh::Int`: Straight-line segments per trajectory (velocity redrawn
+  between trajectories).
+"""
+struct MCGalileanWalk <: MCRoutine
+    n_refresh::Int
+    function MCGalileanWalk(; n_refresh::Int=8)
+        n_refresh > 0 || throw(ArgumentError("n_refresh must be positive"))
+        new(n_refresh)
+    end
+end
+
+"""
+    nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters,
+                          mc_routine::MCGalileanWalk; ns_iteration::Int=0)
+
+One canonical nested-sampling step decorrelated by the Galilean reflective walk:
+the shape of the serial random-walk step (plateau-aware tie eviction included,
+with refill walks running the reflective kernel below the plateau), with the
+replacement clone drawn from the survivors and decorrelated through
+`MC_galilean_walk!`. Returns the serial steps' five-value shape, so the driver
+records `log_compression` as usual.
+"""
+function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingParameters, mc_routine::MCGalileanWalk; ns_iteration::Int=0)
+    sort_by_energy!(liveset)
+    ats = liveset.walkers
+    pot = liveset.potential
+    iter::Union{Missing,Int} = missing
+    emax::Union{Missing,typeof(0.0u"eV")} = liveset.walkers[1].energy
+    log_t::Union{Missing,Float64} = missing
+    n_live = length(ats)
+    n_tied = _tie_block_length(ats)
+    if (n_tied >= 2 || ns_params.plateau_refill_target != 0) && n_tied < n_live
+        if ns_params.plateau_refill_target == 0
+            ns_params.plateau_refill_target = n_live
+        end
+        popfirst!(ats)
+        update_iter!(liveset)
+        iter = liveset.walkers[1].iter
+        log_t = log((n_live - 1) / n_live)
+        if n_tied == 1
+            refill_fails = 0
+            while length(ats) < ns_params.plateau_refill_target && refill_fails < ns_params.allowed_fail_count
+                accept_r, _, at_r = MC_galilean_walk!(ns_params.mc_steps, deepcopy(rand(ats)), pot, emax;
+                                                      step_size=ns_params.step_size,
+                                                      n_refresh=mc_routine.n_refresh)
+                if accept_r
+                    push!(ats, at_r)
+                else
+                    refill_fails += 1
+                end
+            end
+            length(ats) < ns_params.plateau_refill_target && @warn "Plateau refill left the live set at $(length(ats)) of $(ns_params.plateau_refill_target) walkers after $(refill_fails) failed decorrelation attempts; subsequent culls are charged with the actual live count."
+            ns_params.plateau_refill_target = 0
+        end
+        return iter, emax, liveset, ns_params, log_t
+    end
+    to_walk = deepcopy(rand(ats[2:end]))
+    accept, rate, at = MC_galilean_walk!(ns_params.mc_steps, to_walk, pot, emax;
+                                         step_size=ns_params.step_size,
+                                         n_refresh=mc_routine.n_refresh)
+    if accept
+        push!(ats, at)
+        popfirst!(ats)
+        update_iter!(liveset)
+        ns_params.fail_count = 0
+        iter = liveset.walkers[1].iter
+        log_t = log(n_live / (n_live + 1))
+    else
+        emax = missing
+        ns_params.fail_count += 1
+    end
+    adjust_step_size(ns_params, rate; range=ns_params.accept_range)
+    return iter, emax, liveset, ns_params, log_t
+end
+
+"""
     struct MCAtomGrandCanonicalMoves <: MCRoutine
 
 Move routine for atomistic ideal-gas-referenced grand-canonical nested sampling:
@@ -2039,9 +2126,15 @@ struct MCAtomGrandCanonicalMoves <: MCRoutine
     p_insert::Float64
     step_rate_source::Symbol
     mc_steps_per_particle::Float64
+    galilean_steps::Int
+    galilean_n_refresh::Int
+    galilean_step_size::Float64
     function MCAtomGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25,
                                        step_rate_source::Symbol=:mixed,
-                                       mc_steps_per_particle::Float64=0.0)
+                                       mc_steps_per_particle::Float64=0.0,
+                                       galilean_steps::Int=0,
+                                       galilean_n_refresh::Int=8,
+                                       galilean_step_size::Float64=0.5)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
         end
@@ -2051,7 +2144,11 @@ struct MCAtomGrandCanonicalMoves <: MCRoutine
         if !(mc_steps_per_particle >= 0.0)
             throw(ArgumentError("mc_steps_per_particle must be non-negative"))
         end
-        new(p_move, p_insert, step_rate_source, mc_steps_per_particle)
+        if galilean_steps < 0 || galilean_n_refresh <= 0 || galilean_step_size <= 0.0
+            throw(ArgumentError("galilean_steps must be non-negative and galilean_n_refresh, galilean_step_size positive"))
+        end
+        new(p_move, p_insert, step_rate_source, mc_steps_per_particle,
+            galilean_steps, galilean_n_refresh, galilean_step_size)
     end
 end
 
@@ -2312,6 +2409,14 @@ function nested_sampling_step!(liveset::AtomWalkers,
                     z0V=z0V, species=params.species,
                     p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
                     step_size=params.step_size)
+                if accept_r && mc_routine.galilean_steps > 0 && at_r.list_num_par[1] > 0
+                    # Optional reflective decorrelation burst at the clone's
+                    # current particle count; measure-preserving at fixed N, so
+                    # the composition preserves the constrained reference
+                    MC_galilean_walk!(mc_routine.galilean_steps, at_r, pot, emax;
+                                      step_size=mc_routine.galilean_step_size,
+                                      n_refresh=mc_routine.galilean_n_refresh)
+                end
                 if accept_r
                     # Re-anchor the clone's energy from scratch: the kernel's
                     # incremental bookkeeping leaves dust that would fragment
@@ -2344,6 +2449,12 @@ function nested_sampling_step!(liveset::AtomWalkers,
         z0V=z0V, species=params.species,
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         step_size=params.step_size)
+    if accept && mc_routine.galilean_steps > 0 && to_walk.list_num_par[1] > 0
+        # Optional reflective decorrelation burst (see the refill branch)
+        MC_galilean_walk!(mc_routine.galilean_steps, to_walk, pot, emax;
+                          step_size=mc_routine.galilean_step_size,
+                          n_refresh=mc_routine.galilean_n_refresh)
+    end
     if accept
         # Re-anchor the clone's energy from scratch (see the refill branch)
         to_walk.energy = interacting_energy(to_walk.configuration, pot,

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -2100,10 +2100,12 @@ end
 
 Move routine for atomistic ideal-gas-referenced grand-canonical nested sampling:
 single-atom displacements mixed with continuous-space insertions and deletions through
-the atomistic `MC_grand_canonical_walk!` kernel. Deliberately lean: the lattice
-`MCGrandCanonicalMoves` carries cluster and biased-insertion configuration that has no
-continuous-space counterpart yet, and silently ignored fields on a mismatched routine
-are a known hazard class.
+the atomistic `MC_grand_canonical_walk!` kernel, optionally cavity-biased through the
+kernel's deterministic grid-cell channel (`p_bias`, `bias_radius`, `bias_grid`,
+forwarded verbatim; the defaults keep the uniform channel and its random stream
+bit-identically). Deliberately lean otherwise: the lattice `MCGrandCanonicalMoves`
+carries cluster configuration that has no continuous-space counterpart, and silently
+ignored fields on a mismatched routine are a known hazard class.
 
 # Fields
 - `p_move::Float64`: Probability of a displacement move.
@@ -2129,12 +2131,18 @@ struct MCAtomGrandCanonicalMoves <: MCRoutine
     galilean_steps::Int
     galilean_n_refresh::Int
     galilean_step_size::Float64
+    p_bias::Float64
+    bias_radius::Float64
+    bias_grid::Int
     function MCAtomGrandCanonicalMoves(; p_move::Float64=0.5, p_insert::Float64=0.25,
                                        step_rate_source::Symbol=:mixed,
                                        mc_steps_per_particle::Float64=0.0,
                                        galilean_steps::Int=0,
                                        galilean_n_refresh::Int=8,
-                                       galilean_step_size::Float64=0.5)
+                                       galilean_step_size::Float64=0.5,
+                                       p_bias::Float64=0.0,
+                                       bias_radius::Float64=0.0,
+                                       bias_grid::Int=0)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
         end
@@ -2147,8 +2155,18 @@ struct MCAtomGrandCanonicalMoves <: MCRoutine
         if galilean_steps < 0 || galilean_n_refresh <= 0 || galilean_step_size <= 0.0
             throw(ArgumentError("galilean_steps must be non-negative and galilean_n_refresh, galilean_step_size positive"))
         end
+        if p_bias < 0.0 || p_bias > 1.0
+            throw(ArgumentError("p_bias must lie in [0, 1]"))
+        end
+        if p_bias > 0.0 && (bias_radius <= 0.0 || bias_grid < 1)
+            throw(ArgumentError("a biased insertion channel (p_bias > 0) requires bias_radius > 0 and bias_grid >= 1"))
+        end
+        if p_bias == 1.0
+            @warn "p_bias = 1: any deletion whose vacated cell is not a post-deletion cavity cell auto-rejects, which can freeze dense states; a mixed channel (p_bias < 1) keeps the chain irreducible." maxlog=1
+        end
         new(p_move, p_insert, step_rate_source, mc_steps_per_particle,
-            galilean_steps, galilean_n_refresh, galilean_step_size)
+            galilean_steps, galilean_n_refresh, galilean_step_size,
+            p_bias, bias_radius, bias_grid)
     end
 end
 
@@ -2408,7 +2426,9 @@ function nested_sampling_step!(liveset::AtomWalkers,
                     _gc_walk_length(params, mc_routine, at_r.list_num_par[1]), at_r, pot, emax;
                     z0V=z0V, species=params.species,
                     p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
-                    step_size=params.step_size)
+                    step_size=params.step_size,
+                    p_bias=mc_routine.p_bias, bias_radius=mc_routine.bias_radius,
+                    bias_grid=mc_routine.bias_grid)
                 if accept_r && mc_routine.galilean_steps > 0 && at_r.list_num_par[1] > 0
                     # Optional reflective decorrelation burst at the clone's
                     # current particle count; measure-preserving at fixed N, so
@@ -2448,7 +2468,9 @@ function nested_sampling_step!(liveset::AtomWalkers,
         _gc_walk_length(params, mc_routine, to_walk.list_num_par[1]), to_walk, pot, emax;
         z0V=z0V, species=params.species,
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
-        step_size=params.step_size)
+        step_size=params.step_size,
+        p_bias=mc_routine.p_bias, bias_radius=mc_routine.bias_radius,
+        bias_grid=mc_routine.bias_grid)
     if accept && mc_routine.galilean_steps > 0 && to_walk.list_num_par[1] > 0
         # Optional reflective decorrelation burst (see the refill branch)
         MC_galilean_walk!(mc_routine.galilean_steps, to_walk, pot, emax;

--- a/src/SamplingSchemes/nvt_monte_carlo.jl
+++ b/src/SamplingSchemes/nvt_monte_carlo.jl
@@ -12,7 +12,9 @@ Parameters for the Metropolis Monte Carlo algorithm.
 - `step_size_up::Float64`: The upper bound of the step size.
 - `accept_range::Tuple{Float64, Float64}`: The range of acceptance rates for adjusting the step size.
 e.g. (0.25, 0.75) means that the step size will decrease if the acceptance rate is below 0.25 and increase if it is above 0.75.
-- `random_seed::Int64`: The seed for the random number generator.
+- `random_seed::Int64`: The seed for the random number generator. The `monte_carlo_sampling`
+drivers seed the equilibration phase with `random_seed` and the production phase with
+`random_seed + 1`, so the two phases never share a random stream.
 """
 mutable struct MetropolisMCParameters <: SamplingParameters
     temperatures::Vector{Float64}
@@ -173,7 +175,8 @@ function nvt_monte_carlo(
 
     current_walker = deepcopy(walker)
     current_energy = interacting_energy(current_walker.configuration, pot, current_walker.list_num_par, current_walker.frozen) + current_walker.energy_frozen_part
-    
+    current_walker.energy = current_energy
+
     for i in 1:num_steps
         proposed_walker = deepcopy(current_walker)
         # move the atoms by 1% of the average cell size
@@ -186,10 +189,15 @@ function nvt_monte_carlo(
         if ΔE < 0*e_unit || rand() < exp(-ΔE.val / (kb * temperature))
             current_walker.configuration = proposed_walker.configuration
             current_energy = proposed_energy
+            # Keep the walker's energy field in sync with the tracked energy,
+            # so stored snapshots carry the energy of their own configuration
+            current_walker.energy = current_energy
             accepted_steps += 1
         end
         energies[i] = current_energy
-        configurations[i] = current_walker
+        # Store an independent snapshot: storing the mutated walker itself
+        # would alias every recorded step to the final configuration
+        configurations[i] = deepcopy(current_walker)
     end
 
     return energies, configurations, accepted_steps
@@ -222,7 +230,10 @@ function nvt_monte_carlo(
         freq = [mc_routine.walks_freq, mc_routine.swaps_freq]
         swap_prob = freq[2] / sum(freq)
         proposed_walker = deepcopy(current_walker)
-        # Propose a move
+        # Propose a move: one channel draw per step, so every step performs
+        # exactly one move type (two independent draws would leave a
+        # walks_freq*swaps_freq-weighted channel where neither branch fires and
+        # the unchanged configuration is accepted at ΔE = 0 as a null move)
         if rand() > swap_prob
             config = proposed_walker.configuration
             free_index = free_par_index(proposed_walker)
@@ -233,7 +244,7 @@ function nvt_monte_carlo(
             pos = single_atom_random_walk!(pos, step_size)
             pos = periodic_boundary_wrap!(pos, config)
             config.position[i_at] = pos
-        elseif rand() <= swap_prob
+        else
             #println("Performing a swap move")
             config = proposed_walker.configuration
             free_comp = free_component_index(proposed_walker)
@@ -255,7 +266,9 @@ function nvt_monte_carlo(
             accepted_steps += 1
         end
         energies[i] = current_energy
-        configurations[i] = current_walker
+        # Store an independent snapshot: consecutive rejections would otherwise
+        # alias repeated entries to one mutable walker
+        configurations[i] = deepcopy(current_walker)
         # println(configurations[i])
     end
 
@@ -325,14 +338,16 @@ function monte_carlo_sampling(
         @info "Temperature: $temp K, Equilibration energy: $equi_mean, Variance: $(round(equi_var; sigdigits=4)), Acceptance rate: $(round(equi_rate; sigdigits=4))"
 
 
-        # Sample the lattice
+        # Sample the lattice. The production seed is derived from the
+        # equilibration seed (random_seed + 1): passing the same seed replays
+        # the equilibration random stream, correlating the two phases
         sampling_energies, sampling_configurations, sampling_accepted_steps = nvt_monte_carlo(
             mc_routine,
             equilibration_configurations[end],
             h,
             temp,
             mc_params.sampling_steps,
-            mc_params.random_seed
+            mc_params.random_seed + 1
         )
 
         # Compute the heat capacity
@@ -419,7 +434,9 @@ function monte_carlo_sampling(
 
         @info "Temperature: $temp K, Equilibration energy: $equi_mean, Variance: $(round(equi_var.val; sigdigits=4)), Acceptance rate: $(round(equi_rate; sigdigits=4)), Step size: $(round(mc_params.step_size; sigdigits=4))"
 
-        # Sample the lattice
+        # Sample the walker. The production seed is derived from the
+        # equilibration seed (random_seed + 1): passing the same seed replays
+        # the equilibration random stream, correlating the two phases
         sampling_energies, sampling_configurations, sampling_accepted_steps = nvt_monte_carlo(
             mc_routine,
             equilibration_configurations[end],
@@ -427,7 +444,7 @@ function monte_carlo_sampling(
             temp,
             mc_params.sampling_steps,
             mc_params.step_size,
-            mc_params.random_seed
+            mc_params.random_seed + 1
         )
 
         # Compute the heat capacity

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,8 @@ include("test-AnalysisTools.jl")
 
 include("test-EnergyEval.jl")
 
+include("test-EnergyEval-forces.jl")
+
 include("test-EnergyEval-clusters.jl")
 
 include("test-MonteCarloMoves.jl")

--- a/test/test-EnergyEval-forces.jl
+++ b/test/test-EnergyEval-forces.jl
@@ -1,0 +1,122 @@
+@testset "Pairwise forces and displacement vectors" begin
+    using Random
+
+    box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+    lj = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.0, shift=true)
+
+    @testset "pair_force: analytic vs finite difference" begin
+        # well, wall, and mid-range; the FD fallback and the analytic override
+        # agree to the FD truncation class away from the cutoff
+        for r in (2.2, 2.5, 2.806, 3.2, 4.0, 4.8)
+            f_fd = ustrip(u"eV/Å",
+                invoke(pair_force, Tuple{typeof(1.0u"Å"), SingleComponentPotential{Pairwise}},
+                       (r)u"Å", lj))
+            f_an = ustrip(u"eV/Å", pair_force((r)u"Å", lj))
+            # rtol for the generic scale; atol covers the zero-crossing
+            # neighborhood, where the FD absolute error class is ~1e-10
+            @test isapprox(f_an, f_fd; rtol=1e-7, atol=1e-9)
+        end
+        # the truncation discontinuity is pinned from both sides
+        rc = 2.0 * 2.5
+        @test pair_force((rc + 1e-9)u"Å", lj) == 0.0u"eV/Å"
+        @test abs(ustrip(u"eV/Å", pair_force((rc - 1e-9)u"Å", lj))) > 1e-4
+        # zero crossing at the minimum r0 = 2^(1/6) sigma
+        r0 = 2.5 * 2.0^(1 / 6)
+        @test abs(ustrip(u"eV/Å", pair_force((r0)u"Å", lj))) < 1e-12
+        @test ustrip(u"eV/Å", pair_force((r0 - 0.1)u"Å", lj)) > 0.0
+        @test ustrip(u"eV/Å", pair_force((r0 + 0.1)u"Å", lj)) < 0.0
+    end
+
+    @testset "pbc_displacement: minimum image and norm agreement" begin
+        pbc_sys = FastSystem(atomic_system([:Ar => [0.5, 5.0, 5.0]u"Å",
+                                            :Ar => [9.5, 5.0, 5.0]u"Å"], box, (true, true, true)))
+        d = pbc_displacement(position(pbc_sys, 1), position(pbc_sys, 2), pbc_sys)
+        @test isapprox(ustrip(u"Å", d[1]), 1.0; atol=1e-12)   # wraps, not -9
+        @test ustrip(u"Å", d[2]) == 0.0 && ustrip(u"Å", d[3]) == 0.0
+        mixed = FastSystem(atomic_system([:Ar => [0.5, 5.0, 0.5]u"Å",
+                                          :Ar => [9.5, 5.0, 9.5]u"Å"], box, (true, true, false)))
+        dm = pbc_displacement(position(mixed, 1), position(mixed, 2), mixed)
+        @test isapprox(ustrip(u"Å", dm[1]), 1.0; atol=1e-12)   # periodic axis wraps
+        @test isapprox(ustrip(u"Å", dm[3]), -9.0; atol=1e-12)  # open axis does not
+        Random.seed!(30301)
+        for _ in 1:50
+            sys = FastSystem(periodic_system([:Ar => rand(3), :Ar => rand(3)], box, fractional=true))
+            dd = pbc_displacement(position(sys, 1), position(sys, 2), sys)
+            nrm = sqrt(sum(x -> ustrip(u"Å", x)^2, dd))
+            @test isapprox(nrm, ustrip(u"Å", pbc_dist(position(sys, 1), position(sys, 2), sys));
+                           rtol=1e-12, atol=1e-12)
+        end
+    end
+
+    @testset "interacting_gradient vs finite differences" begin
+        Random.seed!(30302)
+        coor = [:Ar => rand(3) for _ in 1:5]
+        sys = FastSystem(periodic_system(coor, box, fractional=true))
+        w = AtomWalker(sys)
+        g = interacting_gradient(w.configuration, lj, w.list_num_par, w.frozen)
+        h = 1e-5
+        for i in 1:5, k in 1:3
+            orig = position(w.configuration, i)
+            shift = SVector(k == 1 ? h : 0.0, k == 2 ? h : 0.0, k == 3 ? h : 0.0)u"Å"
+            w.configuration.position[i] = orig + shift
+            Ep = ustrip(u"eV", interacting_energy(w.configuration, lj, w.list_num_par, w.frozen))
+            w.configuration.position[i] = orig - shift
+            Em = ustrip(u"eV", interacting_energy(w.configuration, lj, w.list_num_par, w.frozen))
+            w.configuration.position[i] = orig
+            @test isapprox(ustrip(u"eV/Å", g[i][k]), (Ep - Em) / (2h); rtol=1e-6, atol=1e-10)
+        end
+        # translation invariance: the gradient sums to zero over an all-free
+        # periodic system
+        tot = sum(g)
+        @test all(abs(ustrip(u"eV/Å", tot[k])) < 1e-12 for k in 1:3)
+        # symmetric fixture: the middle particle of an equidistant colinear
+        # triple feels no net force
+        trip = AtomWalker(FastSystem(atomic_system(
+            [:Ar => [2.0, 5.0, 5.0]u"Å", :Ar => [4.8, 5.0, 5.0]u"Å",
+             :Ar => [7.6, 5.0, 5.0]u"Å"], box, (true, true, true))))
+        gt = interacting_gradient(trip.configuration, lj, trip.list_num_par, trip.frozen)
+        @test all(abs(ustrip(u"eV/Å", gt[2][k])) < 1e-14 for k in 1:3)
+    end
+
+    @testset "frozen split" begin
+        # one free Ar and two frozen Xe: the frozen entries are exactly zero,
+        # the free entry matches the hand-built two-body sum, and the
+        # frozen-frozen pair contributes nothing anywhere
+        sys = FastSystem(atomic_system([:Ar => [3.0, 5.0, 5.0]u"Å",
+                                        :Xe => [6.0, 5.0, 5.0]u"Å",
+                                        :Xe => [6.0, 7.5, 5.0]u"Å"], box, (true, true, true)))
+        w = AtomWalker(sys; freeze_species=[:Xe])
+        @test w.frozen == [true, false] || w.frozen == [false, true]
+        g = interacting_gradient(w.configuration, lj, w.list_num_par, w.frozen)
+        # locate the free particle (components are sorted by atomic number)
+        free_idx = findfirst(i -> species(w.configuration, i) == ChemicalSpecies(:Ar), 1:3)
+        for i in 1:3
+            if i == free_idx
+                hand = SVector(0.0u"eV/Å", 0.0u"eV/Å", 0.0u"eV/Å")
+                for j in 1:3
+                    j == free_idx && continue
+                    disp = pbc_displacement(position(w.configuration, free_idx),
+                                            position(w.configuration, j), w.configuration)
+                    r = sqrt(sum(x -> x^2, disp))
+                    hand += (-pair_force(r, lj) / r) * disp
+                end
+                # atol per the house tie-charge convention; equally sharp for
+                # a two-term sum, robust to cross-architecture reassociation
+                @test all(isapprox(g[free_idx][k], hand[k]; atol=1e-14u"eV/Å") for k in 1:3)
+            else
+                @test g[i] == SVector(0.0u"eV/Å", 0.0u"eV/Å", 0.0u"eV/Å")
+            end
+        end
+    end
+
+    @testset "short-circuits" begin
+        empty_sys = FastSystem(box, (true, true, true),
+                               SVector{3, typeof(1.0u"Å")}[], ChemicalSpecies[],
+                               typeof(1.0u"u")[])
+        @test interacting_gradient(empty_sys, lj, [0], [false]) == SVector{3, typeof(0.0u"eV/Å")}[]
+        single = FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"], box, (true, true, true)))
+        g1 = interacting_gradient(single, lj, [1], [false])
+        @test length(g1) == 1
+        @test g1[1] == SVector(0.0u"eV/Å", 0.0u"eV/Å", 0.0u"eV/Å")
+    end
+end

--- a/test/test-FreeBirdIO.jl
+++ b/test/test-FreeBirdIO.jl
@@ -140,3 +140,84 @@
 
 
 end
+@testset "Overlap-aware periodic starting configurations" begin
+    # Minimum-image pairwise distance under the generated system's own metric
+    function _test_min_dist(sys)
+        L = ustrip(u"Å", cell_vectors(sys)[1][1])
+        pbc = periodicity(sys)
+        n = length(sys)
+        dmin = Inf
+        for i in 1:(n - 1), j in (i + 1):n
+            d2 = 0.0
+            for k in 1:3
+                δ = ustrip(u"Å", position(sys, i)[k] - position(sys, j)[k])
+                if pbc[k]
+                    δ -= L * round(δ / L)
+                end
+                d2 += δ^2
+            end
+            dmin = min(dmin, sqrt(d2))
+        end
+        return dmin
+    end
+
+    @testset "Default path is stream-neutral" begin
+        Random.seed!(31415)
+        sys_new = FreeBirdIO.generate_random_starting_config(100.0, 5)
+        Random.seed!(31415)
+        box_length = (100.0 * 5)^(1 / 3)
+        legacy_positions = [[rand(), rand(), rand()] .* box_length * u"Å" for _ in 1:5]
+        @test all(position(sys_new, i) == SVector{3}(legacy_positions[i]) for i in 1:5)
+        @test periodicity(sys_new) == (false, false, false)
+    end
+
+    @testset "Periodicity propagation" begin
+        sys = FreeBirdIO.generate_random_starting_config(100.0, 3; periodicity=(true, true, false))
+        @test periodicity(sys) == (true, true, false)
+        sys_p = FreeBirdIO.generate_random_starting_config(100.0, 3; periodicity=(true, true, true))
+        @test periodicity(sys_p) == (true, true, true)
+    end
+
+    @testset "Separation invariant at a dense point" begin
+        # 24 particles at 15.625 A^3 each (box 7.211 A): packing fraction 0.257
+        # at the 2.125 A separation, safely under the sequential-insertion regime
+        Random.seed!(2718)
+        sys = FreeBirdIO.generate_random_starting_config(15.625, 24;
+            periodicity=(true, true, true), min_separation=2.125, max_attempts=5000)
+        @test length(sys) == 24
+        @test _test_min_dist(sys) >= 2.125
+        Random.seed!(2718)
+        sys_m = FreeBirdIO.generate_random_starting_config(15.625, 24;
+            periodicity=(true, true, false), min_separation=2.125, max_attempts=5000)
+        @test _test_min_dist(sys_m) >= 2.125
+    end
+
+    @testset "Infeasible packing throws" begin
+        Random.seed!(1618)
+        @test_throws ArgumentError FreeBirdIO.generate_random_starting_config(15.625, 24;
+            periodicity=(true, true, true), min_separation=4.0, max_attempts=200)
+    end
+
+    @testset "Lattice starting configuration" begin
+        sys1 = FreeBirdIO.generate_lattice_starting_config(12.5, 100)
+        sys2 = FreeBirdIO.generate_lattice_starting_config(12.5, 100)
+        @test length(sys1) == 100
+        @test periodicity(sys1) == (true, true, true)
+        # deterministic at jitter = 0
+        @test all(position(sys1, i) == position(sys2, i) for i in 1:100)
+        # separation bound: at least the grid spacing (100 sites on a 5^3 grid)
+        @test _test_min_dist(sys1) >= 12.5 / 5 - 1e-9
+        # partial fill keeps the bound
+        sys3 = FreeBirdIO.generate_lattice_starting_config(12.5, 30)
+        @test length(sys3) == 30
+        @test _test_min_dist(sys3) >= 12.5 / ceil(Int, cbrt(30)) - 1e-9
+        # jitter: seeded reproducibility and the documented separation bound
+        Random.seed!(999)
+        sysj1 = FreeBirdIO.generate_lattice_starting_config(12.5, 100; jitter=0.2)
+        Random.seed!(999)
+        sysj2 = FreeBirdIO.generate_lattice_starting_config(12.5, 100; jitter=0.2)
+        @test all(position(sysj1, i) == position(sysj2, i) for i in 1:100)
+        @test _test_min_dist(sysj1) >= 12.5 / 5 - 2 * sqrt(3) * 0.2 - 1e-9
+        @test_throws ArgumentError FreeBirdIO.generate_lattice_starting_config(12.5, 0)
+    end
+end

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -1224,3 +1224,204 @@ FreeBird.AbstractPotentials.pair_energy(r::typeof(1.0u"Å"), hp::HarmonicPairPot
         @test w.energy == E_re
     end
 end
+
+@testset "continuous cavity-biased insertion channel" begin
+    using Random
+    # Calibration ledger (gates at >= 3x the max three-seed deviation, per stat,
+    # per corner):
+    # - Stationarity with the bias on (ideal gas, non-binding ceiling,
+    #   p_bias = 0.5, bias_radius = 2.3, bias_grid = 10; seeds 6100x):
+    #   z0V = 3 max devs mean 0.0378, var 0.0947 (gates 0.12, 0.29);
+    #   z0V = 8 max devs mean 0.0943, var 0.3382 (gates 0.29, 1.05).
+    # - Ensemble invariance at p_bias = 1 (1500 chains from exact
+    #   Poisson-uniform prior draws, 15 kernel steps; seeds 6200x): max devs
+    #   mean 0.0633, var 0.0458, p0 0.0035 (gates 0.19, 0.14, 0.011).
+    box_c = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+    pbc_c = (true, true, true)
+    seed_c = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box_c, pbc_c))
+    mkempty_c() = FastSystem(cell_vectors(seed_c), periodicity(seed_c),
+                             empty(position(seed_c, :)), empty(species(seed_c, :)),
+                             empty(mass(seed_c, :)))
+    mkwalker_c() = (w = AtomWalker{1}(mkempty_c()); w.energy = 0.0u"eV"; w)
+    lj0_c = LJParameters(epsilon=0.0)
+    emax_inf_c = Inf * u"eV"
+    boxt = (10.0u"Å", 10.0u"Å", 10.0u"Å")
+    logfact_c(n) = n == 0 ? 0.0 : sum(log, 1:n)
+    poisson_pmf_c(l, n) = exp(n * log(l) - l - logfact_c(n))
+
+    # Naive full-scan oracle for the locator
+    function naive_cavity(config, grid, r_cav; skip=0)
+        L = 10.0
+        h = L / grid
+        pbc = periodicity(config)
+        out = Int[]
+        li = LinearIndices((grid, grid, grid))
+        for iz in 0:(grid - 1), iy in 0:(grid - 1), ix in 0:(grid - 1)
+            c = ((ix + 0.5) * h, (iy + 0.5) * h, (iz + 0.5) * h)
+            clear = true
+            for p in 1:length(config)
+                p == skip && continue
+                pos = ustrip.(u"Å", position(config, p))
+                d2 = 0.0
+                for (ck, pk, per) in zip(c, pos, pbc)
+                    δ = ck - pk
+                    per && (δ -= L * round(δ / L))
+                    d2 += δ^2
+                end
+                if d2 < r_cav^2
+                    clear = false
+                    break
+                end
+            end
+            clear && push!(out, li[ix + 1, iy + 1, iz + 1])
+        end
+        return out
+    end
+
+    @testset "locator units" begin
+        # empty box: every cell is a cavity cell
+        w = mkwalker_c()
+        @test continuous_cavity_cells(w.configuration, boxt, 6, 2.0) == collect(1:216)
+        # centered particle: locator equals the naive oracle
+        insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+        @test continuous_cavity_cells(w.configuration, boxt, 10, 2.3) ==
+              naive_cavity(w.configuration, 10, 2.3)
+        # corner particle: wrap marks cells across the periodic boundary
+        w2 = mkwalker_c()
+        insert_particle!(w2, SVector(0.1, 0.1, 0.1)u"Å", :Ar)
+        cav = continuous_cavity_cells(w2.configuration, boxt, 10, 2.3)
+        far_corner = LinearIndices((10, 10, 10))[10, 10, 10]   # center (9.5, 9.5, 9.5)
+        @test !(far_corner in cav)                              # min-image distance ~1.04
+        @test cav == naive_cavity(w2.configuration, 10, 2.3)
+        # skip semantics: excluding a particle equals removing it
+        w3 = mkwalker_c()
+        insert_particle!(w3, SVector(2.0, 2.0, 2.0)u"Å", :Ar)
+        insert_particle!(w3, SVector(7.0, 7.0, 7.0)u"Å", :Ar)
+        with_skip = continuous_cavity_cells(w3.configuration, boxt, 8, 2.0; skip=2)
+        remove_particle!(w3, 2)
+        @test with_skip == continuous_cavity_cells(w3.configuration, boxt, 8, 2.0)
+        # random configurations: mark-by-particle equals the naive oracle
+        Random.seed!(60001)
+        for _ in 1:10
+            wr = mkwalker_c()
+            for _ in 1:rand(1:6)
+                insert_particle!(wr, SVector(rand() * 10, rand() * 10, rand() * 10)u"Å", :Ar)
+            end
+            @test continuous_cavity_cells(wr.configuration, boxt, 7, 1.9) ==
+                  naive_cavity(wr.configuration, 7, 1.9)
+        end
+    end
+
+    @testset "argument validation" begin
+        w = mkwalker_c()
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w, lj0_c, emax_inf_c;
+            z0V=1.0, species=:Ar, p_bias=1.5, bias_radius=2.0, bias_grid=8)
+        @test_throws ArgumentError MC_grand_canonical_walk!(1, w, lj0_c, emax_inf_c;
+            z0V=1.0, species=:Ar, p_bias=0.5)
+        @test_logs (:warn, r"p_bias = 1") match_mode = :any begin
+            MC_grand_canonical_walk!(1, w, lj0_c, emax_inf_c;
+                z0V=1.0, species=:Ar, p_bias=1.0, bias_radius=2.0, bias_grid=8)
+        end
+    end
+
+    @testset "stationarity with the bias on (seeded, calibrated)" begin
+        for (z0V, tol_m, tol_v) in ((3.0, 0.12, 0.29), (8.0, 0.29, 1.05))
+            Random.seed!(61001)
+            w = mkwalker_c()
+            MC_grand_canonical_walk!(20_000, w, lj0_c, emax_inf_c; z0V=z0V, species=:Ar,
+                                     p_bias=0.5, bias_radius=2.3, bias_grid=10)
+            ns = Int[]
+            for _ in 1:20_000
+                _, _, _, stats = MC_grand_canonical_walk!(10, w, lj0_c, emax_inf_c;
+                    z0V=z0V, species=:Ar, p_bias=0.5, bias_radius=2.3, bias_grid=10)
+                push!(ns, w.list_num_par[1])
+            end
+            @test abs(mean(ns) - z0V) < tol_m
+            @test abs(var(ns) - z0V) < tol_v
+        end
+        # the biased sub-channel genuinely fires and its counters split cleanly
+        Random.seed!(61010)
+        w = mkwalker_c()
+        _, _, _, stats = MC_grand_canonical_walk!(5_000, w, lj0_c, emax_inf_c;
+            z0V=3.0, species=:Ar, p_bias=0.5, bias_radius=2.3, bias_grid=10)
+        @test stats.insert_biased_attempted > 0
+        @test stats.insert_biased_accepted <= stats.insert_biased_attempted
+        @test stats.insert_biased_attempted <= stats.insert_attempted
+    end
+
+    @testset "ensemble invariance at p_bias = 1 (seeded, calibrated)" begin
+        Random.seed!(62001)
+        z0V = 3.0
+        finals = Int[]
+        for _ in 1:1500
+            w = mkwalker_c()
+            u = rand()
+            c = poisson_pmf_c(z0V, 0)
+            k = 0
+            while u > c
+                k += 1
+                c += poisson_pmf_c(z0V, k)
+            end
+            for _ in 1:k
+                insert_particle!(w, SVector(rand() * 10, rand() * 10, rand() * 10)u"Å", :Ar)
+            end
+            MC_grand_canonical_walk!(15, w, lj0_c, emax_inf_c; z0V=z0V, species=:Ar,
+                p_bias=1.0, bias_radius=2.3, bias_grid=10, p_move=0.0, p_insert=0.5)
+            push!(finals, w.list_num_par[1])
+        end
+        @test abs(mean(finals) - z0V) < 0.19
+        @test abs(var(finals) - z0V) < 0.14
+        @test abs(count(iszero, finals) / 1500 - poisson_pmf_c(z0V, 0)) < 0.011
+    end
+
+    @testset "null proposal and zero reverse density (forced branches)" begin
+        # Empty cavity set: one particle whose exclusion sphere covers every
+        # cell center (max min-image distance sqrt(3)*5 < 9 A); a biased
+        # insertion is a null proposal, counted as attempted, no further draws
+        # (channel draw + sub-channel draw = 2)
+        Random.seed!(881)
+        probe = [rand() for _ in 1:8]
+        @test probe[2] < 0.9   # branch precondition: the sub-draw lands biased
+        Random.seed!(881)
+        w = mkwalker_c()
+        insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+        _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0_c, emax_inf_c;
+            z0V=3.0, species=:Ar, p_move=0.0, p_insert=1.0,
+            p_bias=0.9, bias_radius=9.0, bias_grid=4)
+        @test w.list_num_par == [1]
+        @test (stats.insert_attempted, stats.insert_biased_attempted, stats.insert_accepted) == (1, 1, 0)
+        @test rand() == probe[3]
+
+        # Zero reverse density at p_bias = 1: the vacated position's cell sits
+        # inside the survivor's exclusion sphere, so the deletion rejects with
+        # NO Metropolis draw (channel draw + index draw = 2)
+        Random.seed!(882)
+        probe2 = [rand() for _ in 1:8]
+        Random.seed!(882)
+        w2 = mkwalker_c()
+        insert_particle!(w2, SVector(4.0, 5.0, 5.0)u"Å", :Ar)
+        insert_particle!(w2, SVector(6.0, 5.0, 5.0)u"Å", :Ar)
+        _, _, _, stats2 = MC_grand_canonical_walk!(1, w2, lj0_c, emax_inf_c;
+            z0V=3.0, species=:Ar, p_move=0.0, p_insert=0.0,
+            p_bias=1.0, bias_radius=3.0, bias_grid=5)
+        @test w2.list_num_par == [2]
+        @test (stats2.delete_attempted, stats2.delete_accepted) == (1, 0)
+        @test rand() == probe2[3]
+    end
+
+    @testset "stream neutrality at the defaults" begin
+        # bit-identical trajectories with and without the new kwargs at their
+        # defaults (the shipped digit pins run unmodified elsewhere in this file)
+        lj_n = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+        Random.seed!(63001)
+        w1 = mkwalker_c()
+        MC_grand_canonical_walk!(3_000, w1, lj_n, 1.0e5u"eV"; z0V=4.0, species=:Ar, step_size=1.0)
+        Random.seed!(63001)
+        w2 = mkwalker_c()
+        MC_grand_canonical_walk!(3_000, w2, lj_n, 1.0e5u"eV"; z0V=4.0, species=:Ar, step_size=1.0,
+                                 p_bias=0.0, bias_radius=0.0, bias_grid=0)
+        @test w1.list_num_par == w2.list_num_par
+        @test w1.energy == w2.energy
+        @test position(w1.configuration, :) == position(w2.configuration, :)
+    end
+end

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -878,3 +878,175 @@
 
 end
 
+
+@testset "atomistic muVT kernel tests" begin
+    using Random
+    # Calibration ledger (gates at >= 3x the max three-seed deviation, per stat):
+    # - Ideal-gas Poisson closure, zV = 3, T = 300 K, seeds 91001/91002/91003:
+    #   max devs mean 0.036, var 0.059, p0 0.0018; gates 0.11, 0.18, 0.0055.
+    # - Fixed-N pair-distance Boltzmann ratio (bins [2.5,2.9)/[3.3,3.7) A,
+    #   quadrature reference 0.7929), seeds 92001/92002/92003: max rel dev
+    #   0.0039; gate 0.012 relative.
+    box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+    pbc = (true, true, true)
+    seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+    mkempty() = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                           empty(position(seed_at, :)), empty(species(seed_at, :)),
+                           empty(mass(seed_at, :)))
+    mkwalker() = (w = AtomWalker{1}(mkempty()); w.energy = 0.0u"eV"; w)
+    lj0 = LJParameters(epsilon=0.0)
+    T300 = 300.0
+    logfact(n) = n == 0 ? 0.0 : sum(log, 1:n)
+    poisson_pmf(lam, n) = exp(n * log(lam) - lam - logfact(n))
+
+    @testset "argument validation" begin
+        w = mkwalker()
+        @test_throws ArgumentError MC_muVT_walk!(1, w, lj0, T300; zV=0.0, species=:Ar)
+        @test_throws ArgumentError MC_muVT_walk!(1, w, lj0, 0.0; zV=1.0, species=:Ar)
+        @test_throws ArgumentError MC_muVT_walk!(1, w, lj0, T300; zV=1.0, species=:Ar, p_move=0.7, p_insert=0.4)
+        frozen_w = AtomWalker(FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc));
+                              freeze_species=[:Ar])
+        @test_throws ArgumentError MC_muVT_walk!(1, frozen_w, lj0, T300; zV=1.0, species=:Ar)
+    end
+
+    @testset "RNG-stream contract (forced branches)" begin
+        # Insertion, combined ratio >= 1 (zV huge, zero-interaction): accept
+        # with NO Metropolis draw (channel + three position uniforms = 4)
+        Random.seed!(778)
+        probe = [rand() for _ in 1:8]
+        @test probe[1] < 0.75
+        Random.seed!(778)
+        w = mkwalker()
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=1.0e6, species=:Ar, p_move=0.0, p_insert=0.75)
+        @test w.list_num_par == [1]
+        @test (stats.insert_attempted, stats.insert_accepted) == (1, 1)
+        @test rand() == probe[5]
+
+        # Insertion, combined < 1: the Metropolis uniform IS drawn (5 draws;
+        # p_delete = 0 forces the ratio to zero)
+        Random.seed!(778)
+        w = mkwalker()
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=8.0, species=:Ar, p_move=0.0, p_insert=1.0)
+        @test w.list_num_par == [0]
+        @test (stats.insert_attempted, stats.insert_accepted) == (1, 0)
+        @test rand() == probe[6]
+
+        # Deletion, combined >= 1: accept with NO Metropolis draw (2 draws)
+        Random.seed!(777)
+        probe = [rand() for _ in 1:8]
+        @test probe[1] >= 0.25
+        Random.seed!(777)
+        w = mkwalker()
+        insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=0.01, species=:Ar, p_move=0.0, p_insert=0.25)
+        @test w.list_num_par == [0]
+        @test (stats.delete_attempted, stats.delete_accepted) == (1, 1)
+        @test rand() == probe[3]
+
+        # Deletion, combined < 1: the Metropolis uniform IS drawn (3 draws)
+        Random.seed!(777)
+        w = mkwalker()
+        insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=1.0e6, species=:Ar, p_move=0.0, p_insert=0.25)
+        @test w.list_num_par == [1]
+        @test (stats.delete_attempted, stats.delete_accepted) == (1, 0)
+        @test rand() == probe[4]
+
+        # Zero-interaction displacement: dU = 0 accepts downhill-style with NO
+        # Metropolis draw (channel + index + three walk displacements = 5)
+        Random.seed!(779)
+        probe779 = [rand() for _ in 1:8]
+        @test probe779[1] < 1.0
+        Random.seed!(779)
+        w = mkwalker()
+        insert_particle!(w, SVector(5.0, 5.0, 5.0)u"Å", :Ar)
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=1.0, species=:Ar, p_move=1.0, p_insert=0.0)
+        @test (stats.move_attempted, stats.move_accepted) == (1, 1)
+        @test rand() == probe779[6]
+
+        # Uphill displacement from the exact pair minimum: any move raises the
+        # pair energy, so the Metropolis uniform IS drawn (6 draws)
+        lj_up = LJParameters(epsilon=0.05, sigma=2.5, cutoff=3.0, shift=true)
+        r0 = 2.5 * 2.0^(1 / 6)
+        Random.seed!(781)
+        probe781 = [rand() for _ in 1:8]
+        Random.seed!(781)
+        wp = AtomWalker(FastSystem(atomic_system(
+            [:Ar => [2.0, 5.0, 5.0]u"Å", :Ar => [2.0 + r0, 5.0, 5.0]u"Å"], box, pbc)))
+        wp.energy = interacting_energy(wp.configuration, lj_up, wp.list_num_par, wp.frozen)
+        _, _, stats = MC_muVT_walk!(1, wp, lj_up, T300; zV=1.0, species=:Ar,
+                                    p_move=1.0, p_insert=0.0, step_size=0.3)
+        @test stats.move_attempted == 1
+        @test rand() == probe781[7]
+
+        # Guard skips consume only the channel draw and count no attempt
+        Random.seed!(777)
+        w = mkwalker()
+        _, _, stats = MC_muVT_walk!(1, w, lj0, T300; zV=8.0, species=:Ar, p_move=0.0, p_insert=0.25)
+        @test stats == (move_attempted=0, move_accepted=0, insert_attempted=0,
+                        insert_accepted=0, delete_attempted=0, delete_accepted=0)
+        @test rand() == probe[2]
+    end
+
+    @testset "ideal-gas Poisson closure (seeded, calibrated)" begin
+        Random.seed!(91001)
+        w = mkwalker()
+        MC_muVT_walk!(20_000, w, lj0, T300; zV=3.0, species=:Ar)
+        ns = Int[]
+        for _ in 1:20_000
+            MC_muVT_walk!(10, w, lj0, T300; zV=3.0, species=:Ar)
+            push!(ns, w.list_num_par[1])
+        end
+        @test abs(mean(ns) - 3.0) < 0.11
+        @test abs(var(ns) - 3.0) < 0.18
+        @test abs(count(iszero, ns) / length(ns) - poisson_pmf(3.0, 0)) < 0.0055
+        @test length(w.configuration) == w.list_num_par[1]
+    end
+
+    @testset "fixed-N Boltzmann law for the pair distance (seeded, calibrated)" begin
+        lj = LJParameters(epsilon=0.02, sigma=2.5, cutoff=2.5, shift=true)
+        kb = 8.617333262e-5
+        β = 1 / (kb * T300)
+        u_of(r) = ustrip(u"eV", FreeBird.AbstractPotentials.lj_energy((r)u"Å", lj))
+        simpson(f, a, b; n=2000) = (h = (b - a) / n;
+            h / 3 * sum(k -> f(a + k * h) * (k == 0 || k == n ? 1 : (isodd(k) ? 4 : 2)), 0:n))
+        R_ref = simpson(r -> r^2 * exp(-β * u_of(r)), 2.5, 2.9) /
+                simpson(r -> r^2 * exp(-β * u_of(r)), 3.3, 3.7)
+        Random.seed!(92001)
+        w = AtomWalker(FastSystem(atomic_system(
+            [:Ar => [2.0, 5.0, 5.0]u"Å", :Ar => [4.8, 5.0, 5.0]u"Å"], box, pbc)))
+        w.energy = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen)
+        MC_muVT_walk!(50_000, w, lj, T300; zV=1.0, species=:Ar, p_move=1.0, p_insert=0.0, step_size=0.8)
+        c1 = 0; c2 = 0
+        for _ in 1:200_000
+            MC_muVT_walk!(5, w, lj, T300; zV=1.0, species=:Ar, p_move=1.0, p_insert=0.0, step_size=0.8)
+            d = ustrip(u"Å", FreeBird.EnergyEval.pbc_dist(position(w.configuration, 1),
+                                                          position(w.configuration, 2),
+                                                          w.configuration))
+            (2.5 <= d < 2.9) && (c1 += 1)
+            (3.3 <= d < 3.7) && (c2 += 1)
+        end
+        @test abs(c1 / c2 - R_ref) / R_ref < 0.012
+    end
+
+    @testset "incremental-energy drift audit" begin
+        lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5, shift=true)
+        Random.seed!(93001)
+        w = mkwalker()
+        MC_muVT_walk!(20_000, w, lj, T300; zV=6.0, species=:Ar, step_size=0.6)
+        E_re = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen) + w.energy_frozen_part
+        @test abs(ustrip(u"eV", w.energy - E_re)) < 5e-10
+        @test length(w.configuration) == w.list_num_par[1]
+    end
+
+    @testset "same-seed determinism" begin
+        lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5, shift=true)
+        outs = map(1:2) do _
+            Random.seed!(94001)
+            w = mkwalker()
+            _, rate, stats = MC_muVT_walk!(5_000, w, lj, T300; zV=4.0, species=:Ar)
+            (w.list_num_par[1], ustrip(u"eV", w.energy), rate, stats)
+        end
+        @test outs[1] == outs[2]
+    end
+end

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -1050,3 +1050,176 @@ end
         @test outs[1] == outs[2]
     end
 end
+
+# Test-local pairwise potential for the Galilean measure tests: a harmonic pair
+# whose ceiling-constrained relative coordinate is exactly uniform in a ball
+# (struct defined at file top level; testset bodies cannot define types)
+struct HarmonicPairPotential <: FreeBird.AbstractPotentials.SingleComponentPotential{FreeBird.AbstractPotentials.Pairwise}
+    k::typeof(1.0u"eV/Å^2")
+end
+FreeBird.AbstractPotentials.pair_energy(r::typeof(1.0u"Å"), hp::HarmonicPairPotential) = hp.k * r^2
+
+@testset "Galilean reflective walk kernel" begin
+    using Random
+    # Calibration ledger (gates at >= 3x the max three-seed deviation, per stat):
+    # - Free-particle uniformity (20 A box, 40k trajectories, seeds 8500x):
+    #   max octant-occupancy dev 0.0034 (gate 0.011); mean-x dev 0.031 A (gate 0.1).
+    # - Harmonic-pair ball (k = 0.01 eV/A^2, emax = 0.09 eV, R = 3 A, seeds
+    #   8600x): <r^2> max rel dev 0.0053 vs the closed form 3R^2/5 (gate 0.016);
+    #   the support never exceeds R (exact bound).
+    # - LJ shell vs a rejection-sampled reference (mean pair distance ref
+    #   3.0769, seeds 8800x): max dev 0.0018 (gate 0.006).
+    box20 = [[20.0, 0.0, 0.0], [0.0, 20.0, 0.0], [0.0, 0.0, 20.0]]u"Å"
+    pbc20 = (true, true, true)
+    lj_g = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.0, shift=true)
+
+    @testset "argument validation and guards" begin
+        w = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"], box20, pbc20)))
+        w.energy = 0.0u"eV"
+        @test_throws ArgumentError MC_galilean_walk!(1, w, lj_g, 1.0u"eV"; step_size=0.0, n_refresh=4)
+        @test_throws ArgumentError MC_galilean_walk!(1, w, lj_g, 1.0u"eV"; step_size=0.5, n_refresh=0)
+        frozen_w = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"], box20, pbc20));
+                              freeze_species=[:Ar])
+        @test_throws ArgumentError MC_galilean_walk!(1, frozen_w, lj_g, 1.0u"eV"; step_size=0.5, n_refresh=4)
+        # non-periodic walls mirror positions without reversing the velocity,
+        # which breaks reversibility: the kernel rejects them at entry
+        open_w = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"], box20,
+                                                     (true, true, false))))
+        open_w.energy = 0.0u"eV"
+        @test_throws ArgumentError MC_galilean_walk!(1, open_w, lj_g, 1.0u"eV"; step_size=0.5, n_refresh=4)
+        # empty walker: unchanged, no acceptance
+        empty_sys = FastSystem(cell_vectors(w.configuration), pbc20,
+                               empty(position(w.configuration, :)),
+                               empty(species(w.configuration, :)),
+                               empty(mass(w.configuration, :)))
+        we = AtomWalker{1}(empty_sys); we.energy = 0.0u"eV"
+        acc, rate, _ = MC_galilean_walk!(3, we, lj_g, 1.0u"eV"; step_size=0.5, n_refresh=4)
+        @test acc == false && rate == 0.0
+        # a single free particle under a non-binding ceiling never reflects
+        Random.seed!(84001)
+        w1 = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"], box20, pbc20)))
+        w1.energy = 0.0u"eV"
+        acc, rate, _ = MC_galilean_walk!(10, w1, LJParameters(epsilon=0.0), 1.0u"eV";
+                                         step_size=2.0, n_refresh=4)
+        @test acc == true && rate == 1.0
+    end
+
+    @testset "Householder reflection: norm preservation and involution" begin
+        Random.seed!(84002)
+        v = [SVector(randn(), randn(), randn()) for _ in 1:4]
+        nrm = sqrt(sum(vi -> sum(abs2, vi), v))
+        v = [vi / nrm for vi in v]
+        g = [SVector(randn(), randn(), randn()) * u"eV/Å" for _ in 1:4]
+        v1, ok1 = FreeBird.MonteCarloMoves._galilean_reflect(v, g)
+        @test ok1
+        @test isapprox(sqrt(sum(vi -> sum(abs2, vi), v1)), 1.0; rtol=1e-12)
+        v2, _ = FreeBird.MonteCarloMoves._galilean_reflect(v1, g)
+        @test all(isapprox(v2[i][k], v[i][k]; atol=1e-13) for i in 1:4 for k in 1:3)
+        # specular answer at an axis-aligned plane: only the x component flips
+        vp = [SVector(0.6, 0.8, 0.0)]
+        gp = [SVector(1.0, 0.0, 0.0) * u"eV/Å"]
+        vr, _ = FreeBird.MonteCarloMoves._galilean_reflect(vp, gp)
+        @test isapprox(vr[1][1], -0.6; atol=1e-14)
+        @test isapprox(vr[1][2], 0.8; atol=1e-14)
+        # zero gradient reports failure and leaves the velocity alone
+        vz, okz = FreeBird.MonteCarloMoves._galilean_reflect(vp, [SVector(0.0, 0.0, 0.0) * u"eV/Å"])
+        @test okz == false && vz === vp
+    end
+
+    @testset "trajectory reversibility through reflections" begin
+        # forward trajectory from (x, v), reverse from (x_end, -v_end): every
+        # trial retraces to the start; per the cross-architecture pin policy the
+        # gate is a floating-point atol, never a digit pin on the cascade
+        w0 = AtomWalker(FastSystem(atomic_system(
+            [:Ar => [10.0, 10.0, 10.0]u"Å", :Ar => [12.9, 10.0, 10.0]u"Å",
+             :Ar => [10.0, 12.9, 10.0]u"Å"], box20, pbc20)))
+        w0.energy = interacting_energy(w0.configuration, lj_g, w0.list_num_par, w0.frozen)
+        emax_r = w0.energy + 0.004u"eV"
+        x0 = copy(w0.configuration.position)
+        n_perturbed = 0
+        for trial in 1:20
+            w = deepcopy(w0)
+            Random.seed!(87000 + trial)
+            raw = [SVector(randn(), randn(), randn()) for _ in 1:3]
+            nrm = sqrt(sum(vi -> sum(abs2, vi), raw))
+            v = [vi / nrm for vi in raw]
+            v_end, ni = FreeBird.MonteCarloMoves._galilean_trajectory!(w, lj_g, emax_r, v, 6, 0.9)
+            ni < 6 && (n_perturbed += 1)
+            v_back = [-vi for vi in v_end]
+            FreeBird.MonteCarloMoves._galilean_trajectory!(w, lj_g, emax_r, v_back, 6, 0.9)
+            dev = maximum(maximum(abs.(ustrip.(u"Å", w.configuration.position[i] - x0[i])))
+                          for i in 1:3)
+            @test dev < 1e-9
+        end
+        # the fixture genuinely exercises reflections and reversals
+        @test n_perturbed == 20
+    end
+
+    @testset "measure preservation: free particle is uniform (seeded, calibrated)" begin
+        Random.seed!(85001)
+        w = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"], box20, pbc20)))
+        w.energy = 0.0u"eV"
+        counts = zeros(Int, 8)
+        xsum = 0.0
+        n_samp = 40_000
+        for _ in 1:n_samp
+            MC_galilean_walk!(1, w, LJParameters(epsilon=0.0), 1.0u"eV"; step_size=4.0, n_refresh=4)
+            p = ustrip.(u"Å", position(w.configuration, 1))
+            counts[1 + (p[1] > 10) + 2 * (p[2] > 10) + 4 * (p[3] > 10)] += 1
+            xsum += p[1]
+        end
+        @test maximum(abs.(counts ./ n_samp .- 0.125)) < 0.011
+        @test abs(xsum / n_samp - 10.0) < 0.1
+    end
+
+    @testset "measure preservation: harmonic pair fills the ball uniformly (seeded, calibrated)" begin
+        # the ceiling-constrained relative coordinate is uniform in the ball of
+        # radius R = sqrt(emax/k): <r^2> = 3R^2/5, and the support never leaves
+        # the ball; the reflection direction here comes from the generic
+        # finite-difference pair_force fallback, exercised in production use
+        hp = HarmonicPairPotential(0.01u"eV/Å^2")
+        Random.seed!(86001)
+        w = AtomWalker(FastSystem(atomic_system(
+            [:Ar => [10.0, 10.0, 10.0]u"Å", :Ar => [11.0, 10.0, 10.0]u"Å"], box20, pbc20)))
+        w.energy = interacting_energy(w.configuration, hp, w.list_num_par, w.frozen)
+        r2sum = 0.0
+        r2max = 0.0
+        n_samp = 40_000
+        for _ in 1:n_samp
+            MC_galilean_walk!(1, w, hp, 0.09u"eV"; step_size=1.5, n_refresh=4)
+            d = pbc_displacement(position(w.configuration, 1), position(w.configuration, 2),
+                                 w.configuration)
+            r2 = sum(x -> ustrip(u"Å", x)^2, d)
+            r2sum += r2
+            r2max = max(r2max, r2)
+        end
+        @test abs(r2sum / n_samp - 5.4) / 5.4 < 0.016
+        @test r2max <= 9.0
+    end
+
+    @testset "measure preservation: LJ shell against a rejection-sampled reference (seeded, calibrated)" begin
+        emax_s = -0.02
+        Random.seed!(1)
+        rs = Float64[]
+        while length(rs) < 400_000
+            r = 5.0 * cbrt(rand())
+            (ustrip(u"eV", FreeBird.AbstractPotentials.lj_energy((r)u"Å", lj_g)) < emax_s) && push!(rs, r)
+        end
+        ref = mean(rs)
+        Random.seed!(88001)
+        w = AtomWalker(FastSystem(atomic_system(
+            [:Ar => [10.0, 10.0, 10.0]u"Å", :Ar => [12.8, 10.0, 10.0]u"Å"], box20, pbc20)))
+        w.energy = interacting_energy(w.configuration, lj_g, w.list_num_par, w.frozen)
+        dsum = 0.0
+        n_samp = 40_000
+        for _ in 1:n_samp
+            MC_galilean_walk!(1, w, lj_g, (emax_s)u"eV"; step_size=0.8, n_refresh=4)
+            dsum += ustrip(u"Å", pbc_dist(position(w.configuration, 1),
+                                          position(w.configuration, 2), w.configuration))
+        end
+        @test abs(dsum / n_samp - ref) < 0.006
+        # full-recompute energies never drift from the configuration
+        E_re = interacting_energy(w.configuration, lj_g, w.list_num_par, w.frozen)
+        @test w.energy == E_re
+    end
+end

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -798,7 +798,8 @@
             _, _, _, stats = MC_grand_canonical_walk!(1, w, lj0, emax_inf; z0V=8.0, species=:Ar, p_move=0.0, p_insert=0.25)
             @test w.list_num_par == [0]
             @test stats == (move_attempted=0, move_accepted=0, insert_attempted=0,
-                            insert_accepted=0, delete_attempted=0, delete_accepted=0)
+                            insert_accepted=0, insert_biased_attempted=0,
+                            insert_biased_accepted=0, delete_attempted=0, delete_accepted=0)
             @test rand() == probe[2]
             Random.seed!(779)
             probe779 = [rand() for _ in 1:4]

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -7,6 +7,7 @@
     # test NVT Monte Carlo
     include("test-nvt_monte_carlo.jl")
 include("test-muvt-monte-carlo.jl")
+include("test-atomistic-gc-interacting-regressions.jl")
     # test Wang-Landau
     include("test-wang_landau.jl")
     # test grand-canonical nested sampling

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -6,6 +6,7 @@
     include("test-nested_sampling.jl")
     # test NVT Monte Carlo
     include("test-nvt_monte_carlo.jl")
+include("test-muvt-monte-carlo.jl")
     # test Wang-Landau
     include("test-wang_landau.jl")
     # test grand-canonical nested sampling

--- a/test/test-SamplingSchemes/test-atomistic-gc-interacting-regressions.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gc-interacting-regressions.jl
@@ -1,0 +1,219 @@
+# Interacting-regime regression coverage for the continuous grand-canonical
+# constructions.
+#
+# Calibration ledger (all gates at >= 3x the max three-seed deviation, per
+# stat, per point; total wall-clock budget about four minutes single-thread):
+#
+# - Second-virial block (LJ epsilon = 0.04 eV, sigma = 2.0 A, cutoff 2.5 so
+#   r_c = 5 A <= L/2 = 6 A, shift = true, T = 200 K, beta*epsilon = 2.32;
+#   b2 = 2 pi int (e^(-beta u) - 1) r^2 dr = +170.47 A^3, so the pooled excess
+#   S = sum_zV [logXi - zV] over zV in {0.5, 0.8, 1.0} predicts
+#   S = b2/V (0.25 + 0.64 + 1.0) = 0.1863 nats; the ideal-gas foil predicts 0).
+#   Seeds 76001/76002/76003 (K = 200, 4000 steps, z0V = 1): S = 0.193, 0.300,
+#   0.288; the pooled mean 0.260 sits 0.074 above S_pred = 0.1864 (a positive
+#   cross-order bias at this coupling), so the pooled-mean gate ships at 0.23
+#   (3x the 0.074 deviation of the tested statistic) with the foil floor
+#   S_mean > 0.10; per-point |logXi - (zV + zV^2 b2/V)| max 0.108, gate 0.35;
+#   per-point |mean_N - (zV + 2 zV^2 b2/V)| max 0.347, gate 1.05.
+#   The expansion fails OUTSIDE this window at this coupling: at zV = 2 the
+#   measured excess reaches ~1.9 nats with <N> ~ 10 (cluster formation), which
+#   is why the gate points stay at zV <= 1 (and why S carries the small
+#   positive bias the pooled gate absorbs).
+# - Tightened cross-route block (LJ epsilon = 0.02 eV, sigma = 2.5 A, cutoff
+#   3.0, shift = true, 300 K, beta*epsilon = 0.77; igref K = 200, 4000 steps,
+#   z0V = 6, vs fixed-N stitching N = 0:24 at K = 48/sector). Seeds
+#   77001-77003 at zV = 4 (top-sector truncation < 2e-5): |dlogXi| max 0.0771
+#   (gate 0.24, well under the shipped dilute gate 1.05), TV(p_N) max 0.0895
+#   (gate 0.27), |dmean_N| max 0.4681 (gate 1.41). The zV = 6 companion carries
+#   ~1% top-sector truncation and gates loosely at 1.7 (3x its 0.5535 max).
+#   RESCOPE, documented: at beta*epsilon = 1.16 and above, activities with
+#   <N> in the targeted 8-15 window sit inside the attractive clustering
+#   onset, where the N <= 24 stitching truncates 21-79% of the reweighted
+#   mass and the routes legitimately disagree by nats; beta*epsilon = 0.77 is
+#   the strongest coupling at which both routes converge in this budget.
+# - Metropolis-vs-igref distribution block (same epsilon = 0.02 fixture,
+#   rungs (300 K, zV = 4) and (350 K, zV = 4) with per-rung mu matched to the
+#   rung's own activity). Seeds 78001-78003 measured the 300 K class TV
+#   0.0414-0.0732, mean_N offsets <= 0.15; gates TV 0.25 and |dmean_N| 0.5
+#   per rung. A shared mu across rungs is deliberately NOT used: at fixed mu,
+#   heating raises the activity (zV(350 K) = 26.3 from the 300 K anchor) and
+#   lands outside the ledger's particle-number support.
+# - Route-channel blocks reuse the alternation and cavity gates calibrated in
+#   their home test files (0.55 and 1.85 nats on this fixture class).
+@testset "interacting-regime regressions for the continuous GC constructions" begin
+    using Random
+
+    reg_L = 12.0
+    reg_V = reg_L^3
+    reg_box = [[reg_L * u"Å", 0u"Å", 0u"Å"],
+               [0u"Å", reg_L * u"Å", 0u"Å"],
+               [0u"Å", 0u"Å", reg_L * u"Å"]]
+    reg_kb = 8.617333262e-5
+    reg_lam(T) = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(39.948u"u", T * u"K"))
+    reg_mu(zV, T) = (reg_kb * T * (log(zV / reg_V) + 3 * log(reg_lam(T)))) * u"eV"
+    reg_simpson(f, a, b; n=6000) = (h = (b - a) / n;
+        h / 3 * sum(k -> f(a + k * h) * (k == 0 || k == n ? 1 : (isodd(k) ? 4 : 2)), 0:n))
+    function reg_uwalker(N, pot)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            sys = FastSystem(periodic_system(coor, reg_box, fractional=true))
+            E = ustrip(u"eV", interacting_energy(sys, pot))
+            (isfinite(E) && E < 100.0) && return AtomWalker(sys)
+        end
+    end
+    reg_save(tag) = SaveEveryN(df_filename="_$(tag).csv", wk_filename="_$(tag).w.extxyz",
+                               ls_filename="_$(tag).l.extxyz",
+                               n_traj=10^8, n_snap=10^8, n_info=10^8)
+    reg_rm(tag) = for f in ("_$(tag).csv", "_$(tag).w.extxyz", "_$(tag).l.extxyz")
+        rm(f, force=true)
+    end
+    function reg_igref(pot, z0V, seed, tag; K=200, n_steps=4000, mc_steps=200,
+                       routine=MCAtomGrandCanonicalMoves(), record=false)
+        Random.seed!(seed)
+        ls = LJAtomWalkers([reg_uwalker(1, pot) for _ in 1:K], pot)
+        params = AtomisticIGRefGCNSParameters(mc_steps=mc_steps,
+            reference_activity=(z0V / reg_V)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        df, fls, pout = ideal_gas_referenced_nested_sampling(ls, params, n_steps, routine,
+            reg_save(tag); record_move_rates=record)
+        reg_rm(tag)
+        live_e = [ustrip(u"eV", w.energy) for w in fls.walkers]
+        live_n = [w.list_num_par[1] for w in fls.walkers]
+        return df, live_e, live_n, pout
+    end
+    reg_tv(p, q) = (m = min(length(p), length(q));
+        0.5 * (sum(abs.(p[1:m] .- q[1:m])) + sum(p[m+1:end]) + sum(q[m+1:end])))
+
+    @testset "second-virial closed form on the ideal-referenced route (pooled seeds)" begin
+        lj = LJParameters(epsilon=0.04, sigma=2.0, cutoff=2.5, shift=true)
+        T0 = 200.0
+        β = 1 / (reg_kb * T0)
+        u_of(r) = ustrip(u"eV", FreeBird.AbstractPotentials.lj_energy((r)u"Å", lj))
+        b2 = 2π * reg_simpson(r -> (exp(-β * u_of(r)) - 1) * r^2, 1.0e-6, 5.0)
+        zVs = [0.5, 0.8, 1.0]
+        S_pred = b2 / reg_V * sum(z^2 for z in zVs)
+        S_seeds = Float64[]
+        for seed in (76001, 76002, 76003)
+            df, live_e, live_n, _ = reg_igref(lj, 1.0, seed, "b2$seed")
+            out = gc_thermodynamic_stats_ideal_ref(df, (reg_V)u"Å^3", 39.948u"u",
+                (1.0 / reg_V)u"Å^-3", [reg_mu(z, T0) for z in zVs], [T0]u"K";
+                live_emax=live_e, live_numbers=live_n)
+            for (i, z) in enumerate(zVs)
+                @test abs(out.logXi[i, 1] - (z + z^2 * b2 / reg_V)) < 0.35
+                @test abs(out.mean_N[i, 1] - (z + 2 * z^2 * b2 / reg_V)) < 1.05
+            end
+            push!(S_seeds, sum(out.logXi[i, 1] - zVs[i] for i in eachindex(zVs)))
+        end
+        S_mean = mean(S_seeds)
+        @test abs(S_mean - S_pred) < 0.23
+        # foil floor: the ideal-gas reference (S = 0) is rejected
+        @test S_mean > 0.10
+    end
+
+    @testset "tightened cross-route at genuine coupling (seeded, calibrated)" begin
+        lj = LJParameters(epsilon=0.02, sigma=2.5, cutoff=3.0, shift=true)
+        T0 = 300.0
+        mus = [reg_mu(4.0, T0), reg_mu(6.0, T0)]
+        df, live_e, live_n, _ = reg_igref(lj, 6.0, 77001, "xr")
+        ig = gc_thermodynamic_stats_ideal_ref(df, (reg_V)u"Å^3", 39.948u"u",
+            (6.0 / reg_V)u"Å^-3", mus, [T0]u"K"; live_emax=live_e, live_numbers=live_n)
+        Nmax = 24
+        ns_outputs = Vector{DataFrame}(undef, Nmax + 1)
+        live_all = Vector{Vector{Float64}}(undef, Nmax + 1)
+        ns_outputs[1] = DataFrame(iter=Int[], emax=Float64[])
+        live_all[1] = Float64[]
+        n_synth = 3000
+        ns_outputs[2] = DataFrame(iter=collect(1:n_synth), emax=zeros(n_synth))
+        live_all[2] = zeros(48)
+        for N in 2:Nmax
+            Random.seed!(77501 + N)
+            lsN = LJAtomWalkers([reg_uwalker(N, lj) for _ in 1:48], lj)
+            pN = NestedSamplingParameters(mc_steps=250, initial_step_size=0.3, step_size=0.3,
+                step_size_lo=0.01, step_size_up=2.0, accept_range=(0.25, 0.75),
+                allowed_fail_count=1000, energy_perturbation=1e-12)
+            n_steps = ceil(Int, 1.4 * 48 * (2.0 * N + 15))
+            dfN, flsN, _ = nested_sampling(lsN, pN, n_steps, MCRandomWalkClone(), reg_save("fx$N"))
+            reg_rm("fx$N")
+            ns_outputs[N + 1] = dfN
+            live_all[N + 1] = [ustrip(u"eV", w.energy) for w in flsN.walkers]
+        end
+        fx = gc_thermodynamic_stats_fixed_N(ns_outputs, collect(0:Nmax), (reg_V)u"Å^3",
+            39.948u"u", mus, [T0]u"K"; n_walkers=48, live_emax=live_all)
+        # the valid gate point: top-sector truncation below 1e-4
+        @test fx.p_N[1, 1, end] < 1e-4
+        @test abs(ig.logXi[1, 1] - fx.logXi[1, 1]) < 0.24
+        @test abs(ig.mean_N[1, 1] - fx.mean_N[1, 1]) < 1.41
+        @test reg_tv(ig.p_N[1, 1, :], fx.p_N[1, 1, :]) < 0.27
+        # the truncation-sensitivity companion: ~1% top-sector mass, loose gate
+        @test abs(ig.logXi[2, 1] - fx.logXi[2, 1]) < 1.7
+    end
+
+    @testset "Metropolis-vs-ideal-referenced particle-number distributions (seeded, calibrated)" begin
+        lj = LJParameters(epsilon=0.02, sigma=2.5, cutoff=3.0, shift=true)
+        rungs = [(300.0, 4.0), (350.0, 4.0)]
+        df, live_e, live_n, _ = reg_igref(lj, 6.0, 78001, "mv")
+        for (T, zV) in rungs
+            ig = gc_thermodynamic_stats_ideal_ref(df, (reg_V)u"Å^3", 39.948u"u",
+                (6.0 / reg_V)u"Å^-3", [reg_mu(zV, T)], [T]u"K";
+                live_emax=live_e, live_numbers=live_n)
+            mp = MuVTMCParameters([T], [zV]; equilibrium_steps=20_000,
+                sampling_steps=300_000, sampling_interval=10, random_seed=78051)
+            w0 = reg_uwalker(3, lj)
+            w0.energy = interacting_energy(w0.configuration, lj, w0.list_num_par, w0.frozen)
+            mv = monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w0, lj, mp)
+            @test reg_tv(ig.p_N[1, 1, :], mv.p_N[1]) < 0.25
+            @test abs(ig.mean_N[1, 1] - mv.mean_N[1]) < 0.5
+        end
+    end
+
+    @testset "reflective and cavity channels leave the evidence unchanged (seeded, calibrated)" begin
+        lj = LJParameters(epsilon=0.02, sigma=2.5, cutoff=3.0, shift=true)
+        mu4 = reg_mu(4.0, 300.0)
+        function reduce_short(routine, seed, tag)
+            df, live_e, live_n, _ = reg_igref(lj, 6.0, seed, tag; K=16, n_steps=150, mc_steps=100,
+                                              routine=routine)
+            out = gc_thermodynamic_stats_ideal_ref(df, (reg_V)u"Å^3", 39.948u"u",
+                (6.0 / reg_V)u"Å^-3", [mu4], [300.0]u"K";
+                live_emax=live_e, live_numbers=live_n)
+            return out.logXi[1, 1]
+        end
+        base = reduce_short(MCAtomGrandCanonicalMoves(), 79001, "rb")
+        gal = reduce_short(MCAtomGrandCanonicalMoves(galilean_steps=3, galilean_step_size=1.0),
+                           79101, "rg")
+        cav = reduce_short(MCAtomGrandCanonicalMoves(p_bias=0.4, bias_radius=2.3, bias_grid=10),
+                           79201, "rc")
+        @test abs(base - gal) < 0.55
+        @test abs(base - cav) < 1.85
+    end
+
+    @testset "shift-semantics pin" begin
+        # shift = true subtracts the cutoff energy inside r_c and never beyond:
+        # a deterministic potential-level pin guarding silent default drift
+        lj_s = LJParameters(epsilon=0.02, sigma=2.5, cutoff=3.0, shift=true)
+        lj_u = LJParameters(epsilon=0.02, sigma=2.5, cutoff=3.0, shift=false)
+        r_in = 3.0
+        # stated in the implementation's own expression order (u_shifted is
+        # computed as u_unshifted minus the stored shift, bitwise)
+        @test FreeBird.AbstractPotentials.lj_energy((r_in)u"Å", lj_s) ==
+              FreeBird.AbstractPotentials.lj_energy((r_in)u"Å", lj_u) - lj_s.shift
+        @test lj_s.shift != 0.0u"eV"
+        r_out = 8.0
+        @test FreeBird.AbstractPotentials.lj_energy((r_out)u"Å", lj_s) == 0.0u"eV"
+        @test FreeBird.AbstractPotentials.lj_energy((r_out)u"Å", lj_u) == 0.0u"eV"
+    end
+
+    @testset "acceptance-ledger weld and decay diagnostic" begin
+        lj = LJParameters(epsilon=0.02, sigma=2.5, cutoff=3.0, shift=true)
+        df, _, _, pout = reg_igref(lj, 6.0, 80001, "aw"; K=64, n_steps=1500, record=true)
+        for name in ("move_attempted", "move_accepted", "insert_attempted",
+                     "insert_accepted", "delete_attempted", "delete_accepted")
+            @test sum(df[!, name]) == get(pout.move_stats, Symbol(name), 0)
+        end
+        # the insertion acceptance decays with descent depth: last quartile
+        # strictly below the first (the production diagnostic this ledger exists for)
+        q = nrow(df) ÷ 4
+        acc_first = sum(df.insert_accepted[1:q]) / max(sum(df.insert_attempted[1:q]), 1)
+        acc_last = sum(df.insert_accepted[end-q+1:end]) / max(sum(df.insert_attempted[end-q+1:end]), 1)
+        @test acc_last < acc_first
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -511,7 +511,7 @@ end
             n_walkers=K, ω0=ω0_test, live_emax=live_all)
         @test propertynames(out) == (:Xi, :mean_N, :var_N, :mean_U, :logXi,
                                      :var_U, :cov_UN, :log_Z_N, :N_values,
-                                     :observables)
+                                     :p_N, :N_support, :observables)
         @test out[1] === out.Xi && out[2] === out.mean_N &&
               out[3] === out.var_N && out[4] === out.mean_U
         @test isempty(out.observables)

--- a/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
@@ -222,3 +222,165 @@
         @test seen_ns == df.num_particles
     end
 end
+
+@testset "Interacting-regime controls" begin
+    using Random
+    # Fixtures calibrated in-session; see the assertions for the measured
+    # separations. Bound-dimer walkers at slightly different separations give a
+    # continuous energy ladder with collapsed insertion/deletion acceptance at
+    # tiny z0V (Metropolis ratio z0V/(N+1)), while displacements stay healthy.
+    hard_L = 12.0
+    hard_box = [[hard_L * u"Å", 0u"Å", 0u"Å"],
+                [0u"Å", hard_L * u"Å", 0u"Å"],
+                [0u"Å", 0u"Å", hard_L * u"Å"]]
+    hard_lj = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.0, shift=true)
+    hard_pair(r) = AtomWalker(FastSystem(periodic_system(
+        [:Ar => [0.3, 0.5, 0.5], :Ar => [0.3 + r / hard_L, 0.5, 0.5]],
+        hard_box, fractional=true)))
+
+    @testset "Routine and parameter validation" begin
+        r = MCAtomGrandCanonicalMoves()
+        @test r.step_rate_source == :mixed
+        @test r.mc_steps_per_particle == 0.0
+        @test_throws ArgumentError MCAtomGrandCanonicalMoves(step_rate_source=:invalid)
+        @test_throws ArgumentError MCAtomGrandCanonicalMoves(mc_steps_per_particle=-1.0)
+        p = AtomisticIGRefGCNSParameters()
+        @test p.allowed_fail_count == 100
+        @test p.refill_fail_budget == 0
+        @test_throws ArgumentError AtomisticIGRefGCNSParameters(refill_fail_budget=-1)
+    end
+
+    @testset "Walk-length arithmetic" begin
+        p = AtomisticIGRefGCNSParameters(mc_steps=100)
+        @test FreeBird.SamplingSchemes._gc_walk_length(p, MCAtomGrandCanonicalMoves(), 50) == 100
+        @test FreeBird.SamplingSchemes._gc_walk_length(p, MCAtomGrandCanonicalMoves(mc_steps_per_particle=2.0), 50) == 200
+        @test FreeBird.SamplingSchemes._gc_walk_length(p, MCAtomGrandCanonicalMoves(mc_steps_per_particle=1.5), 2) == 103
+    end
+
+    @testset "Step-rate source A/B" begin
+        # Calibrated at seed 3000: the mixed rate ~ 0.3*A_move + 0.35*A_ins +
+        # 0.35*A_del sits below the 0.2 band edge (measured A_ins ~ A_del ~ 0.010,
+        # A_move 0.56-0.64),
+        # so :mixed shrinks the step (measured 0.028) while :move holds it
+        # inside the wide band (measured 0.104)
+        results = Dict{Symbol,Float64}()
+        stats = Dict{Symbol,Dict{Symbol,Int}}()
+        for src in (:mixed, :move)
+            Random.seed!(3000)
+            ls = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+            params = AtomisticIGRefGCNSParameters(mc_steps=100,
+                reference_activity=(0.05 / hard_L^3)u"Å^-3", species=:Ar,
+                step_size=0.1, accept_range=(0.2, 0.9), allowed_fail_count=100_000)
+            routine = MCAtomGrandCanonicalMoves(p_move=0.3, p_insert=0.35, step_rate_source=src)
+            z0V = FreeBird.SamplingSchemes._atomistic_igref_z0V(ls, params)
+            for i in 1:30
+                FreeBird.SamplingSchemes.nested_sampling_step!(ls, params, routine; ns_iteration=i, z0V=z0V)
+            end
+            results[src] = params.step_size
+            stats[src] = copy(params.move_stats)
+        end
+        for src in (:mixed, :move)
+            ms = stats[src]
+            @test ms[:move_accepted] / ms[:move_attempted] > 0.5
+            @test ms[:insert_accepted] / ms[:insert_attempted] < 0.05
+        end
+        @test results[:mixed] < 0.05
+        @test results[:move] > 0.09
+    end
+
+    @testset "Refill failure budget" begin
+        # Bit-exact duplicate dimers form a tie block above three slightly
+        # deeper dimers; five-step walks at step 1.5 rarely land below the tie
+        # energy, so the cumulative budget (allowed_fail_count = 2) abandons
+        # the refill where a dedicated budget completes it. Calibrated at
+        # seeds 4000/4001: n_live 3 vs 6 at both.
+        for (budget, expected) in ((0, 3), (300, 6))
+            Random.seed!(4000)
+            dup = hard_pair(2.90)
+            ls = LJAtomWalkers([deepcopy(dup), deepcopy(dup), deepcopy(dup),
+                                hard_pair(2.82), hard_pair(2.83), hard_pair(2.84)], hard_lj)
+            params = AtomisticIGRefGCNSParameters(mc_steps=5,
+                reference_activity=(0.05 / hard_L^3)u"Å^-3", species=:Ar,
+                step_size=1.5, allowed_fail_count=2, refill_fail_budget=budget)
+            routine = MCAtomGrandCanonicalMoves(p_move=0.6, p_insert=0.2)
+            z0V = FreeBird.SamplingSchemes._atomistic_igref_z0V(ls, params)
+            for i in 1:6
+                FreeBird.SamplingSchemes.nested_sampling_step!(ls, params, routine; ns_iteration=i, z0V=z0V)
+            end
+            @test length(ls.walkers) == expected
+        end
+    end
+
+    @testset "Stall-continue resets the step size" begin
+        # Zero-interaction degenerate live set: every replacement fails, and on
+        # the stop_on_stall=false branch the step size returns to initial
+        Random.seed!(5000)
+        seeds = [AtomWalker(FastSystem(periodic_system(
+            [:Ar => [0.5, 0.5, 0.5]], hard_box, fractional=true))) for _ in 1:4]
+        ls = GenericAtomWalkers(seeds, IdealGasParameters())
+        params = AtomisticIGRefGCNSParameters(mc_steps=10,
+            reference_activity=(2.0 / hard_L^3)u"Å^-3", species=:Ar,
+            initial_step_size=0.5, step_size=1.7, allowed_fail_count=3)
+        save = SaveEveryN(df_filename="_t_stall.csv", wk_filename="_t_stall.traj.extxyz",
+                          ls_filename="_t_stall.ls.extxyz",
+                          n_traj=10^7, n_snap=10^7, n_info=10^7)
+        df, ls, params = ideal_gas_referenced_nested_sampling(
+            ls, params, 3, MCAtomGrandCanonicalMoves(), save; stop_on_stall=false)
+        for f in ("_t_stall.csv", "_t_stall.traj.extxyz", "_t_stall.ls.extxyz")
+            rm(f, force=true)
+        end
+        @test params.step_size == params.initial_step_size
+        @test nrow(df) == 0
+    end
+
+    @testset "Per-iteration acceptance ledger" begin
+        Random.seed!(6000)
+        ls = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+        params = AtomisticIGRefGCNSParameters(mc_steps=60,
+            reference_activity=(6.0 / hard_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        save = SaveEveryN(df_filename="_t_rates.csv", wk_filename="_t_rates.traj.extxyz",
+                          ls_filename="_t_rates.ls.extxyz",
+                          n_traj=10^7, n_snap=10^7, n_info=10^7)
+        df, ls, params = ideal_gas_referenced_nested_sampling(
+            ls, params, 40, MCAtomGrandCanonicalMoves(), save; record_move_rates=true)
+        rate_names = ["move_attempted", "move_accepted", "insert_attempted",
+                      "insert_accepted", "delete_attempted", "delete_accepted"]
+        @test names(df) == vcat(["iter", "emax", "num_particles", "log_compression"], rate_names)
+        # Closure: recorded per-iteration deltas sum to the run totals
+        for name in rate_names
+            @test sum(df[!, name]) == get(params.move_stats, Symbol(name), 0)
+        end
+        # The default keeps the shipped four-column schema
+        Random.seed!(6000)
+        ls2 = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+        params2 = AtomisticIGRefGCNSParameters(mc_steps=60,
+            reference_activity=(6.0 / hard_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        save2 = SaveEveryN(df_filename="_t_rates.csv", wk_filename="_t_rates.traj.extxyz",
+                           ls_filename="_t_rates.ls.extxyz",
+                           n_traj=10^7, n_snap=10^7, n_info=10^7)
+        df2, _, _ = ideal_gas_referenced_nested_sampling(
+            ls2, params2, 40, MCAtomGrandCanonicalMoves(), save2)
+        @test names(df2) == ["iter", "emax", "num_particles", "log_compression"]
+        # Same seed, recording on or off: identical sampling trajectory
+        @test df2.emax == df.emax
+        for f in ("_t_rates.csv", "_t_rates.traj.extxyz", "_t_rates.ls.extxyz")
+            rm(f, force=true)
+        end
+        # The rate columns are reserved: observables cannot collide with them
+        @test_throws ArgumentError FreeBird.SamplingSchemes._validate_observables(
+            [:insert_accepted => cfg -> 0.0], ls)
+    end
+
+    @testset "Minimum-image cutoff guard" begin
+        cfg = hard_pair(2.9).configuration
+        over = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.5, shift=true)   # 6.25 > 6.0
+        under = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.0, shift=true)  # 5.0 <= 6.0
+        untr = LJParameters(epsilon=0.05, sigma=2.5)                           # Inf: never warns
+        @test_logs (:warn, r"minimum-image") FreeBird.SamplingSchemes._warn_min_image_cutoff(over, cfg)
+        @test_logs FreeBird.SamplingSchemes._warn_min_image_cutoff(under, cfg)
+        @test_logs FreeBird.SamplingSchemes._warn_min_image_cutoff(untr, cfg)
+        @test SamplingSchemes.AbstractPotentials._max_interaction_range(IdealGasParameters()) === missing
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
@@ -512,3 +512,108 @@ end
         @test e1.num_particles == e2.num_particles
     end
 end
+
+@testset "cavity-bias plumbing for the ideal-gas-referenced driver" begin
+    using Random
+    # Calibration ledger: driver-level biased (p_bias = 0.4, r = 2.3 A,
+    # grid = 10) vs uniform runs on the dilute LJ fixture (z0V = 6, K = 16,
+    # 150 steps, logXi at the 300 K anchor; seeds 7400x/7410x): diffs 0.2027,
+    # 0.6164, 0.1150, mixed signs; gate 1.85 nats (3x the max). This wiring
+    # gate is deliberately loose: the kernel-level stationarity, invariance,
+    # and locator-oracle tests carry the sharp end of the bias correctness.
+    cav_L = 12.0
+    cav_box = [[cav_L * u"Å", 0u"Å", 0u"Å"],
+               [0u"Å", cav_L * u"Å", 0u"Å"],
+               [0u"Å", 0u"Å", cav_L * u"Å"]]
+    cav_lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=3.0, shift=true)
+    function cav_uwalker(N)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            sys = FastSystem(periodic_system(coor, cav_box, fractional=true))
+            E = ustrip(u"eV", interacting_energy(sys, cav_lj))
+            (isfinite(E) && E < 100.0) && return AtomWalker(sys)
+        end
+    end
+    cav_save(tag) = SaveEveryN(df_filename="_$(tag).csv", wk_filename="_$(tag).w.extxyz",
+                               ls_filename="_$(tag).l.extxyz",
+                               n_traj=10^8, n_snap=10^8, n_info=10^8)
+    cav_rm(tag) = for f in ("_$(tag).csv", "_$(tag).w.extxyz", "_$(tag).l.extxyz")
+        rm(f, force=true)
+    end
+    function cav_run(routine, seed, tag; n_steps=150)
+        Random.seed!(seed)
+        ls = LJAtomWalkers([cav_uwalker(1) for _ in 1:16], cav_lj)
+        params = AtomisticIGRefGCNSParameters(mc_steps=100,
+            reference_activity=(6.0 / cav_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        df, fls, pout = ideal_gas_referenced_nested_sampling(ls, params, n_steps, routine, cav_save(tag))
+        cav_rm(tag)
+        return df, fls, pout
+    end
+
+    @testset "routine validation" begin
+        r = MCAtomGrandCanonicalMoves()
+        @test r.p_bias == 0.0 && r.bias_radius == 0.0 && r.bias_grid == 0
+        @test_throws ArgumentError MCAtomGrandCanonicalMoves(p_bias=1.5, bias_radius=2.0, bias_grid=8)
+        @test_throws ArgumentError MCAtomGrandCanonicalMoves(p_bias=0.5)
+        @test_logs (:warn, r"p_bias = 1") match_mode = :any begin
+            MCAtomGrandCanonicalMoves(p_bias=1.0, bias_radius=2.0, bias_grid=8)
+        end
+    end
+
+    @testset "defaults stream identity" begin
+        df1, _, _ = cav_run(MCAtomGrandCanonicalMoves(), 75001, "cd1")
+        df2, _, _ = cav_run(MCAtomGrandCanonicalMoves(p_bias=0.0, bias_radius=0.0, bias_grid=0),
+                            75001, "cd2")
+        @test df1.emax == df2.emax
+        @test df1.num_particles == df2.num_particles
+    end
+
+    @testset "driver-level biased run (seeded, calibrated)" begin
+        kb = 8.617333262e-5
+        lam300 = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(39.948u"u", 300.0u"K"))
+        mu300 = (kb * 300 * (log(6.0 / cav_L^3) + 3 * log(lam300))) * u"eV"
+        function reduce_run(df, fls)
+            live_e = [ustrip(u"eV", w.energy) for w in fls.walkers]
+            live_n = [w.list_num_par[1] for w in fls.walkers]
+            out = gc_thermodynamic_stats_ideal_ref(df, (cav_L^3)u"Å^3", 39.948u"u",
+                (6.0 / cav_L^3)u"Å^-3", [mu300], [300.0]u"K";
+                live_emax=live_e, live_numbers=live_n)
+            return out.logXi[1, 1]
+        end
+        df_off, fls_off, _ = cav_run(MCAtomGrandCanonicalMoves(), 74001, "coff")
+        df_on, fls_on, p_on = cav_run(MCAtomGrandCanonicalMoves(p_bias=0.4, bias_radius=2.3, bias_grid=10),
+                                      74101, "con")
+        @test names(df_on) == names(df_off)
+        @test abs(reduce_run(df_off, fls_off) - reduce_run(df_on, fls_on)) < 1.85
+        # the biased sub-channel fired and its counters flowed into the run totals
+        @test get(p_on.move_stats, :insert_biased_attempted, 0) > 0
+        @test get(p_on.move_stats, :insert_biased_accepted, 0) <=
+              get(p_on.move_stats, :insert_biased_attempted, 0)
+    end
+
+    @testset "refill-path forwarding" begin
+        # the shipped tie fixture with the channel enabled: the deterministic
+        # eviction charges are unchanged (exact logs of integer ratios), and the
+        # refill path runs the biased kernel without disturbing the contract
+        Random.seed!(52530)
+        dup_sys = FastSystem(periodic_system([:Ar => [0.30, 0.5, 0.5]], cav_box, fractional=true))
+        dups = [AtomWalker{1}(deepcopy(dup_sys)) for _ in 1:4]
+        for d in dups
+            d.energy = 0.0u"eV"
+        end
+        deeper = [cav_uwalker(2) for _ in 1:2]
+        ls = LJAtomWalkers(vcat(dups, deeper), cav_lj)
+        params = AtomisticIGRefGCNSParameters(mc_steps=40,
+            reference_activity=(2.0 / cav_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        routine = MCAtomGrandCanonicalMoves(p_bias=0.4, bias_radius=2.3, bias_grid=10)
+        df, fls, _ = ideal_gas_referenced_nested_sampling(ls, params, 30, routine, cav_save("crf"))
+        cav_rm("crf")
+        # walkers below zero exist (the deeper pair walkers), so the E = 0
+        # plateau of the four duplicates is a genuine tie block
+        charges = df.log_compression[1:3]
+        @test charges ≈ [log(5 / 6), log(4 / 5), log(3 / 4)] atol = 1e-14
+        @test length(fls.walkers) >= 2
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
@@ -384,3 +384,131 @@ end
         @test SamplingSchemes.AbstractPotentials._max_interaction_range(IdealGasParameters()) === missing
     end
 end
+
+@testset "Galilean routine and grand-canonical alternation" begin
+    using Random
+    # Calibration ledger (gates at >= 3x the max three-seed deviation, per stat):
+    # - Canonical cross-route log_Z_N (N = 3 LJ-fluid sector, 12 A box, K = 32,
+    #   500 steps, reduced at 200 K; RW seeds 7100x vs Galilean seeds 7110x):
+    #   diffs 0.0901, 0.0776, 0.0349; gate 0.28 nats.
+    # - Ideal-gas-referenced alternation on/off (dilute LJ, z0V = 6, K = 16,
+    #   150 steps, logXi at the 300 K anchor; seeds 7200x/7210x): diffs 0.0322,
+    #   0.0184, 0.1709; gate 0.55 nats.
+    gal_L = 12.0
+    gal_box = [[gal_L * u"Å", 0u"Å", 0u"Å"],
+               [0u"Å", gal_L * u"Å", 0u"Å"],
+               [0u"Å", 0u"Å", gal_L * u"Å"]]
+    gal_lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=3.0, shift=true)
+    function gal_uwalker(N)
+        while true
+            coor = [:Ar => [rand(), rand(), rand()] for _ in 1:N]
+            sys = FastSystem(periodic_system(coor, gal_box, fractional=true))
+            E = ustrip(u"eV", interacting_energy(sys, gal_lj))
+            (isfinite(E) && E < 100.0) && return AtomWalker(sys)
+        end
+    end
+    gal_save(tag) = SaveEveryN(df_filename="_$(tag).csv", wk_filename="_$(tag).w.extxyz",
+                               ls_filename="_$(tag).l.extxyz",
+                               n_traj=10^8, n_snap=10^8, n_info=10^8)
+    gal_rm(tag) = for f in ("_$(tag).csv", "_$(tag).w.extxyz", "_$(tag).l.extxyz")
+        rm(f, force=true)
+    end
+
+    @testset "routine and field validation" begin
+        @test MCGalileanWalk().n_refresh == 8
+        @test_throws ArgumentError MCGalileanWalk(n_refresh=0)
+        r = MCAtomGrandCanonicalMoves()
+        @test r.galilean_steps == 0 && r.galilean_n_refresh == 8 && r.galilean_step_size == 0.5
+        @test_throws ArgumentError MCAtomGrandCanonicalMoves(galilean_steps=-1)
+        @test_throws ArgumentError MCAtomGrandCanonicalMoves(galilean_step_size=0.0)
+    end
+
+    @testset "canonical cross-route agreement (seeded, calibrated)" begin
+        function run_route(routine, seed, tag)
+            Random.seed!(seed)
+            ls = LJAtomWalkers([gal_uwalker(3) for _ in 1:32], gal_lj)
+            p = NestedSamplingParameters(mc_steps=300, initial_step_size=0.3, step_size=0.3,
+                step_size_lo=0.01, step_size_up=2.0, accept_range=(0.25, 0.75),
+                allowed_fail_count=1000, energy_perturbation=1e-12)
+            df, fls, _ = nested_sampling(ls, p, 500, routine, gal_save(tag))
+            gal_rm(tag)
+            live = [ustrip(u"eV", w.energy) for w in fls.walkers]
+            out = gc_thermodynamic_stats_fixed_N(
+                [DataFrame(iter=Int[], emax=Float64[]), df], [0, 3],
+                (gal_L^3)u"Å^3", 39.948u"u", [-0.20u"eV"], [200.0]u"K";
+                n_walkers=32, live_emax=[Float64[], live])
+            return out.log_Z_N[2, 1], df
+        end
+        a, df_rw = run_route(MCRandomWalkClone(), 71001, "xrw")
+        b, df_gw = run_route(MCGalileanWalk(n_refresh=6), 71101, "xgw")
+        @test abs(a - b) < 0.28
+        # the Galilean route drives a genuine descent with the serial ledger schema
+        @test names(df_gw) == ["iter", "emax", "log_compression"]
+        @test nrow(df_gw) >= 400
+        @test issorted(df_gw.emax, rev=true) || maximum(diff(df_gw.emax)) <= 1e-12
+    end
+
+    @testset "step-method contract and plateau cooperation (tie fixture)" begin
+        # bit-exact duplicate dimers above two deeper dimers: the new step
+        # method's plateau branch must charge the deterministic Fowlie-Handley-Su
+        # schedule (exact logs of integer ratios) and refill through the
+        # reflective kernel
+        gal_pair(r) = AtomWalker(FastSystem(periodic_system(
+            [:Ar => [0.3, 0.5, 0.5], :Ar => [0.3 + r / gal_L, 0.5, 0.5]],
+            gal_box, fractional=true)))
+        Random.seed!(76543)
+        dup = gal_pair(2.90)
+        ls = LJAtomWalkers([deepcopy(dup), deepcopy(dup), deepcopy(dup),
+                            gal_pair(2.82), gal_pair(2.84)], gal_lj)
+        p = NestedSamplingParameters(mc_steps=5, initial_step_size=0.5, step_size=0.5,
+            step_size_lo=0.01, step_size_up=2.0, accept_range=(0.25, 0.75),
+            allowed_fail_count=1000, energy_perturbation=1e-12)
+        df, fls, _ = nested_sampling(ls, p, 4, MCGalileanWalk(n_refresh=4), gal_save("tie"))
+        gal_rm("tie")
+        @test df.log_compression[1:3] ≈ [log(4 / 5), log(3 / 4), log(2 / 3)] atol = 1e-14
+        @test length(fls.walkers) >= 2
+        # a direct step call returns the serial steps' five-value shape
+        Random.seed!(76544)
+        ls2 = LJAtomWalkers([gal_pair(2.80 + 0.02k) for k in 1:4], gal_lj)
+        p2 = NestedSamplingParameters(mc_steps=5, initial_step_size=0.5, step_size=0.5,
+            step_size_lo=0.01, step_size_up=2.0, accept_range=(0.25, 0.75),
+            allowed_fail_count=1000, energy_perturbation=1e-12)
+        out = FreeBird.SamplingSchemes.nested_sampling_step!(ls2, p2, MCGalileanWalk())
+        @test length(out) == 5
+        @test out[3] === ls2
+        @test out[5] isa Union{Missing,Float64}
+    end
+
+    @testset "grand-canonical alternation (seeded, calibrated)" begin
+        kb = 8.617333262e-5
+        lam300 = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(39.948u"u", 300.0u"K"))
+        mu300 = (kb * 300 * (log(6.0 / gal_L^3) + 3 * log(lam300))) * u"eV"
+        function run_igref(routine, seed, tag)
+            Random.seed!(seed)
+            ls = LJAtomWalkers([gal_uwalker(1) for _ in 1:16], gal_lj)
+            params = AtomisticIGRefGCNSParameters(mc_steps=100,
+                reference_activity=(6.0 / gal_L^3)u"Å^-3", species=:Ar,
+                allowed_fail_count=100_000)
+            df, fls, _ = ideal_gas_referenced_nested_sampling(ls, params, 150, routine, gal_save(tag))
+            gal_rm(tag)
+            live_e = [ustrip(u"eV", w.energy) for w in fls.walkers]
+            live_n = [w.list_num_par[1] for w in fls.walkers]
+            out = gc_thermodynamic_stats_ideal_ref(df, (gal_L^3)u"Å^3", 39.948u"u",
+                (6.0 / gal_L^3)u"Å^-3", [mu300], [300.0]u"K";
+                live_emax=live_e, live_numbers=live_n)
+            return out.logXi[1, 1], df
+        end
+        off, df_off = run_igref(MCAtomGrandCanonicalMoves(), 72001, "aoff")
+        on, df_on = run_igref(MCAtomGrandCanonicalMoves(galilean_steps=3, galilean_step_size=1.0),
+                              72101, "aon")
+        @test abs(off - on) < 0.55
+        # the channel changes nothing structural: same schema and stall contract
+        @test names(df_on) == names(df_off)
+        # zero-default draw-count identity: an explicit galilean_steps = 0 run
+        # reproduces the default routine digit for digit
+        _, e1 = run_igref(MCAtomGrandCanonicalMoves(), 73001, "ab1")
+        _, e2 = run_igref(MCAtomGrandCanonicalMoves(galilean_steps=0), 73001, "ab2")
+        @test e1.emax == e2.emax
+        @test e1.num_particles == e2.num_particles
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-stats.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-stats.jl
@@ -202,3 +202,131 @@
         end
     end
 end
+
+@testset "particle-number distributions from the reductions" begin
+    kb = 8.617333262e-5
+    Vq = 1000.0u"Å^3"
+    V = 1000.0
+    mass_ar = 39.948u"u"
+    lam(T) = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass_ar, T * u"K"))
+    mu_for(zV, T) = (kb * T * (log(zV / V) + 3 * log(lam(T)))) * u"eV"
+    logfact(n) = n == 0 ? 0.0 : sum(log, 1:n)
+    poisson_pmf(lam0, n) = exp(n * log(lam0) - lam0 - logfact(n))
+    function poisson_ledger(z0V; nmax=60)
+        p = [poisson_pmf(z0V, n) for n in 0:nmax]
+        remainder = max(1.0 - sum(p), 1.0e-300)
+        masses = vcat(p, remainder)
+        X = reverse(cumsum(reverse(masses)))
+        lc = [log(X[j+1] / X[j]) for j in 1:nmax+1]
+        df = DataFrame(iter=collect(1:nmax+1), emax=zeros(nmax + 1),
+                       num_particles=collect(0:nmax), log_compression=lc)
+        return df, [0.0], [nmax + 1]
+    end
+
+    @testset "exact Poisson closure of p_N" begin
+        z0V = 3.0
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = poisson_ledger(z0V)
+        T = 300.0
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0,
+            [mu_for(2.0, T), mu_for(5.0, T)], [T]u"K";
+            live_emax=live_e, live_numbers=live_n)
+        @test stats.N_support == 0:61
+        @test size(stats.p_N) == (2, 1, 62)
+        for (i, zV) in enumerate([2.0, 5.0])
+            for n in 0:15
+                @test abs(stats.p_N[i, 1, n + 1] - poisson_pmf(zV, n)) < 1e-11
+            end
+            @test abs(sum(stats.p_N[i, 1, :]) - 1.0) < 1e-12
+        end
+    end
+
+    @testset "moment identities per grid point" begin
+        z0V = 4.0
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = poisson_ledger(z0V; nmax=40)
+        Ts = [250.0, 350.0]
+        mus = [mu_for(1.5, 300.0), mu_for(4.0, 300.0)]
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, Ts * u"K";
+            live_emax=live_e, live_numbers=live_n)
+        Ns = collect(stats.N_support)
+        for i in 1:2, j in 1:2
+            m1 = sum(stats.p_N[i, j, :] .* Ns)
+            m2 = sum(stats.p_N[i, j, :] .* Ns .^ 2)
+            @test isapprox(m1, stats.mean_N[i, j]; rtol=1e-12)
+            # The two routes reassociate m2 - m1^2 differently, so the identity
+            # carries an eps*m2 cancellation floor where the variance collapses
+            @test isapprox(m2 - m1^2, stats.var_N[i, j]; rtol=1e-11,
+                           atol=1e-11 * max(1.0, m2))
+        end
+    end
+
+    @testset "live-tail mixture weld, bit-for-bit" begin
+        z0V = 2.5
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = poisson_ledger(z0V; nmax=8)
+        T = 300.0
+        mu = mu_for(3.0, T)
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, [mu], [T]u"K";
+            live_emax=live_e, live_numbers=live_n)
+        # hand assembly replicating the source arithmetic exactly
+        lc = Vector{Float64}(df.log_compression)
+        cs = cumsum(lc)
+        log_w0 = vcat(0.0 .+ vcat(0.0, cs[1:end-1]) .+ log.(-expm1.(lc)),
+                      [cs[end] - log(1)])
+        Es = vcat(zeros(9), live_e)
+        Nsamp = vcat(Vector{Float64}(df.num_particles), Float64.(live_n))
+        β = 1.0 / (kb * T)
+        s = β * ustrip(u"eV", mu) - 3.0 * log(lam(T)) - log(ustrip(u"Å^-3", z0))
+        log_w = log_w0 .+ s .* Nsamp .- β .* Es
+        max_log = maximum(log_w)
+        ws = exp.(log_w .- max_log)
+        sum_w = sum(ws)
+        acc = zeros(Float64, maximum(Int.(Nsamp)) + 1)
+        for k in eachindex(ws)
+            acc[Int(Nsamp[k]) + 1] += ws[k]
+        end
+        @test stats.p_N[1, 1, :] == acc ./ sum_w
+    end
+
+    @testset "support holes stay exactly zero" begin
+        # masses on N in {0, 2} only, live tail at N = 4: N = 1 and N = 3 are
+        # in-support holes that must carry exactly 0.0
+        masses = [0.4, 0.35, 0.25]
+        X = reverse(cumsum(reverse(masses)))
+        lc = [log(X[j+1] / X[j]) for j in 1:2]
+        df = DataFrame(iter=[1, 2], emax=zeros(2), num_particles=[0, 2],
+                       log_compression=lc)
+        T = 300.0
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, (2.0 / V)u"Å^-3",
+            [mu_for(2.0, T)], [T]u"K"; live_emax=[0.0], live_numbers=[4])
+        @test stats.N_support == 0:4
+        @test stats.p_N[1, 1, 2] == 0.0
+        @test stats.p_N[1, 1, 4] == 0.0
+        @test abs(sum(stats.p_N[1, 1, :]) - 1.0) < 1e-12
+    end
+
+    @testset "fixed-N parity with the documented recipe" begin
+        N_values = [0, 1, 2]
+        ns_outputs = [DataFrame(iter=Int[], emax=Float64[]),
+                      DataFrame(iter=collect(1:50), emax=zeros(50)),
+                      DataFrame(iter=collect(1:60),
+                                emax=collect(range(-0.010, -0.020, length=60)))]
+        live_all = [Float64[], zeros(8), fill(-0.0201, 8)]
+        T = 300.0
+        mus = [mu_for(1.0, T), mu_for(3.0, T)]
+        out = gc_thermodynamic_stats_fixed_N(ns_outputs, N_values, Vq, mass_ar,
+            mus, [T]u"K"; n_walkers=8, live_emax=live_all)
+        @test out.N_support == [0, 1, 2]
+        @test size(out.p_N) == (2, 1, 3)
+        β = 1.0 / (kb * T)
+        for (k, mu) in enumerate(mus)
+            w = out.log_Z_N[:, 1] .+ β * ustrip(u"eV", mu) .* N_values
+            w .-= maximum(w)
+            pw = exp.(w) ./ sum(exp.(w))
+            for n_idx in 1:3
+                @test isapprox(out.p_N[k, 1, n_idx], pw[n_idx]; rtol=1e-12, atol=1e-15)
+            end
+        end
+    end
+end

--- a/test/test-SamplingSchemes/test-muvt-monte-carlo.jl
+++ b/test/test-SamplingSchemes/test-muvt-monte-carlo.jl
@@ -1,0 +1,141 @@
+# Fixed-temperature grand-canonical (muVT) Metropolis sampling driver.
+#
+# Calibration ledger (gates at >= 3x the max three-seed deviation, per stat):
+# - Ideal-gas closure, T = [300, 400] K, zV = [3, 5], seeds 95001/95002/95003:
+#   max devs mean 0.0411, var 0.1479; gates 0.13 and 0.45.
+# - Dilute-LJ second-virial mean gate (epsilon = 0.01 eV, sigma = 2.0 A,
+#   cutoff 2.5 so r_c = 5.0 A = L/2, guard-clean; b2 = +1.2458 A^3 at 300 K,
+#   N_ref = 0.80159 at zV = 0.8), seeds 96001/96002/96003: max dev 0.00968;
+#   gate 0.03.
+@testset "muVT Metropolis sampling driver" begin
+    using Random
+
+    box = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]]u"Å"
+    pbc = (true, true, true)
+    mk1() = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"], box, pbc)))
+    lj0 = LJParameters(epsilon=0.0)
+
+    @testset "parameter and entry validation" begin
+        @test_throws ArgumentError MuVTMCParameters([300.0], [1.0, 2.0])
+        @test_throws ArgumentError MuVTMCParameters([300.0], [-1.0])
+        @test_throws ArgumentError MuVTMCParameters([300.0], [1.0]; sampling_interval=0)
+        params = MuVTMCParameters([300.0], [1.0])
+        # omitting the routine hits the muVT catch-all, not a bare MethodError
+        @test_throws ArgumentError monte_carlo_sampling(mk1(), lj0, params)
+        # an empty starting walker carries no species record
+        empty_sys = FastSystem(cell_vectors(mk1().configuration), pbc,
+                               empty(position(mk1().configuration, :)),
+                               empty(species(mk1().configuration, :)),
+                               empty(mass(mk1().configuration, :)))
+        w_empty = AtomWalker{1}(empty_sys)
+        @test_throws ArgumentError monte_carlo_sampling(MCAtomGrandCanonicalMoves(),
+            w_empty, lj0, params)
+    end
+
+    @testset "ideal-gas closure over a temperature ladder (seeded, calibrated)" begin
+        params = MuVTMCParameters([300.0, 400.0], [3.0, 5.0];
+            equilibrium_steps=20_000, sampling_steps=200_000, sampling_interval=10,
+            random_seed=95001)
+        w = mk1(); w.energy = 0.0u"eV"
+        out = monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, lj0, params)
+        for (i, zV) in enumerate([3.0, 5.0])
+            @test abs(out.mean_N[i] - zV) < 0.13
+            @test abs(out.var_N[i] - zV) < 0.45
+            @test abs(sum(out.p_N[i]) - 1.0) < 1e-12
+            @test length(out.N_series[i]) == 200_000 ÷ 10
+            @test out.N_support[i] == 0:maximum(out.N_series[i])
+        end
+        @test all(out.mean_U .== 0.0)
+    end
+
+    @testset "dilute-LJ second-virial mean gate (seeded, calibrated)" begin
+        lj = LJParameters(epsilon=0.01, sigma=2.0, cutoff=2.5, shift=true)
+        kb = 8.617333262e-5
+        T = 300.0
+        β = 1 / (kb * T)
+        u_of(r) = ustrip(u"eV", FreeBird.AbstractPotentials.lj_energy((r)u"Å", lj))
+        simpson(f, a, b; n=4000) = (h = (b - a) / n;
+            h / 3 * sum(k -> f(a + k * h) * (k == 0 || k == n ? 1 : (isodd(k) ? 4 : 2)), 0:n))
+        b2 = 2π * simpson(r -> (exp(-β * u_of(r)) - 1) * r^2, 1.0e-6, 5.0)
+        zV = 0.8
+        N_ref = zV + 2 * zV^2 * b2 / 1000.0
+        params = MuVTMCParameters([T], [zV];
+            equilibrium_steps=20_000, sampling_steps=400_000, sampling_interval=10,
+            random_seed=96001)
+        w = mk1(); w.energy = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen)
+        out = monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, lj, params)
+        @test abs(out.mean_N[1] - N_ref) < 0.03
+        # production acceptance counters are populated and channel-consistent
+        acc = out.acceptance[1]
+        @test acc.insert_attempted > 0 && acc.delete_attempted > 0
+        @test acc.insert_accepted <= acc.insert_attempted
+        @test acc.delete_accepted <= acc.delete_attempted
+        # the returned walker's incremental energy stays anchored
+        wf = out.walkers[1]
+        E_re = interacting_energy(wf.configuration, lj, wf.list_num_par, wf.frozen) +
+               wf.energy_frozen_part
+        @test abs(ustrip(u"eV", wf.energy - E_re)) < 5e-10
+    end
+
+    @testset "phase seeding and frozen production (contract emulation)" begin
+        # The driver's documented contract: equilibration seeded random_seed in
+        # ten adaptation blocks on the displacement-only rate; production seeded
+        # random_seed + 1 with the step size frozen. An independent emulation of
+        # that contract must reproduce the recorded series exactly.
+        lj = LJParameters(epsilon=0.01, sigma=2.0, cutoff=2.5, shift=true)
+        seed = 97001
+        params = MuVTMCParameters([300.0], [2.0];
+            equilibrium_steps=2_000, sampling_steps=8_000, sampling_interval=20,
+            random_seed=seed)
+        w = mk1(); w.energy = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen)
+        out = monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, lj, params)
+
+        emu_params = MuVTMCParameters([300.0], [2.0];
+            equilibrium_steps=2_000, sampling_steps=8_000, sampling_interval=20,
+            random_seed=seed)
+        we = mk1(); we.energy = interacting_energy(we.configuration, lj, we.list_num_par, we.frozen)
+        sp_e = species(we.configuration, 1)
+        Random.seed!(seed)
+        for _ in 1:10
+            _, _, stats = MC_muVT_walk!(200, we, lj, 300.0; zV=2.0, species=sp_e,
+                                        step_size=emu_params.step_size)
+            if stats.move_attempted > 0
+                FreeBird.SamplingSchemes.adjust_step_size(emu_params,
+                    stats.move_accepted / stats.move_attempted; range=emu_params.accept_range)
+            end
+        end
+        Random.seed!(seed + 1)
+        ns_emu = Int[]
+        for _ in 1:(8_000 ÷ 20)
+            MC_muVT_walk!(20, we, lj, 300.0; zV=2.0, species=sp_e,
+                          step_size=emu_params.step_size)
+            push!(ns_emu, we.list_num_par[1])
+        end
+        @test out.N_series[1] == ns_emu
+        @test out.mean_N[1] == mean(ns_emu)
+    end
+
+    @testset "same-seed determinism" begin
+        lj = LJParameters(epsilon=0.01, sigma=2.0, cutoff=2.5, shift=true)
+        outs = map(1:2) do _
+            params = MuVTMCParameters([300.0, 350.0], [1.0, 2.0];
+                equilibrium_steps=1_000, sampling_steps=5_000, sampling_interval=10,
+                random_seed=98001)
+            w = mk1(); w.energy = interacting_energy(w.configuration, lj, w.list_num_par, w.frozen)
+            monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, lj, params)
+        end
+        @test outs[1].mean_N == outs[2].mean_N
+        @test outs[1].N_series == outs[2].N_series
+        @test outs[1].acceptance == outs[2].acceptance
+    end
+
+    @testset "cutoff guard at driver entry" begin
+        over = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5, shift=true)   # 6.25 > 5.0
+        params = MuVTMCParameters([300.0], [1.0];
+            equilibrium_steps=100, sampling_steps=200, sampling_interval=10)
+        w = mk1(); w.energy = interacting_energy(w.configuration, over, w.list_num_par, w.frozen)
+        @test_logs (:warn, r"minimum-image") match_mode = :any begin
+            monte_carlo_sampling(MCAtomGrandCanonicalMoves(), w, over, params)
+        end
+    end
+end

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -800,7 +800,7 @@
         stats3 = gc_thermodynamic_stats_ideal_ref(df, M, z0, μs, Ts, K)
         @test isempty(stats3.observables)
         @test keys(stats3) == (:logXi, :mean_N, :var_N, :mean_U, :N_eff,
-                               :var_U, :cov_UN, :observables)
+                               :var_U, :cov_UN, :p_N, :N_support, :observables)
         lX, mN, vN, mU, Ne = stats3
         @test lX == stats3.logXi && Ne == stats3.N_eff
 
@@ -917,7 +917,7 @@
             n_walkers=K, ω0=ω0, live_emax=live_E)
         @test keys(stats_nc) == (:logXi, :mean_N, :var_N, :mean_U,
                                  :log_Z_N, :N_values, :var_U, :cov_UN,
-                                 :observables)
+                                 :p_N, :N_support, :observables)
         @test isempty(stats_nc.observables)
         @test stats_nc.logXi ≈ stats.logXi rtol = 1e-14
 

--- a/test/test-SamplingSchemes/test-nvt_monte_carlo.jl
+++ b/test/test-SamplingSchemes/test-nvt_monte_carlo.jl
@@ -157,3 +157,97 @@ end
 
     end
 end
+@testset "NVT MC loop hardening (aliasing, null moves, phase seeding)" begin
+    # Shared fixture: a 4-atom periodic LJ walker in a 10 A cubic box.
+    # Calibration ledger: null-move surplus (accepted - changepoints)/n on
+    #   MCMixedMoves(5, 1), n = 2000, T = 300 K, seeds 777/778/779: measured
+    #   0.0435, 0.0380, 0.0435 (accepted identity swaps only; expectation
+    #   (1/6)*(1/4) ~ 0.042, binomial sigma ~ 0.0045). The historical
+    #   double-draw loop adds null moves at 5/36 ~ 0.139 on top, landing near
+    #   0.146. Gate: surplus <= 0.09, over 10 sigma above the measured band's
+    #   ceiling and over 12 sigma below the defect value.
+    hardening_box = [[10.0u"Å", 0u"Å", 0u"Å"],
+                     [0u"Å", 10.0u"Å", 0u"Å"],
+                     [0u"Å", 0u"Å", 10.0u"Å"]]
+    hardening_coords = [:H => [0.2, 0.2, 0.2], :H => [0.7, 0.3, 0.4],
+                        :H => [0.3, 0.7, 0.6], :H => [0.6, 0.6, 0.3]]
+    hardening_at = AtomWalker(FastSystem(periodic_system(hardening_coords, hardening_box, fractional=true)))
+    hardening_lj = LJParameters(epsilon=0.1, sigma=2.5, cutoff=3.0, shift=true)
+
+    # State-changing acceptances, counted from the stored snapshots
+    function count_changepoints(configs, at_start)
+        prev = at_start.configuration.position
+        n = 0
+        for c in configs
+            if c.configuration.position != prev
+                n += 1
+            end
+            prev = c.configuration.position
+        end
+        return n
+    end
+
+    @testset "Stored trajectory snapshots are independent (MCRandomWalkMaxE)" begin
+        energies, configs, accepted = nvt_monte_carlo(
+            MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, 300.0, 200, 0.4, 4242)
+        @test 0 < accepted < 200
+        # Distinct objects, not one aliased walker repeated
+        @test all(configs[i] !== configs[j] for i in 1:20 for j in (i + 1):20)
+        # The stored trajectory actually varies
+        @test any(configs[i].configuration.position != configs[end].configuration.position for i in 1:199)
+        # Each snapshot's energy field matches a from-scratch recompute of its
+        # own configuration (incremental-accumulation drift class)
+        for i in (1, 50, 100, 150, 200)
+            E_re = interacting_energy(configs[i].configuration, hardening_lj,
+                                      configs[i].list_num_par, configs[i].frozen) +
+                   configs[i].energy_frozen_part
+            @test isapprox(configs[i].energy, E_re; atol=1e-9u"eV")
+            @test configs[i].energy == energies[i]
+        end
+        # Walk-only path: every acceptance changes the configuration, exactly
+        @test accepted == count_changepoints(configs, hardening_at)
+    end
+
+    @testset "Null-move accounting (MCMixedMoves single channel draw)" begin
+        n_steps = 2000
+        energies, configs, accepted = nvt_monte_carlo(
+            MCMixedMoves(5, 1), deepcopy(hardening_at), hardening_lj, 300.0, n_steps, 0.4, 777)
+        # Accepted identity swaps (same atom drawn twice in the swap channel)
+        # are the only legal accepted-without-change steps; the historical
+        # double-draw loop added a 5/36 null-move channel on top. See the
+        # calibration ledger above.
+        surplus = (accepted - count_changepoints(configs, hardening_at)) / n_steps
+        @test 0.0 <= surplus <= 0.09
+        @test all(configs[i] !== configs[j] for i in 1:20 for j in (i + 1):20)
+        for i in (1, 1000, 2000)
+            @test configs[i].energy == energies[i]
+        end
+    end
+
+    @testset "Equilibration and production streams are independent" begin
+        # Lattice driver wiring: the production leg must reproduce an explicit
+        # nvt_monte_carlo call seeded with random_seed + 1 from the
+        # equilibration end configuration
+        lattice = SLattice{SquareLattice}(supercell_dimensions=(2, 2, 1), components=[[1, 2]])
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        seed = 4242
+        params = MetropolisMCParameters([300.0];
+            equilibrium_steps=60, sampling_steps=80, random_seed=seed)
+        d_energies, d_configs, d_cvs, d_rates = monte_carlo_sampling(MCNewSample(), lattice, ham, params)
+        eq_e, eq_c, eq_acc = nvt_monte_carlo(MCNewSample(), lattice, ham, 300.0, 60, seed)
+        pr_e, pr_c, pr_acc = nvt_monte_carlo(MCNewSample(), eq_c[end], ham, 300.0, 80, seed + 1)
+        @test d_energies[1] == mean(pr_e)
+        @test d_rates[1] == pr_acc / 80
+        # Atomistic driver: same-seed reproducibility end to end
+        p1 = MetropolisMCParameters([500.0];
+            equilibrium_steps=100, sampling_steps=100, step_size=0.3, random_seed=99)
+        p2 = MetropolisMCParameters([500.0];
+            equilibrium_steps=100, sampling_steps=100, step_size=0.3, random_seed=99)
+        e1, ls1, cv1, r1 = monte_carlo_sampling(MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, p1)
+        e2, ls2, cv2, r2 = monte_carlo_sampling(MCRandomWalkMaxE(), deepcopy(hardening_at), hardening_lj, p2)
+        @test e1 == e2
+        @test cv1 == cv2
+        @test r1 == r2
+        @test ls1.walkers[1].configuration.position == ls2.walkers[1].configuration.position
+    end
+end


### PR DESCRIPTION
Implements #218. Test-only; consumes the interacting-regime controls, the particle-number distributions, the grand-canonical Metropolis sampling driver, the reflective-walk routine, and the cavity channel with its driver plumbing, all of this round.

- Second-virial block: for the truncated-shifted potential with the interaction range inside half the cell edge, the minimum-image Mayer integral collapses radially, so the pooled excess over three activity points has the closed-form prediction (b2/V) times the sum of squared activities. Gates: per-point evidence and mean-count welds against the second-virial forms, a pooled-mean gate, and an ideal-gas foil floor. The header documents where the expansion fails at this coupling (cluster formation at twice the top gate activity, with a measured 1.9-nat excess) and the small positive cross-order bias the pooled gate absorbs.
- Tightened cross-route block: ideal-referenced evidence against fixed-N stitching at genuine coupling, gated at 0.24 nats on the truncation-clean point (against the shipped dilute gate of 1.05), with a total-variation gate on the particle-number distributions and a loosely gated truncation-sensitivity companion. Disclosure, documented in the header: the issue's coupling window sits inside the attractive clustering onset, where the sector stitching truncates 21 to 79 percent of the reweighted mass and the routes legitimately disagree by nats; the block ships at the strongest coupling at which both routes converge in the stated budget.
- Metropolis-versus-ideal-referenced block: the two independent grand-canonical routes agree on the particle-number distribution at two temperature rungs (total-variation and mean gates), with the activity matched per rung; a shared chemical potential across rungs is deliberately not used, since heating at fixed chemical potential raises the activity outside the ledger's particle-number support.
- Route-channel gates for the reflective and cavity channels, a deterministic shift-semantics pin (stated in the implementation's own expression order), and the acceptance-ledger closure weld with a monotone-decay diagnostic on the insertion acceptance.
- Every statistical gate is sized at three times the maximum multi-seed deviation at the gates' own granularity, with the calibration ledger (seeds, measured deviations, wall-clock budget of about four minutes) in the file header.

Adversarially reviewed (issue-promise round-trip, independent-oracle physics, determinism and assertion accounting), and the full suite passes on the shipped bytes.
