### PR TITLE
Anchored and relative effective-sample-size reductions for ideal-gas-referenced ledgers

### DIFF
--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -16,6 +16,7 @@ export gc_thermodynamic_stats_fixed_N
 export microcanonical_entropy, caloric_derivatives, inflection_transitions
 export transition_convergence
 export gc_thermodynamic_stats_ideal_ref
+export kish_effective_sample_size
 
 """
     read_output(filename::String)
@@ -93,6 +94,47 @@ function ωᵢ(log_compression::AbstractVector{Float64}; ω0::Float64=1.0)
     X = ω0 .* exp.(cumsum(log_compression))
     Xprev = [ω0; X[1:end-1]]
     return Xprev .- X
+end
+
+"""
+    kish_effective_sample_size(log_weights::AbstractVector{<:Real})
+
+Computes the Kish effective sample size
+```math
+N_\\mathrm{eff} = \\frac{\\left(\\sum_i w_i\\right)^2}{\\sum_i w_i^2}
+```
+of a weighted sample from its log-weights. The maximum log-weight is subtracted
+before exponentiation, so a common additive constant in the log-weights (a common
+scale factor in the weights, such as an `ω0` convention) cannot overflow or
+underflow the ratio, and weight collections spanning hundreds of nats — where
+linear-space weights underflow to `0.0` — are handled without loss.
+
+The value ranges from 1 (a single weight dominates) to `length(log_weights)`
+(all weights equal) and measures how many equally-weighted samples the weighted
+collection is worth for estimator-variance purposes. Entries of `-Inf` (zero
+weights) are legal and drop out of both sums, so the returned value is the
+effective sample size of the surviving finite-weight entries.
+
+# Arguments
+- `log_weights::AbstractVector{<:Real}`: Natural logs of the (unnormalized)
+  sample weights. Must be non-empty, must not contain `NaN` or `+Inf`, and must
+  contain at least one finite entry.
+
+# Returns
+- The Kish effective sample size, a `Float64` in `[1, length(log_weights)]`.
+"""
+function kish_effective_sample_size(log_weights::AbstractVector{<:Real})
+    isempty(log_weights) && throw(ArgumentError("log_weights must be non-empty"))
+    for lw in log_weights
+        (isnan(lw) || lw == Inf) && throw(ArgumentError(
+            "log_weights must not contain NaN or +Inf entries"))
+    end
+    m = maximum(log_weights)
+    m == -Inf && throw(ArgumentError(
+        "log_weights must contain at least one finite entry"))
+    ws = exp.(log_weights .- m)
+    sum_w = sum(ws)
+    return Float64(sum_w^2 / sum(abs2, ws))
 end
 
 """

--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -17,6 +17,7 @@ export microcanonical_entropy, caloric_derivatives, inflection_transitions
 export transition_convergence
 export gc_thermodynamic_stats_ideal_ref
 export kish_effective_sample_size
+export gc_effective_sample_size_ideal_ref
 
 """
     read_output(filename::String)
@@ -460,8 +461,15 @@ observables (`mean_N`, `var_N`, `mean_U`) are insensitive to `ω0`.
 The reweighting factor `(z/z0)^{N_j}` is pure importance sampling in μ: its
 reliability at each grid point is reported by the Kish effective sample size
 `N_eff = (Σ w)² / Σ w²`, which collapses as `|βμ − ln z0|` grows beyond
-roughly `1/√Var(N)`. Treat grid points with small `N_eff` (≲ 100) as
-unreliable and re-run with z0 closer to the target fugacity.
+roughly `1/√Var(N)`. Because the combined weights also carry the shell decay
+and the Boltzmann factor, the raw `N_eff` has no run-independent baseline —
+judge grid points by degradation relative to the run's own reference point
+`μ0(T) = k_B T ln z0` (a threshold on the ratio, computed by
+`gc_effective_sample_size_ideal_ref` with `relative = true`) rather than by an
+absolute cutoff, and re-run with z0 closer to the target fugacity when the
+ratio collapses. `N_eff` diagnoses μ-reweighting reliability, not ladder
+convergence: pooled live-tail rows can hold it near `K` on an under-converged
+ladder.
 
 Athermal (hard-core) models sampled with the finite-J recipe (see the
 `GenericLatticeHamiltonian` docstring) are evaluated here at a temperature low
@@ -930,6 +938,257 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
     return (logXi=logXi, mean_N=mean_N, var_N=var_N, mean_U=mean_U, N_eff=N_eff,
             var_U=var_U, cov_UN=cov_UN, p_N=p_N, N_support=N_support,
             observables=obs_out)
+end
+
+function _check_ess_mode(mode::Symbol, T0::Union{Nothing,Float64})
+    mode in (:kish, :anchored, :anchored_uniform) || throw(ArgumentError(
+        "mode must be :kish, :anchored, or :anchored_uniform (got :$mode)"))
+    if mode === :kish && T0 !== nothing
+        throw(ArgumentError(
+            "T0 is meaningful only for the anchored modes; mode = :kish " *
+            "ignores it, so passing both is an error"))
+    end
+    if T0 !== nothing && !(T0 > 0.0)
+        throw(ArgumentError("T0 must be a positive temperature"))
+    end
+    return nothing
+end
+
+# One grid cell of the effective-sample-size reduction: s is the reweighting
+# exponent per particle (zero exactly at the reference point), β the target's
+# inverse temperature, β0 the anchor's (β0 == β strips the energy factor).
+function _igref_ess_value(mode::Symbol, log_w0::Vector{Float64},
+                          Es::Vector{Float64}, Ns::Vector{Float64},
+                          s::Float64, β::Float64, β0::Float64)
+    if mode === :kish
+        return kish_effective_sample_size(log_w0 .+ s .* Ns .- β .* Es)
+    elseif mode === :anchored
+        return kish_effective_sample_size(log_w0 .+ s .* Ns .- (β - β0) .* Es)
+    else # :anchored_uniform
+        return kish_effective_sample_size(s .* Ns .- (β - β0) .* Es)
+    end
+end
+
+"""
+    gc_effective_sample_size_ideal_ref(df::DataFrame, n_sites::Int, z0::Float64,
+                                       μs::Vector{Float64}, Ts::Vector{Float64},
+                                       n_walkers::Int; kwargs...)
+    gc_effective_sample_size_ideal_ref(df::DataFrame, V, atomic_mass,
+                                       reference_activity, μ_grid, T_grid; kwargs...)
+
+Effective-sample-size reduction for ideal-gas-referenced grand-canonical
+nested-sampling output: returns a `Matrix{Float64}` of size
+`(length(μs), length(Ts))`, indexed `[i_μ, i_T]` like the fields of
+`gc_thermodynamic_stats_ideal_ref`, without evaluating any of that function's
+moment or distribution surfaces. The first method is the lattice route
+(`z = exp(βμ)`, shell weights rebuilt from `df.iter`); the second is the
+atomistic route (`z = exp(βμ)/Λ(T)^3`, shell weights decoded from
+`df.log_compression`), mirroring the sibling's dispatch, ledger conventions,
+and live-tail handling exactly. `n_cull` and `n_walkers` are lattice-route
+arguments only.
+
+Three modes, selected by the `mode` keyword:
+
+- `:kish` (default): the Kish effective sample size of the full combined
+  weights `ω_j (z/z0)^{N_j} e^{-βE_j}` — identical in value to the `N_eff`
+  field of `gc_thermodynamic_stats_ideal_ref`.
+- `:anchored`: the Kish effective sample size with the reweighting factor
+  anchored to a reference temperature,
+  `r_j = (z/z0)^{N_j} exp[-(E_j/k_B)(1/T - 1/T0)]`. The default
+  `T0 = nothing` means per-target `T0 = T`, under which the energy factor
+  drops out entirely and the mode measures μ-reweighting concentration alone;
+  at the reference point it then equals the run-independent prior-weight value
+  `(1 + r)(1 - r^J)^2 / ((1 - r)(1 - r^(2J)))` with `r = K/(K + n_cull)`
+  (about `2K + 1` on deep ladders at `n_cull = 1`; `2K/n_cull + 1` in
+  general), which is what makes it thresholdable.
+- `:anchored_uniform`: the unit-weight effective sample size of the anchored
+  factors alone, `(Σ r_j)^2 / Σ r_j^2`. Under the default per-target `T0` it
+  peaks at the reference point (where it equals the row count exactly) and
+  decays monotonically along rays away from it, unlike the two Kish modes, so
+  it locates a window center.
+
+`relative = true` divides each temperature column by the same mode's value at
+that temperature's reference point — the chemical potential
+`μ0(T) = k_B T ln z0` (lattice) or `k_B T (ln z0 + 3 ln Λ(T))` (atomistic)
+where the reweighting exponent vanishes; the anchor is evaluated with the
+exponent set to zero exactly, not through a rounded `μ0`. The returned surface
+then reads directly as degradation relative to the run's own center. The
+anchor value of `:kish` is not a maximum and the surface need not decrease
+monotonically away from it: a target whose thermal factor counteracts the
+geometric shell decay flattens the combined weights and raises the value.
+
+The effective sample size diagnoses μ-reweighting reliability, not ladder
+convergence: pooled live-tail rows can hold it near `K` on an under-converged
+ladder. Passing `T0` with `mode = :kish` throws an `ArgumentError`.
+
+# Arguments (lattice method)
+- `df::DataFrame`: NS output with columns `[:iter, :emax, :num_particles]`.
+- `n_sites::Int`: Number of lattice sites M.
+- `z0::Float64`: Reference fugacity of the prior used in the run (must match!).
+- `μs::Vector{Float64}`: Chemical potential grid (same energy units as `df.emax`).
+- `Ts::Vector{Float64}`: Temperature grid in K.
+- `n_walkers::Int`: Number of walkers K used in the NS run.
+- `mode::Symbol=:kish`: `:kish`, `:anchored`, or `:anchored_uniform` (above).
+- `relative::Bool=false`: Divide each column by its reference-point value.
+- `T0::Union{Nothing,Float64}=nothing`: Anchor temperature in K for the
+  anchored modes; `nothing` means per-target `T0 = T`.
+- `n_cull::Int=1`: Number of walkers culled per iteration.
+- `ω0::Float64=1.0`: Initial phase-space volume factor.
+- `live_emax::Union{Nothing,Vector{Float64}}=nothing`: Energies of the
+  surviving live walkers.
+- `live_numbers::Union{Nothing,Vector{Int}}=nothing`: Particle counts of the
+  surviving live walkers.
+- `kb::Float64`: Boltzmann constant (default: eV/K).
+
+The atomistic method replaces `(n_sites, z0, n_walkers)` with
+`(V, atomic_mass, reference_activity)` in the sibling's Unitful types, takes
+Unitful `μ_grid`/`T_grid`, types `T0` as a Unitful temperature, and requires
+the ledger's `:log_compression` column whenever `df` has rows.
+
+# Returns
+- A `Matrix{Float64}` of size `(length(μs), length(Ts))`, indexed `[i_μ, i_T]`.
+"""
+function gc_effective_sample_size_ideal_ref(df::DataFrame,
+                                            n_sites::Int,
+                                            z0::Float64,
+                                            μs::Vector{Float64},
+                                            Ts::Vector{Float64},
+                                            n_walkers::Int;
+                                            mode::Symbol=:kish,
+                                            relative::Bool=false,
+                                            T0::Union{Nothing,Float64}=nothing,
+                                            n_cull::Int=1,
+                                            ω0::Float64=1.0,
+                                            live_emax::Union{Nothing,Vector{Float64}}=nothing,
+                                            live_numbers::Union{Nothing,Vector{Int}}=nothing,
+                                            kb::Float64=8.617333262e-5)
+    _check_ess_mode(mode, T0)
+    if z0 <= 0.0
+        throw(ArgumentError("z0 must be positive"))
+    end
+    if n_sites <= 0
+        throw(ArgumentError("n_sites must be positive"))
+    end
+    if (live_emax === nothing) != (live_numbers === nothing)
+        throw(ArgumentError("live_emax and live_numbers must be provided together"))
+    end
+    if live_emax !== nothing && length(live_emax) != length(live_numbers)
+        throw(DimensionMismatch("live_emax and live_numbers must have the same length"))
+    end
+    n_dead = nrow(df)
+    if n_dead == 0 && (live_emax === nothing || isempty(live_emax))
+        throw(ArgumentError("df is empty and no live walkers were provided"))
+    end
+
+    # Weight assembly mirrors gc_thermodynamic_stats_ideal_ref: iteration-based
+    # shell weights in log space, live tail X_n/K per walker with no ω0 factor
+    log_w0 = n_dead > 0 ?
+        (log(ω0) + log(n_cull / (n_walkers + n_cull))) .+
+        Vector{Float64}(df.iter) .* log(n_walkers / (n_walkers + n_cull)) : Float64[]
+    Es = n_dead > 0 ? Vector{Float64}(df.emax) : Float64[]
+    Ns = n_dead > 0 ? Vector{Float64}(df.num_particles) : Float64[]
+    if live_emax !== nothing && !isempty(live_emax)
+        n_iters = n_dead > 0 ? maximum(df.iter) : 0
+        log_tail = n_iters * log(n_walkers / (n_walkers + n_cull)) - log(n_walkers)
+        log_w0 = vcat(log_w0, fill(log_tail, length(live_emax)))
+        Es = vcat(Es, live_emax)
+        Ns = vcat(Ns, Float64.(live_numbers))
+    end
+
+    log_z0 = log(z0)
+    out = Matrix{Float64}(undef, length(μs), length(Ts))
+    Threads.@threads for j in eachindex(Ts)
+        β = 1.0 / (kb * Ts[j])
+        β0 = T0 === nothing ? β : 1.0 / (kb * T0)
+        for i in eachindex(μs)
+            s = β * μs[i] - log_z0
+            out[i, j] = _igref_ess_value(mode, log_w0, Es, Ns, s, β, β0)
+        end
+        if relative
+            anchor = _igref_ess_value(mode, log_w0, Es, Ns, 0.0, β, β0)
+            for i in eachindex(μs)
+                out[i, j] /= anchor
+            end
+        end
+    end
+    return out
+end
+
+function gc_effective_sample_size_ideal_ref(df::DataFrame,
+                                            V::typeof(1.0u"Å^3"),
+                                            atomic_mass::typeof(1.0u"u"),
+                                            reference_activity::typeof(1.0u"Å^-3"),
+                                            μ_grid::AbstractVector{<:typeof(1.0u"eV")},
+                                            T_grid::AbstractVector{<:Unitful.Temperature};
+                                            mode::Symbol=:kish,
+                                            relative::Bool=false,
+                                            T0::Union{Nothing,Unitful.Temperature}=nothing,
+                                            ω0::Float64=1.0,
+                                            live_emax::Union{Nothing,Vector{Float64}}=nothing,
+                                            live_numbers::Union{Nothing,Vector{Int}}=nothing,
+                                            kb::Float64=8.617333262e-5)
+    T0_K = T0 === nothing ? nothing : Float64(ustrip(u"K", T0))
+    _check_ess_mode(mode, T0_K)
+    if reference_activity <= 0.0u"Å^-3"
+        throw(ArgumentError("reference_activity must be positive"))
+    end
+    if V <= 0.0u"Å^3"
+        throw(ArgumentError("V must be positive"))
+    end
+    if (live_emax === nothing) != (live_numbers === nothing)
+        throw(ArgumentError("live_emax and live_numbers must be provided together"))
+    end
+    if live_emax !== nothing && length(live_emax) != length(live_numbers)
+        throw(DimensionMismatch("live_emax and live_numbers must have the same length"))
+    end
+    n_dead = nrow(df)
+    if n_dead == 0 && (live_emax === nothing || isempty(live_emax))
+        throw(ArgumentError("df is empty and no live walkers were provided"))
+    end
+    if n_dead > 0
+        hasproperty(df, :log_compression) || throw(ArgumentError(
+            "the ledger has rows but no :log_compression column, so its compression " *
+            "cannot be reconstructed; only zero-accept (empty) ledgers may omit it"))
+    end
+    lc = n_dead > 0 ? Vector{Float64}(df.log_compression) : Float64[]
+    if any(x -> !isfinite(x) || x >= 0.0, lc)
+        throw(ArgumentError(
+            "corrupted :log_compression column: every entry must be finite and negative"))
+    end
+
+    # Weight assembly mirrors the atomistic gc_thermodynamic_stats_ideal_ref:
+    # compression-column shells, tail split over the surviving walkers with ω0
+    cs = cumsum(lc)
+    log_w0 = n_dead > 0 ?
+        (log(ω0) .+ vcat(0.0, cs[1:end-1]) .+ log.(-expm1.(lc))) : Float64[]
+    Es = n_dead > 0 ? Vector{Float64}(df.emax) : Float64[]
+    Ns = n_dead > 0 ? Vector{Float64}(df.num_particles) : Float64[]
+    if live_emax !== nothing && !isempty(live_emax)
+        log_tail = log(ω0) + (n_dead > 0 ? cs[end] : 0.0) - log(length(live_emax))
+        log_w0 = vcat(log_w0, fill(log_tail, length(live_emax)))
+        Es = vcat(Es, live_emax)
+        Ns = vcat(Ns, Float64.(live_numbers))
+    end
+
+    log_z0 = log(ustrip(u"Å^-3", reference_activity))
+    out = Matrix{Float64}(undef, length(μ_grid), length(T_grid))
+    Threads.@threads for j in eachindex(T_grid)
+        T_K = ustrip(u"K", T_grid[j])
+        β = 1.0 / (kb * T_K)
+        β0 = T0_K === nothing ? β : 1.0 / (kb * T0_K)
+        logΛ = log(ustrip(u"Å", _thermal_wavelength(atomic_mass, T_grid[j])))
+        for i in eachindex(μ_grid)
+            s = β * ustrip(u"eV", μ_grid[i]) - 3.0 * logΛ - log_z0
+            out[i, j] = _igref_ess_value(mode, log_w0, Es, Ns, s, β, β0)
+        end
+        if relative
+            anchor = _igref_ess_value(mode, log_w0, Es, Ns, 0.0, β, β0)
+            for i in eachindex(μ_grid)
+                out[i, j] /= anchor
+            end
+        end
+    end
+    return out
 end
 
 

--- a/test/test-AnalysisTools.jl
+++ b/test/test-AnalysisTools.jl
@@ -197,4 +197,111 @@
             @test_throws ArgumentError inflection_transitions(df, K; edge=0)
         end
     end
+
+    @testset "kish_effective_sample_size" begin
+        using Random
+
+        # Exact closures: uniform log-weights return exactly n (the ratio
+        # n^2/n is exact); the two-point value against an independent
+        # linear-space hand computation
+        for n in (1, 2, 7, 100)
+            @test kish_effective_sample_size(zeros(n)) == Float64(n)
+            @test kish_effective_sample_size(fill(3.7, n)) == Float64(n)
+        end
+        let a = 0.3, b = -1.2
+            wa, wb = exp(a), exp(b)
+            @test isapprox(kish_effective_sample_size([a, b]),
+                           (wa + wb)^2 / (wa^2 + wb^2); rtol=1e-12)
+        end
+
+        # Shift invariance: generic shifts at rtol (the addition rounds each
+        # entry before the max-shift can remove it, so bitwise equality there
+        # would be rounding luck); bitwise on an exact-dyadic fixture whose
+        # entries and shift are multiples of 2^-16 with bounded magnitude, so
+        # every addition is exact and the max-shift restores the residuals
+        rng = MersenneTwister(91021)
+        lw = randn(rng, 200)
+        base = kish_effective_sample_size(lw)
+        for c in (pi, -17.3)
+            @test isapprox(kish_effective_sample_size(lw .+ c), base; rtol=1e-12)
+        end
+        # An extreme shift costs precision in the inputs themselves (ulp(1e6)
+        # is ~1.2e-10, rounding every entry before the max-shift can act), so
+        # its gate reflects input rounding, not the ratio: measured 3.5e-12
+        @test isapprox(kish_effective_sample_size(lw .+ 1e6), base; rtol=1e-9)
+        lwd = Float64.(rand(rng, -2^18:2^18, 300)) ./ 2^16
+        cshift = 7.0 * 2.0^-5
+        @test kish_effective_sample_size(lwd .+ cshift) ==
+              kish_effective_sample_size(lwd)
+
+        # Bounds, with both equality cases hit exactly (uniform above; a
+        # dominant weight whose competitors underflow to exact zeros here)
+        for seed in (91031, 91032, 91033)
+            lwr = 3 .* randn(MersenneTwister(seed), 500)
+            e = kish_effective_sample_size(lwr)
+            @test 1.0 <= e <= 500.0
+        end
+        @test kish_effective_sample_size([0.0, -800.0, -800.0]) == 1.0
+
+        # Geometric shell weights (the nested-sampling prior profile): the
+        # closed form (1 + r)(1 - r^J)^2 / ((1 - r)(1 - r^(2J))) with
+        # r = K/(K + 1), and its deep-ladder limit 2K + 1
+        for (K, J) in ((10, 200), (500, 50_000))
+            r = K / (K + 1)
+            lw_geo = (1:J) .* log(r) .- log(K + 1)
+            closed = (1 + r) * (1 - r^J)^2 / ((1 - r) * (1 - r^(2J)))
+            @test isapprox(kish_effective_sample_size(lw_geo), closed; rtol=1e-12)
+        end
+        let K = 500, J = 50_000
+            r = K / (K + 1)
+            lw_geo = (1:J) .* log(r) .- log(K + 1)
+            @test isapprox(kish_effective_sample_size(lw_geo), 2K + 1; rtol=1e-10)
+        end
+
+        # Independent-draw laws for iid weights a^N: ESS/n concentrates on
+        # exp(-λ(a-1)^2) for N ~ Poisson(λ) and on
+        # ((1 + p(a-1))^2 / (1 + p(a^2-1)))^M for N ~ Binomial(M, p).
+        # Gates calibrated from three seeds each (91001-91003, 91011-91013)
+        # at >= 3x the maximum relative deviation, per statistic; shipped
+        # seeds 91001/91011 (measured deviations 0.00006/0.00141 and
+        # 0.00010/0.02173 against gates 0.0015/0.07 and 0.006/0.24).
+        binom_draw(rng, M, p) = count(_ -> rand(rng) < p, 1:M)
+        function pois_draw(rng, lam)
+            L = exp(-lam)
+            k = 0
+            acc = rand(rng)
+            while acc > L
+                k += 1
+                acc *= rand(rng)
+            end
+            return k
+        end
+        n_iid = 40_000
+        let rng_b = MersenneTwister(91001)
+            Ns = [binom_draw(rng_b, 64, 0.5) for _ in 1:n_iid]
+            for (s, gate) in ((0.05, 0.0015), (0.2, 0.07))
+                a = exp(s)
+                pred = ((1 + 0.5 * (a - 1))^2 / (1 + 0.5 * (a^2 - 1)))^64
+                meas = kish_effective_sample_size(s .* Ns) / n_iid
+                @test abs(meas / pred - 1) < gate
+            end
+        end
+        let rng_p = MersenneTwister(91011)
+            Ns = [pois_draw(rng_p, 8.0) for _ in 1:n_iid]
+            for (s, gate) in ((0.1, 0.006), (0.3, 0.24))
+                a = exp(s)
+                pred = exp(-8.0 * (a - 1)^2)
+                meas = kish_effective_sample_size(s .* Ns) / n_iid
+                @test abs(meas / pred - 1) < gate
+            end
+        end
+
+        # Errors and zero weights: -Inf entries are legal zero weights that
+        # drop out; NaN, +Inf, emptiness, and all-(-Inf) throw
+        @test kish_effective_sample_size([-Inf, 0.0, 0.0]) == 2.0
+        @test_throws ArgumentError kish_effective_sample_size(Float64[])
+        @test_throws ArgumentError kish_effective_sample_size([1.0, NaN])
+        @test_throws ArgumentError kish_effective_sample_size([1.0, Inf])
+        @test_throws ArgumentError kish_effective_sample_size([-Inf, -Inf])
+    end
 end

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -22,6 +22,8 @@ include("test-atomistic-gc-interacting-regressions.jl")
     include("test-atomistic-igref-gcns.jl")
     # test the atomistic ideal-gas-referenced ledger assembly
     include("test-atomistic-igref-stats.jl")
+    # test the ideal-gas-referenced effective-sample-size reductions
+    include("test-igref-ess.jl")
     # regression coverage for the continuous-space grand-canonical route
     include("test-atomistic-gc-regressions.jl")
     # test atomistic GC-NS fixed-N post-processing (ideal gas reference)

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -334,6 +334,14 @@
         # smaller effective sample size than an in-window point
         @test stats.N_eff[1, 1] < stats.N_eff[4, 1] / 10
         @test all(stats.N_eff .<= nrow(df) + length(live_E))
+
+        # The effective-sample-size reduction reproduces the collapse
+        # ordering and the row-count ceiling on the same fixture
+        ess_l = gc_effective_sample_size_ideal_ref(
+            df, igref_n_sites, 1.0, μs, Ts, n_walkers;
+            ω0=(n_walkers + 1) / n_walkers, live_emax=live_E, live_numbers=live_N)
+        @test ess_l[1, 1] < ess_l[4, 1] / 10
+        @test all(ess_l .<= nrow(df) + length(live_E))
     end
 
     # ================================================================

--- a/test/test-SamplingSchemes/test-igref-ess.jl
+++ b/test/test-SamplingSchemes/test-igref-ess.jl
@@ -1,0 +1,249 @@
+# Effective-sample-size reductions for ideal-gas-referenced ledgers:
+# gc_effective_sample_size_ideal_ref (modes :kish / :anchored /
+# :anchored_uniform, relative normalization, explicit T0), welded to the
+# N_eff field of gc_thermodynamic_stats_ideal_ref and to closed forms.
+@testset "gc_effective_sample_size_ideal_ref" begin
+    using Random
+
+    kb_ess = 8.617333262e-5
+
+    # Shared lattice fixture: seeded synthetic igref ledger with energies and
+    # a live tail (descending emax, dense iter, K = 20)
+    rng_ess = MersenneTwister(91201)
+    n_fix = 400
+    df_fix = DataFrame(iter=1:n_fix,
+                       emax=sort(randn(rng_ess, n_fix) .* 0.05; rev=true),
+                       num_particles=rand(rng_ess, 0:12, n_fix))
+    live_E_fix = sort(randn(rng_ess, 20) .* 0.01; rev=true) .+
+                 (minimum(df_fix.emax) - 0.05)
+    live_N_fix = rand(rng_ess, 0:12, 20)
+    K_fix = 20
+    mus_fix = [-0.08, -0.02, 0.0, 0.02]
+    Ts_fix = [200.0, 400.0]
+    z0_fix = 0.7
+
+    # Contrast fixture: athermal, N = 0 on the shallow half and N = 8 on the
+    # deep half of a 4-nat ladder, so a positive reweighting exponent can
+    # counteract the geometric shell decay inside the mu window
+    n_con, K_con = 2000, 500
+    df_con = DataFrame(iter=1:n_con, emax=zeros(n_con),
+                       num_particles=vcat(zeros(Int, 1000), fill(8, 1000)))
+    r_con = K_con / (K_con + 1)
+    closed_con = (1 + r_con) * (1 - r_con^n_con)^2 /
+                 ((1 - r_con) * (1 - r_con^(2 * n_con)))
+
+    @testset ":kish welds to the N_eff field (lattice)" begin
+        for (le, ln_) in ((nothing, nothing), (live_E_fix, live_N_fix))
+            ess = gc_effective_sample_size_ideal_ref(
+                df_fix, 16, z0_fix, mus_fix, Ts_fix, K_fix;
+                live_emax=le, live_numbers=ln_)
+            st = gc_thermodynamic_stats_ideal_ref(
+                df_fix, 16, z0_fix, mus_fix, Ts_fix, K_fix;
+                live_emax=le, live_numbers=ln_)
+            @test size(ess) == (4, 2)
+            @test all(isapprox.(ess, st.N_eff; rtol=1e-12))
+        end
+    end
+
+    @testset "anchored closed form and run-independence at the anchor" begin
+        # z0 = 1 makes the reference chemical potential exactly zero, so the
+        # grid point mu = 0.0 evaluates the reweighting exponent as exact 0.0
+        rng_b = MersenneTwister(91211)
+        df_b = DataFrame(iter=1:n_con, emax=sort(rand(rng_b, n_con); rev=true),
+                         num_particles=rand(rng_b, 0:16, n_con))
+        eA = gc_effective_sample_size_ideal_ref(
+            df_con, 16, 1.0, [0.0], [300.0], K_con; mode=:anchored)
+        eB = gc_effective_sample_size_ideal_ref(
+            df_b, 16, 1.0, [0.0], [300.0], K_con; mode=:anchored)
+        @test isapprox(eA[1, 1], closed_con; rtol=1e-12)
+        # Two structurally different fixtures (different energies and particle
+        # numbers, same J and K): bitwise-equal anchor values
+        @test eA[1, 1] == eB[1, 1]
+    end
+
+    @testset ":anchored_uniform anchor, monotone rays, :kish non-monotonicity" begin
+        mus_con = collect(range(-0.03, 0.03; length=61))
+        i0 = findfirst(==(0.0), mus_con)
+        eu = gc_effective_sample_size_ideal_ref(
+            df_con, 16, 1.0, mus_con, [300.0], K_con; mode=:anchored_uniform)
+        @test eu[i0, 1] == Float64(n_con)
+        @test all(diff(eu[i0:end, 1]) .<= 1e-12)
+        @test all(diff(reverse(eu[1:i0, 1])) .<= 1e-12)
+        # On the same fixture the raw Kish mode rises well above its anchor
+        # value along the ray (measured peak ratio 1.572 at mu = 0.006): the
+        # anchor is a baseline, not a maximum
+        ek = gc_effective_sample_size_ideal_ref(
+            df_con, 16, 1.0, mus_con, [300.0], K_con)
+        @test maximum(ek[:, 1]) > 1.2 * ek[i0, 1]
+        # With all energies zero the default :anchored mode is bitwise the
+        # same surface, so the non-monotonicity statement covers both Kish
+        # modes on this fixture
+        @test gc_effective_sample_size_ideal_ref(
+            df_con, 16, 1.0, mus_con, [300.0], K_con; mode=:anchored) == ek
+    end
+
+    @testset "explicit T0 anchoring" begin
+        df_t = DataFrame(iter=1:5, emax=[0.4, 0.3, 0.2, 0.1, 0.05],
+                         num_particles=[1, 2, 3, 2, 4])
+        K_t, T_t, T0_t, mu_t, z0_t = 3, 350.0, 250.0, -0.03, 0.6
+        beta_t = 1.0 / (kb_ess * T_t)
+        beta0_t = 1.0 / (kb_ess * T0_t)
+        s_t = beta_t * mu_t - log(z0_t)
+        lw_hand = [log(1 / (K_t + 1)) + q * log(K_t / (K_t + 1)) +
+                   df_t.num_particles[q] * s_t -
+                   (beta_t - beta0_t) * df_t.emax[q] for q in 1:5]
+        w_hand = exp.(lw_hand .- maximum(lw_hand))
+        e_anc = gc_effective_sample_size_ideal_ref(
+            df_t, 16, z0_t, [mu_t], [T_t], K_t; mode=:anchored, T0=T0_t)
+        @test isapprox(e_anc[1, 1], sum(w_hand)^2 / sum(w_hand .^ 2); rtol=1e-12)
+        lr_hand = [df_t.num_particles[q] * s_t -
+                   (beta_t - beta0_t) * df_t.emax[q] for q in 1:5]
+        r_hand = exp.(lr_hand .- maximum(lr_hand))
+        e_unif = gc_effective_sample_size_ideal_ref(
+            df_t, 16, z0_t, [mu_t], [T_t], K_t; mode=:anchored_uniform, T0=T0_t)
+        @test isapprox(e_unif[1, 1], sum(r_hand)^2 / sum(r_hand .^ 2); rtol=1e-12)
+        # T0 equal to the target temperature reproduces the default
+        # per-target path bitwise (beta0 evaluates through the identical
+        # expression, so the anchored exponent is exact 0.0 both ways)
+        e_def = gc_effective_sample_size_ideal_ref(
+            df_t, 16, z0_t, [mu_t], [T_t], K_t; mode=:anchored)
+        e_T0T = gc_effective_sample_size_ideal_ref(
+            df_t, 16, z0_t, [mu_t], [T_t], K_t; mode=:anchored, T0=T_t)
+        @test e_T0T == e_def
+    end
+
+    @testset "athermal ledger: T-independence at mu = 0 only" begin
+        rng_a = MersenneTwister(91221)
+        n_a, K_a = 300, 30
+        df_a = DataFrame(iter=1:n_a, emax=zeros(n_a),
+                         num_particles=rand(rng_a, 0:10, n_a))
+        ek = gc_effective_sample_size_ideal_ref(
+            df_a, 16, 0.5, [0.0, 0.05], [200.0, 400.0], K_a)
+        # At mu = 0 the exponent collapses to -ln z0 for every T: bitwise
+        # T-independent. At mu != 0 the beta*mu term survives and the columns
+        # legitimately differ.
+        @test ek[1, 1] == ek[1, 2]
+        @test ek[2, 1] != ek[2, 2]
+        # With all energies exactly zero, :kish coincides bitwise with
+        # :anchored under the default per-target T0
+        ea = gc_effective_sample_size_ideal_ref(
+            df_a, 16, 0.5, [0.0, 0.05], [200.0, 400.0], K_a; mode=:anchored)
+        @test ek == ea
+    end
+
+    @testset "omega0 scale invariance (dead points only)" begin
+        for mode in (:kish, :anchored, :anchored_uniform)
+            e1 = gc_effective_sample_size_ideal_ref(
+                df_fix, 16, z0_fix, mus_fix, Ts_fix, K_fix; mode=mode)
+            e2 = gc_effective_sample_size_ideal_ref(
+                df_fix, 16, z0_fix, mus_fix, Ts_fix, K_fix; mode=mode, ω0=1.05)
+            e3 = gc_effective_sample_size_ideal_ref(
+                df_fix, 16, z0_fix, mus_fix, Ts_fix, K_fix; mode=mode, ω0=21.0)
+            @test all(isapprox.(e1, e2; rtol=1e-12))
+            @test all(isapprox.(e1, e3; rtol=1e-12))
+        end
+    end
+
+    @testset "relative normalization" begin
+        mus_r = [-0.02, 0.0, 0.03]
+        Ts_r = [250.0, 350.0]
+        e_abs = gc_effective_sample_size_ideal_ref(
+            df_con, 16, 1.0, mus_r, Ts_r, K_con)
+        e_rel = gc_effective_sample_size_ideal_ref(
+            df_con, 16, 1.0, mus_r, Ts_r, K_con; relative=true)
+        @test all(isapprox.(e_rel[2, :], 1.0; rtol=1e-12))
+        for j in 1:2
+            @test all(isapprox.(e_rel[:, j], e_abs[:, j] ./ e_abs[2, j]; rtol=1e-12))
+        end
+        eur = gc_effective_sample_size_ideal_ref(
+            df_con, 16, 1.0, mus_r, Ts_r, K_con; mode=:anchored_uniform, relative=true)
+        @test all(eur[2, :] .== 1.0)
+    end
+
+    @testset "symmetric degradation on a particle-hole-symmetric fixture" begin
+        # z0 = 1, E = 0, N ~ iid Binomial(16, 1/2): degradation is symmetric
+        # in ln(z/z0) in distribution. Gate calibrated from seeds 91101-91103
+        # at >= 3x the maximum |ratio - 1| = 0.0764, which the shipped seed
+        # 91101 itself attains (gate 0.23 = 3.0x; seeds 91102/91103 measured
+        # 0.0479/0.0283). Both flanks must also sit well below the anchored
+        # baseline, so the symmetry claim is about a real degradation
+        # (measured 0.637/0.689 of baseline at the shipped seed; gate 0.8).
+        binom_ess(rng, M, p) = count(_ -> rand(rng) < p, 1:M)
+        n_s, K_s = 3000, 1000
+        rng_s = MersenneTwister(91101)
+        df_s = DataFrame(iter=1:n_s, emax=zeros(n_s),
+                         num_particles=[binom_ess(rng_s, 16, 0.5) for _ in 1:n_s])
+        mu_s = 0.3 * kb_ess * 300.0
+        e_s = gc_effective_sample_size_ideal_ref(
+            df_s, 16, 1.0, [-mu_s, mu_s], [300.0], K_s)
+        @test abs(e_s[2, 1] / e_s[1, 1] - 1) < 0.23
+        r_s = K_s / (K_s + 1)
+        base_s = (1 + r_s) * (1 - r_s^n_s)^2 / ((1 - r_s) * (1 - r_s^(2 * n_s)))
+        @test e_s[1, 1] < 0.8 * base_s
+        @test e_s[2, 1] < 0.8 * base_s
+    end
+
+    @testset "atomistic method" begin
+        n_at, K_at = 150, 15
+        rng_at = MersenneTwister(91231)
+        df_at = DataFrame(iter=1:n_at,
+                          emax=sort(rand(rng_at, n_at) .* 0.5; rev=true),
+                          num_particles=rand(rng_at, 0:6, n_at),
+                          log_compression=fill(log(K_at / (K_at + 1)), n_at))
+        V_at = 1000.0u"Å^3"
+        m_at = 39.948u"u"
+        act_at = 0.01u"Å^-3"
+        mu_at = [-0.15u"eV", -0.05u"eV"]
+        T_at = [250.0u"K", 350.0u"K"]
+        live_E_at = fill(0.0, 10)
+        live_N_at = fill(3, 10)
+        for (le, ln_) in ((nothing, nothing), (live_E_at, live_N_at))
+            ess = gc_effective_sample_size_ideal_ref(
+                df_at, V_at, m_at, act_at, mu_at, T_at;
+                live_emax=le, live_numbers=ln_)
+            st = gc_thermodynamic_stats_ideal_ref(
+                df_at, V_at, m_at, act_at, mu_at, T_at;
+                live_emax=le, live_numbers=ln_)
+            @test all(isapprox.(ess, st.N_eff; rtol=1e-12))
+        end
+        # Zero-row live-only ledger is legal (mirrors the sibling's contract:
+        # only ledgers with rows must carry :log_compression)
+        df_empty_at = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[])
+        e_live = gc_effective_sample_size_ideal_ref(
+            df_empty_at, V_at, m_at, act_at, mu_at, T_at;
+            live_emax=live_E_at, live_numbers=live_N_at)
+        @test all(isfinite, e_live) && all(e_live .>= 1.0)
+        # Unitful T0 dispatch on the anchored mode
+        e_t0 = gc_effective_sample_size_ideal_ref(
+            df_at, V_at, m_at, act_at, mu_at, T_at; mode=:anchored, T0=300.0u"K")
+        @test size(e_t0) == (2, 2) && all(isfinite, e_t0)
+    end
+
+    @testset "argument validation" begin
+        @test_throws ArgumentError gc_effective_sample_size_ideal_ref(
+            df_fix, 16, z0_fix, mus_fix, Ts_fix, K_fix; T0=300.0)
+        @test_throws ArgumentError gc_effective_sample_size_ideal_ref(
+            df_fix, 16, z0_fix, mus_fix, Ts_fix, K_fix; mode=:bogus)
+        @test_throws ArgumentError gc_effective_sample_size_ideal_ref(
+            df_fix, 16, z0_fix, mus_fix, Ts_fix, K_fix; live_emax=live_E_fix)
+        @test_throws DimensionMismatch gc_effective_sample_size_ideal_ref(
+            df_fix, 16, z0_fix, mus_fix, Ts_fix, K_fix;
+            live_emax=live_E_fix, live_numbers=[1])
+        @test_throws ArgumentError gc_effective_sample_size_ideal_ref(
+            DataFrame(iter=Int[], emax=Float64[], num_particles=Int[]),
+            16, z0_fix, mus_fix, Ts_fix, K_fix)
+        @test_throws ArgumentError gc_effective_sample_size_ideal_ref(
+            df_fix, 16, -1.0, mus_fix, Ts_fix, K_fix)
+        # Atomistic mirrors: rows without :log_compression; corrupted column
+        df_nolc = DataFrame(iter=1:3, emax=[0.3, 0.2, 0.1], num_particles=[1, 1, 1])
+        @test_throws ArgumentError gc_effective_sample_size_ideal_ref(
+            df_nolc, 1000.0u"Å^3", 39.948u"u", 0.01u"Å^-3",
+            [-0.1u"eV"], [300.0u"K"])
+        df_badlc = DataFrame(iter=1:3, emax=[0.3, 0.2, 0.1],
+                             num_particles=[1, 1, 1],
+                             log_compression=[-0.1, 0.5, -0.1])
+        @test_throws ArgumentError gc_effective_sample_size_ideal_ref(
+            df_badlc, 1000.0u"Å^3", 39.948u"u", 0.01u"Å^-3",
+            [-0.1u"eV"], [300.0u"K"])
+    end
+end


### PR DESCRIPTION
Implements #256.

- Adds `gc_effective_sample_size_ideal_ref`: a dedicated effective-sample-size reduction for ideal-gas-referenced grand-canonical ledgers, with lattice and atomistic methods mirroring the sibling's dispatch, weight assembly, and live-tail conventions exactly, returning the (μ, T) matrix without evaluating the sibling's moment or distribution surfaces. The sibling's body is untouched; equality of the default `:kish` mode with its `N_eff` field is enforced by a weld test at rtol 10<sup>−12</sup> (observed exact on this machine), so no default-path numerics can move. The internal duplication of the weight assembly is deliberate and disclosed here.
- Modes: `:kish` (the raw diagnostic), `:anchored` (the reweighting factor anchored to `T0`, per-target `T0 = T` by default so the energy factor drops out and the mode measures μ-reweighting concentration alone; at the reference point it equals the run-independent prior-weight closed form, about 2K + 1 on deep ladders), and `:anchored_uniform` (the unit-weight ESS of the anchored factors, which peaks at the reference point and decays monotonically along rays). `relative = true` divides each temperature column by the same mode's value at that temperature's reference point, evaluated with the reweighting exponent set to zero exactly rather than through a rounded μ<sub>0</sub>.
- The sibling's `N_eff` docstring guidance is rewritten in the relative form, replacing the stale absolute ≲ 100 rule: the raw value has no run-independent baseline, and it diagnoses μ-reweighting reliability, not ladder convergence.
- Verified here: a full-reduction reliability sweep costs 16.8× the ESS-only sweep on a 50,000-row ledger; the raw `N_eff` at the reference point measures 1544.78 against the prior-weight baseline of exactly 2K + 1 = 1001 (the Boltzmann factor moves it in either direction), while the μ-only anchored value restores the baseline (1001.00; the prior-weight evaluation matches the closed form to a relative deviation of 6.8×10<sup>−16</sup>).
- Tests: the `N_eff` weld on both methods (tails on and off), the anchored closed form with bitwise run-independence at an exact z<sub>0</sub> = 1 anchor, the `:anchored_uniform` exact anchor value and monotone rays on a fixture where both Kish modes demonstrably rise 1.57× above their own anchor (they are bitwise-identical there since every recorded energy is zero), hand-assembled explicit-`T0` ratios plus the bitwise `T0 = T` degeneracy, athermal T-independence restricted to the μ = 0 column, ω0 scale invariance, relative normalization, a particle-hole-symmetric degradation gate calibrated from three seeds at ≥ 3× the maximum deviation (shipped seed 91101 itself attains the calibration maximum 0.0764, gate 0.23 = 3.0×; the two below-0.8×-baseline flank assertions are an addition beyond the issue's plan), the far-point/near-point collapse ordering and row-count ceiling mirrored onto the existing Langmuir driver fixture next to the sibling's own `N_eff` pins, the atomistic zero-row live-only contract with Unitful `T0` dispatch, and the argument-validation surface including the `T0`-with-`:kish` throw.

Adversarially reviewed (issue-promise round-trip, independent-oracle mathematics, determinism and assertion accounting), and the full suite passes on the shipped bytes.
