### PR TITLE
Per-iteration acceptance and step-size ledger for canonical nested sampling

### DIFF
--- a/src/AbstractHamiltonians/AbstractHamiltonians.jl
+++ b/src/AbstractHamiltonians/AbstractHamiltonians.jl
@@ -14,6 +14,7 @@ export ClassicalHamiltonian
 export GenericLatticeHamiltonian, MLatticeHamiltonian
 export ClusterInteraction, ClusterLatticeHamiltonian
 export SiteFieldLatticeHamiltonian
+export supports_site_deltas
 
 abstract type AbstractHamiltonian end
 
@@ -462,5 +463,23 @@ function Base.show(io::IO, h::SiteFieldLatticeHamiltonian{H,U}) where {H,U}
             ustrip(lo), ", ", ustrip(hi), "] ", unit(U))
     println(io, "    base: ", h.base)
 end
+
+"""
+    supports_site_deltas(hamiltonian::ClassicalHamiltonian) -> Bool
+
+Opt-in trait: whether an exact O(z) single-site occupancy-flip energy delta
+(`site_flip_delta` in `EnergyEval`) is available for the Hamiltonian type.
+
+The `false` fallback is a contract, not a failure: consumers fall back to
+full recomputation instead of silently mis-evaluating. `ClusterLatticeHamiltonian`
+deliberately stays `false` (an exact cluster delta needs precomputed
+site-to-embedding incidence lists that do not exist yet), and the site-field
+wrapper delegates to its base. New `ClassicalHamiltonian` types opt in by
+adding a method alongside their `site_flip_delta` method.
+"""
+supports_site_deltas(::ClassicalHamiltonian) = false
+supports_site_deltas(::GenericLatticeHamiltonian) = true
+supports_site_deltas(::MLatticeHamiltonian) = true
+supports_site_deltas(h::SiteFieldLatticeHamiltonian) = supports_site_deltas(h.base)
 
 end # module Hamiltonians

--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -24,6 +24,7 @@ export insert_particle!, remove_particle!
 export LatticeWalker
 export LatticeGeometry, SquareLattice, TriangularLattice, GenericLattice
 export MLattice, SLattice, GLattice
+export replicate_walkers
 export update_walker!
 export num_sites, occupied_site_count
 export order_parameter_c2x2

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -413,6 +413,24 @@ mutable struct MLattice{C,G} <: AbstractLattice
         
         return new{C,G}(lattice_vectors, positions, basis, supercell_dimensions, periodicity, cutoff_radii, components, neighbors, adsorptions)
     end
+
+    # Shared-geometry constructor: alias the eight run-invariant fields of
+    # `source` (they are written only during construction; the Monte Carlo
+    # kernels mutate occupancies exclusively) and install the fresh
+    # `components`. Skips lattice_positions and the all-pairs
+    # compute_neighbors entirely; see `replicate_walkers` for the exported
+    # entry point.
+    function MLattice{C,G}(::Val{:share_geometry},
+                           source::MLattice{C,G},
+                           components::Vector{Vector{Bool}}) where {C,G}
+        if length(components) != C
+            throw(ArgumentError("For a $C-component system, got $(length(components)) components!"))
+        end
+        return new{C,G}(source.lattice_vectors, source.positions,
+                        source.basis, source.supercell_dimensions,
+                        source.periodicity, source.cutoff_radii,
+                        components, source.neighbors, source.adsorptions)
+    end
 end
 
 """
@@ -1493,4 +1511,26 @@ function Base.show(io::IO, walker::Vector{LatticeWalker})
     for (ind, w) in enumerate(walker)
         println(io, "[", ind, "] ", w)
     end
+end
+
+"""
+    replicate_walkers(template::MLattice{C,G}, K::Int) -> Vector{LatticeWalker}
+
+Build `K` walkers whose configurations share the template's run-invariant
+geometry (lattice vectors, positions, basis, supercell dimensions,
+periodicity, cutoff radii, neighbor lists, and adsorption mask) by
+reference, each with its own independent occupancy vectors copied from the
+template. The geometry fields are written only during construction and the
+Monte Carlo kernels mutate occupancies exclusively, so sharing is safe on
+the serial lattice drivers; relative to the `deepcopy(template)` idiom the
+saving is one whole neighbor nest per walker. Walkers start at
+`energy = 0.0u"eV"`, `iter = 0`, matching the deepcopy idiom's usual
+construction.
+"""
+function replicate_walkers(template::MLattice{C,G}, K::Int) where {C,G}
+    return [LatticeWalker(
+                MLattice{C,G}(Val(:share_geometry), template,
+                              [copy(v) for v in template.components]),
+                energy=0.0u"eV", iter=0)
+            for _ in 1:K]
 end

--- a/src/EnergyEval/EnergyEval.jl
+++ b/src/EnergyEval/EnergyEval.jl
@@ -16,6 +16,7 @@ using AtomsCalculators
 export pbc_dist, pbc_displacement
 export interacting_energy, frozen_energy
 export single_site_energy
+export site_flip_delta
 export pair_force, interacting_gradient
 
 # definitions of frozen_energy and interacting_energy

--- a/src/EnergyEval/lattice_energies.jl
+++ b/src/EnergyEval/lattice_energies.jl
@@ -195,6 +195,75 @@ function interacting_energy(lattice::SLattice, h::SiteFieldLatticeHamiltonian{H,
 end
 
 """
+    site_flip_delta(lattice::SLattice, h::GenericLatticeHamiltonian{N,U}, site::Int) where {N,U}
+
+Exact energy change from flipping the occupancy of `site`:
+`E(after) − E(before)`, computed as a local O(z) sum over the flipped site's
+neighbor entries (z the per-site neighbor entry count), the lattice
+counterpart of the audited `single_site_energy` path on the continuous side.
+
+The formula respects both conventions of the full sweep
+([`lattice_interaction_energy`](@ref)): each ordered neighbor entry carries
+half a coupling, so an ordinary neighbor `j != site` (appearing once in the
+flipped site's list and once in `j`'s) contributes `occ[j]` times the full
+coupling to the delta, while a self-image entry (`j == site`, present under
+`image_multiplicity = true`) appears only in the flipped site's own row and
+contributes exactly half the coupling per image. The adsorption term mirrors
+the on-site channel of the full evaluation.
+
+Availability for a Hamiltonian type is declared by the
+`supports_site_deltas` trait; consumers fall back to full recomputation when
+it is `false`. Throws the same shell-count `ArgumentError` as the full sweep
+when the Hamiltonian couples more shells than the lattice provides.
+"""
+function site_flip_delta(lattice::SLattice, h::GenericLatticeHamiltonian{N,U},
+                         site::Int) where {N,U}
+    _check_shell_counts(lattice.neighbors, N)
+    occ = lattice.components[1]
+    sgn = occ[site] ? -1 : 1
+    acc::U = lattice.adsorptions[site] ? h.on_site_interaction :
+             zero(h.on_site_interaction)
+    nbrs = lattice.neighbors[site]
+    for n in 1:N
+        Jn = h.nth_neighbor_interactions[n]
+        for j in nbrs[n]
+            if j == site
+                acc += Jn / 2
+            elseif occ[j]
+                acc += Jn
+            end
+        end
+    end
+    return sgn * acc
+end
+
+"""
+    site_flip_delta(lattice::SLattice, h::MLatticeHamiltonian{C,N,U}, site::Int) where {C,N,U}
+
+Single-component delta under a multi-component Hamiltonian: delegates to
+`h.Hamiltonians[1, 1]`, matching the corresponding `interacting_energy`
+method for `SLattice`.
+"""
+function site_flip_delta(lattice::SLattice, h::MLatticeHamiltonian{C,N,U},
+                         site::Int) where {C,N,U}
+    return site_flip_delta(lattice, h.Hamiltonians[1, 1], site)
+end
+
+"""
+    site_flip_delta(lattice::SLattice, h::SiteFieldLatticeHamiltonian{H,U}, site::Int) where {H,U}
+
+Delta under the site-field wrapper: the base Hamiltonian's delta plus the
+signed field entry of the flipped site, mirroring the wrapper's
+`interacting_energy` method.
+"""
+function site_flip_delta(lattice::SLattice, h::SiteFieldLatticeHamiltonian{H,U},
+                         site::Int) where {H,U}
+    base_delta = site_flip_delta(lattice, h.base, site)
+    sgn = lattice.components[1][site] ? -1 : 1
+    return base_delta + sgn * h.field[site]
+end
+
+"""
     interacting_energy(lattice::MLattice{C,G}, h::MLatticeHamiltonian{C,N,U})
 
 Compute the interaction energy of a multi-component lattice configuration using the Hamiltonian parameters.

--- a/src/MonteCarloMoves/cluster_moves.jl
+++ b/src/MonteCarloMoves/cluster_moves.jl
@@ -18,6 +18,11 @@ The parameter `p` controls the average cluster size: `p ≈ 0` gives single-site
 # Arguments
 - `lattice::MLattice{C,SquareLattice}`: The lattice to perform the cluster move on.
 - `p::Float64`: Growth probability for BFS cluster construction (0 < p < 1).
+- `record::Union{Nothing,Vector{Tuple{Int,Int}}}=nothing`: When a vector is
+  supplied, every applied (site, reflected_site) pair is appended to it;
+  re-applying the recorded pairs (each pair swap is an involution) reverts
+  the move exactly. The `nothing` default changes no behavior and no
+  random-number draw.
 
 # Returns
 - `lattice::MLattice{C,SquareLattice}`: The mutated lattice after the cluster swap.
@@ -35,7 +40,8 @@ The parameter `p` controls the average cluster size: `p ≈ 0` gives single-site
 - Heringa & Blöte, Phys. Rev. E 57, 4976 (1998) — geometric cluster MC framework.
 - Adaptation uses fixed growth probability (configuration-independent) for symmetric proposals.
 """
-function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64) where C
+function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64;
+                                 record::Union{Nothing,Vector{Tuple{Int,Int}}}=nothing) where C
     if length(lattice.basis) != 1
         throw(ArgumentError("geometric_cluster_swap! on a square lattice " *
             "requires the single-site basis, got " *
@@ -57,13 +63,12 @@ function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64)
     reflect = s -> _reflect_site(s, pivot_gx, pivot_gy, Lx, Ly, Lz)
     cluster = _build_geometric_cluster(lattice, seed, reflect, p)
 
-    # Swap occupation states for each (site, reflected_site) pair
-    for (a, b) in cluster
-        if a != b
-            for comp in 1:C
-                lattice.components[comp][a], lattice.components[comp][b] =
-                    lattice.components[comp][b], lattice.components[comp][a]
-            end
+    # Swap occupation states for each applied (site, reflected_site) pair;
+    # the recorded pairs revert the move when re-applied (involution)
+    _apply_cluster_pairs!(lattice, cluster)
+    if record !== nothing
+        for pr in cluster
+            pr[1] != pr[2] && push!(record, pr)
         end
     end
 
@@ -71,6 +76,27 @@ function geometric_cluster_swap!(lattice::MLattice{C,SquareLattice}, p::Float64)
 end
 
 # --- Internal helpers (not exported) ---
+
+"""
+    _apply_cluster_pairs!(lattice::MLattice{C,G}, pairs::Vector{Tuple{Int,Int}}) where {C,G}
+
+Apply the occupancy exchange for each (site, reflected_site) pair with distinct
+indices, across all components. Each pair swap is an involution, so re-applying
+the same pair list reverts a cluster move exactly; the copy-free kernels use it
+as the revert path for rejected cluster proposals.
+"""
+function _apply_cluster_pairs!(lattice::MLattice{C,G},
+                               pairs::Vector{Tuple{Int,Int}}) where {C,G}
+    for (a, b) in pairs
+        if a != b
+            for comp in 1:C
+                lattice.components[comp][a], lattice.components[comp][b] =
+                    lattice.components[comp][b], lattice.components[comp][a]
+            end
+        end
+    end
+    return lattice
+end
 
 """
     _site_to_grid(site::Int, Lx::Int, Ly::Int) -> Tuple{Int,Int,Int}
@@ -226,7 +252,8 @@ energy-ceiling accept test (Heringa & Blöte, Phys. Rev. E 57, 4976
 Requires the two-site basis and a strictly two-dimensional supercell
 (`supercell_dimensions[3] == 1`); violations throw an `ArgumentError`.
 """
-function geometric_cluster_swap!(lattice::MLattice{C,TriangularLattice}, p::Float64) where C
+function geometric_cluster_swap!(lattice::MLattice{C,TriangularLattice}, p::Float64;
+                                 record::Union{Nothing,Vector{Tuple{Int,Int}}}=nothing) where C
     if length(lattice.basis) != 2
         throw(ArgumentError("geometric_cluster_swap! on a triangular lattice " *
             "requires the two-site centered-rectangular basis, got " *
@@ -254,13 +281,12 @@ function geometric_cluster_swap!(lattice::MLattice{C,TriangularLattice}, p::Floa
     reflect = s -> _tri_reflect_site(s, hpx, hpy, nx, ny)
     cluster = _build_geometric_cluster(lattice, seed, reflect, p)
 
-    # Swap occupation states for each (site, reflected_site) pair
-    for (a, b) in cluster
-        if a != b
-            for comp in 1:C
-                lattice.components[comp][a], lattice.components[comp][b] =
-                    lattice.components[comp][b], lattice.components[comp][a]
-            end
+    # Swap occupation states for each applied (site, reflected_site) pair;
+    # the recorded pairs revert the move when re-applied (involution)
+    _apply_cluster_pairs!(lattice, cluster)
+    if record !== nothing
+        for pr in cluster
+            pr[1] != pr[2] && push!(record, pr)
         end
     end
 
@@ -276,7 +302,8 @@ geometries, whose reflection maps are integer grid involutions on the site indic
 `ArgumentError` before drawing any randomness. Use swap-only decorrelation
 (`clusters_freq = 0`) for generic geometries.
 """
-function geometric_cluster_swap!(lattice::MLattice{C,GenericLattice}, p::Float64) where C
+function geometric_cluster_swap!(lattice::MLattice{C,GenericLattice}, p::Float64;
+                                 record::Union{Nothing,Vector{Tuple{Int,Int}}}=nothing) where C
     throw(ArgumentError("geometric_cluster_swap! supports square and triangular " *
         "lattices only, got a GenericLattice configuration; use swap-only " *
         "decorrelation (clusters_freq = 0) for generic geometries"))

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -1732,6 +1732,9 @@ function _galilean_trajectory!(at::AtomWalker{1},
     config = at.configuration
     n = at.list_num_par[1]
     n_inside = 0
+    n_reflect_att = 0
+    n_reflect_eval = 0
+    n_reflect_acc = 0
     current_E = at.energy
     for _ in 1:n_refresh
         saved = copy(config.position)
@@ -1746,6 +1749,8 @@ function _galilean_trajectory!(at::AtomWalker{1},
             n_inside += 1
             continue
         end
+        # First trial failed: exactly one gradient per such segment
+        n_reflect_att += 1
         grad = interacting_gradient(config, pot, at.list_num_par, at.frozen)
         v_r, ok = _galilean_reflect(v, grad)
         if ok
@@ -1753,10 +1758,13 @@ function _galilean_trajectory!(at::AtomWalker{1},
                 pos = config.position[i] + (step_size * v_r[i]) * u"Å"
                 config.position[i] = periodic_boundary_wrap!(pos, config)
             end
+            # Usable gradient: the second trial energy is evaluated
+            n_reflect_eval += 1
             E2 = interacting_energy(config, pot, at.list_num_par, at.frozen) + at.energy_frozen_part
             if E2 < emax
                 current_E = E2
                 n_inside += 1
+                n_reflect_acc += 1
                 v = v_r
                 continue
             end
@@ -1766,7 +1774,7 @@ function _galilean_trajectory!(at::AtomWalker{1},
         v = [-vi for vi in v]
     end
     at.energy = current_E
-    return v, n_inside
+    return v, n_inside, n_reflect_att, n_reflect_eval, n_reflect_acc
 end
 
 """
@@ -1793,6 +1801,16 @@ the velocity, which would break reversibility); an empty walker returns unchange
 - `accept_this_walker::Bool`: Whether any segment ended inside the constraint.
 - `accept_rate::Float64`: Fraction of segments ending inside the constraint.
 - `at::AtomWalker{1}`: The updated walker.
+- `stats::NamedTuple`: Integer segment counters, in order
+  `(galilean_attempted, galilean_accepted, galilean_reflect_attempted,
+  galilean_reflect_evals, galilean_reflect_accepted)`: segments run
+  (`n_steps` × `n_refresh`), segments ending inside (the rate numerator, so
+  `rate == galilean_accepted / galilean_attempted` is an identity), segments
+  whose first trial failed (each computing exactly one gradient), reflections
+  with a usable gradient (each evaluating the second trial energy, so full
+  energy evaluations = `galilean_attempted + galilean_reflect_evals`), and
+  reflected segments ending inside. A trailing addition: three-name
+  destructures of the previous return keep working.
 """
 function MC_galilean_walk!(n_steps::Int,
                            at::AtomWalker{1},
@@ -1816,17 +1834,37 @@ function MC_galilean_walk!(n_steps::Int,
         end
     end
     n = at.list_num_par[1]
-    n == 0 && return false, 0.0, at
+    n == 0 && return false, 0.0, at,
+                (galilean_attempted=0, galilean_accepted=0,
+                 galilean_reflect_attempted=0, galilean_reflect_evals=0,
+                 galilean_reflect_accepted=0)
 
     total_inside = 0
+    total_reflect_att = 0
+    total_reflect_eval = 0
+    total_reflect_acc = 0
     for _ in 1:n_steps
         raw = [SVector(randn(), randn(), randn()) for _ in 1:n]
         nrm = sqrt(sum(vi -> vi[1]^2 + vi[2]^2 + vi[3]^2, raw))
         v = [vi / nrm for vi in raw]
-        _, n_inside = _galilean_trajectory!(at, pot, emax, v, n_refresh, step_size)
+        _, n_inside, r_att, r_eval, r_acc =
+            _galilean_trajectory!(at, pot, emax, v, n_refresh, step_size)
         total_inside += n_inside
+        total_reflect_att += r_att
+        total_reflect_eval += r_eval
+        total_reflect_acc += r_acc
     end
-    return total_inside > 0, total_inside / (n_steps * n_refresh), at
+    # Trailing stats element (integer counters only, no draws, no
+    # floating-point change): closes the call-count accounting exactly.
+    # Full energy evaluations = galilean_attempted + galilean_reflect_evals;
+    # gradient evaluations = galilean_reflect_attempted;
+    # rate == galilean_accepted / galilean_attempted stays an identity.
+    return total_inside > 0, total_inside / (n_steps * n_refresh), at,
+           (galilean_attempted=n_steps * n_refresh,
+            galilean_accepted=total_inside,
+            galilean_reflect_attempted=total_reflect_att,
+            galilean_reflect_evals=total_reflect_eval,
+            galilean_reflect_accepted=total_reflect_acc)
 end
 
 """

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -340,20 +340,21 @@ function MC_random_walk!(n_steps::Int,
     emax = emax * unit(lattice.energy)
 
     for i_mc_step in 1:n_steps
-        current_lattice = lattice.configuration
+        config = lattice.configuration
 
-        proposed_lattice = deepcopy(current_lattice)
+        # In-place proposal: the hop-pair walk mutates the live configuration
+        # and returns the drawn pair; a rejected proposal is reverted by
+        # replaying the pair (involution). No random draw changes.
+        hop_from, hop_to = _lattice_walk_draw!(config)
 
-        lattice_random_walk!(proposed_lattice)
-        
         perturbation_energy = energy_perturb * (rand() - 0.5) * unit(lattice.energy)
-        proposed_energy = interacting_energy(proposed_lattice, h) + perturbation_energy
+        proposed_energy = interacting_energy(config, h) + perturbation_energy
 
         @debug "proposed_energy = $proposed_energy, perturbed_energy = $(perturbation_energy), emax = $(emax)), accept = $(proposed_energy < emax)"
         if proposed_energy >= emax
+            _lattice_walk_apply!(config, hop_from, hop_to)
             continue
         else
-            lattice.configuration = proposed_lattice
             lattice.energy = proposed_energy
             n_accept += 1
             accept_this_walker = true
@@ -525,16 +526,68 @@ Perform a Monte Carlo random walk on the single-component lattice system.
 - `lattice::SLattice`: The proposed lattice after the random walk.
 """
 function lattice_random_walk!(lattice::SLattice)
+    _lattice_walk_draw!(lattice)
+    return lattice
+end
+
+"""
+    _lattice_walk_draw!(lattice) -> (hop_from, hop_to)
+
+Internal: perform one hop-pair walk step with exactly the draws of
+`lattice_random_walk!`, in the same order, returning the drawn pair so the
+copy-free kernels can revert a rejected proposal. The conditional exchange
+applied for a drawn pair is an involution, so replaying the pair through
+`_lattice_walk_apply!` reverts the step exactly.
+"""
+function _lattice_walk_draw!(lattice::SLattice)
     # pick a random site to hop from
     hop_from = rand(eachindex(lattice.components[1]))
     # pick a random site to hop to (can be the same as hop_from)
     hop_to = rand(eachindex(lattice.components[1]))
+    _lattice_walk_apply!(lattice, hop_from, hop_to)
+    return hop_from, hop_to
+end
+
+function _lattice_walk_draw!(lattice::MLattice{C,G}) where {C,G}
+    # pick a random component to hop in (draw kept for stream identity;
+    # all component vectors share the same site index range)
+    picked_comp::Int = rand(1:C)
+    # pick a random site to hop from
+    hop_from::Int = rand(eachindex(lattice.components[picked_comp]))
+    # pick a random site to hop to (can be the same as hop_from)
+    hop_to::Int = rand(eachindex(lattice.components[picked_comp]))
+    _lattice_walk_apply!(lattice, hop_from, hop_to)
+    return hop_from, hop_to
+end
+
+"""
+    _lattice_walk_apply!(lattice, hop_from, hop_to)
+
+Internal: apply the conditional occupancy exchange of the hop-pair walk for an
+already-drawn pair, with no random draws. Self-inverse for every case (the
+empty/occupied exchange, the cross-component exchange, and the no-op), so a
+second call with the same pair reverts the first.
+"""
+function _lattice_walk_apply!(lattice::SLattice, hop_from::Int, hop_to::Int)
     # propose a swap in occupation state (only if it maintains constant N)
-    # proposed_lattice = deepcopy(lattice)
     if lattice.components[1][hop_from] != lattice.components[1][hop_to]
-        lattice.components[1][hop_from], lattice.components[1][hop_to] = 
+        lattice.components[1][hop_from], lattice.components[1][hop_to] =
         lattice.components[1][hop_to], lattice.components[1][hop_from]
     end
+    return lattice
+end
+
+function _lattice_walk_apply!(lattice::MLattice{C,G}, hop_from::Int, hop_to::Int) where {C,G}
+    # case 1: occupied/unoccupied swap
+    is_occupied_from::Bool = any([lattice.components[comp][hop_from] for comp in 1:C])
+    is_occupied_to::Bool = any([lattice.components[comp][hop_to] for comp in 1:C])
+    if is_occupied_from != is_occupied_to # only swap if the occupation state changes
+        return swap_empty_occupied_sites!(lattice, hop_from, hop_to)
+    # case 2: both sites occupied, swap components
+    elseif is_occupied_from && is_occupied_to
+        return swap_occupied_sites_across_components!(lattice, hop_from, hop_to)
+    end
+    # case 3: both sites unoccupied, do nothing
     return lattice
 end
 
@@ -549,27 +602,7 @@ Perform a Monte Carlo random walk on the multi-component lattice system.
 - `lattice::MLattice{C,G}`: The proposed lattice after the random walk.
 """
 function lattice_random_walk!(lattice::MLattice{C,G}) where {C,G}
-    # pick a random component to hop in
-    picked_comp::Int = rand(1:C)
-    # pick a random site to hop from
-    hop_from::Int = rand(eachindex(lattice.components[picked_comp]))
-    # pick a random site to hop to (can be the same as hop_from)
-    hop_to::Int = rand(eachindex(lattice.components[picked_comp]))
-
-    # println("hop from: $hop_from, hop to: $hop_to, comp: $comp") # debug
-    
-    # case 1: occupied/unoccupied swap
-    is_occupied_from::Bool = any([lattice.components[comp][hop_from] for comp in 1:C])
-    is_occupied_to::Bool = any([lattice.components[comp][hop_to] for comp in 1:C])
-    # println("is_occupied_from: $is_occupied_from, is_occupied_to: $is_occupied_to") # debug
-    if is_occupied_from != is_occupied_to # only swap if the occupation state changes
-        # swap the occupation state of the sites
-        return swap_empty_occupied_sites!(lattice, hop_from, hop_to)
-    # case 2: both sites occupied, swap components
-    elseif is_occupied_from && is_occupied_to
-        return swap_occupied_sites_across_components!(lattice, hop_from, hop_to)
-    end
-    # case 3: both sites unoccupied, do nothing
+    _lattice_walk_draw!(lattice)
     return lattice
 end
 
@@ -652,18 +685,23 @@ function MC_cluster_walk!(n_steps::Int,
     accept_this_walker = false
     emax_u = emax * unit(lattice.energy)
 
+    cluster_pairs = Tuple{Int,Int}[]
     for _ in 1:n_steps
-        proposed_lattice = deepcopy(lattice.configuration)
-        geometric_cluster_swap!(proposed_lattice, cluster_p)
+        config = lattice.configuration
+        # In-place proposal: record the applied pairs so a rejected cluster
+        # move reverts by re-applying them (involution). No random draw changes.
+        empty!(cluster_pairs)
+        geometric_cluster_swap!(config, cluster_p; record=cluster_pairs)
 
         perturbation_energy = energy_perturb * (rand() - 0.5) * unit(lattice.energy)
-        proposed_energy = interacting_energy(proposed_lattice, h) + perturbation_energy
+        proposed_energy = interacting_energy(config, h) + perturbation_energy
 
         if proposed_energy < emax_u
-            lattice.configuration = proposed_lattice
             lattice.energy = proposed_energy
             n_accept += 1
             accept_this_walker = true
+        else
+            _apply_cluster_pairs!(config, cluster_pairs)
         end
     end
     return accept_this_walker, n_accept / max(n_steps, 1), lattice
@@ -706,18 +744,20 @@ Insert a particle at a random empty site. Returns `true` if successful,
 # Returns
 - `success::Bool`: Whether a particle was inserted.
 - `lattice::SLattice`: The mutated lattice.
+- `site::Int`: The inserted site index (0 when unsuccessful). A trailing
+  addition: two-name destructures of the previous return keep working.
 """
 function lattice_insert_particle!(lattice::SLattice)
     n_sites = num_sites(lattice)
     n_occ = sum(lattice.components[1])
     if n_occ >= n_sites
-        return false, lattice
+        return false, lattice, 0
     end
     # Collect empty site indices
     empty_sites = findall(.!lattice.components[1])
     site = rand(empty_sites)
     lattice.components[1][site] = true
-    return true, lattice
+    return true, lattice, site
 end
 
 """
@@ -732,16 +772,18 @@ Delete a particle from a random occupied site. Returns `true` if successful,
 # Returns
 - `success::Bool`: Whether a particle was deleted.
 - `lattice::SLattice`: The mutated lattice.
+- `site::Int`: The vacated site index (0 when unsuccessful). A trailing
+  addition: two-name destructures of the previous return keep working.
 """
 function lattice_delete_particle!(lattice::SLattice)
     n_occ = sum(lattice.components[1])
     if n_occ == 0
-        return false, lattice
+        return false, lattice, 0
     end
     occupied_sites = findall(lattice.components[1])
     site = rand(occupied_sites)
     lattice.components[1][site] = false
-    return true, lattice
+    return true, lattice, site
 end
 
 """
@@ -945,22 +987,31 @@ function MC_grand_canonical_walk!(n_steps::Int,
     insert_site = 0
     insert_from_biased = false
     deleted_site = 0
+    # In-place proposal state: proposals mutate the live configuration and a
+    # rejected proposal is reverted from this per-move record (hop pair,
+    # cluster pair list, or flipped site). Every revert is an involution
+    # replay or a single flip, so the reverted state is bit-identical, and
+    # no random draw is added or removed anywhere on this path.
+    hop_from = 0
+    hop_to = 0
+    cluster_pairs = Tuple{Int,Int}[]
 
     for _ in 1:n_steps
         r = rand()
-        proposed_lattice = deepcopy(lattice.configuration)
-        n = sum(proposed_lattice.components[1])
+        config = lattice.configuration
+        n = sum(config.components[1])
 
         if r < p_move
             # Fixed-N branch: choose cluster or local swap
             if p_cluster_in_move > 0.0 && rand() < p_cluster_in_move
                 # Geometric cluster move
-                geometric_cluster_swap!(proposed_lattice, cluster_p)
+                empty!(cluster_pairs)
+                geometric_cluster_swap!(config, cluster_p; record=cluster_pairs)
                 move_type = :cluster
                 cluster_total_count += 1
             else
                 # Local swap
-                lattice_random_walk!(proposed_lattice)
+                hop_from, hop_to = _lattice_walk_draw!(config)
                 move_type = :move
                 swap_attempted += 1
             end
@@ -973,7 +1024,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 # Composite channel. S(x) is computed ONCE per attempt and
                 # reused for both the biased draw and the composite proposal
                 # density in the acceptance below.
-                biased_set = lattice_biased_sites(proposed_lattice;
+                biased_set = lattice_biased_sites(config;
                                                   predicate=bias_predicate,
                                                   shells=bias_shells)
                 if rand() < p_bias
@@ -988,15 +1039,15 @@ function MC_grand_canonical_walk!(n_steps::Int,
                     # as lattice_insert_particle!, inlined to capture the site
                     # for the composite density (keep in lockstep with it)
                     insert_uniform_attempted += 1
-                    empty_sites = findall(.!proposed_lattice.components[1])
+                    empty_sites = findall(.!config.components[1])
                     insert_site = rand(empty_sites)
                     insert_from_biased = false
                 end
-                proposed_lattice.components[1][insert_site] = true
+                config.components[1][insert_site] = true
             else
                 # p_bias == 0: legacy path, bit-identical RNG stream (no
                 # channel draw; lattice_insert_particle! draws exactly once)
-                success, proposed_lattice = lattice_insert_particle!(proposed_lattice)
+                success, _, insert_site = lattice_insert_particle!(config)
                 if !success
                     continue
                 end
@@ -1014,11 +1065,11 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 # Inlined uniform deletion (the same single rand(::Vector)
                 # draw as lattice_delete_particle!) to capture the vacated
                 # site for the reverse composite density (keep in lockstep)
-                occupied_sites = findall(proposed_lattice.components[1])
+                occupied_sites = findall(config.components[1])
                 deleted_site = rand(occupied_sites)
-                proposed_lattice.components[1][deleted_site] = false
+                config.components[1][deleted_site] = false
             else
-                success, proposed_lattice = lattice_delete_particle!(proposed_lattice)
+                success, _, deleted_site = lattice_delete_particle!(config)
                 if !success
                     continue
                 end
@@ -1028,11 +1079,13 @@ function MC_grand_canonical_walk!(n_steps::Int,
         end
 
         perturbation_energy = energy_perturb * (rand() - 0.5) * unit(lattice.energy)
-        proposed_energy = interacting_energy(proposed_lattice, h) + perturbation_energy
-        n_new = sum(proposed_lattice.components[1])
+        proposed_energy = interacting_energy(config, h) + perturbation_energy
+        n_new = sum(config.components[1])
         proposed_omega = proposed_energy - mu * n_new * unit(lattice.energy)
 
         if proposed_omega >= omega_max_u
+            _gc_revert_move!(config, move_type, hop_from, hop_to,
+                             cluster_pairs, insert_site, deleted_site)
             continue
         end
 
@@ -1057,7 +1110,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
         elseif move_type == :delete
             if p_bias > 0.0
                 # Reverse composite density on the POST-deletion configuration
-                rev_set = lattice_biased_sites(proposed_lattice;
+                rev_set = lattice_biased_sites(config;
                                                predicate=bias_predicate,
                                                shells=bias_shells)
                 q_rev = p_insert * ((deleted_site in rev_set ?
@@ -1084,7 +1137,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
         end
 
         if accept
-            lattice.configuration = proposed_lattice
+            # The live configuration already carries the proposal; keep it
+            # (the walker's configuration field is never rebound to a copy)
             lattice.energy = proposed_energy
             n_accept += 1
             accept_this_walker = true
@@ -1101,6 +1155,9 @@ function MC_grand_canonical_walk!(n_steps::Int,
             else # :delete
                 delete_accepted += 1
             end
+        else
+            _gc_revert_move!(config, move_type, hop_from, hop_to,
+                             cluster_pairs, insert_site, deleted_site)
         end
     end
 
@@ -1113,6 +1170,31 @@ function MC_grand_canonical_walk!(n_steps::Int,
             insert_biased_attempted=insert_biased_attempted,
             insert_biased_accepted=insert_biased_accepted,
             delete_attempted=delete_attempted, delete_accepted=delete_accepted)
+end
+
+"""
+    _gc_revert_move!(config, move_type, hop_from, hop_to, cluster_pairs,
+                     insert_site, deleted_site)
+
+Internal: revert a rejected in-place grand-canonical proposal. Swap and
+cluster proposals revert by involution replay (`_lattice_walk_apply!`,
+`_apply_cluster_pairs!`); insertion and deletion revert by flipping the
+recorded site back. No random draws.
+"""
+@inline function _gc_revert_move!(config, move_type::Symbol,
+                                  hop_from::Int, hop_to::Int,
+                                  cluster_pairs::Vector{Tuple{Int,Int}},
+                                  insert_site::Int, deleted_site::Int)
+    if move_type == :move
+        _lattice_walk_apply!(config, hop_from, hop_to)
+    elseif move_type == :cluster
+        _apply_cluster_pairs!(config, cluster_pairs)
+    elseif move_type == :insert
+        config.components[1][insert_site] = false
+    else # :delete
+        config.components[1][deleted_site] = true
+    end
+    return config
 end
 
 """

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -911,6 +911,13 @@ Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
   re-anchors the accumulator. The default is draw-count and digit identical
   to the shipped arithmetic; the delta path accumulates in a different
   floating-point order, so same-seed trajectories differ from the default.
+- `swap_mode::Symbol=:uniform_pair`: Local-swap proposal distribution.
+  `:uniform_pair` keeps the shipped uniform site-pair draw (equal-occupancy
+  pairs are accepted no-ops, counted by the `swap_null_*` subset counters);
+  `:occupied_empty` (opt-in, changes the random stream) draws `hop_from`
+  uniform over occupied and `hop_to` uniform over empty sites, symmetric
+  with no acceptance correction and zero nulls, guard-skipped on empty and
+  full lattices.
 
 # Returns
 - `accept_this_walker::Bool`: Whether at least one move was accepted.
@@ -919,7 +926,8 @@ Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
 - `cluster_accepted_count::Int`: Number of accepted cluster moves (for adaptive tuning).
 - `cluster_total_count::Int`: Number of attempted cluster moves (for adaptive tuning).
 - `move_stats::NamedTuple`: Per-move-type attempt/accept counters for the walk:
-  `swap_*`, `cluster_*` (duplicating the two preceding elements),
+  `swap_*`, `swap_null_*` (subsets of the swap pair: equal-occupancy no-op
+  proposals), `cluster_*` (duplicating the two preceding elements),
   `insert_uniform_*`, `insert_biased_*`, `delete_*`. Attempts are counted at
   proposal: ceiling rejections included, guard skips excluded, and an
   empty-biased-set null proposal counts as an attempted biased insert.
@@ -940,7 +948,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   p_bias::Float64=0.0,
                                   bias_predicate::Symbol=:contact,
                                   bias_shells::Int=1,
-                                  incremental::Bool=false)
+                                  incremental::Bool=false,
+                                  swap_mode::Symbol=:uniform_pair)
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
@@ -955,6 +964,9 @@ function MC_grand_canonical_walk!(n_steps::Int,
     end
     if bias_shells < 1
         throw(ArgumentError("bias_shells must be >= 1, got $bias_shells"))
+    end
+    if swap_mode !== :uniform_pair && swap_mode !== :occupied_empty
+        throw(ArgumentError("unknown swap_mode :$swap_mode; expected :uniform_pair or :occupied_empty"))
     end
     if p_bias > 0.0
         nbrs = lattice.configuration.neighbors
@@ -982,6 +994,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
     cluster_total_count = 0
     swap_attempted = 0
     swap_accepted = 0
+    swap_null_attempted = 0
+    swap_null_accepted = 0
     insert_uniform_attempted = 0
     insert_uniform_accepted = 0
     insert_biased_attempted = 0
@@ -1013,13 +1027,21 @@ function MC_grand_canonical_walk!(n_steps::Int,
     # in the identical order and draws the identical random stream.
     use_deltas = incremental && supports_site_deltas(h)
     zero_e = 0.0 * unit(lattice.energy)
-    raw = use_deltas ? interacting_energy(lattice.configuration, h) : zero_e
+    # The unperturbed-energy anchor serves two consumers: the incremental
+    # path advances it by exact deltas, and a detected null swap carries it
+    # instead of re-evaluating an unchanged configuration. On the default
+    # path the anchor only ever holds fresh full-recompute values, so the
+    # null-swap carry is bit-identical to the evaluation it skips
+    # (interacting_energy is deterministic); on the opt-in incremental path
+    # the carry is raw + 0, exact under the delta discipline.
+    raw = interacting_energy(lattice.configuration, h)
     step_delta = zero_e
 
     for _ in 1:n_steps
         r = rand()
         config = lattice.configuration
         n = sum(config.components[1])
+        was_null = false
 
         if r < p_move
             # Fixed-N branch: choose cluster or local swap
@@ -1031,7 +1053,29 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 cluster_total_count += 1
             else
                 # Local swap
-                if use_deltas
+                if swap_mode === :occupied_empty
+                    # Opt-in zero-null proposal: hop_from uniform over
+                    # occupied sites, hop_to uniform over empty sites. The
+                    # proposal probability of every candidate pair is
+                    # 1/(N(M-N)) in both directions (the reverse swap sees
+                    # the same N), so the move is symmetric with no
+                    # acceptance correction and conserves N. Empty and full
+                    # lattices have no valid proposal: guard skip, not
+                    # counted as an attempt (the insert/delete convention).
+                    if n == 0 || n == n_sites
+                        continue
+                    end
+                    hop_from = rand(findall(config.components[1]))
+                    hop_to = rand(findall(.!config.components[1]))
+                    if use_deltas
+                        step_delta = site_flip_delta(config, h, hop_from)
+                        config.components[1][hop_from] = !config.components[1][hop_from]
+                        step_delta += site_flip_delta(config, h, hop_to)
+                        config.components[1][hop_to] = !config.components[1][hop_to]
+                    else
+                        _lattice_walk_apply!(config, hop_from, hop_to)
+                    end
+                elseif use_deltas
                     # Inlined draws in lockstep with _lattice_walk_draw!
                     # (identical order). A non-null pair composes two flips
                     # with the second delta evaluated on the intermediate
@@ -1045,13 +1089,19 @@ function MC_grand_canonical_walk!(n_steps::Int,
                         step_delta += site_flip_delta(config, h, hop_to)
                         config.components[1][hop_to] = !config.components[1][hop_to]
                     else
-                        step_delta = zero_e
+                        was_null = true
                     end
                 else
                     hop_from, hop_to = _lattice_walk_draw!(config)
+                    # Post-exchange classification: a non-null pair still
+                    # differs after the exchange; an equal-occupancy pair
+                    # was a no-op
+                    was_null = config.components[1][hop_from] ==
+                               config.components[1][hop_to]
                 end
                 move_type = :move
                 swap_attempted += 1
+                was_null && (swap_null_attempted += 1)
             end
         elseif r < p_move + p_insert
             # Insertion
@@ -1127,7 +1177,12 @@ function MC_grand_canonical_walk!(n_steps::Int,
         end
 
         perturbation_energy = energy_perturb * (rand() - 0.5) * unit(lattice.energy)
-        if use_deltas && move_type != :cluster
+        if was_null
+            # A null swap left the configuration untouched: carry the
+            # anchored unperturbed energy instead of re-evaluating it
+            # (bit-identical, and the O(M) sweep is skipped)
+            proposed_raw = raw
+        elseif use_deltas && move_type != :cluster
             proposed_raw = raw + step_delta
         else
             proposed_raw = interacting_energy(config, h)
@@ -1200,6 +1255,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 cluster_accepted_count += 1
             elseif move_type == :move
                 swap_accepted += 1
+                was_null && (swap_null_accepted += 1)
             elseif move_type == :insert
                 if insert_from_biased
                     insert_biased_accepted += 1
@@ -1218,6 +1274,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
     return accept_this_walker, n_accept / max(n_steps, 1), lattice,
            cluster_accepted_count, cluster_total_count,
            (swap_attempted=swap_attempted, swap_accepted=swap_accepted,
+            swap_null_attempted=swap_null_attempted,
+            swap_null_accepted=swap_null_accepted,
             cluster_attempted=cluster_total_count, cluster_accepted=cluster_accepted_count,
             insert_uniform_attempted=insert_uniform_attempted,
             insert_uniform_accepted=insert_uniform_accepted,

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -904,6 +904,13 @@ Cluster moves are symmetric (no Metropolis correction), accepted if Ω < Ω_max.
   is an immediate reject. `0.0` reproduces the legacy sampler bit-for-bit.
 - `bias_predicate::Symbol=:contact`: Biased-set predicate, `:contact` or `:cavity`.
 - `bias_shells::Int=1`: Neighbor shells scanned by the predicate.
+- `incremental::Bool=false`: Opt-in incremental energy evaluation: non-cluster
+  proposals under a Hamiltonian with `supports_site_deltas` advance a per-walk
+  raw-energy anchor by exact O(z) `site_flip_delta` sums; cluster proposals
+  and unsupported Hamiltonians fall back to the full recompute, which also
+  re-anchors the accumulator. The default is draw-count and digit identical
+  to the shipped arithmetic; the delta path accumulates in a different
+  floating-point order, so same-seed trajectories differ from the default.
 
 # Returns
 - `accept_this_walker::Bool`: Whether at least one move was accepted.
@@ -932,7 +939,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   z0::Float64=1.0,
                                   p_bias::Float64=0.0,
                                   bias_predicate::Symbol=:contact,
-                                  bias_shells::Int=1)
+                                  bias_shells::Int=1,
+                                  incremental::Bool=false)
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
@@ -996,6 +1004,18 @@ function MC_grand_canonical_walk!(n_steps::Int,
     hop_to = 0
     cluster_pairs = Tuple{Int,Int}[]
 
+    # Opt-in incremental energy path: anchor the unperturbed energy once per
+    # walk (bounding floating-point drift to about n_steps ulps, reset by the
+    # next walk's anchor) and advance it by exact O(z) site_flip_delta sums.
+    # Cluster proposals and Hamiltonians without supports_site_deltas fall
+    # back to the shipped full recompute, which also re-anchors the
+    # accumulator exactly. The default path computes the identical arithmetic
+    # in the identical order and draws the identical random stream.
+    use_deltas = incremental && supports_site_deltas(h)
+    zero_e = 0.0 * unit(lattice.energy)
+    raw = use_deltas ? interacting_energy(lattice.configuration, h) : zero_e
+    step_delta = zero_e
+
     for _ in 1:n_steps
         r = rand()
         config = lattice.configuration
@@ -1011,7 +1031,25 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 cluster_total_count += 1
             else
                 # Local swap
-                hop_from, hop_to = _lattice_walk_draw!(config)
+                if use_deltas
+                    # Inlined draws in lockstep with _lattice_walk_draw!
+                    # (identical order). A non-null pair composes two flips
+                    # with the second delta evaluated on the intermediate
+                    # state; an equal-occupancy pair performs no flips and
+                    # contributes exactly zero.
+                    hop_from = rand(eachindex(config.components[1]))
+                    hop_to = rand(eachindex(config.components[1]))
+                    if config.components[1][hop_from] != config.components[1][hop_to]
+                        step_delta = site_flip_delta(config, h, hop_from)
+                        config.components[1][hop_from] = !config.components[1][hop_from]
+                        step_delta += site_flip_delta(config, h, hop_to)
+                        config.components[1][hop_to] = !config.components[1][hop_to]
+                    else
+                        step_delta = zero_e
+                    end
+                else
+                    hop_from, hop_to = _lattice_walk_draw!(config)
+                end
                 move_type = :move
                 swap_attempted += 1
             end
@@ -1054,6 +1092,11 @@ function MC_grand_canonical_walk!(n_steps::Int,
                 insert_uniform_attempted += 1
                 insert_from_biased = false
             end
+            if use_deltas
+                # Post-flip delta by exact sign symmetry: the back-flip delta
+                # is the exact floating-point negation of the applied one
+                step_delta = -site_flip_delta(config, h, insert_site)
+            end
             move_type = :insert
         else
             # Deletion: site selection is uniform over occupied sites in both
@@ -1074,12 +1117,22 @@ function MC_grand_canonical_walk!(n_steps::Int,
                     continue
                 end
             end
+            if use_deltas
+                # Post-flip delta by exact sign symmetry (see the insertion
+                # branch)
+                step_delta = -site_flip_delta(config, h, deleted_site)
+            end
             delete_attempted += 1
             move_type = :delete
         end
 
         perturbation_energy = energy_perturb * (rand() - 0.5) * unit(lattice.energy)
-        proposed_energy = interacting_energy(config, h) + perturbation_energy
+        if use_deltas && move_type != :cluster
+            proposed_raw = raw + step_delta
+        else
+            proposed_raw = interacting_energy(config, h)
+        end
+        proposed_energy = proposed_raw + perturbation_energy
         n_new = sum(config.components[1])
         proposed_omega = proposed_energy - mu * n_new * unit(lattice.energy)
 
@@ -1139,6 +1192,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
         if accept
             # The live configuration already carries the proposal; keep it
             # (the walker's configuration field is never rebound to a copy)
+            raw = proposed_raw
             lattice.energy = proposed_energy
             n_accept += 1
             accept_this_walker = true

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1459,6 +1459,72 @@ function _shared_geometry_walker(w::LatticeWalker, cfg::MLattice{C,G}) where {C,
 end
 
 """
+    _perturbation_energy_bound(h, lattice) -> Union{Float64,Nothing}
+
+Magnitude bound on the lattice energy in the Hamiltonian's own energy
+units: the on-site magnitude times the site count, plus each coupled
+shell's magnitude times its total ordered-entry count over two (image
+multiplicity included, read from the built neighbor lists), plus the
+site-field and cluster magnitudes where applicable. Returns `nothing` for
+Hamiltonian types without a method, which skips the tie-breaker warning.
+"""
+function _perturbation_energy_bound(h::GenericLatticeHamiltonian{N,U},
+                                    lattice) where {N,U}
+    nbrs = lattice.neighbors
+    b = abs(ustrip(h.on_site_interaction)) * length(lattice.components[1])
+    shells = isempty(nbrs) ? 0 : length(nbrs[1])
+    for n in 1:min(N, shells)
+        entries = sum(length(nbrs[i][n]) for i in eachindex(nbrs))
+        b += abs(ustrip(h.nth_neighbor_interactions[n])) * entries / 2
+    end
+    return b
+end
+function _perturbation_energy_bound(h::SiteFieldLatticeHamiltonian, lattice)
+    b = _perturbation_energy_bound(h.base, lattice)
+    b === nothing && return nothing
+    return b + sum(x -> abs(ustrip(x)), h.field)
+end
+_perturbation_energy_bound(h::MLatticeHamiltonian, lattice) =
+    _perturbation_energy_bound(h.Hamiltonians[1, 1], lattice)
+function _perturbation_energy_bound(h::ClusterLatticeHamiltonian, lattice)
+    b = _perturbation_energy_bound(h.pair_ham, lattice)
+    b === nothing && return nothing
+    for c in h.clusters
+        b += abs(ustrip(c.coupling)) * length(c.embeddings)
+    end
+    return b
+end
+_perturbation_energy_bound(h, lattice) = nothing
+
+"""
+    _warn_perturbation_scale(liveset::LatticeGasWalkers, delta::Float64)
+
+Warn once, at driver entry, when the configured `energy_perturbation` sits
+below the documented degenerate-plateau resolution floor
+`K^2 * eps(E_bound)`: below it the K walkers cannot reliably draw
+distinct tie-breaking values on a degenerate plateau, and the failure mode
+is silent (plateaus decompress at machine granularity and read as poor
+mixing). A warning, never a throw; a zero perturbation is a deliberate
+no-perturbation choice and is not warned about.
+"""
+function _warn_perturbation_scale(liveset::LatticeGasWalkers, delta::Float64)
+    isempty(liveset.walkers) && return nothing
+    bound = _perturbation_energy_bound(liveset.hamiltonian,
+                                       liveset.walkers[1].configuration)
+    bound === nothing && return nothing
+    floor_delta = length(liveset.walkers)^2 * eps(bound)
+    if 0.0 < delta < floor_delta
+        @warn "energy_perturbation = $delta sits below the degenerate-" *
+              "plateau resolution floor K^2 * eps(E_bound) = $floor_delta " *
+              "(E_bound = $bound in the Hamiltonian's energy units, K = " *
+              "$(length(liveset.walkers))); ties may decompress at machine " *
+              "granularity and read as poor mixing. Recommended minimum: " *
+              "$floor_delta."
+    end
+    return nothing
+end
+
+"""
     _init_gc_walkers!(liveset::LatticeGasWalkers, gc_params::GrandCanonicalNestedSamplingParameters)
 
 Initialize walkers with random microstates for grand-canonical NS.
@@ -1511,18 +1577,26 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     mu = gc_params.chemical_potential
     n_walkers = length(ats)
 
-    # Sort by grand potential (descending — worst first)
-    sort!(ats, by = w -> _grand_potential(w, mu), rev=true)
+    # Sort by grand potential (descending — worst first): one O(K·M) key
+    # sweep, then a stable sortperm on the cached keys. The comparisons see
+    # the identical key values, so the resulting order (ties included), the
+    # random stream, and every recorded digit match the by-comparator sort,
+    # while the per-iteration cost drops from O(K·M·log K) to
+    # O(K·M + K·log K); the cached keys are reused below.
+    omega_keys = [_grand_potential(w, mu) for w in ats]
+    omega_perm = sortperm(omega_keys, rev=true)
+    permute!(ats, omega_perm)
+    permute!(omega_keys, omega_perm)
 
     iter::Union{Missing,Int} = missing
     worst = ats[1]
-    omega_worst = _grand_potential(worst, mu)
+    omega_worst = omega_keys[1]
     energy_worst = worst.energy
     n_worst = sum(worst.configuration.components[1])
 
     # Select parent: prefer walkers strictly below omega_worst
     omega_max_val = omega_worst.val  # unitless for the MC function
-    eligible = [k for k in 2:n_walkers if _grand_potential(ats[k], mu) < omega_worst]
+    eligible = [k for k in 2:n_walkers if omega_keys[k] < omega_worst]
     if !isempty(eligible)
         parent_idx = rand(eligible)
     else
@@ -1589,6 +1663,11 @@ highest-Ω walker, record (Ω, E, N), replace with a decorrelated clone.
   `(iter, walker) -> ...` invoked with the culled walker immediately after
   its ledger row is pushed; see [`nested_sampling`](@ref) for the contract.
 
+- `stop_on_stall::Bool=false`: When true and `fail_count` reaches
+  `allowed_fail_count`, warn once and return the partial ledger and the
+  intact live set (`fail_count` stays at threshold); the default keeps the
+  shipped warn-and-continue behavior byte-identically.
+
 # Returns
 - `df::DataFrame`: Columns `[:iter, :omega, :energy, :num_particles]`,
   plus one column per requested observable.
@@ -1601,9 +1680,11 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
                                          mc_routine::MCGrandCanonicalMoves,
                                          save_strategy::DataSavingStrategy;
                                          observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
-                                         dead_point_callback::Union{Nothing,Function}=nothing)
+                                         dead_point_callback::Union{Nothing,Function}=nothing,
+                                         stop_on_stall::Bool=false)
     # Initialize walkers with random microstates
     _init_gc_walkers!(liveset, gc_params)
+    _warn_perturbation_scale(liveset, gc_params.energy_perturbation)
 
     # Initialize cluster_p and reset counters from MCGrandCanonicalMoves if applicable
     if mc_routine.clusters_freq > 0
@@ -1632,11 +1713,13 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
 
         if observables !== nothing || dead_point_callback !== nothing
-            # Pre-sort with the step's own comparator (Ω = E − μN, descending)
-            # and hold the walker the step will cull; see `nested_sampling`.
-            sort!(liveset.walkers,
-                  by = w -> _grand_potential(w, gc_params.chemical_potential),
-                  rev=true)
+            # Pre-sort with the step's own ordering (Ω = E − μN, descending,
+            # cached keys through a stable sortperm, order-identical to the
+            # by-comparator sort) and hold the walker the step will cull;
+            # see `nested_sampling`.
+            pre_keys = [_grand_potential(w, gc_params.chemical_potential)
+                        for w in liveset.walkers]
+            permute!(liveset.walkers, sortperm(pre_keys, rev=true))
             culled = liveset.walkers[1]
         end
 
@@ -1647,6 +1730,13 @@ function grand_canonical_nested_sampling(liveset::LatticeGasWalkers,
 
         if gc_params.fail_count >= gc_params.allowed_fail_count
             @warn "GC-NS: Failed $(gc_params.allowed_fail_count) times in a row."
+            # Opt-in stall stop: return the partial ledger and the intact
+            # live set instead of burning the remaining iteration budget
+            # (the driver re-initializes its live set on entry, so a stalled
+            # run cannot be chunked around from outside). The break leaves
+            # fail_count at threshold so a caller can distinguish a stalled
+            # return (the atomistic convention).
+            stop_on_stall && break
             gc_params.fail_count = 0
         end
 
@@ -1954,6 +2044,11 @@ extract them from the returned liveset.
   a valid estimator of the second Hamiltonian's grand potential over the
   same ladder, with the returned Kish N_eff as its fidelity diagnostic.
 
+- `stop_on_stall::Bool=false`: When true and `fail_count` reaches
+  `allowed_fail_count`, warn once and return the partial ledger and the
+  intact live set (`fail_count` stays at threshold); the default keeps the
+  shipped warn-and-continue behavior byte-identically.
+
 # Returns
 - `df::DataFrame`: Columns `[:iter, :emax, :num_particles]`,
   plus one column per requested observable.
@@ -1966,9 +2061,11 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
                                               mc_routine::MCGrandCanonicalMoves,
                                               save_strategy::DataSavingStrategy;
                                               observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
-                                              dead_point_callback::Union{Nothing,Function}=nothing)
+                                              dead_point_callback::Union{Nothing,Function}=nothing,
+                                              stop_on_stall::Bool=false)
     # Initialize walkers as i.i.d. draws from the Bernoulli(z0/(1+z0)) prior
     _init_ideal_gas_ref_walkers!(liveset, params)
+    _warn_perturbation_scale(liveset, params.energy_perturbation)
 
     # Initialize cluster_p and reset counters from MCGrandCanonicalMoves if applicable
     if mc_routine.clusters_freq > 0
@@ -2010,6 +2107,9 @@ function ideal_gas_referenced_nested_sampling(liveset::LatticeGasWalkers,
 
         if params.fail_count >= params.allowed_fail_count
             @warn "IG-ref GC-NS: Failed $(params.allowed_fail_count) times in a row."
+            # Opt-in stall stop (see grand_canonical_nested_sampling); the
+            # break leaves fail_count at threshold
+            stop_on_stall && break
             params.fail_count = 0
         end
 

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -289,6 +289,16 @@ particle insertion and deletion.
 - `bias_predicate::Symbol`: Biased-set predicate, `:contact` or `:cavity`
   (default `:contact`).
 - `bias_shells::Int`: Neighbor shells scanned by the predicate (default 1).
+- `incremental::Bool`: Opt-in incremental energy evaluation in the walk kernel
+  (default `false` = the shipped full-recompute arithmetic, draw-count and
+  digit identical). When `true`, non-cluster proposals under a Hamiltonian
+  with `supports_site_deltas` advance a per-walk raw-energy anchor by exact
+  O(z) `site_flip_delta` sums; cluster proposals and unsupported Hamiltonians
+  fall back to the full recompute, which also re-anchors the accumulator.
+  The delta path accumulates energy in a different floating-point order, so
+  same-seed trajectories are not digit-identical to the default; flipping
+  the default is deliberately out of scope (a published-run reproducibility
+  contract).
 
 When `clusters_freq == 0` (the default), the fixed-N branch uses only local swaps
 (`lattice_random_walk!`), preserving backward compatibility with existing scripts.
@@ -315,6 +325,7 @@ struct MCGrandCanonicalMoves <: MCRoutine
     p_bias::Float64
     bias_predicate::Symbol
     bias_shells::Int
+    incremental::Bool
     function MCGrandCanonicalMoves(;
             p_move::Float64=0.5,
             p_insert::Float64=0.25,
@@ -327,7 +338,8 @@ struct MCGrandCanonicalMoves <: MCRoutine
             cluster_p_ceiling::Float64=1.0,
             p_bias::Float64=0.0,
             bias_predicate::Symbol=:contact,
-            bias_shells::Int=1)
+            bias_shells::Int=1,
+            incremental::Bool=false)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
         end
@@ -349,7 +361,7 @@ struct MCGrandCanonicalMoves <: MCRoutine
         new(p_move, p_insert, clusters_freq, swaps_freq,
             initial_cluster_p, target_cluster_accept, cluster_adjust_interval,
             cluster_p_floor, cluster_p_ceiling,
-            p_bias, bias_predicate, bias_shells)
+            p_bias, bias_predicate, bias_shells, incremental)
     end
 end
 
@@ -1510,7 +1522,8 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
         cluster_p=gc_params.cluster_p,
         p_bias=mc_routine.p_bias,
         bias_predicate=mc_routine.bias_predicate,
-        bias_shells=mc_routine.bias_shells)
+        bias_shells=mc_routine.bias_shells,
+        incremental=mc_routine.incremental)
 
     if accept
         push!(ats, to_walk)
@@ -1860,7 +1873,8 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
         cluster_p=params.cluster_p,
         p_bias=mc_routine.p_bias,
         bias_predicate=mc_routine.bias_predicate,
-        bias_shells=mc_routine.bias_shells)
+        bias_shells=mc_routine.bias_shells,
+        incremental=mc_routine.incremental)
 
     if accept
         push!(ats, to_walk)

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -46,6 +46,7 @@ mutable struct NestedSamplingParameters <: SamplingParameters
     cluster_accept_history::Vector{Float64}
     cluster_adjust_iterations::Vector{Int}
     plateau_refill_target::Int64
+    move_stats::Dict{Symbol,Int}
 end
 
 function NestedSamplingParameters(;
@@ -66,8 +67,9 @@ function NestedSamplingParameters(;
             cluster_accept_history::Vector{Float64}=Float64[],
             cluster_adjust_iterations::Vector{Int}=Int[],
             plateau_refill_target::Int64=0,
+            move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
             )
-    NestedSamplingParameters(mc_steps, initial_step_size, step_size, step_size_lo, step_size_up, accept_range, fail_count, allowed_fail_count, energy_perturbation, random_seed, cluster_p, cluster_accepted, cluster_total, cluster_p_history, cluster_accept_history, cluster_adjust_iterations, plateau_refill_target)
+    NestedSamplingParameters(mc_steps, initial_step_size, step_size, step_size_lo, step_size_up, accept_range, fail_count, allowed_fail_count, energy_perturbation, random_seed, cluster_p, cluster_accepted, cluster_total, cluster_p_history, cluster_accept_history, cluster_adjust_iterations, plateau_refill_target, move_stats)
 end
 
 """
@@ -692,6 +694,13 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
     end
     # accept, rate, at = MC_random_walk!(ns_params.mc_steps, to_walk, lj, ns_params.step_size, emax)
     # @info "iter: $(liveset.walkers[1].iter), acceptance rate: $(round(rate; sigdigits=4)), emax: $(round(typeof(1.0u"eV"), emax; sigdigits=10)), is_accepted: $accept, step_size: $(round(ns_params.step_size; sigdigits=4))"
+    # Driver-side counter synthesis, no kernel change: the kernel attempts a
+    # displacement every step and returns the rate as an integer ratio over
+    # exactly mc_steps steps, so the rounding recovers the acceptance count
+    # bit-exactly. Refill walks above are deliberately not accumulated.
+    _accumulate_move_stats!(ns_params,
+        (move_attempted=ns_params.mc_steps,
+         move_accepted=round(Int, rate * ns_params.mc_steps)))
     if accept
         push!(ats, at)
         popfirst!(ats)
@@ -1328,6 +1337,18 @@ Perform a nested sampling loop for a given number of steps.
   prior-volume weights depend only on the iteration index, so the
   substituted column is a valid estimator over the same ladder). The
   default `nothing` changes nothing.
+- `record_move_rates::Bool=false`: Per-iteration acceptance and step-size
+  ledger, supported for the serial atomistic routines (`MCRandomWalkMaxE`,
+  `MCRandomWalkClone`, `MCGalileanWalk`) on an `AtomWalkers` liveset only;
+  other liveset or routine types throw up front, since their step methods
+  run different kernels. When true the ledger declares `log_compression`
+  eagerly, then the routine's rate columns (`move_attempted`/`move_accepted`
+  for the random-walk routines, the five Galilean counters for the
+  reflective one), then a `step_size` column recording the adapted value at
+  each row push; observables follow. Deltas are snapshot-differenced run
+  totals: plateau rows record zeros, failed iterations fold into the next
+  recorded row, and refill walks are never accumulated. The default keeps
+  the shipped schema byte-identically.
 
 # Returns
 - `df`: A DataFrame containing the iteration number and maximum energy for each step,
@@ -1341,7 +1362,8 @@ function nested_sampling(liveset::AbstractLiveSet,
                                 mc_routine::MCRoutine,
                                 save_strategy::DataSavingStrategy;
                                 observables::Union{Nothing,AbstractVector{<:Pair{Symbol,<:Any}}}=nothing,
-                                dead_point_callback::Union{Nothing,Function}=nothing)
+                                dead_point_callback::Union{Nothing,Function}=nothing,
+                                record_move_rates::Bool=false)
     # Initialize cluster_p and reset counters from MCMixedMoves if applicable
     if mc_routine isa MCMixedMoves && mc_routine.clusters_freq > 0
         ns_params.cluster_p = mc_routine.initial_cluster_p
@@ -1354,7 +1376,34 @@ function nested_sampling(liveset::AbstractLiveSet,
     # Defensive: a parameters object recovered from a run that ended inside a
     # plateau block must not arm a fresh run's first cull as a tie eviction.
     ns_params.plateau_refill_target = 0
+    empty!(ns_params.move_stats)
+    if record_move_rates
+        # Both halves of the restriction are load-bearing: the per-iteration
+        # ledger relies on the five-value, log-compression-emitting step
+        # returns and the counter accumulation of the serial atomistic step
+        # methods. Another liveset type (a lattice liveset, or the surface
+        # walkers with their own step method) dispatches to a different step
+        # even under an allowed routine, so it is rejected up front, before
+        # any walker is touched.
+        (liveset isa AtomWalkers && !(liveset isa LJSurfaceWalkers) &&
+         mc_routine isa Union{MCRandomWalkMaxE,MCRandomWalkClone,MCGalileanWalk}) ||
+            throw(ArgumentError(
+                "record_move_rates: supported only for the serial atomistic " *
+                "routines (MCRandomWalkMaxE, MCRandomWalkClone, " *
+                "MCGalileanWalk) on an AtomWalkers liveset"))
+    end
     df = DataFrame(iter=Int[], emax=Float64[])
+    can_rate_cols = record_move_rates ? _move_rate_columns(mc_routine) : ()
+    if record_move_rates
+        # Eager column declaration: the allowed routines' step methods all
+        # emit log_t, so the lazy log_compression addition below never fires
+        # first and the column order is deterministic
+        df[!, :log_compression] = Float64[]
+        for name in can_rate_cols
+            df[!, name] = Int[]
+        end
+        df[!, :step_size] = Float64[]
+    end
     if observables !== nothing
         mc_routine isa MCRoutineParallel && throw(ArgumentError(
             "observables: parallel/multi-cull MC routines are not supported " *
@@ -1373,6 +1422,8 @@ function nested_sampling(liveset::AbstractLiveSet,
             "undefined"))
     end
     culled = nothing
+    can_rate_prev = record_move_rates ?
+        _move_stats_snapshot(ns_params, can_rate_cols) : nothing
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
         write_walker_every_n(liveset.walkers[1], i, save_strategy)
@@ -1412,10 +1463,24 @@ function nested_sampling(liveset::AbstractLiveSet,
                 # column can be added lazily without backfilling.
                 df[!, :log_compression] = Float64[]
             end
-            row = observables === nothing ? (iter, emax.val) :
-                (iter, emax.val,
-                 (Float64(f(culled.configuration)) for (_, f) in observables)...)
-            push!(df, log_t === missing ? row : (row..., log_t))
+            if record_move_rates
+                # Snapshot-differenced per-iteration deltas plus the adapted
+                # step size at row push; plateau-eviction rows run no walk and
+                # record zeros, failed iterations fold into the next recorded
+                # row, and each column sums to its run total
+                snap = _move_stats_snapshot(ns_params, can_rate_cols)
+                rate_row = (snap .- can_rate_prev..., ns_params.step_size)
+                can_rate_prev = snap
+                push!(df, observables === nothing ?
+                    (iter, emax.val, log_t, rate_row...) :
+                    (iter, emax.val, log_t, rate_row...,
+                     (Float64(f(culled.configuration)) for (_, f) in observables)...))
+            else
+                row = observables === nothing ? (iter, emax.val) :
+                    (iter, emax.val,
+                     (Float64(f(culled.configuration)) for (_, f) in observables)...)
+                push!(df, log_t === missing ? row : (row..., log_t))
+            end
             dead_point_callback === nothing || dead_point_callback(iter, culled)
         end
         print_message(i, iter, emax, ns_params.step_size, print_info, liveset)
@@ -2229,9 +2294,12 @@ function nested_sampling_step!(liveset::AtomWalkers, ns_params::NestedSamplingPa
         return iter, emax, liveset, ns_params, log_t
     end
     to_walk = deepcopy(rand(ats[2:end]))
-    accept, rate, at = MC_galilean_walk!(ns_params.mc_steps, to_walk, pot, emax;
+    accept, rate, at, gal_stats = MC_galilean_walk!(ns_params.mc_steps, to_walk, pot, emax;
                                          step_size=ns_params.step_size,
                                          n_refresh=mc_routine.n_refresh)
+    # Segment counters accumulate on the ordinary path only; refill walks
+    # above are deliberately not accumulated (the plateau contract)
+    _accumulate_move_stats!(ns_params, gal_stats)
     if accept
         push!(ats, at)
         popfirst!(ats)
@@ -2458,6 +2526,12 @@ _move_rate_columns(mc_routine::MCAtomGrandCanonicalMoves) =
     (_MOVE_RATE_COLUMNS...,
      (mc_routine.p_bias > 0 ? _CAVITY_RATE_COLUMNS : ())...,
      (mc_routine.galilean_steps > 0 ? _GALILEAN_RATE_COLUMNS : ())...)
+# Canonical (fixed-N) routes: the serial random-walk routines synthesize
+# displacement counters driver-side; the reflective route records the
+# Galilean segment counters
+_move_rate_columns(::Union{MCRandomWalkMaxE,MCRandomWalkClone}) =
+    (:move_attempted, :move_accepted)
+_move_rate_columns(::MCGalileanWalk) = _GALILEAN_RATE_COLUMNS
 
 """
     _warn_min_image_cutoff(pot, config)

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -507,7 +507,11 @@ end
 
 const _RESERVED_LEDGER_COLUMNS = (:iter, :emax, :omega, :energy, :num_particles, :log_compression,
                                   :move_attempted, :move_accepted, :insert_attempted,
-                                  :insert_accepted, :delete_attempted, :delete_accepted)
+                                  :insert_accepted, :delete_attempted, :delete_accepted,
+                                  :insert_biased_attempted, :insert_biased_accepted,
+                                  :galilean_attempted, :galilean_accepted,
+                                  :galilean_reflect_attempted, :galilean_reflect_evals,
+                                  :galilean_reflect_accepted, :step_size)
 
 """
     _validate_observables(observables, liveset::AbstractLiveSet)
@@ -2429,9 +2433,31 @@ end
 # schema order when `record_move_rates=true`)
 const _MOVE_RATE_COLUMNS = (:move_attempted, :move_accepted, :insert_attempted,
                             :insert_accepted, :delete_attempted, :delete_accepted)
+const _CAVITY_RATE_COLUMNS = (:insert_biased_attempted, :insert_biased_accepted)
+const _GALILEAN_RATE_COLUMNS = (:galilean_attempted, :galilean_accepted,
+                                :galilean_reflect_attempted,
+                                :galilean_reflect_evals,
+                                :galilean_reflect_accepted)
 
 _move_stats_snapshot(params::SamplingParameters) =
-    Tuple(get(params.move_stats, k, 0) for k in _MOVE_RATE_COLUMNS)
+    _move_stats_snapshot(params, _MOVE_RATE_COLUMNS)
+_move_stats_snapshot(params::SamplingParameters, cols::Tuple) =
+    Tuple(get(params.move_stats, k, 0) for k in cols)
+
+"""
+    _move_rate_columns(mc_routine::MCAtomGrandCanonicalMoves) -> Tuple
+
+The per-iteration rate-column set for the atomistic ideal-gas-referenced
+ledger, conditional on the routine's active channels: the six base
+grand-canonical columns always, the cavity pair when `p_bias > 0` (the run
+totals already carry the keys), and the five Galilean counters when
+`galilean_steps > 0`. Conditional-on-active-channel keeps the shipped
+six-column schema byte-identical for routines that use neither channel.
+"""
+_move_rate_columns(mc_routine::MCAtomGrandCanonicalMoves) =
+    (_MOVE_RATE_COLUMNS...,
+     (mc_routine.p_bias > 0 ? _CAVITY_RATE_COLUMNS : ())...,
+     (mc_routine.galilean_steps > 0 ? _GALILEAN_RATE_COLUMNS : ())...)
 
 """
     _warn_min_image_cutoff(pot, config)
@@ -2620,10 +2646,17 @@ function nested_sampling_step!(liveset::AtomWalkers,
         p_bias=mc_routine.p_bias, bias_radius=mc_routine.bias_radius,
         bias_grid=mc_routine.bias_grid)
     if accept && mc_routine.galilean_steps > 0 && to_walk.list_num_par[1] > 0
-        # Optional reflective decorrelation burst (see the refill branch)
-        MC_galilean_walk!(mc_routine.galilean_steps, to_walk, pot, emax;
+        # Optional reflective decorrelation burst (see the refill branch).
+        # Its counters accumulate immediately, unconditionally on the
+        # subsequent re-anchor outcome: the burst's cost is paid either way,
+        # and the delta ledger's fold-forward semantics keep the per-column
+        # closure against the run totals exact. Refill-branch bursts stay
+        # unaccumulated, per the plateau contract.
+        _, _, _, gal_stats = MC_galilean_walk!(mc_routine.galilean_steps,
+                          to_walk, pot, emax;
                           step_size=mc_routine.galilean_step_size,
                           n_refresh=mc_routine.galilean_n_refresh)
+        _accumulate_move_stats!(params, gal_stats)
     end
     if accept
         # Re-anchor the clone's energy from scratch (see the refill branch)
@@ -2690,11 +2723,20 @@ With `record_move_rates=true` the ledger gains the per-iteration acceptance colu
 `[:move_attempted, :move_accepted, :insert_attempted, :insert_accepted,
 :delete_attempted, :delete_accepted]`, recorded as the change in the run-total
 counters since the previous recorded row: the production diagnostic for how the
-per-channel acceptances evolve with descent depth. A recorded row therefore also
-carries the attempts of any failed replacements since the previous row;
-plateau-eviction rows run no decorrelation walk of their own, and refill-walk
-counters are deliberately not accumulated. The recorded columns sum exactly to
-the `move_stats` run totals accumulated through the last recorded row. The names are reserved ledger columns, rejected as
+per-channel acceptances evolve with descent depth. The column set is conditional
+on the routine's active channels: `p_bias > 0` adds the cavity pair
+`[:insert_biased_attempted, :insert_biased_accepted]` (subsets of the insertion
+columns), and `galilean_steps > 0` adds the five Galilean counters
+`[:galilean_attempted, :galilean_accepted, :galilean_reflect_attempted,
+:galilean_reflect_evals, :galilean_reflect_accepted]` accumulated from every
+ordinary-cull burst (unconditionally on the subsequent re-anchor outcome, so
+every paid burst appears in some row's delta). A trailing `:step_size` column
+records the adapted step size at each row push. A recorded row also carries the
+attempts of any failed replacements since the previous row; plateau-eviction
+rows run no decorrelation walk of their own, and refill-walk counters
+(including refill bursts) are deliberately not accumulated. The recorded
+columns sum exactly to the `move_stats` run totals accumulated through the
+last recorded row. The names are reserved ledger columns, rejected as
 observable names.
 
 Observable callbacks must handle empty configurations: under this construction a
@@ -2726,10 +2768,12 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
     empty!(params.move_stats)
 
     df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[], log_compression=Float64[])
+    rate_cols = _move_rate_columns(mc_routine)
     if record_move_rates
-        for name in _MOVE_RATE_COLUMNS
+        for name in rate_cols
             df[!, name] = Int[]
         end
+        df[!, :step_size] = Float64[]
     end
     if observables !== nothing
         _validate_observables(observables, liveset)
@@ -2739,7 +2783,7 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
     end
     culled = nothing
     empty_frame_warned = false
-    rate_prev = record_move_rates ? _move_stats_snapshot(params) : nothing
+    rate_prev = record_move_rates ? _move_stats_snapshot(params, rate_cols) : nothing
 
     for i in 1:n_steps
         print_info = i % save_strategy.n_info == 0
@@ -2784,8 +2828,10 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
                     "but the pre-sorted worst walker had $(culled.energy))")
             end
             if record_move_rates
-                snap = _move_stats_snapshot(params)
-                rate_row = snap .- rate_prev
+                snap = _move_stats_snapshot(params, rate_cols)
+                # step_size is recorded at row push, after the iteration's
+                # adjustment (the last recorded row carries the final value)
+                rate_row = (snap .- rate_prev..., params.step_size)
                 rate_prev = snap
             else
                 rate_row = ()

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -1440,6 +1440,25 @@ function _grand_potential(walker::LatticeWalker{1}, mu::Float64)
 end
 
 """
+    _clone_walker_shared_geometry(w::LatticeWalker)
+
+Clone a lattice walker for a replacement walk, copying only its occupancy
+vectors, energy, and iteration counter while sharing the run-invariant
+geometry by reference (the `Val(:share_geometry)` constructor). The
+geometry fields are never mutated after construction and the lattice
+drivers are serial loops, so the clone is behaviorally identical to a
+`deepcopy`: it draws no randomness and changes no floating-point value.
+"""
+_clone_walker_shared_geometry(w::LatticeWalker) =
+    _shared_geometry_walker(w, w.configuration)
+
+function _shared_geometry_walker(w::LatticeWalker, cfg::MLattice{C,G}) where {C,G}
+    shared = MLattice{C,G}(Val(:share_geometry), cfg,
+                           [copy(v) for v in cfg.components])
+    return LatticeWalker(shared, energy=w.energy, iter=w.iter)
+end
+
+"""
     _init_gc_walkers!(liveset::LatticeGasWalkers, gc_params::GrandCanonicalNestedSamplingParameters)
 
 Initialize walkers with random microstates for grand-canonical NS.
@@ -1509,7 +1528,7 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     else
         parent_idx = rand(2:n_walkers)
     end
-    to_walk = deepcopy(ats[parent_idx])
+    to_walk = _clone_walker_shared_geometry(ats[parent_idx])
 
     # Decorrelate via GC MCMC
     accept, rate, to_walk, cl_accepted, cl_total, move_stats = MC_grand_canonical_walk!(
@@ -1858,7 +1877,7 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     else
         parent_idx = rand(2:n_walkers)
     end
-    to_walk = deepcopy(ats[parent_idx])
+    to_walk = _clone_walker_shared_geometry(ats[parent_idx])
 
     # Decorrelate via GC MCMC: with mu = 0 the Ω ceiling reduces to an energy
     # ceiling, and z0 weights the insert/delete acceptance to preserve the

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -299,6 +299,14 @@ particle insertion and deletion.
   same-seed trajectories are not digit-identical to the default; flipping
   the default is deliberately out of scope (a published-run reproducibility
   contract).
+- `swap_mode::Symbol`: Local-swap proposal distribution, `:uniform_pair`
+  (default; the shipped uniform site-pair draw, in which equal-occupancy
+  pairs are accepted no-ops counted by the `swap_null_*` subset counters) or
+  `:occupied_empty` (opt-in; `hop_from` uniform over occupied sites and
+  `hop_to` uniform over empty sites, symmetric with no acceptance
+  correction, zero nulls by construction, guard-skipped on empty and full
+  lattices). `:occupied_empty` changes the random stream and stays off by
+  default.
 
 When `clusters_freq == 0` (the default), the fixed-N branch uses only local swaps
 (`lattice_random_walk!`), preserving backward compatibility with existing scripts.
@@ -326,6 +334,7 @@ struct MCGrandCanonicalMoves <: MCRoutine
     bias_predicate::Symbol
     bias_shells::Int
     incremental::Bool
+    swap_mode::Symbol
     function MCGrandCanonicalMoves(;
             p_move::Float64=0.5,
             p_insert::Float64=0.25,
@@ -339,9 +348,13 @@ struct MCGrandCanonicalMoves <: MCRoutine
             p_bias::Float64=0.0,
             bias_predicate::Symbol=:contact,
             bias_shells::Int=1,
-            incremental::Bool=false)
+            incremental::Bool=false,
+            swap_mode::Symbol=:uniform_pair)
         if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
             throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
+        end
+        if swap_mode !== :uniform_pair && swap_mode !== :occupied_empty
+            throw(ArgumentError("unknown swap_mode :$swap_mode; expected :uniform_pair or :occupied_empty"))
         end
         if !(0.0 <= p_bias <= 1.0)
             throw(ArgumentError("p_bias must satisfy 0 <= p_bias <= 1"))
@@ -361,7 +374,7 @@ struct MCGrandCanonicalMoves <: MCRoutine
         new(p_move, p_insert, clusters_freq, swaps_freq,
             initial_cluster_p, target_cluster_accept, cluster_adjust_interval,
             cluster_p_floor, cluster_p_ceiling,
-            p_bias, bias_predicate, bias_shells, incremental)
+            p_bias, bias_predicate, bias_shells, incremental, swap_mode)
     end
 end
 
@@ -1616,7 +1629,8 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
         p_bias=mc_routine.p_bias,
         bias_predicate=mc_routine.bias_predicate,
         bias_shells=mc_routine.bias_shells,
-        incremental=mc_routine.incremental)
+        incremental=mc_routine.incremental,
+        swap_mode=mc_routine.swap_mode)
 
     if accept
         push!(ats, to_walk)
@@ -1983,7 +1997,8 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
         p_bias=mc_routine.p_bias,
         bias_predicate=mc_routine.bias_predicate,
         bias_shells=mc_routine.bias_shells,
-        incremental=mc_routine.incremental)
+        incremental=mc_routine.incremental,
+        swap_mode=mc_routine.swap_mode)
 
     if accept
         push!(ats, to_walk)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,8 @@ include("test-EnergyEval-forces.jl")
 
 include("test-EnergyEval-clusters.jl")
 
+include("test-lattice-site-deltas.jl")
+
 include("test-MonteCarloMoves.jl")
 
 include("test-SamplingSchemes/test-SamplingSchemes.jl")

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -1358,4 +1358,106 @@
         end
     end
 
+    @testset "shared-geometry walkers and clones" begin
+        using Random
+        using Unitful
+        using DataFrames
+
+        sg_lat() = MLattice{1,SquareLattice}(lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false), cutoff_radii=[1.1],
+            components=[[false for _ in 1:16]], adsorptions=:full)
+        sg_ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+
+        @testset "share_geometry constructor" begin
+            src = sg_lat()
+            Random.seed!(98001)
+            for i in 1:16
+                src.components[1][i] = rand() < 0.5
+            end
+            occ = [copy(v) for v in src.components]
+            cp = MLattice{1,SquareLattice}(Val(:share_geometry), src, occ)
+            @test cp.lattice_vectors === src.lattice_vectors
+            @test cp.positions === src.positions
+            @test cp.basis === src.basis
+            @test cp.supercell_dimensions === src.supercell_dimensions
+            @test cp.periodicity === src.periodicity
+            @test cp.cutoff_radii === src.cutoff_radii
+            @test cp.neighbors === src.neighbors
+            @test cp.adsorptions === src.adsorptions
+            @test cp.components !== src.components
+            @test cp.components[1] !== src.components[1]
+            @test interacting_energy(cp, sg_ham) ==
+                  interacting_energy(src, sg_ham)
+            @test_throws ArgumentError MLattice{1,SquareLattice}(
+                Val(:share_geometry), src, Vector{Bool}[])
+        end
+
+        @testset "replicate_walkers" begin
+            tmpl = sg_lat()
+            ws = replicate_walkers(tmpl, 5)
+            @test length(ws) == 5
+            @test all(w.configuration.neighbors === tmpl.neighbors
+                      for w in ws)
+            @test all(w.configuration.positions === tmpl.positions
+                      for w in ws)
+            @test length(unique(objectid(w.configuration.components[1])
+                                for w in ws)) == 5
+            @test all(w.energy == 0.0u"eV" && w.iter == 0 for w in ws)
+            # independent occupancies: mutating one walker leaves the rest
+            ws[1].configuration.components[1][1] = true
+            @test !ws[2].configuration.components[1][1]
+        end
+
+        @testset "same-seed driver equivalence and aliasing safety" begin
+            # A replicate_walkers live set matches the deepcopy idiom
+            # digit-for-digit: both drivers re-initialize occupancies on
+            # entry, so the random streams coincide
+            sg_save = SaveEveryN("t_sg.csv", "t_sg.traj", "t_sg.ls",
+                                 1000000, 1000000, 1000000)
+            sg_cleanup() = rm.(["t_sg.csv", "t_sg.traj", "t_sg.ls"],
+                               force=true)
+            function sg_run(build)
+                Random.seed!(98002)
+                tmpl = sg_lat()
+                ws = build(tmpl)
+                ls = LatticeGasWalkers(ws, sg_ham; assign_energy=false)
+                p = IdealGasReferencedGCNSParameters(mc_steps=20,
+                    reference_fugacity=1.0, energy_perturbation=1e-9)
+                d, lsx, _ = ideal_gas_referenced_nested_sampling(ls, p,
+                    Int64(50), MCGrandCanonicalMoves(), sg_save)
+                sg_cleanup()
+                return d, lsx
+            end
+            dS, lsS = sg_run(t -> replicate_walkers(t, 10))
+            dD, lsD = sg_run(t -> [LatticeWalker(deepcopy(t),
+                                                 energy=0.0u"eV", iter=0)
+                                   for _ in 1:10])
+            @test dS.iter == dD.iter
+            @test dS.emax == dD.emax
+            @test dS.num_particles == dD.num_particles
+            @test [w.energy.val for w in lsS.walkers] ==
+                  [w.energy.val for w in lsD.walkers]
+            # aliasing safety: after the run every live walker still shares
+            # the one geometry (nothing rebinds or copies it back)
+            nb1 = lsS.walkers[1].configuration.neighbors
+            @test all(w.configuration.neighbors === nb1
+                      for w in lsS.walkers)
+        end
+
+        @testset "clone allocation guard" begin
+            # Compile-warmed shared clone at M = 4096 under a generous fixed
+            # byte ceiling (never time-based): the payload is one occupancy
+            # vector plus constant-size shells
+            big = MLattice{1,SquareLattice}(lattice_constant=1.0,
+                basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(64, 64, 1),
+                periodicity=(true, true, false), cutoff_radii=[1.1],
+                components=[[false for _ in 1:4096]], adsorptions=:full)
+            wk = LatticeWalker(big, energy=0.0u"eV", iter=0)
+            FreeBird.SamplingSchemes._clone_walker_shared_geometry(wk)
+            bytes = @allocated FreeBird.SamplingSchemes._clone_walker_shared_geometry(wk)
+            @test bytes < 50_000
+        end
+    end
+
 end

--- a/test/test-MonteCarloMoves.jl
+++ b/test/test-MonteCarloMoves.jl
@@ -1425,3 +1425,87 @@ end
         @test position(w1.configuration, :) == position(w2.configuration, :)
     end
 end
+
+@testset "Galilean walk kernel statistics" begin
+    using Random
+    gs_box = [[20.0, 0.0, 0.0], [0.0, 20.0, 0.0], [0.0, 0.0, 20.0]]u"Å"
+    gs_pbc = (true, true, true)
+    gs_lj = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.0, shift=true)
+
+    @testset "key order and the zero-filled empty return" begin
+        w0 = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"],
+                                                 gs_box, gs_pbc)))
+        w0.energy = 0.0u"eV"
+        Random.seed!(84100)
+        _, _, _, st = MC_galilean_walk!(2, w0, LJParameters(epsilon=0.0),
+                                        1.0u"eV"; step_size=0.5, n_refresh=4)
+        @test keys(st) == (:galilean_attempted, :galilean_accepted,
+                           :galilean_reflect_attempted,
+                           :galilean_reflect_evals,
+                           :galilean_reflect_accepted)
+        empty_sys = FastSystem(cell_vectors(w0.configuration), gs_pbc,
+                               empty(position(w0.configuration, :)),
+                               empty(species(w0.configuration, :)),
+                               empty(mass(w0.configuration, :)))
+        we = AtomWalker{1}(empty_sys)
+        we.energy = 0.0u"eV"
+        acc_e, rate_e, _, st_e = MC_galilean_walk!(3, we, gs_lj, 1.0u"eV";
+                                                   step_size=0.5, n_refresh=4)
+        @test acc_e == false && rate_e == 0.0
+        @test st_e == (galilean_attempted=0, galilean_accepted=0,
+                       galilean_reflect_attempted=0, galilean_reflect_evals=0,
+                       galilean_reflect_accepted=0)
+    end
+
+    @testset "closed-form counter fixtures" begin
+        # A free particle under a non-binding ceiling never reflects
+        Random.seed!(84101)
+        w1 = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"],
+                                                 gs_box, gs_pbc)))
+        w1.energy = 0.0u"eV"
+        acc1, rate1, _, st1 = MC_galilean_walk!(10, w1,
+            LJParameters(epsilon=0.0), 1.0u"eV"; step_size=2.0, n_refresh=4)
+        @test acc1 == true && rate1 == 1.0
+        @test st1.galilean_attempted == 40
+        @test st1.galilean_accepted == 40
+        @test st1.galilean_reflect_attempted == 0
+        @test st1.galilean_reflect_evals == 0
+        @test st1.galilean_reflect_accepted == 0
+
+        # The same potential under an unreachable ceiling reflects every
+        # segment with a degenerate (zero) gradient: one gradient per
+        # segment, never a second trial energy
+        Random.seed!(84102)
+        w2 = AtomWalker(FastSystem(atomic_system([:Ar => [5.0, 5.0, 5.0]u"Å"],
+                                                 gs_box, gs_pbc)))
+        w2.energy = 0.0u"eV"
+        acc2, rate2, _, st2 = MC_galilean_walk!(5, w2,
+            LJParameters(epsilon=0.0), -1.0u"eV"; step_size=1.0, n_refresh=4)
+        @test acc2 == false && rate2 == 0.0
+        @test st2.galilean_attempted == 20
+        @test st2.galilean_reflect_attempted == 20
+        @test st2.galilean_reflect_evals == 0
+        @test st2.galilean_reflect_accepted == 0
+        @test st2.galilean_accepted == 0
+    end
+
+    @testset "interacting fixture: chain and identities" begin
+        # A bound pair under a tight ceiling (the shipped reversibility
+        # class): reflections fire, every Lennard-Jones gradient is usable,
+        # and the counter chain and rate identity hold exactly
+        Random.seed!(84103)
+        wp = AtomWalker(FastSystem(atomic_system(
+            [:Ar => [8.0, 10.0, 10.0]u"Å", :Ar => [11.0, 10.0, 10.0]u"Å"],
+            gs_box, gs_pbc)))
+        wp.energy = interacting_energy(wp.configuration, gs_lj,
+                                       wp.list_num_par, wp.frozen)
+        emaxp = wp.energy + 0.004u"eV"
+        accp, ratep, _, stp = MC_galilean_walk!(20, wp, gs_lj, emaxp;
+                                                step_size=0.9, n_refresh=6)
+        @test stp.galilean_reflect_accepted <= stp.galilean_reflect_evals <=
+              stp.galilean_reflect_attempted <= stp.galilean_attempted
+        @test ratep == stp.galilean_accepted / stp.galilean_attempted
+        @test stp.galilean_reflect_attempted > 0
+        @test stp.galilean_reflect_evals == stp.galilean_reflect_attempted
+    end
+end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -14,6 +14,8 @@ include("test-atomistic-gc-interacting-regressions.jl")
     include("test-grand_canonical_ns.jl")
     # test ideal-gas-referenced grand-canonical nested sampling
     include("test-ideal-gas-ref-gcns.jl")
+    # seeded trajectory pins for the lattice grand-canonical kernels/drivers
+    include("test-lattice-gc-trajectory-pins.jl")
     # test atomistic ideal-gas-referenced grand-canonical nested sampling
     include("test-atomistic-igref-gcns.jl")
     # test the atomistic ideal-gas-referenced ledger assembly

--- a/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gcns-fixed-n.jl
@@ -1830,3 +1830,124 @@ end
         end
     end
 end
+
+@testset "Canonical per-iteration ledger" begin
+    using Random
+    cl_box = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+    cl_pbc = (true, true, true)
+    cl_lj = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.0, shift=true)
+    cl_pair(d) = AtomWalker(FastSystem(atomic_system(
+        [:Ar => [5.0, 6.0, 6.0]u"Å", :Ar => [5.0 + d, 6.0, 6.0]u"Å"],
+        cl_box, cl_pbc)))
+    function cl_liveset()
+        ws = [cl_pair(2.80 + 0.02k) for k in 1:6]
+        for w in ws
+            w.energy = interacting_energy(w.configuration, cl_lj,
+                                          w.list_num_par, w.frozen)
+        end
+        return LJAtomWalkers(ws, cl_lj)
+    end
+    cl_params() = NestedSamplingParameters(mc_steps=64, initial_step_size=0.3,
+        step_size=0.3, allowed_fail_count=100_000)
+    cl_save() = SaveEveryN(df_filename="_t_cl.csv",
+                           wk_filename="_t_cl.traj.extxyz",
+                           ls_filename="_t_cl.ls.extxyz",
+                           n_traj=10^7, n_snap=10^7, n_info=10^7)
+    cl_cleanup() = for f in ("_t_cl.csv", "_t_cl.traj.extxyz",
+                             "_t_cl.ls.extxyz")
+        rm(f, force=true)
+    end
+    gal5 = ["galilean_attempted", "galilean_accepted",
+            "galilean_reflect_attempted", "galilean_reflect_evals",
+            "galilean_reflect_accepted"]
+
+    @testset "restriction matrix" begin
+        # The liveset half of the gate is load-bearing: a lattice liveset
+        # with an allowed routine dispatches to the lattice step methods
+        lat = MLattice{1,SquareLattice}(lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false), cutoff_radii=[1.1],
+            components=[[false for _ in 1:16]], adsorptions=:full)
+        lham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        lls = LatticeGasWalkers([LatticeWalker(deepcopy(lat), energy=0.0u"eV",
+                                               iter=0) for _ in 1:4], lham;
+                                assign_energy=false)
+        @test_throws ArgumentError nested_sampling(lls, cl_params(), Int64(5),
+            MCRandomWalkClone(), cl_save(); record_move_rates=true)
+        # Parallel/multi-cull routines are rejected too
+        @test_throws ArgumentError nested_sampling(cl_liveset(), cl_params(),
+            Int64(5), MCRandomWalkCloneParallel(), cl_save();
+            record_move_rates=true)
+    end
+
+    @testset "random-walk ledger and synthesis exactness" begin
+        Random.seed!(7100)
+        df, _, pout = nested_sampling(cl_liveset(), cl_params(), Int64(40),
+            MCRandomWalkClone(), cl_save(); record_move_rates=true)
+        cl_cleanup()
+        @test names(df) == ["iter", "emax", "log_compression",
+                            "move_attempted", "move_accepted", "step_size"]
+        for name in ("move_attempted", "move_accepted")
+            @test sum(df[!, name]) == get(pout.move_stats, Symbol(name), 0)
+        end
+        # Walked rows carry positive integer multiples of mc_steps (failed
+        # iterations fold forward); plateau-eviction rows carry zeros
+        @test all(r -> r == 0 || (r > 0 && r % 64 == 0), df.move_attempted)
+        @test all(df.move_accepted .<= df.move_attempted)
+        @test df.step_size[end] == pout.step_size
+        # Round-trip synthesis on a direct kernel call: with a power-of-two
+        # step count the returned rate is exactly representable and the
+        # rounding inverts it bit-exactly
+        Random.seed!(7101)
+        wk = cl_pair(2.9)
+        wk.energy = interacting_energy(wk.configuration, cl_lj,
+                                       wk.list_num_par, wk.frozen)
+        _, r, _ = MC_random_walk!(64, wk, cl_lj, 0.3, wk.energy + 0.05u"eV")
+        @test isinteger(r * 64)
+        @test 0 <= round(Int, r * 64) <= 64
+
+        # Default-off keeps the shipped schema and trajectory
+        Random.seed!(7102)
+        dfa, _, _ = nested_sampling(cl_liveset(), cl_params(), Int64(30),
+            MCRandomWalkClone(), cl_save(); record_move_rates=true)
+        cl_cleanup()
+        Random.seed!(7102)
+        dfb, _, _ = nested_sampling(cl_liveset(), cl_params(), Int64(30),
+            MCRandomWalkClone(), cl_save())
+        cl_cleanup()
+        @test names(dfb) == ["iter", "emax", "log_compression"]
+        @test dfa.iter == dfb.iter
+        @test dfa.emax == dfb.emax
+        @test dfa.log_compression == dfb.log_compression
+    end
+
+    @testset "Galilean ledger" begin
+        Random.seed!(7103)
+        gp = NestedSamplingParameters(mc_steps=4, initial_step_size=0.5,
+            step_size=0.5, allowed_fail_count=100_000)
+        df, _, pout = nested_sampling(cl_liveset(), gp, Int64(30),
+            MCGalileanWalk(n_refresh=4), cl_save(); record_move_rates=true)
+        cl_cleanup()
+        @test names(df) == vcat(["iter", "emax", "log_compression"], gal5,
+                                ["step_size"])
+        for name in gal5
+            @test sum(df[!, name]) == get(pout.move_stats, Symbol(name), 0)
+        end
+        @test get(pout.move_stats, :galilean_attempted, 0) > 0
+        @test df.step_size[end] == pout.step_size
+    end
+
+    @testset "parameters carry and reset the counter dictionary" begin
+        p = NestedSamplingParameters()
+        @test p.move_stats isa Dict{Symbol,Int}
+        @test isempty(p.move_stats)
+        p.move_stats[:move_attempted] = 7
+        Random.seed!(7104)
+        nested_sampling(cl_liveset(), p, Int64(5), MCRandomWalkClone(),
+                        cl_save())
+        cl_cleanup()
+        # The driver clears stale counters at entry, then accumulates fresh
+        # (5 steps at the constructor's default mc_steps = 200)
+        @test get(p.move_stats, :move_attempted, 0) == 5 * 200
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
@@ -137,6 +137,38 @@
         @test all(length(w.configuration) == w.list_num_par[1] for w in ls.walkers)
     end
 
+    @testset "refill bursts stay unledgered (galilean_steps > 0)" begin
+        # The same plateau-block construction with the reflective burst
+        # armed: the plateau rows run no walk, the terminal refill's
+        # decorrelation walks accept nonempty clones (so refill bursts
+        # execute on the accept_r && N > 0 path), and none of it may reach
+        # the Galilean run totals. An accidental accumulation at the refill
+        # site fails the zero pin below.
+        lj_rb = LJParameters(epsilon=0.05, sigma=2.5, cutoff=2.5)
+        rmin_rb = 2.0^(1 / 6) * 2.5
+        wrb = AtomWalker{1}[]
+        push!(wrb, mkat([[1.0, 1.0, 1.0]]))
+        push!(wrb, mkat([[1.0, 6.0, 1.0]]))
+        push!(wrb, mkat([[6.0, 1.0, 1.0]]))
+        push!(wrb, mkat([[6.0, 6.0, 6.0]]))
+        push!(wrb, mkat([[3.0, 3.0, 3.0], [3.0 + rmin_rb, 3.0, 3.0]]))
+        push!(wrb, mkat([[9.0, 9.0, 9.0], [9.0 - rmin_rb, 9.0, 9.0]]))
+        ls_rb = GenericAtomWalkers(wrb, lj_rb)
+        Random.seed!(52531)
+        params_rb = AtomisticIGRefGCNSParameters(mc_steps=100,
+            reference_activity=(2.0 / V)u"Å^-3", species=:Ar,
+            allowed_fail_count=200, step_size=0.5)
+        routine_rb = MCAtomGrandCanonicalMoves(galilean_steps=2,
+            galilean_n_refresh=4, galilean_step_size=0.5)
+        for _ in 1:4
+            FreeBird.SamplingSchemes.nested_sampling_step!(ls_rb, params_rb,
+                                                           routine_rb)
+        end
+        @test length(ls_rb.walkers) == 6
+        @test get(params_rb.move_stats, :galilean_attempted, 0) == 0
+        @test get(params_rb.move_stats, :galilean_reflect_attempted, 0) == 0
+    end
+
     @testset "dilute interacting end-to-end with same-seed determinism" begin
         function run_e2e(seed)
             Random.seed!(seed)
@@ -374,6 +406,107 @@ end
         # The rate columns are reserved: observables cannot collide with them
         @test_throws ArgumentError FreeBird.SamplingSchemes._validate_observables(
             [:insert_accepted => cfg -> 0.0], ls)
+    end
+
+    @testset "Conditional ledger channels and step size" begin
+        ch_save() = SaveEveryN(df_filename="_t_ch.csv",
+                               wk_filename="_t_ch.traj.extxyz",
+                               ls_filename="_t_ch.ls.extxyz",
+                               n_traj=10^7, n_snap=10^7, n_info=10^7)
+        ch_cleanup() = for f in ("_t_ch.csv", "_t_ch.traj.extxyz",
+                                 "_t_ch.ls.extxyz")
+            rm(f, force=true)
+        end
+        base_names = ["iter", "emax", "num_particles", "log_compression"]
+        rate6 = ["move_attempted", "move_accepted", "insert_attempted",
+                 "insert_accepted", "delete_attempted", "delete_accepted"]
+        cav2 = ["insert_biased_attempted", "insert_biased_accepted"]
+        gal5 = ["galilean_attempted", "galilean_accepted",
+                "galilean_reflect_attempted", "galilean_reflect_evals",
+                "galilean_reflect_accepted"]
+
+        # Both optional channels active: full 13-column rate block plus the
+        # trailing step-size column, each rate column closing against its
+        # run total
+        Random.seed!(6100)
+        ls = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+        params = AtomisticIGRefGCNSParameters(mc_steps=60,
+            reference_activity=(6.0 / hard_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        mc = MCAtomGrandCanonicalMoves(galilean_steps=2, galilean_n_refresh=4,
+            galilean_step_size=0.5, p_bias=0.3, bias_radius=2.0, bias_grid=6)
+        df, ls, params = ideal_gas_referenced_nested_sampling(
+            ls, params, 40, mc, ch_save(); record_move_rates=true)
+        ch_cleanup()
+        @test names(df) == vcat(base_names, rate6, cav2, gal5, ["step_size"])
+        for name in vcat(rate6, cav2, gal5)
+            @test sum(df[!, name]) == get(params.move_stats, Symbol(name), 0)
+        end
+        # Subset and chain identities on the recorded totals
+        @test sum(df.insert_biased_attempted) <= sum(df.insert_attempted)
+        @test sum(df.galilean_reflect_accepted) <=
+              sum(df.galilean_reflect_evals) <=
+              sum(df.galilean_reflect_attempted) <=
+              sum(df.galilean_attempted)
+        # Bursts fired on this seeded descent and their cost is now ledgered
+        @test get(params.move_stats, :galilean_attempted, 0) > 0
+        # Bursts fire whole or not at all, and failed iterations fold whole
+        # bursts forward: every recorded row is a multiple of the segment
+        # count galilean_steps * galilean_n_refresh
+        @test all(v -> v % (2 * 4) == 0, df.galilean_attempted)
+        # step_size records the adapted value at each row push; the last
+        # recorded row carries the final adapted value
+        @test df.step_size[end] == params.step_size
+        @test all(params.step_size_lo .<= df.step_size .<= params.step_size_up)
+
+        # Galilean-only routine: the cavity pair stays absent, the schema is
+        # conditional on the active channels
+        Random.seed!(6101)
+        ls2 = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+        params2 = AtomisticIGRefGCNSParameters(mc_steps=60,
+            reference_activity=(6.0 / hard_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        df2, _, params2 = ideal_gas_referenced_nested_sampling(
+            ls2, params2, 40, MCAtomGrandCanonicalMoves(galilean_steps=2),
+            ch_save(); record_move_rates=true)
+        ch_cleanup()
+        @test names(df2) == vcat(base_names, rate6, gal5, ["step_size"])
+        for name in gal5
+            @test sum(df2[!, name]) == get(params2.move_stats, Symbol(name), 0)
+        end
+
+        # Recording on or off never touches the trajectory, with the burst
+        # channel active
+        Random.seed!(6102)
+        ls3 = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+        params3 = AtomisticIGRefGCNSParameters(mc_steps=60,
+            reference_activity=(6.0 / hard_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        df3, _, _ = ideal_gas_referenced_nested_sampling(
+            ls3, params3, 40,
+            MCAtomGrandCanonicalMoves(galilean_steps=2, p_bias=0.3,
+                                      bias_radius=2.0, bias_grid=6),
+            ch_save(); record_move_rates=true)
+        ch_cleanup()
+        Random.seed!(6102)
+        ls4 = LJAtomWalkers([hard_pair(2.80 + 0.02k) for k in 1:6], hard_lj)
+        params4 = AtomisticIGRefGCNSParameters(mc_steps=60,
+            reference_activity=(6.0 / hard_L^3)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        df4, _, _ = ideal_gas_referenced_nested_sampling(
+            ls4, params4, 40,
+            MCAtomGrandCanonicalMoves(galilean_steps=2, p_bias=0.3,
+                                      bias_radius=2.0, bias_grid=6),
+            ch_save())
+        ch_cleanup()
+        @test df3.emax == df4.emax
+        @test df3.num_particles == df4.num_particles
+
+        # The new names are reserved against observable collisions
+        @test_throws ArgumentError FreeBird.SamplingSchemes._validate_observables(
+            [:galilean_attempted => cfg -> 0.0], ls)
+        @test_throws ArgumentError FreeBird.SamplingSchemes._validate_observables(
+            [:step_size => cfg -> 0.0], ls)
     end
 
     @testset "Minimum-image cutoff guard" begin

--- a/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
@@ -346,7 +346,10 @@ end
             ls, params, 40, MCAtomGrandCanonicalMoves(), save; record_move_rates=true)
         rate_names = ["move_attempted", "move_accepted", "insert_attempted",
                       "insert_accepted", "delete_attempted", "delete_accepted"]
-        @test names(df) == vcat(["iter", "emax", "num_particles", "log_compression"], rate_names)
+        # Schema pin updated for the trailing step-size column (an
+        # order-preserving append under the same kwarg; disclosed)
+        @test names(df) == vcat(["iter", "emax", "num_particles", "log_compression"],
+                                rate_names, ["step_size"])
         # Closure: recorded per-iteration deltas sum to the run totals
         for name in rate_names
             @test sum(df[!, name]) == get(params.move_stats, Symbol(name), 0)

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -812,4 +812,125 @@
         @test [k for k in 2:6 if keys_m[k] < worst_m] ==
               [k for k in 2:6 if gp_e(mixed[k]) < worst_m]
     end
+
+    @testset "null-move accounting and swap modes" begin
+        using Random
+
+        ns_lat() = MLattice{1,SquareLattice}(lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false), cutoff_radii=[1.1],
+            components=[[false for _ in 1:16]], adsorptions=:full)
+        ns_ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        function swap_only_walk(lat; swap_mode=:uniform_pair, nsteps=400)
+            wk = LatticeWalker(lat, energy=interacting_energy(lat, ns_ham),
+                               iter=0)
+            _, _, _, _, _, ms = MC_grand_canonical_walk!(nsteps, wk, ns_ham,
+                1.0e3, 0.0; p_move=1.0, p_insert=0.0, z0=1.0,
+                energy_perturb=1e-9, swap_mode=swap_mode)
+            return wk, ms
+        end
+
+        @testset "null classification" begin
+            # All-empty and all-occupied fixtures make every uniform-pair
+            # proposal a null
+            Random.seed!(99101)
+            _, ms_e = swap_only_walk(ns_lat())
+            @test ms_e.swap_attempted == 400
+            @test ms_e.swap_null_attempted == ms_e.swap_attempted
+            lat_f = ns_lat()
+            lat_f.components[1] .= true
+            Random.seed!(99102)
+            _, ms_f = swap_only_walk(lat_f)
+            @test ms_f.swap_null_attempted == ms_f.swap_attempted
+            # Mixed coverage: subset identities
+            lat_m = ns_lat()
+            Random.seed!(99103)
+            for i in 1:16
+                lat_m.components[1][i] = rand() < 0.5
+            end
+            _, ms_m = swap_only_walk(lat_m)
+            @test ms_m.swap_null_accepted <= ms_m.swap_null_attempted
+            @test ms_m.swap_null_attempted <= ms_m.swap_attempted
+            @test ms_m.swap_null_attempted > 0
+            @test ms_m.swap_attempted > ms_m.swap_null_attempted
+        end
+
+        @testset "run totals carry the new keys" begin
+            ns_save = SaveEveryN("t_nsw.csv", "t_nsw.traj", "t_nsw.ls",
+                                 1000000, 1000000, 1000000)
+            Random.seed!(99104)
+            ws = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV",
+                                iter=0) for _ in 1:8]
+            ls = LatticeGasWalkers(ws, ham; assign_energy=false)
+            gc = GrandCanonicalNestedSamplingParameters(mc_steps=20,
+                chemical_potential=-0.05, energy_perturbation=1e-9)
+            _, _, pout = grand_canonical_nested_sampling(ls, gc, Int64(20),
+                MCGrandCanonicalMoves(), ns_save)
+            rm.(["t_nsw.csv", "t_nsw.traj", "t_nsw.ls"], force=true)
+            @test haskey(pout.move_stats, :swap_null_attempted)
+            @test haskey(pout.move_stats, :swap_null_accepted)
+            @test pout.move_stats[:swap_null_attempted] <=
+                  pout.move_stats[:swap_attempted]
+        end
+
+        @testset "swap_mode default A/B and occupied-empty mechanics" begin
+            # Same-seed A/B: a routine that never mentions swap_mode against
+            # the explicit default
+            function ab_run(mode)
+                Random.seed!(99105)
+                lat = ns_lat()
+                for i in 1:16
+                    lat.components[1][i] = rand() < 0.5
+                end
+                wk = LatticeWalker(lat,
+                    energy=interacting_energy(lat, ns_ham), iter=0)
+                if mode === nothing
+                    # A call that never mentions the keyword
+                    _, r, _, _, _, ms = MC_grand_canonical_walk!(300, wk,
+                        ns_ham, 1.0e3, 0.0; p_move=0.4, p_insert=0.3, z0=1.0,
+                        energy_perturb=1e-9)
+                else
+                    _, r, _, _, _, ms = MC_grand_canonical_walk!(300, wk,
+                        ns_ham, 1.0e3, 0.0; p_move=0.4, p_insert=0.3, z0=1.0,
+                        energy_perturb=1e-9, swap_mode=mode)
+                end
+                return wk.energy.val, sum(wk.configuration.components[1]), r,
+                       ms
+            end
+            eA, nA, rA, msA = ab_run(nothing)
+            eB, nB, rB, msB = ab_run(:uniform_pair)
+            @test eA == eB
+            @test nA == nB
+            @test rA == rB
+            @test msA == msB
+
+            # occupied-empty: zero nulls, N conserved on the swap-only walk,
+            # guard skips on empty and full lattices
+            lat_oe = ns_lat()
+            Random.seed!(99106)
+            for i in 1:16
+                lat_oe.components[1][i] = rand() < 0.5
+            end
+            n0 = sum(lat_oe.components[1])
+            wk_oe, ms_oe = swap_only_walk(lat_oe; swap_mode=:occupied_empty)
+            @test ms_oe.swap_null_attempted == 0
+            @test ms_oe.swap_attempted == 400
+            @test sum(wk_oe.configuration.components[1]) == n0
+            Random.seed!(99107)
+            _, ms_oee = swap_only_walk(ns_lat(); swap_mode=:occupied_empty)
+            @test ms_oee.swap_attempted == 0
+            lat_oef = ns_lat()
+            lat_oef.components[1] .= true
+            Random.seed!(99108)
+            _, ms_oef = swap_only_walk(lat_oef; swap_mode=:occupied_empty)
+            @test ms_oef.swap_attempted == 0
+
+            # constructor and kernel validation reject unknown modes
+            @test_throws ArgumentError MCGrandCanonicalMoves(
+                swap_mode=:diagonal)
+            bad_wk = LatticeWalker(ns_lat(), energy=0.0u"eV", iter=0)
+            @test_throws ArgumentError MC_grand_canonical_walk!(1, bad_wk,
+                ns_ham, 1.0e3, 0.0; swap_mode=:diagonal)
+        end
+    end
 end

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -698,4 +698,116 @@
         @test dfA.energy == dfB.energy
         @test dfA.num_particles == dfB.num_particles
     end
+
+    @testset "driver controls (Omega route)" begin
+        using Random
+
+        # Cached-key sortperm reproduces the by-comparator ordering
+        # including tie order (both are stable with identical key values):
+        # a tie-heavy walker vector sorted both ways gives the identical
+        # object sequence
+        Random.seed!(99001)
+        tie_ws = LatticeWalker[]
+        for i in 1:20
+            l = deepcopy(square_lattice)
+            w = LatticeWalker(l, energy=Float64(mod(i, 3)) * 0.01u"eV",
+                              iter=i)
+            push!(tie_ws, w)
+        end
+        mu_tie = -0.05
+        byfun = w -> SamplingSchemes._grand_potential(w, mu_tie)
+        a = copy(tie_ws)
+        sort!(a, by=byfun, rev=true)
+        b = copy(tie_ws)
+        permute!(b, sortperm([byfun(w) for w in b], rev=true))
+        @test all(a[i] === b[i] for i in eachindex(a))
+
+        # Parameter-crafted stall: empty initial occupancies with a
+        # deletion-only move mix are permanently guard-skipped, so every
+        # step fails. stop_on_stall = true returns the partial (empty)
+        # ledger and the intact live set after one warning.
+        stall_save = SaveEveryN("t_stall_gc.csv", "t_stall_gc.traj",
+                                "t_stall_gc.ls", 1000000, 1000000, 1000000)
+        stall_cleanup() = rm.(["t_stall_gc.csv", "t_stall_gc.traj",
+                               "t_stall_gc.ls"], force=true)
+        function stall_run(; kwargs...)
+            Random.seed!(99002)
+            ws = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV",
+                                iter=0) for _ in 1:8]
+            ls = LatticeGasWalkers(ws, ham; assign_energy=false)
+            gc = GrandCanonicalNestedSamplingParameters(mc_steps=10,
+                chemical_potential=-0.05, energy_perturbation=1e-9,
+                init_occupation_p=0.0, allowed_fail_count=3)
+            d, lsx, _ = grand_canonical_nested_sampling(ls, gc, Int64(40),
+                MCGrandCanonicalMoves(p_move=0.0, p_insert=0.0), stall_save;
+                kwargs...)
+            stall_cleanup()
+            return d, lsx
+        end
+        d_stop, ls_stop = @test_logs (:warn, r"GC-NS: Failed") match_mode=:any stall_run(
+            stop_on_stall=true)
+        @test nrow(d_stop) == 0
+        @test length(ls_stop.walkers) == 8
+        # The default warn-and-continue burns the whole budget but returns
+        # the same (empty) ledger; explicit false matches the unmentioned
+        # default digit-for-digit
+        d_def, _ = stall_run()
+        d_off, _ = stall_run(stop_on_stall=false)
+        @test nrow(d_def) == 0
+        @test d_def.iter == d_off.iter
+
+        # The default A/B on a healthy (non-stalling) fixture: explicit
+        # stop_on_stall = false against a call that never mentions it,
+        # digit-identical ledgers and live sets
+        function healthy_run(; kwargs...)
+            Random.seed!(99010)
+            ws = [LatticeWalker(deepcopy(square_lattice), energy=0.0u"eV",
+                                iter=0) for _ in 1:8]
+            ls = LatticeGasWalkers(ws, ham; assign_energy=false)
+            gc = GrandCanonicalNestedSamplingParameters(mc_steps=20,
+                chemical_potential=-0.05, energy_perturbation=1e-9)
+            d, lsx, _ = grand_canonical_nested_sampling(ls, gc, Int64(30),
+                MCGrandCanonicalMoves(), stall_save; kwargs...)
+            stall_cleanup()
+            return d, lsx
+        end
+        h_def, ls_hd = healthy_run()
+        h_off, ls_ho = healthy_run(stop_on_stall=false)
+        @test nrow(h_def) > 0
+        @test h_def.omega == h_off.omega
+        @test h_def.energy == h_off.energy
+        @test [w.energy.val for w in ls_hd.walkers] ==
+              [w.energy.val for w in ls_ho.walkers]
+
+        # Observables and the dead-point callback ride the rewritten cached-
+        # key pre-sort: a run with both on records the identical physics
+        # columns as the plain same-seed run
+        obs_d, _ = healthy_run(observables=[:n_occ =>
+                                   cfg -> Float64(sum(cfg.components[1]))],
+                               dead_point_callback=(iter, w) -> nothing)
+        @test obs_d.omega == h_def.omega
+        @test obs_d.energy == h_def.energy
+        @test obs_d.num_particles == h_def.num_particles
+
+        # Eligible-set contents on a crafted degenerate (all-tied) live set
+        # match the by-comparator comprehension: both are empty, and on a
+        # mixed set both agree entry-for-entry
+        mu_e = -0.05
+        gp_e = w -> SamplingSchemes._grand_potential(w, mu_e)
+        tied = [LatticeWalker(deepcopy(square_lattice),
+                              energy=0.1u"eV", iter=0) for _ in 1:6]
+        keys_t = [gp_e(w) for w in tied]
+        worst_t = maximum(keys_t)
+        elig_cached = [k for k in 2:6 if keys_t[k] < worst_t]
+        elig_direct = [k for k in 2:6 if gp_e(tied[k]) < worst_t]
+        @test elig_cached == elig_direct == Int[]
+        mixed = [LatticeWalker(deepcopy(square_lattice),
+                               energy=Float64(mod(i, 3)) * 0.01u"eV", iter=i)
+                 for i in 1:6]
+        sort!(mixed, by=gp_e, rev=true)
+        keys_m = [gp_e(w) for w in mixed]
+        worst_m = keys_m[1]
+        @test [k for k in 2:6 if keys_m[k] < worst_m] ==
+              [k for k in 2:6 if gp_e(mixed[k]) < worst_m]
+    end
 end

--- a/test/test-SamplingSchemes/test-grand_canonical_ns.jl
+++ b/test/test-SamplingSchemes/test-grand_canonical_ns.jl
@@ -225,7 +225,9 @@
             p_move=0.5, p_insert=0.25, energy_perturb=0.0)
         @test counters isa NamedTuple
         @test keys(counters) == (
-            :swap_attempted, :swap_accepted, :cluster_attempted, :cluster_accepted,
+            :swap_attempted, :swap_accepted,
+            :swap_null_attempted, :swap_null_accepted,
+            :cluster_attempted, :cluster_accepted,
             :insert_uniform_attempted, :insert_uniform_accepted,
             :insert_biased_attempted, :insert_biased_accepted,
             :delete_attempted, :delete_accepted)

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -872,4 +872,100 @@
             energy_perturb=1e-9, incremental=true)
         @test alloc_bytes < 2_000_000
     end
+
+    @testset "driver controls (ideal-gas-referenced route)" begin
+        dc_lat() = MLattice{1,SquareLattice}(lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false), cutoff_radii=[1.1],
+            components=[[false for _ in 1:16]], adsorptions=:full)
+        dc_ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        dc_save = SaveEveryN("t_dc_ig.csv", "t_dc_ig.traj", "t_dc_ig.ls",
+                             1000000, 1000000, 1000000)
+        dc_cleanup() = rm.(["t_dc_ig.csv", "t_dc_ig.traj", "t_dc_ig.ls"],
+                           force=true)
+
+        # Parameter-crafted stall: a near-zero reference fugacity
+        # initializes every walker empty and a deletion-only move mix is
+        # permanently guard-skipped
+        function dc_stall(; kwargs...)
+            Random.seed!(99003)
+            ws = [LatticeWalker(deepcopy(dc_lat()), energy=0.0u"eV", iter=0)
+                  for _ in 1:8]
+            ls = LatticeGasWalkers(ws, dc_ham; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=10,
+                reference_fugacity=1e-8, energy_perturbation=1e-9,
+                allowed_fail_count=3)
+            d, lsx, _ = ideal_gas_referenced_nested_sampling(ls, p,
+                Int64(40), MCGrandCanonicalMoves(p_move=0.0, p_insert=0.0),
+                dc_save; kwargs...)
+            dc_cleanup()
+            return d, lsx
+        end
+        d_stop, ls_stop = @test_logs (:warn, r"IG-ref GC-NS: Failed") match_mode=:any dc_stall(
+            stop_on_stall=true)
+        @test nrow(d_stop) == 0
+        @test length(ls_stop.walkers) == 8
+        d_def, _ = dc_stall()
+        @test nrow(d_def) == 0
+
+        # Tie-breaker scale warning: hand-computed bound on the 4x4
+        # one-shell fixture is 0.04*16 + 0.01*64/2 = 0.96 in eV units; the
+        # site-field wrapper adds its magnitude sum, the cluster wrapper
+        # its coupling-times-embeddings sum, and an unknown Hamiltonian
+        # type opts out (no warning)
+        b0 = SamplingSchemes._perturbation_energy_bound(dc_ham, dc_lat())
+        @test isapprox(b0, 0.96; rtol=1e-12)
+        fld = collect(0.01 .* (1:16)) .* u"eV"
+        bsf = SamplingSchemes._perturbation_energy_bound(
+            SiteFieldLatticeHamiltonian(dc_ham, fld), dc_lat())
+        @test isapprox(bsf, 0.96 + sum(0.01 .* (1:16)); rtol=1e-12)
+        bcl = SamplingSchemes._perturbation_energy_bound(
+            ClusterLatticeHamiltonian(dc_ham,
+                [ClusterInteraction(0.1u"eV", [(1, 2, 5)])]), dc_lat())
+        @test isapprox(bcl, 0.96 + 0.1; rtol=1e-12)
+        @test SamplingSchemes._perturbation_energy_bound(:not_a_hamiltonian,
+            dc_lat()) === nothing
+        # Image-multiplicity cell (2x2, wrap-around bonds counted per image,
+        # self-image entries included by the entries/2 form): each site
+        # carries 4 ordered entries (two images per axis), 16 total, so
+        # b = 0.04*4 + 0.01*16/2 = 0.24
+        im_lat = MLattice{1,SquareLattice}(lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(2, 2, 1),
+            periodicity=(true, true, false), cutoff_radii=[1.1],
+            components=[[false for _ in 1:4]], adsorptions=:full,
+            image_multiplicity=true)
+        @test isapprox(SamplingSchemes._perturbation_energy_bound(dc_ham,
+            im_lat), 0.24; rtol=1e-12)
+        # Multi-component Hamiltonian delegates to [1, 1], matching the
+        # energy and delta paths
+        @test isapprox(SamplingSchemes._perturbation_energy_bound(
+            MLatticeHamiltonian(1, [dc_ham]), dc_lat()), 0.96; rtol=1e-12)
+
+        # Below-floor perturbation warns at driver entry; an in-range one
+        # never does
+        function dc_short(delta)
+            Random.seed!(99004)
+            ws = [LatticeWalker(deepcopy(dc_lat()), energy=0.0u"eV", iter=0)
+                  for _ in 1:10]
+            ls = LatticeGasWalkers(ws, dc_ham; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=5,
+                reference_fugacity=1.0, energy_perturbation=delta)
+            d, _, _ = ideal_gas_referenced_nested_sampling(ls, p, Int64(3),
+                MCGrandCanonicalMoves(), dc_save)
+            dc_cleanup()
+            return d
+        end
+        logs_lo, _ = Test.collect_test_logs() do
+            dc_short(1e-15)
+        end
+        floor_warns = [l for l in logs_lo
+                       if occursin("resolution floor", string(l.message))]
+        @test length(floor_warns) == 1
+        @test occursin("Recommended minimum", string(floor_warns[1].message))
+        logs_hi, _ = Test.collect_test_logs() do
+            dc_short(1e-9)
+        end
+        @test !any(occursin("resolution floor", string(l.message))
+                   for l in logs_hi)
+    end
 end

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -714,4 +714,162 @@
         @test dfA.emax == dfB.emax
         @test dfA.num_particles == dfB.num_particles
     end
+
+    @testset "opt-in incremental walk" begin
+        # Calibration ledger (gates at >= 3x the max three-seed deviation,
+        # per statistic): incremental = true full-descent ladders on the
+        # 4x4 two-shell fixture (K = 64, mc_steps = 40, 820 steps, z0 = 1,
+        # reduced at mu = 0, T = 600 K), seeds 96001/96002/96003 measured
+        # |d logXi| = 0.153 / 0.282 / 0.156 (sigma class sqrt(16 ln2 / 64)
+        # ~ 0.42, matching the shipped substitution-closure calibration) and
+        # |d mean_N| = 0.057 / 0.088 / 0.076: gates 0.85 and 0.27.
+        inc_lat() = MLattice{1,SquareLattice}(lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false), cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:16]], adsorptions=:full)
+        inc_ham = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+        inc_save = SaveEveryN("t_inc.csv", "t_inc.traj", "t_inc.ls",
+                              1000000, 1000000, 1000000)
+        inc_cleanup() = rm.(["t_inc.csv", "t_inc.traj", "t_inc.ls"],
+                            force=true)
+        inc_T = 600.0
+        inc_mu = 0.0
+        inc_beta = 1 / (kb * inc_T)
+
+        # Exact grand sum by per-sector enumeration, computed before any
+        # seeding because exact_enumeration consumes the global RNG
+        inc_lnZs = Float64[]
+        for N in 0:16
+            occ = vcat(fill(true, N), fill(false, 16 - N))
+            latN = inc_lat()
+            latN.components[1] .= occ
+            dfe, _ = exact_enumeration(latN, inc_ham)
+            Es = [ustrip(u"eV", e) for e in dfe.energy]
+            Emin = minimum(Es)
+            push!(inc_lnZs, inc_beta * inc_mu * N - inc_beta * Emin +
+                            log(sum(exp.(-inc_beta .* (Es .- Emin)))))
+        end
+        inc_m = maximum(inc_lnZs)
+        inc_lnXi = inc_m + log(sum(exp.(inc_lnZs .- inc_m)))
+        inc_meanN = sum((0:16) .* exp.(inc_lnZs .- inc_m)) /
+                    sum(exp.(inc_lnZs .- inc_m))
+
+        # Same-seed A/B stream identity: a routine that never mentions the
+        # field against incremental = false, on the driver
+        function inc_ab(seed, routine)
+            Random.seed!(seed)
+            ws = [LatticeWalker(deepcopy(inc_lat()), energy=0.0u"eV", iter=0)
+                  for _ in 1:16]
+            ls = LatticeGasWalkers(ws, inc_ham; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=20,
+                reference_fugacity=1.0, energy_perturbation=1e-9)
+            d, lsx, _ = ideal_gas_referenced_nested_sampling(ls, p,
+                Int64(100), routine, inc_save)
+            inc_cleanup()
+            return d, lsx
+        end
+        dA, lsA = inc_ab(97001, MCGrandCanonicalMoves())
+        dB, lsB = inc_ab(97001, MCGrandCanonicalMoves(incremental=false))
+        @test dA.iter == dB.iter
+        @test dA.emax == dB.emax
+        @test dA.num_particles == dB.num_particles
+        @test [w.energy.val for w in lsA.walkers] ==
+              [w.energy.val for w in lsB.walkers]
+
+        # Statistical gate against the exact grand sum, three seeds
+        for seed in (96001, 96002, 96003)
+            Random.seed!(seed)
+            ws = [LatticeWalker(deepcopy(inc_lat()), energy=0.0u"eV", iter=0)
+                  for _ in 1:64]
+            ls = LatticeGasWalkers(ws, inc_ham; assign_energy=false)
+            p = IdealGasReferencedGCNSParameters(mc_steps=40,
+                reference_fugacity=1.0, energy_perturbation=1e-9)
+            d, lsx, _ = ideal_gas_referenced_nested_sampling(ls, p,
+                Int64(820), MCGrandCanonicalMoves(incremental=true), inc_save)
+            inc_cleanup()
+            live_E = [w.energy.val for w in lsx.walkers]
+            live_N = [Int(sum(w.configuration.components[1]))
+                      for w in lsx.walkers]
+            s = gc_thermodynamic_stats_ideal_ref(d, 16, 1.0, [inc_mu],
+                [inc_T], 64; ω0=65 / 64, live_emax=live_E,
+                live_numbers=live_N)
+            @test abs(s.logXi[1, 1] - inc_lnXi) < 0.85
+            @test abs(s.mean_N[1, 1] - inc_meanN) < 0.27
+        end
+
+        # Anchor-drift weld: with a zero perturbation the stored walker
+        # energy IS the raw accumulator, so a long incremental walk must
+        # agree with a from-scratch recompute in the 1e-12 eV class
+        weld_lat = MLattice{1,SquareLattice}(lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(6, 6, 1),
+            periodicity=(true, true, false), cutoff_radii=[1.1, 1.5],
+            components=[[false for _ in 1:36]], adsorptions=:full)
+        Random.seed!(97002)
+        for i in 1:36
+            weld_lat.components[1][i] = rand() < 0.5
+        end
+        weld_wk = LatticeWalker(weld_lat,
+            energy=interacting_energy(weld_lat, inc_ham), iter=0)
+        MC_grand_canonical_walk!(5000, weld_wk, inc_ham, 1.0e3, 0.0;
+            p_move=0.4, p_insert=0.3, z0=1.0, energy_perturb=0.0,
+            clusters_freq=2, swaps_freq=2, cluster_p=0.3, incremental=true)
+        @test abs(ustrip(u"eV", weld_wk.energy -
+                  interacting_energy(weld_wk.configuration, inc_ham))) <= 1e-12
+
+        # Null-pair fixture at extreme coverage: a swap-only walk on a
+        # nearly full lattice is dominated by equal-occupancy pairs, which
+        # must contribute exactly zero delta (the weld exposes a corrupted
+        # accumulator)
+        null_lat = inc_lat()
+        null_lat.components[1] .= true
+        null_lat.components[1][3] = false
+        Random.seed!(97003)
+        null_wk = LatticeWalker(null_lat,
+            energy=interacting_energy(null_lat, inc_ham), iter=0)
+        MC_grand_canonical_walk!(2000, null_wk, inc_ham, 1.0e3, 0.0;
+            p_move=1.0, p_insert=0.0, z0=1.0, energy_perturb=0.0,
+            incremental=true)
+        @test abs(ustrip(u"eV", null_wk.energy -
+                  interacting_energy(null_wk.configuration, inc_ham))) <= 1e-12
+
+        # Trait fallback: an unsupported Hamiltonian under incremental =
+        # true recomputes fully each step and stays digit-identical to the
+        # same-seed default
+        cl_ham = ClusterLatticeHamiltonian(inc_ham,
+            [ClusterInteraction(0.1u"eV", [(1, 2, 5)])])
+        function inc_cl(inc)
+            Random.seed!(97004)
+            l = inc_lat()
+            for i in 1:16
+                l.components[1][i] = rand() < 0.5
+            end
+            w = LatticeWalker(l, energy=interacting_energy(l, cl_ham), iter=0)
+            _, r, _, _, _, _ = MC_grand_canonical_walk!(500, w, cl_ham,
+                1.0e3, 0.0; p_move=0.4, p_insert=0.3, z0=1.0,
+                energy_perturb=1e-9, incremental=inc)
+            return w.energy.val, sum(w.configuration.components[1]), r
+        end
+        eT, nT, rT = inc_cl(true)
+        eF, nF, rF = inc_cl(false)
+        @test eT == eF
+        @test nT == nF
+        @test rT == rF
+
+        # Allocation ceiling on a compile-warmed incremental walk (generous
+        # fixed byte bound, never time-based)
+        alloc_lat = inc_lat()
+        Random.seed!(97005)
+        for i in 1:16
+            alloc_lat.components[1][i] = rand() < 0.5
+        end
+        alloc_wk = LatticeWalker(alloc_lat,
+            energy=interacting_energy(alloc_lat, inc_ham), iter=0)
+        MC_grand_canonical_walk!(100, alloc_wk, inc_ham, 1.0e3, 0.0;
+            p_move=0.4, p_insert=0.3, z0=1.0, energy_perturb=1e-9,
+            incremental=true)
+        alloc_bytes = @allocated MC_grand_canonical_walk!(100, alloc_wk,
+            inc_ham, 1.0e3, 0.0; p_move=0.4, p_insert=0.3, z0=1.0,
+            energy_perturb=1e-9, incremental=true)
+        @test alloc_bytes < 2_000_000
+    end
 end

--- a/test/test-SamplingSchemes/test-lattice-gc-trajectory-pins.jl
+++ b/test/test-SamplingSchemes/test-lattice-gc-trajectory-pins.jl
@@ -1,0 +1,191 @@
+@testset "Lattice GC trajectory pins" begin
+    using Random
+    using Unitful
+    using DataFrames
+
+    # Absolute seeded bit-identity pins on the lattice grand-canonical
+    # trajectories, recorded on the shipped kernels and drivers. Every other
+    # seeded lattice trajectory test is relative (same-seed self- or A/B
+    # equality), so none of them can falsify a "trajectories are bit-for-bit
+    # unchanged" promise from kernel-internals work; these pins can.
+    #
+    # Determinism across CI architectures: every recorded float is produced by
+    # a short, source-ordered sequence of scalar operations (the fixed nested
+    # accumulation of lattice_interaction_energy, one perturbation product per
+    # step, one mu*N subtraction for Omega), with no vectorized reductions, so
+    # exact == pins are expected to hold on every CI leg. Disclosed fallback:
+    # should any leg falsify that argument on the energy digits, those specific
+    # pins drop to the atomistic rtol 1e-12 convention while every integer pin
+    # stays exact.
+    #
+    # move_stats pins are asserted per key, by name, never as an exact key set
+    # or exact-tuple comparison, so later changes that append subset counters
+    # extend the key set without touching this file.
+    #
+    # Captured at dev 60cec59e; capture reproduced identically across two
+    # separate Julia processes before recording.
+
+    pin_lattice() = MLattice{1,SquareLattice}(lattice_constant=1.0,
+        basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(4, 4, 1),
+        periodicity=(true, true, false), cutoff_radii=[1.1],
+        components=[[false for _ in 1:16]], adsorptions=:full)
+
+    pin_ham() = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+
+    pin_save(tag) = SaveEveryN("t_pin_$(tag).csv", "t_pin_$(tag).traj",
+                               "t_pin_$(tag).ls", 1000000, 1000000, 1000000)
+    pin_cleanup(tag) = rm.(["t_pin_$(tag).csv", "t_pin_$(tag).traj",
+                            "t_pin_$(tag).ls"], force=true)
+
+    pin_keys = (:swap_attempted, :swap_accepted,
+        :cluster_attempted, :cluster_accepted,
+        :insert_uniform_attempted, :insert_uniform_accepted,
+        :insert_biased_attempted, :insert_biased_accepted,
+        :delete_attempted, :delete_accepted)
+
+    function pin_run_igref(seed, routine, tag)
+        Random.seed!(seed)
+        lat = pin_lattice()
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                   for _ in 1:10]
+        ls = LatticeGasWalkers(walkers, pin_ham(); assign_energy=false)
+        params = IdealGasReferencedGCNSParameters(mc_steps=30,
+            reference_fugacity=1.0, energy_perturbation=1e-9)
+        df, _, pout = ideal_gas_referenced_nested_sampling(ls, params,
+            Int64(50), routine, pin_save(tag))
+        pin_cleanup(tag)
+        return df, pout
+    end
+
+    function pin_run_omega(seed, tag)
+        Random.seed!(seed)
+        lat = pin_lattice()
+        walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0)
+                   for _ in 1:10]
+        ls = LatticeGasWalkers(walkers, pin_ham(); assign_energy=false)
+        gc = GrandCanonicalNestedSamplingParameters(mc_steps=30,
+            chemical_potential=-0.05, energy_perturbation=1e-9)
+        df, _, pout = grand_canonical_nested_sampling(ls, gc, Int64(50),
+            MCGrandCanonicalMoves(), pin_save(tag))
+        pin_cleanup(tag)
+        return df, pout
+    end
+
+    @testset "ideal-gas-referenced driver pin" begin
+        df, pout = pin_run_igref(90231, MCGrandCanonicalMoves(), "a")
+        @test nrow(df) == 50
+        @test df.iter == collect(1:50)
+        @test df.emax == [-0.2699999999644116, -0.35000000042328644, -0.36999999979314385, -0.39000000005592456, -0.39000000046720606, -0.41000000027337313, -0.410000000342582, -0.4199999999512617, -0.4400000004303773, -0.449999999637877, -0.4500000000943816, -0.46000000016108417, -0.4600000003650343, -0.460000000497379, -0.46999999970808093, -0.5100000000263559, -0.519999999625387, -0.5199999998185273, -0.5299999996474583, -0.5300000001131523, -0.5300000002052305, -0.5599999998829622, -0.5799999996419265, -0.580000000314528, -0.5800000003592434, -0.5899999996467072, -0.5900000004915871, -0.5999999998134353, -0.6000000002701145, -0.6499999995846582, -0.6599999995732023, -0.6599999996888175, -0.6600000002741281, -0.6600000004280429, -0.6699999995186419, -0.6699999997320831, -0.6699999998576416, -0.6699999999810813, -0.67000000014307, -0.7199999995272947, -0.719999999583073, -0.7199999996755059, -0.7200000002702595, -0.7200000003391624, -0.7200000004629845, -0.7200000004754998, -0.729999999707986, -0.7299999998527085, -0.7299999998696584, -0.7299999998737972]
+        @test df.num_particles == [6, 7, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13]
+        expected = Dict(:swap_attempted => 741, :swap_accepted => 702,
+            :cluster_attempted => 0, :cluster_accepted => 0,
+            :insert_uniform_attempted => 378, :insert_uniform_accepted => 124,
+            :insert_biased_attempted => 0, :insert_biased_accepted => 0,
+            :delete_attempted => 381, :delete_accepted => 136)
+        for k in pin_keys
+            @test pout.move_stats[k] == expected[k]
+        end
+    end
+
+    @testset "ideal-gas-referenced driver pin, cluster branch" begin
+        df, pout = pin_run_igref(90232,
+            MCGrandCanonicalMoves(clusters_freq=2, swaps_freq=2), "b")
+        @test nrow(df) == 50
+        @test df.iter == collect(1:50)
+        @test df.emax == [-0.2300000004182935, -0.3399999997672429, -0.38999999987374245, -0.3900000004700098, -0.39999999957200477, -0.42000000018662215, -0.4200000002205665, -0.4499999995620119, -0.44999999972912813, -0.4500000001240203, -0.4600000002612164, -0.5000000002334599, -0.5100000002560634, -0.5199999999750904, -0.5200000001304839, -0.5299999999059581, -0.5300000001117027, -0.5300000002035519, -0.5300000002146336, -0.539999999686027, -0.5700000003883858, -0.5900000002727569, -0.5900000003044019, -0.5900000004969573, -0.5999999999497403, -0.6099999998167888, -0.6499999997268328, -0.6500000004233193, -0.6599999995451575, -0.6599999995611678, -0.6599999998056706, -0.660000000043681, -0.6600000001236203, -0.660000000275807, -0.6600000003731324, -0.6600000004323584, -0.660000000471613, -0.669999999508748, -0.6699999996064473, -0.6699999996878839, -0.7199999998769969, -0.7299999996237462, -0.7299999997991685, -0.7299999999686371, -0.7300000003368419, -0.7300000003425152, -0.7399999995748048, -0.7400000000570205, -0.7400000001710221, -0.7400000002212038]
+        @test df.num_particles == [5, 7, 8, 8, 8, 8, 8, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13]
+        expected = Dict(:swap_attempted => 405, :swap_accepted => 360,
+            :cluster_attempted => 347, :cluster_accepted => 308,
+            :insert_uniform_attempted => 375, :insert_uniform_accepted => 126,
+            :insert_biased_attempted => 0, :insert_biased_accepted => 0,
+            :delete_attempted => 373, :delete_accepted => 121)
+        for k in pin_keys
+            @test pout.move_stats[k] == expected[k]
+        end
+    end
+
+    @testset "Omega-sorted driver pin" begin
+        df, pout = pin_run_omega(90233, "c")
+        @test nrow(df) == 50
+        @test df.iter == collect(1:50)
+        @test df.omega == [0.02000000013447678, 0.01999999998702584, 0.019999999986485273, 0.019999999984942507, 0.019999999843285043, 0.010000000234017203, 0.009999999923124003, 4.838131562046044e-10, 2.9381996835553537e-11, 2.1772195157865326e-11, -2.8480401370600816e-10, -0.009999999627352818, -0.009999999630286083, -0.009999999772195456, -0.009999999962406192, -0.010000000299792533, -0.01999999960906279, -0.01999999996136026, -0.02000000043075012, -0.029999999790141396, -0.030000000428883733, -0.04000000032482687, -0.04000000038598894, -0.04000000042551077, -0.040000000488346954, -0.04999999994894666, -0.05000000000658367, -0.05000000005244898, -0.05000000033215923, -0.059999999508962176, -0.05999999969670866, -0.059999999806152005, -0.06000000022808638, -0.06000000026363628, -0.06000000036172204, -0.06000000041743647, -0.0600000004348068, -0.06000000046202303, -0.06000000049374843, -0.0699999997062476, -0.06999999980868166, -0.06999999986918726, -0.06999999991370986, -0.06999999999901241, -0.0700000000474903, -0.07000000019467689, -0.07000000025162045, -0.07000000025832032, -0.07000000030623177, -0.07999999995250584]
+        @test df.energy == [-0.27999999986552326, -0.3300000000129742, -0.33000000001351476, -0.1800000000150575, -0.280000000156715, -0.4399999997659828, -0.34000000007687603, -0.44999999951618685, -0.399999999970618, -0.34999999997822784, -0.40000000028480404, -0.45999999962735283, -0.5099999996302861, -0.3599999997721955, -0.5599999999624062, -0.41000000029979256, -0.3699999996090628, -0.5199999999613603, -0.42000000043075014, -0.4799999997901414, -0.5800000004288838, -0.5400000003248269, -0.590000000385989, -0.5400000004255108, -0.540000000488347, -0.5999999999489467, -0.6500000000065838, -0.600000000052449, -0.6500000003321593, -0.6599999995089623, -0.6599999996967088, -0.609999999806152, -0.6600000002280865, -0.6100000002636363, -0.6600000003617221, -0.6100000004174365, -0.6600000004348069, -0.6600000004620231, -0.6600000004937485, -0.6699999997062477, -0.6699999998086817, -0.6699999998691873, -0.66999999991371, -0.6699999999990125, -0.7200000000474903, -0.7200000001946769, -0.6700000002516205, -0.6700000002583204, -0.6700000003062319, -0.7299999999525059]
+        @test df.num_particles == [6, 7, 7, 4, 6, 9, 7, 9, 8, 7, 8, 9, 10, 7, 11, 8, 7, 10, 8, 9, 11, 10, 11, 10, 10, 11, 12, 11, 12, 12, 12, 11, 12, 11, 12, 11, 12, 12, 12, 12, 12, 12, 12, 12, 13, 13, 12, 12, 12, 13]
+        expected = Dict(:swap_attempted => 749, :swap_accepted => 600,
+            :cluster_attempted => 0, :cluster_accepted => 0,
+            :insert_uniform_attempted => 379, :insert_uniform_accepted => 147,
+            :insert_biased_attempted => 0, :insert_biased_accepted => 0,
+            :delete_attempted => 372, :delete_accepted => 147)
+        for k in pin_keys
+            @test pout.move_stats[k] == expected[k]
+        end
+    end
+
+    @testset "canonical kernel pins" begin
+        # The canonical-lattice walk kernels are default-path rewrites too;
+        # these pins (captured on the shipped code, reproduced identically
+        # across two Julia processes) make a stream regression in either
+        # kernel visible to this gate. The random-walk ceiling is binding
+        # (rate 0.945: eleven rejects exercise the revert path inside the
+        # pinned stream).
+        Random.seed!(90235)
+        lat_rw = pin_lattice()
+        for i in 1:16
+            lat_rw.components[1][i] = rand() < 0.5
+        end
+        wk_rw = LatticeWalker(lat_rw,
+            energy=interacting_energy(lat_rw, pin_ham()), iter=0)
+        a_rw, r_rw, _ = MC_random_walk!(200, wk_rw, pin_ham(), -0.44;
+                                        energy_perturb=1e-9)
+        @test a_rw == true
+        @test r_rw == 0.945
+        @test wk_rw.energy.val == -0.48000000037701485
+        @test sum(wk_rw.configuration.components[1]) == 9
+
+        Random.seed!(90236)
+        lat_cl = pin_lattice()
+        for i in 1:16
+            lat_cl.components[1][i] = rand() < 0.5
+        end
+        wk_cl = LatticeWalker(lat_cl,
+            energy=interacting_energy(lat_cl, pin_ham()), iter=0)
+        a_cl, r_cl, _ = MC_cluster_walk!(100, wk_cl, pin_ham(), -0.56, 0.3;
+                                         energy_perturb=1e-9)
+        @test a_cl == true
+        @test r_cl == 1.0
+        @test wk_cl.energy.val == -0.580000000391395
+        @test sum(wk_cl.configuration.components[1]) == 11
+    end
+
+    @testset "kernel-level pin" begin
+        # A permissive ceiling with every channel active: swaps, clusters,
+        # uniform and biased insertion, deletion. The returned rate is a
+        # single division of two integers, one rounding, deterministic.
+        Random.seed!(90234)
+        lat = pin_lattice()
+        for i in 1:16
+            lat.components[1][i] = rand() < 0.5
+        end
+        wk = LatticeWalker(lat, energy=interacting_energy(lat, pin_ham()),
+                           iter=0)
+        accept, rate, wk2, cl_acc, cl_tot, ms = MC_grand_canonical_walk!(
+            200, wk, pin_ham(), 1000.0, 0.0;
+            p_move=0.4, p_insert=0.3, z0=1.0, energy_perturb=1e-9,
+            clusters_freq=2, swaps_freq=2, cluster_p=0.3,
+            p_bias=0.4, bias_predicate=:contact, bias_shells=1)
+        @test accept == true
+        @test rate == 0.88
+        @test wk2.energy.val == -0.39000000036549615
+        @test sum(wk2.configuration.components[1]) == 8
+        @test cl_acc == 41
+        @test cl_tot == 41
+        expected = Dict(:swap_attempted => 41, :swap_accepted => 41,
+            :cluster_attempted => 41, :cluster_accepted => 41,
+            :insert_uniform_attempted => 33, :insert_uniform_accepted => 28,
+            :insert_biased_attempted => 22, :insert_biased_accepted => 20,
+            :delete_attempted => 63, :delete_accepted => 46)
+        for k in pin_keys
+            @test ms[k] == expected[k]
+        end
+    end
+end

--- a/test/test-lattice-random-walks.jl
+++ b/test/test-lattice-random-walks.jl
@@ -512,4 +512,178 @@
         end
 
     end
+
+    @testset "copy-free proposal and revert" begin
+        using Random
+        using Unitful
+
+        cf_lattice() = MLattice{1,SquareLattice}(lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(4, 4, 1),
+            periodicity=(true, true, false), cutoff_radii=[1.1],
+            components=[[false for _ in 1:16]], adsorptions=:full)
+        cf_ham() = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        cf_tri() = SLattice{TriangularLattice}(
+            supercell_dimensions=(6, 4, 1),
+            cutoff_radii=[1.1],
+            components=[[1, 5, 10, 20, 30, 40]],
+            adsorptions=:full)
+
+        @testset "configuration identity through every kernel" begin
+            Random.seed!(91001)
+            lat = cf_lattice()
+            for i in 1:16
+                lat.components[1][i] = rand() < 0.5
+            end
+            wk = LatticeWalker(lat, energy=interacting_energy(lat, cf_ham()),
+                               iter=0)
+            cfg0 = wk.configuration
+            MC_random_walk!(50, wk, cf_ham(), 1.0e3; energy_perturb=1e-9)
+            @test wk.configuration === cfg0
+            MC_cluster_walk!(20, wk, cf_ham(), 1.0e3, 0.3; energy_perturb=1e-9)
+            @test wk.configuration === cfg0
+            MC_grand_canonical_walk!(100, wk, cf_ham(), 1.0e3, 0.0;
+                p_move=0.4, p_insert=0.3, z0=1.0, energy_perturb=1e-9,
+                clusters_freq=2, swaps_freq=2, cluster_p=0.3)
+            @test wk.configuration === cfg0
+        end
+
+        @testset "forced-reject revert exactness" begin
+            # A ceiling below every reachable energy rejects every proposal;
+            # occupancy and the stored energy must be exactly unchanged.
+            Random.seed!(91002)
+            lat = cf_lattice()
+            for i in 1:16
+                lat.components[1][i] = rand() < 0.5
+            end
+            e0 = interacting_energy(lat, cf_ham())
+            wk = LatticeWalker(lat, energy=e0, iter=0)
+            occ0 = copy(lat.components[1])
+            low = -1.0e3
+
+            a1, r1, _ = MC_random_walk!(60, wk, cf_ham(), low;
+                                        energy_perturb=1e-9)
+            @test a1 == false && r1 == 0.0
+            @test wk.configuration.components[1] == occ0
+            @test wk.energy == e0
+
+            a2, r2, _ = MC_cluster_walk!(30, wk, cf_ham(), low, 0.3;
+                                         energy_perturb=1e-9)
+            @test a2 == false && r2 == 0.0
+            @test wk.configuration.components[1] == occ0
+            @test wk.energy == e0
+
+            a3, r3, _, _, _, ms = MC_grand_canonical_walk!(200, wk, cf_ham(),
+                low, 0.0;
+                p_move=0.4, p_insert=0.3, z0=1.0, energy_perturb=1e-9,
+                clusters_freq=2, swaps_freq=2, cluster_p=0.3)
+            @test a3 == false && r3 == 0.0
+            @test wk.configuration.components[1] == occ0
+            @test wk.energy == e0
+            # every default channel proposed under the forced-reject ceiling
+            @test ms.swap_attempted > 0
+            @test ms.cluster_attempted > 0
+            @test ms.insert_uniform_attempted > 0
+            @test ms.delete_attempted > 0
+
+            # composite channel: biased insertion and the inlined deletion
+            # revert through the same path
+            a4, _, _, _, _, ms4 = MC_grand_canonical_walk!(200, wk, cf_ham(),
+                low, 0.0;
+                p_move=0.4, p_insert=0.3, z0=1.0, energy_perturb=1e-9,
+                swaps_freq=1, p_bias=0.4)
+            @test a4 == false
+            @test wk.configuration.components[1] == occ0
+            @test wk.energy == e0
+            @test ms4.insert_biased_attempted > 0
+
+            # triangular cluster revert exercises the recorded-pair replay
+            # on the second geometry
+            Random.seed!(91003)
+            tri = cf_tri()
+            et = interacting_energy(tri, cf_ham())
+            wt = LatticeWalker(tri, energy=et, iter=0)
+            occt = copy(tri.components[1])
+            at, rt, _ = MC_cluster_walk!(30, wt, cf_ham(), low, 0.3;
+                                         energy_perturb=1e-9)
+            @test at == false && rt == 0.0
+            @test wt.configuration.components[1] == occt
+            @test wt.energy == et
+        end
+
+        @testset "multi-component forced-reject revert" begin
+            # The C > 1 revert path replays through the empty/occupied and
+            # cross-component exchanges (both involutions): a forced-reject
+            # walk leaves every component vector exactly unchanged and the
+            # configuration object identity intact
+            Random.seed!(91008)
+            ml = MLattice{2,SquareLattice}(components=[[1, 3, 6], [2, 4, 7]])
+            mlham = MLatticeHamiltonian(2,
+                [cf_ham(), GenericLatticeHamiltonian(-0.02, [-0.005], u"eV"),
+                 cf_ham()])
+            wm = LatticeWalker(ml, energy=interacting_energy(ml, mlham),
+                               iter=0)
+            comps0 = [copy(v) for v in ml.components]
+            e0m = wm.energy
+            cfg0m = wm.configuration
+            am, rm, _ = MC_random_walk!(80, wm, mlham, -1.0e3;
+                                        energy_perturb=1e-9)
+            @test am == false && rm == 0.0
+            @test wm.configuration === cfg0m
+            @test wm.configuration.components[1] == comps0[1]
+            @test wm.configuration.components[2] == comps0[2]
+            @test wm.energy == e0m
+        end
+
+        @testset "cluster record keyword" begin
+            # Recorded pairs re-applied restore the original configuration
+            Random.seed!(91004)
+            lat = cf_lattice()
+            for i in 1:16
+                lat.components[1][i] = rand() < 0.5
+            end
+            ref = deepcopy(lat.components[1])
+            pairs = Tuple{Int,Int}[]
+            geometric_cluster_swap!(lat, 0.4; record=pairs)
+            MonteCarloMoves._apply_cluster_pairs!(lat, pairs)
+            @test lat.components[1] == ref
+
+            Random.seed!(91007)
+            tri = cf_tri()
+            reft = deepcopy(tri.components[1])
+            pt = Tuple{Int,Int}[]
+            geometric_cluster_swap!(tri, 0.4; record=pt)
+            MonteCarloMoves._apply_cluster_pairs!(tri, pt)
+            @test tri.components[1] == reft
+
+            # The nothing default changes neither the configuration nor the
+            # random stream: same-seed A/B with and without a record vector
+            Random.seed!(91005)
+            latA = cf_lattice()
+            for i in 1:16
+                latA.components[1][i] = rand() < 0.5
+            end
+            latB = deepcopy(latA)
+            Random.seed!(91006)
+            geometric_cluster_swap!(latA, 0.4)
+            nextA = rand()
+            Random.seed!(91006)
+            geometric_cluster_swap!(latB, 0.4; record=Tuple{Int,Int}[])
+            nextB = rand()
+            @test latA.components[1] == latB.components[1]
+            @test nextA == nextB
+
+            # The generic-geometry guard keeps its descriptive error with the
+            # keyword passed through
+            gen = MLattice{1,GenericLattice}(
+                [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0],
+                [(0.0, 0.0, 0.0)],
+                (3, 1, 1),
+                (false, false, false),
+                [1.1],
+                [[true, false, false]],
+                fill(false, 3))
+            @test_throws ArgumentError geometric_cluster_swap!(gen, 0.3;
+                record=Tuple{Int,Int}[])
+        end
+    end
 end

--- a/test/test-lattice-site-deltas.jl
+++ b/test/test-lattice-site-deltas.jl
@@ -1,0 +1,140 @@
+# Exactness coverage for the O(z) single-site flip deltas and the
+# supports_site_deltas trait. All assertions are exact or fixed-tolerance;
+# there are no statistical gates. The atol 1e-13 eV carries a 12x margin
+# over the measured worst case of the prototype (<= 8e-15 eV over 200
+# random flips per size).
+
+# Minimal trait fixture: testset bodies cannot define structs, so it sits
+# at the file's top level (identical re-definition on a double include is
+# safe).
+struct SFDMinimalHam <: FreeBird.AbstractHamiltonians.ClassicalHamiltonian end
+
+@testset "Lattice site-flip deltas" begin
+    using Random
+    using Unitful
+
+    function sfd_maxdev(lat, h, seed; nflips=200)
+        Random.seed!(seed)
+        maxdev = 0.0
+        M = length(lat.components[1])
+        for _ in 1:nflips
+            s = rand(1:M)
+            e0 = interacting_energy(lat, h)
+            d = site_flip_delta(lat, h, s)
+            lat.components[1][s] = !lat.components[1][s]
+            e1 = interacting_energy(lat, h)
+            lat.components[1][s] = !lat.components[1][s]
+            maxdev = max(maxdev, abs(ustrip(u"eV", (e1 - e0) - d)))
+        end
+        return maxdev
+    end
+
+    function sfd_square(L; cutoffs=[1.1], adsorptions=:full,
+                        image_multiplicity=false)
+        MLattice{1,SquareLattice}(lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(L, L, 1),
+            periodicity=(true, true, false), cutoff_radii=cutoffs,
+            components=[[false for _ in 1:L*L]], adsorptions=adsorptions,
+            image_multiplicity=image_multiplicity)
+    end
+
+    function sfd_fill!(lat, seed, theta)
+        Random.seed!(seed)
+        for i in eachindex(lat.components[1])
+            lat.components[1][i] = rand() < theta
+        end
+        return lat
+    end
+
+    h1 = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+    h2 = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+
+    @testset "exactness against full-energy differences" begin
+        # square, one shell, full adsorption
+        @test sfd_maxdev(sfd_fill!(sfd_square(4), 92_001, 0.5), h1,
+                         93_001) <= 1e-13
+        # square, two shells
+        @test sfd_maxdev(sfd_fill!(sfd_square(6; cutoffs=[1.1, 1.5]),
+                                   92_002, 0.5), h2, 93_002) <= 1e-13
+        # partial adsorption mask
+        @test sfd_maxdev(sfd_fill!(sfd_square(4;
+                                              adsorptions=[1, 2, 3, 5, 8, 13]),
+                                   92_003, 0.3), h1, 93_003) <= 1e-13
+        # triangular geometry
+        tri = SLattice{TriangularLattice}(supercell_dimensions=(6, 4, 1),
+            cutoff_radii=[1.1], components=[[1, 5, 10, 20, 30, 40]],
+            adsorptions=:full)
+        @test sfd_maxdev(sfd_fill!(tri, 92_004, 0.5), h1, 93_004) <= 1e-13
+        # image-multiplicity small cell: self-image entries and duplicated
+        # image bonds sit under the delta's j == site convention
+        imcell = sfd_square(2; image_multiplicity=true)
+        @test sfd_maxdev(sfd_fill!(imcell, 92_005, 0.5), h1, 93_005) <= 1e-13
+        # site-field wrapper
+        fld = collect(0.001 .* (1:16)) .* u"eV"
+        hsf = SiteFieldLatticeHamiltonian(h1, fld)
+        @test sfd_maxdev(sfd_fill!(sfd_square(4), 92_006, 0.5), hsf,
+                         93_006) <= 1e-13
+        # multi-component Hamiltonian on a single-component lattice
+        mlham = MLatticeHamiltonian(1, [h1])
+        @test sfd_maxdev(sfd_fill!(sfd_square(4), 92_007, 0.5), mlham,
+                         93_007) <= 1e-13
+    end
+
+    @testset "sign symmetry is exact" begin
+        # The accumulator visits the same terms with the opposite sign, so
+        # the back-flip delta is the exact floating-point negation
+        lat = sfd_fill!(sfd_square(6; cutoffs=[1.1, 1.5]), 92_008, 0.5)
+        Random.seed!(93_008)
+        for _ in 1:50
+            s = rand(1:36)
+            d_fwd = site_flip_delta(lat, h2, s)
+            lat.components[1][s] = !lat.components[1][s]
+            d_back = site_flip_delta(lat, h2, s)
+            lat.components[1][s] = !lat.components[1][s]
+            @test d_back == -d_fwd
+        end
+    end
+
+    @testset "swap composition" begin
+        # Two sequentially composed flips, the second evaluated on the
+        # intermediate configuration, reproduce the full-energy difference
+        # of the swap at the single-flip rounding class, including adjacent
+        # origin-destination pairs
+        lat = sfd_fill!(sfd_square(6; cutoffs=[1.1, 1.5]), 92_009, 0.5)
+        Random.seed!(93_009)
+        maxdev = 0.0
+        for trial in 1:100
+            i = rand(1:36)
+            # force adjacency on odd trials: destination = a first-shell
+            # neighbor entry of the origin
+            j = isodd(trial) ? lat.neighbors[i][1][1] : rand(1:36)
+            e0 = interacting_energy(lat, h2)
+            d = site_flip_delta(lat, h2, i)
+            lat.components[1][i] = !lat.components[1][i]
+            d += site_flip_delta(lat, h2, j)
+            lat.components[1][j] = !lat.components[1][j]
+            e1 = interacting_energy(lat, h2)
+            # restore
+            lat.components[1][j] = !lat.components[1][j]
+            lat.components[1][i] = !lat.components[1][i]
+            maxdev = max(maxdev, abs(ustrip(u"eV", (e1 - e0) - d)))
+        end
+        @test maxdev <= 1e-13
+    end
+
+    @testset "trait contract and shell guard" begin
+        fld = collect(0.001 .* (1:16)) .* u"eV"
+        clham = ClusterLatticeHamiltonian(h1,
+            [ClusterInteraction(0.1u"eV", [(1, 2, 3)])])
+        @test supports_site_deltas(h1)
+        @test supports_site_deltas(MLatticeHamiltonian(1, [h1]))
+        @test supports_site_deltas(SiteFieldLatticeHamiltonian(h1, fld))
+        @test !supports_site_deltas(SFDMinimalHam())
+        @test !supports_site_deltas(clham)
+        # the wrapper delegates to its base
+        @test !supports_site_deltas(SiteFieldLatticeHamiltonian(clham, fld))
+        # the delta enforces the same shell-count rule as the full sweep
+        lat1 = sfd_square(4)
+        @test_throws ArgumentError site_flip_delta(lat1, h2, 1)
+    end
+end


### PR DESCRIPTION
Implements #240.

- Adds `record_move_rates` to the canonical (fixed-N) driver, restricted up front to the serial atomistic routines (`MCRandomWalkMaxE`, `MCRandomWalkClone`, `MCGalileanWalk`) on an `AtomWalkers` liveset: the ledger relies on the five-value, log-compression-emitting step returns and driver-side counter accumulation, and another liveset type dispatches to a different step method even under an allowed routine, so it is rejected before any walker is touched.
- Disclosure: `LJSurfaceWalkers` is excluded although it subtypes `AtomWalkers` (it owns a separate step method); the restriction matrix covers the lattice-liveset case, and the surface-walker exclusion is enforced by the same gate.
- `NestedSamplingParameters` gains a trailing `move_stats::Dict{Symbol,Int}` field with a keyword default, emptied at driver entry (the positional arity moves 17 to 18; every construction in the suite is keyword-form). The serial random-walk step synthesizes exact counters with no kernel change (`move_attempted = mc_steps`; `round(Int, rate * mc_steps)` inverts the kernel's integer acceptance ratio bit-exactly), and the reflective step captures the kernel's new statistics element; refill walks are never accumulated.
- Ledger schema with the keyword on: eager `log_compression`, the routine's rate columns, then `step_size`, then observables; the default path is byte-identical, keeping the shipped canonical schema pin untouched.
- Tests: the restriction matrix including the lattice-liveset dangerous case, schema and closure welds for both routines, walked-row divisibility with plateau-row zeros, the power-of-two round-trip synthesis check, default-off identity, and counter reset on parameter reuse.

Adversarially reviewed (issue-promise round-trip, independent-oracle physics, determinism and assertion accounting), and the full suite passes on the shipped bytes.
