### PR TITLE
Bounded-support construction for the atomistic ideal-gas-referenced grand-canonical route

### DIFF
--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -703,6 +703,21 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
 end
 
 
+"""
+    _log_poisson_partial_sum(z0V::Float64, n_max::Int)
+
+The log reference mass of the truncated continuous ideal-gas measure:
+`log(Σ_{N=0}^{n_max} (z0V)^N / N!)`, computed in log space with a max-shifted
+logsumexp so neither `(z0V)^N` nor `N!` overflows. Exactly `0.0` at `n_max = 0`
+(the empty-configuration term alone) and tends to `z0V` as `n_max` grows (the
+unbounded mass `e^{z0V}`).
+"""
+function _log_poisson_partial_sum(z0V::Float64, n_max::Int)
+    n_max >= 0 || throw(ArgumentError("n_max must be non-negative"))
+    logterms = vcat(0.0, cumsum(log.(z0V ./ (1:n_max))))
+    max_log = maximum(logterms)
+    return max_log + log(sum(exp.(logterms .- max_log)))
+end
 
 
 """
@@ -714,7 +729,7 @@ end
                                      T_grid::AbstractVector{<:Unitful.Temperature};
                                      ω0=1.0, live_emax=nothing, live_numbers=nothing,
                                      observable_cols=Symbol[], live_observables=nothing,
-                                     kb=8.617333262e-5)
+                                     kb=8.617333262e-5, n_max=nothing)
 
 Reduce an atomistic energy-sorted ideal-gas-referenced grand-canonical ledger (see the
 `AtomisticIGRefGCNSParameters` method of `ideal_gas_referenced_nested_sampling`) to
@@ -727,6 +742,16 @@ Reduce an atomistic energy-sorted ideal-gas-referenced grand-canonical ledger (s
 with `z = exp(μ/kT)/Λ(T)³` the target activity, `z0` the run's reference activity, and
 `e^{z0V}` the reference measure's total mass. The thermal wavelength and the volume enter
 only here: the sampler is athermal and its ledger is reduced, never re-run.
+
+For a BOUNDED run (a finite `n_max` on `AtomisticIGRefGCNSParameters`), pass the same
+`n_max` here: the reference measure is then the truncated ideal gas on `0:n_max`, whose
+total mass `Σ_{N=0}^{n_max} (z0V)^N/N!` replaces `e^{z0V}` in the assembly
+(`_log_poisson_partial_sum`). The reweighting exponent, every ratio observable, `p_N`,
+and `N_eff` are unchanged — the reference mass is a global constant that cancels from
+all of them — so a bounded run reduced with the default `n_max=nothing` differs ONLY in
+`logXi`, shifted up by exactly `-log P(Poisson(z0V) <= n_max)` (the surplus reference
+mass above the cap). Ledger or live-tail entries
+with `N > n_max` are rejected: they cannot have come from the claimed bounded run.
 
 Three conventions are fixed by measurement and documented here:
 - Shell weights follow the log-compression convention of `ωᵢ(log_compression; ω0=1.0)`,
@@ -768,6 +793,8 @@ follow-up item and out of scope here.
 - `live_observables=nothing`: Required whenever `observable_cols` is non-empty and a
   live-set tail is supplied; same contract as the lattice method above.
 - `kb::Float64`: Boltzmann constant (default: eV/K).
+- `n_max::Union{Nothing,Int}=nothing`: The run's particle-number cap, for bounded
+  constructions. `nothing` (the default) selects the unbounded `e^{z0V}` normalization.
 
 # Returns
 A `NamedTuple` with the same shape as the lattice method: `logXi`, `mean_N`, `var_N`,
@@ -791,9 +818,18 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
                                           live_numbers::Union{Nothing,Vector{Int}}=nothing,
                                           observable_cols::AbstractVector{Symbol}=Symbol[],
                                           live_observables::Union{Nothing,AbstractDict{Symbol}}=nothing,
-                                          kb::Float64=8.617333262e-5)
+                                          kb::Float64=8.617333262e-5,
+                                          n_max::Union{Nothing,Int}=nothing)
     if reference_activity <= 0.0u"Å^-3"
         throw(ArgumentError("reference_activity must be positive"))
+    end
+    if n_max !== nothing && n_max < 0
+        throw(ArgumentError("n_max must be non-negative"))
+    end
+    if n_max !== nothing && n_max > 10^9
+        throw(ArgumentError(
+            "n_max = $n_max looks like an unbounded-run sentinel (typemax); " *
+            "pass n_max=nothing to reduce an unbounded run"))
     end
     if V <= 0.0u"Å^3"
         throw(ArgumentError("V must be positive"))
@@ -876,6 +912,12 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
         Ns = vcat(Ns, Float64.(live_numbers))
     end
 
+    if n_max !== nothing && !isempty(Ns) && maximum(Ns) > n_max
+        throw(ArgumentError(
+            "the ledger or live tail contains a particle count above n_max = $n_max; " *
+            "such samples cannot have come from the claimed bounded run"))
+    end
+
     As = Dict{Symbol,Vector{Float64}}()
     for col in observable_cols
         A = n_dead > 0 ? Vector{Float64}(df[!, col]) : Float64[]
@@ -897,6 +939,9 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
 
     z0V = ustrip(Unitful.NoUnits, reference_activity * V)
     log_z0 = log(ustrip(u"Å^-3", reference_activity))
+    # The log reference mass: e^{z0V} for the unbounded measure, the truncated
+    # partial sum for a bounded run (a global constant entering logXi alone)
+    log_ref = n_max === nothing ? z0V : _log_poisson_partial_sum(z0V, n_max)
 
     n_mu = length(μ_grid)
     n_T = length(T_grid)
@@ -922,7 +967,7 @@ function gc_thermodynamic_stats_ideal_ref(df::DataFrame,
             max_log = maximum(log_w)
             ws = exp.(log_w .- max_log)
             sum_w = sum(ws)
-            logXi[i, j] = z0V + max_log + log(sum_w)
+            logXi[i, j] = log_ref + max_log + log(sum_w)
             n_avg = sum(ws .* Ns) / sum_w
             mean_N[i, j] = n_avg
             var_N[i, j] = sum(ws .* Ns .^ 2) / sum_w - n_avg^2

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -2482,15 +2482,25 @@ enter a run; both enter only in the post-run reduction to Ξ(μ, T).
 - `move_stats::Dict{Symbol,Int}`: Run-total per-move-type attempt/accept counters
   accumulated from every ordinary-cull decorrelation walk (cleared once at run
   start; plateau-refill walks are not accumulated).
+- `n_max::Int64`: Upper bound on the particle count, for BOUNDED constructions. The
+  default `typemax(Int64)` keeps the historical unbounded reference measure
+  draw-for-draw (initialization consumes the identical RNG stream and the kernel
+  guard never fires). A finite `n_max` defines a different, truncated reference
+  measure — the conditional Poisson on `0:n_max` — and is exact for that measure
+  only when all three legs move together: initialization draws the truncated law,
+  the kernel guard-skips insertions above the cap (a null proposal, Metropolis-
+  correct on the truncated measure), and the post-run reduction is normalized by
+  the truncated reference mass. A finite `n_max` therefore OBLIGATES passing the
+  same `n_max` to `gc_thermodynamic_stats_ideal_ref`; mixing a capped run with the
+  unbounded `e^{z0V}` normalization overstates logXi by exactly
+  `-log P(Poisson(z0V) <= n_max)` (the surplus reference mass above the cap).
 
-Three fields carried by sibling parameter structs are deliberately absent. No `n_max`:
-the reference measure has unbounded particle-number support, and a cap silently
-truncates its mass and biases the evidence (the kernel's keyword exists for bounded
-constructions only; this sampler never sets it). No `energy_perturbation`: exact energy
-ties are handled by the plateau-aware eviction machinery, and perturbing recorded
-energies would break the exactly-zero closed-form checks this construction is validated
-against. No `random_seed`: the lattice ideal-gas-referenced sibling documents its field
-as not consumed by the sampling loop; seed the global RNG before the run instead.
+Two fields carried by sibling parameter structs are deliberately absent. No
+`energy_perturbation`: exact energy ties are handled by the plateau-aware eviction
+machinery, and perturbing recorded energies would break the exactly-zero closed-form
+checks this construction is validated against. No `random_seed`: the lattice
+ideal-gas-referenced sibling documents its field as not consumed by the sampling loop;
+seed the global RNG before the run instead.
 """
 mutable struct AtomisticIGRefGCNSParameters <: SamplingParameters
     mc_steps::Int64
@@ -2506,6 +2516,7 @@ mutable struct AtomisticIGRefGCNSParameters <: SamplingParameters
     plateau_refill_target::Int64
     refill_fail_budget::Int64
     move_stats::Dict{Symbol,Int}
+    n_max::Int64
 end
 
 """
@@ -2513,12 +2524,15 @@ end
         mc_steps=100, reference_activity=0.01u"Å^-3", species=:H,
         initial_step_size=0.5, step_size=0.5, step_size_lo=0.01, step_size_up=2.0,
         accept_range=(0.25, 0.75), fail_count=0, allowed_fail_count=100,
-        plateau_refill_target=0, refill_fail_budget=0, move_stats=Dict{Symbol,Int}())
+        plateau_refill_target=0, refill_fail_budget=0, move_stats=Dict{Symbol,Int}(),
+        n_max=typemax(Int64))
 
 Convenience constructor for `AtomisticIGRefGCNSParameters`. `reference_activity` (z0)
 must be positive; choose it so z0V sits near the particle-number range of interest, as
 post-run reweighting to a target (μ, T) carries a factor `(z/z0)^N` per sample whose
-effective sample size degrades away from the reference.
+effective sample size degrades away from the reference. A finite `n_max` selects the
+bounded construction (see the field docstring); it must be at least 1, and the same
+`n_max` must be passed to `gc_thermodynamic_stats_ideal_ref`.
 """
 function AtomisticIGRefGCNSParameters(;
     mc_steps::Int64=100,
@@ -2534,6 +2548,7 @@ function AtomisticIGRefGCNSParameters(;
     plateau_refill_target::Int64=0,
     refill_fail_budget::Int64=0,
     move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
+    n_max::Int64=typemax(Int64),
 )
     if reference_activity <= 0.0u"Å^-3"
         throw(ArgumentError("reference_activity must be positive"))
@@ -2541,10 +2556,14 @@ function AtomisticIGRefGCNSParameters(;
     if refill_fail_budget < 0
         throw(ArgumentError("refill_fail_budget must be non-negative (0 charges refill failures against allowed_fail_count)"))
     end
+    if n_max < 1
+        throw(ArgumentError("n_max must be at least 1 (typemax(Int64) selects the unbounded construction)"))
+    end
     AtomisticIGRefGCNSParameters(
         mc_steps, reference_activity, species,
         initial_step_size, step_size, step_size_lo, step_size_up, accept_range,
         fail_count, allowed_fail_count, plateau_refill_target, refill_fail_budget, move_stats,
+        n_max,
     )
 end
 
@@ -2639,7 +2658,17 @@ function _atomistic_igref_z0V(liveset::AtomWalkers, params::AtomisticIGRefGCNSPa
         cell_vectors(walker.configuration) == cellv || throw(ArgumentError("all walkers must share one cell"))
     end
     V = cellv[1][1] * cellv[2][2] * cellv[3][3]
-    return ustrip(Unitful.NoUnits, params.reference_activity * V)
+    z0V = ustrip(Unitful.NoUnits, params.reference_activity * V)
+    if params.n_max != typemax(Int64)
+        # Bounded construction: the truncated reference must retain workable
+        # mass, or the conditional-Poisson rejection sampler at initialization
+        # degenerates into a near-endless loop
+        trunc_mass = cdf(Poisson(z0V), params.n_max)
+        if trunc_mass < 1e-8
+            throw(ArgumentError("the truncated reference mass P(Poisson(z0V) <= n_max) = $trunc_mass is below 1e-8 at z0V = $z0V, n_max = $(params.n_max); lower reference_activity so the reference law overlaps the bounded support"))
+        end
+    end
+    return z0V
 end
 
 """
@@ -2649,7 +2678,11 @@ end
 
 Initialize walkers as exact i.i.d. draws from the continuous ideal-gas prior at the
 reference activity: each walker's particle count is Poisson(z0V) and its positions are
-uniform in the cell.
+uniform in the cell. Under a finite `params.n_max` the count is drawn from the exact
+conditional Poisson on `0:n_max` by rejection — chosen over inverse-CDF sampling
+because it consumes the identical RNG stream whenever no draw exceeds the cap, which is
+what makes the bounded and unbounded constructions digit-identical away from the cap
+(the workable-mass guard in `_atomistic_igref_z0V` bounds the rejection loop).
 """
 function _init_atomistic_igref_walkers!(liveset::AtomWalkers,
                                         params::AtomisticIGRefGCNSParameters,
@@ -2662,6 +2695,9 @@ function _init_atomistic_igref_walkers!(liveset::AtomWalkers,
             remove_particle!(walker, walker.list_num_par[1])
         end
         n = rand(Poisson(z0V))
+        while n > params.n_max
+            n = rand(Poisson(z0V))
+        end
         for _ in 1:n
             pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])
             insert_particle!(walker, pos, params.species)
@@ -2739,7 +2775,7 @@ function nested_sampling_step!(liveset::AtomWalkers,
                     _gc_walk_length(params, mc_routine, at_r.list_num_par[1]), at_r, pot, emax;
                     z0V=z0V, species=params.species,
                     p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
-                    step_size=params.step_size,
+                    step_size=params.step_size, n_max=params.n_max,
                     p_bias=mc_routine.p_bias, bias_radius=mc_routine.bias_radius,
                     bias_grid=mc_routine.bias_grid)
                 if accept_r && mc_routine.galilean_steps > 0 && at_r.list_num_par[1] > 0
@@ -2781,7 +2817,7 @@ function nested_sampling_step!(liveset::AtomWalkers,
         _gc_walk_length(params, mc_routine, to_walk.list_num_par[1]), to_walk, pot, emax;
         z0V=z0V, species=params.species,
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
-        step_size=params.step_size,
+        step_size=params.step_size, n_max=params.n_max,
         p_bias=mc_routine.p_bias, bias_radius=mc_routine.bias_radius,
         bias_grid=mc_routine.bias_grid)
     if accept && mc_routine.galilean_steps > 0 && to_walk.list_num_par[1] > 0

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -20,6 +20,8 @@ include("test-atomistic-gc-interacting-regressions.jl")
     include("test-lattice-gc-scaling-regressions.jl")
     # test atomistic ideal-gas-referenced grand-canonical nested sampling
     include("test-atomistic-igref-gcns.jl")
+    # absolute seeded pins for the atomistic ideal-gas-referenced driver
+    include("test-atomistic-igref-driver-pins.jl")
     # test the atomistic ideal-gas-referenced ledger assembly
     include("test-atomistic-igref-stats.jl")
     # test the ideal-gas-referenced effective-sample-size reductions

--- a/test/test-SamplingSchemes/test-atomistic-gc-regressions.jl
+++ b/test/test-SamplingSchemes/test-atomistic-gc-regressions.jl
@@ -127,10 +127,13 @@
         @test length(w.configuration) == w.list_num_par[1]
     end
 
-    @testset "particle-number cap stays structurally inactive" begin
-        # the sampler's parameter struct carries no cap at all: a cap would
-        # silently truncate the reference measure's unbounded support
-        @test !hasfield(AtomisticIGRefGCNSParameters, :n_max)
+    @testset "particle-number cap stays inactive by default" begin
+        # DISCLOSURE (rescoped in the bounded-support Add commit): the struct
+        # now carries `n_max` for the bounded construction, but the DEFAULT is
+        # `typemax(Int64)` — draw-for-draw the historical unbounded reference
+        # measure. The default-run behavior below is unchanged.
+        @test hasfield(AtomisticIGRefGCNSParameters, :n_max)
+        @test AtomisticIGRefGCNSParameters().n_max == typemax(Int64)
         Random.seed!(81813)
         ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:16],
                                 LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5))

--- a/test/test-SamplingSchemes/test-atomistic-igref-driver-pins.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-driver-pins.jl
@@ -1,0 +1,203 @@
+# Absolute seeded pins for the atomistic ideal-gas-referenced grand-canonical
+# step and kernel, captured at dev 1c7d4494 (the shipped SHA before the
+# bounded-support and surface rounds) and reproduced digit-identically across
+# two separate Julia processes before recording. The shipped end-to-end
+# testsets compare two same-process runs, so no absolute cross-change pin
+# existed for this route; stream-neutral changes cite these pins as their
+# bit-identity gate.
+#
+# Scope: the pins deliberately EXCLUDE the driver's reference-law
+# initialization. That path draws its particle counts through Distributions'
+# Poisson sampler, whose draw stream is version-dependent (a first capture
+# through the initializer diverged from draw one on every CI leg at
+# z0V = 6.0 while z0V = 12 survived: a sampler-algorithm boundary), so the
+# fixtures build their live sets deterministically (fixed counts, positions
+# from raw uniforms) and pin the step-loop stream, which consumes only
+# Random-stdlib draws — the family the lattice trajectory pins prove stable
+# across CI legs. The initialization law itself is gated by the same-process
+# statistical and stream-identity testsets.
+#
+# Cross-architecture policy (the x64-drift rules): step-loop emax and live-set
+# energies are smooth Lennard-Jones accumulations, pinned elementwise at rtol
+# 1e-12 (a real stream change moves them by orders of magnitude);
+# num_particles sequences are exact integers; compression charges are compared
+# against same-process logs of integer ratios (architecture-exact); the
+# kernel counter pins run on a zero-interaction fixture where every recorded
+# energy is exactly 0.0 eV, so exact equality is defensible on every CI leg.
+# Counter asserts are per key and by name, never an exact key set.
+#
+# Fixture A (seed 424261): K = 16 with two empty walkers, so the descent
+# traverses the exact E = 0 plateau (five eviction charges, log(15/16) down
+# to log(11/12)). Fixture B (seed 424262): K = 12, denser counts 1..12,
+# two eviction charges. Kernel fixture (seed 424253): 500 steps at
+# epsilon = 0 under a 1 eV ceiling.
+@testset "atomistic igref driver pins (absolute, captured at 1c7d4494)" begin
+    using Random
+
+    pin_box = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+    pin_pbc = (true, true, true)
+    pin_seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], pin_box, pin_pbc))
+    pin_mkempty() = FastSystem(cell_vectors(pin_seed_at), periodicity(pin_seed_at),
+                               empty(position(pin_seed_at, :)), empty(species(pin_seed_at, :)),
+                               empty(mass(pin_seed_at, :)))
+    pin_V = 1728.0
+
+    function pin_liveset(counts, lj)
+        walkers = AtomWalker{1}[]
+        for n in counts
+            w = AtomWalker{1}(pin_mkempty())
+            for _ in 1:n
+                pos = SVector(rand() * 12.0, rand() * 12.0, rand() * 12.0)u"Å"
+                FreeBird.AbstractWalkers.insert_particle!(w, pos, :Ar)
+            end
+            push!(walkers, w)
+        end
+        return GenericAtomWalkers(walkers, lj)
+    end
+
+    function pin_step_run(seed::Int, counts, z0V::Float64, mc_steps::Int, n_steps::Int)
+        Random.seed!(seed)
+        lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+        ls = pin_liveset(counts, lj)
+        params = AtomisticIGRefGCNSParameters(mc_steps=mc_steps,
+            reference_activity=(z0V / pin_V)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        iters = Int[]
+        emaxs = Float64[]
+        npars = Int[]
+        logts = Float64[]
+        for k in 1:n_steps
+            iter, emax, n_par, ls, params, log_t = FreeBird.SamplingSchemes.nested_sampling_step!(
+                ls, params, MCAtomGrandCanonicalMoves(); ns_iteration=k, z0V=z0V)
+            if !(iter isa Missing)
+                push!(iters, iter)
+                push!(emaxs, ustrip(u"eV", emax))
+                push!(npars, n_par)
+                push!(logts, log_t)
+            end
+        end
+        live = sort([ustrip(u"eV", w.energy) for w in ls.walkers])
+        return iters, emaxs, npars, logts, live
+    end
+
+    function pin_kernel_run(seed::Int)
+        Random.seed!(seed)
+        w = AtomWalker{1}(pin_mkempty())
+        for pos in ([2.0, 2.0, 2.0], [7.0, 7.0, 7.0], [2.0, 7.0, 2.0])
+            FreeBird.AbstractWalkers.insert_particle!(w, SVector{3}(pos)u"Å", :Ar)
+        end
+        w.energy = 0.0u"eV"
+        lj0 = LJParameters(epsilon=0.0)
+        accept, rate, w, stats = MC_grand_canonical_walk!(500, w, lj0, 1.0u"eV";
+            z0V=4.0, species=:Ar, p_move=0.4, p_insert=0.3, step_size=0.8)
+        return accept, rate, w.list_num_par[1], stats
+    end
+
+    pin_counts_a = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 8]
+    pin_counts_b = collect(1:12)
+    PIN_A_LC_NUM = [16, 16, 15, 14, 13, 12, 11, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16]
+    PIN_A_LC_DEN = [17, 17, 16, 15, 14, 13, 12, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17]
+    PIN_B_LC_NUM = [12, 12, 12, 12, 12, 11, 10, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12]
+    PIN_B_LC_DEN = [13, 13, 13, 13, 13, 12, 11, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13]
+    PIN_A_EMAX = [
+        0.49650308987844566, 0.005567784408978168, 0.0, 0.0,
+        0.0, 0.0, 0.0, -0.0001073907988809283,
+        -0.00011292767604743266, -0.00020951367630830147, -0.0008239444072923945, -0.0009805158933565044,
+        -0.0015397106957732306, -0.002989816253236788, -0.003353093382494646, -0.006613094585540791,
+        -0.0067153573457302915, -0.00714468932937065, -0.007679330050948285, -0.008063262509870175,
+        -0.008470218760268954, -0.009919079870469902, -0.01077104864357166, -0.011238323672012163,
+        -0.012759464584894964, -0.014610876566821779, -0.015101172692519793, -0.015918537969139956,
+        -0.01682128277716249, -0.016914667608249133, -0.017772734750851036, -0.018502451515889733,
+        -0.01855795113253103, -0.020416578292040015, -0.02166104598262431, -0.02186733542220379,
+        -0.022548321323137867, -0.02268780967025878, -0.02308152338599702, -0.023233069983609626,
+        -0.023365278240072864, -0.023373803686156203, -0.023383701360065803, -0.023811600490849908,
+        -0.024514675928337223, -0.02462332825424484, -0.02541383387245483, -0.025885173425747938,
+        -0.02623504028045993, -0.0264979433966434, -0.02679504293639932, -0.02752305688172925,
+        -0.028988678482161762, -0.029668629317186855, -0.029890324681572374, -0.03037292210685511,
+        -0.03198113310138711, -0.032380163888193224, -0.03255871294899312, -0.032968235701439925,
+        -0.032997717356232706, -0.033101585522182876, -0.03357304468058118, -0.03431780282923257,
+        -0.035189526107308924, -0.036274045873984716, -0.036956719888022634, -0.03721872739087561,
+        -0.03797619945797363, -0.03933189235986552, -0.03989052741524547, -0.040181033217279304,
+        -0.04089523694188833, -0.0414046508333025, -0.041910551078641556, -0.04196269332817865,
+        -0.04250006320498496, -0.04255831377183063, -0.042638674284410115, -0.04289385290378052,
+        -0.04330866455818437, -0.04396193365349088, -0.04498262635237586, -0.04511044710485016,
+        -0.04576681639184778, -0.04619034410132479, -0.046549818014362546, -0.04667064243790245,
+        -0.047168077399936115, -0.04756524728975553, -0.05046584065965944, -0.05110468871686705,
+        -0.05113774207550152, -0.051853168551060196, -0.05243704402998366, -0.053015801846527655,
+        -0.053098611099561446, -0.05362580987820714, -0.05384980781518607, -0.054357147349725576,
+        -0.05574277702802663, -0.05654864560128079, -0.056641132542510575, -0.05666317770622394,
+        -0.056698811202237825, -0.056995386106409994, -0.05709415610764919, -0.05718716019707145,
+        -0.05758342515432109, -0.05889880077227439, -0.05943441830518491, -0.05965605862959167,
+        -0.06017244074537433, -0.06033673204260611, -0.060357743462356415, -0.06047541259886642,
+        -0.061292457420684406, -0.06178768802860045, -0.06217256714590098, -0.06227598114412991,
+    ]
+    PIN_A_NPAR = [6, 5, 0, 0, 1, 1, 2, 2, 3, 3, 3, 4, 5, 5, 4, 5, 5, 5, 7, 5, 4, 6, 6, 7, 8, 4, 7, 7, 7, 6, 5, 4, 7, 8, 8, 7, 9, 8, 8, 8, 8, 7, 8, 5, 6, 6, 8, 7, 8, 6, 6, 7, 9, 9, 5, 8, 7, 8, 9, 9, 9, 10, 7, 6, 9, 10, 7, 9, 11, 8, 9, 9, 9, 9, 10, 10, 9, 10, 10, 11, 8, 8, 8, 8, 11, 9, 10, 11, 8, 10, 6, 12, 11, 10, 10, 12, 12, 10, 10, 9, 13, 9, 11, 11, 9, 13, 10, 11, 10, 13, 10, 11, 12, 9, 10, 7, 11, 10, 12, 10]
+    PIN_A_LIVE = [
+        -0.09054368869280663, -0.08154836655860949, -0.08029997698197638, -0.07932163124190357,
+        -0.07647101166652966, -0.07414024477961706, -0.07197632266225525, -0.0718033058069537,
+        -0.06735075149873104, -0.06630696075682387, -0.06537782030975144, -0.06481040922359776,
+        -0.06476584940293108, -0.0642550289296039, -0.06395595518186165, -0.06361822740367877,
+    ]
+    PIN_B_EMAX = [
+        2994.8883255499827, 2.5786639977428, 0.021857781611742764, 0.015175990895690434,
+        0.010466702437576894, 0.0, 0.0, -0.00017487545907056594,
+        -0.0010473248913946223, -0.0013015014148710763, -0.006080130314878283, -0.012222907546631514,
+        -0.013907433160176714, -0.015662660229791712, -0.0197045361615375, -0.020227452313412064,
+        -0.02206647153762751, -0.025531565917946974, -0.027050850745844762, -0.02855588273989433,
+        -0.028690240502911024, -0.030729841846923154, -0.03135437380029623, -0.03654248956410261,
+        -0.038119721925529, -0.040839973188740046, -0.04238728993424989, -0.04310937864021593,
+        -0.04865735378455641, -0.048974415318777005, -0.049608057997187954, -0.05059789513763672,
+        -0.05542170045583214, -0.05737827840565489, -0.05763174410110945, -0.059334237443026926,
+        -0.060571515378430925, -0.061071620458641986, -0.06141775568292222, -0.062124235607597444,
+        -0.06582601815935438, -0.06662380944067647, -0.06770403589364778, -0.06916599340910214,
+        -0.06985532997001528, -0.07065855880587775, -0.07264138273093595, -0.07374240093506991,
+        -0.07389591363920636, -0.07414890724572859, -0.07523405635410964, -0.07661264565963569,
+        -0.07676425158393256, -0.07947957566465773, -0.08096480049231033, -0.08302045083962474,
+        -0.08329833535651876, -0.08443055225384373, -0.08464043929604013, -0.08795732383242695,
+        -0.08817614171131019, -0.09154960665147996, -0.09217625435213611, -0.09219713969106322,
+        -0.09232788252572481, -0.09359550720145389, -0.09735988456989661, -0.09872732489426503,
+        -0.10187954523310573, -0.10237607482008534, -0.10531050081049796, -0.10583082651691188,
+        -0.10675036971327378, -0.10697625754129211, -0.11041761737417012, -0.11131593516741708,
+        -0.11179657708950429, -0.11303993835732476, -0.11344219554342466, -0.11448433036214237,
+    ]
+    PIN_B_NPAR = [11, 8, 6, 12, 10, 1, 2, 3, 4, 7, 6, 5, 7, 7, 7, 9, 10, 11, 7, 9, 10, 8, 8, 9, 11, 9, 13, 10, 10, 10, 14, 11, 12, 9, 11, 14, 10, 11, 11, 12, 11, 11, 13, 13, 13, 11, 13, 13, 9, 12, 12, 13, 16, 14, 14, 13, 15, 14, 15, 13, 14, 13, 14, 11, 17, 13, 14, 13, 16, 14, 15, 15, 16, 14, 14, 15, 13, 17, 14, 14]
+    PIN_B_LIVE = [
+        -0.1298580210467591, -0.12823039993363036, -0.12566080955215025, -0.12241058656469743,
+        -0.12166589708845912, -0.1201598350549118, -0.1192737383086962, -0.11883694052493093,
+        -0.11797676514706185, -0.11708551033046782, -0.11603884659794568, -0.11590144088572349,
+    ]
+    PIN_K_STATS = (move_attempted = 181, move_accepted = 181, insert_attempted = 155,
+                   insert_accepted = 132, insert_biased_attempted = 0,
+                   insert_biased_accepted = 0, delete_attempted = 159,
+                   delete_accepted = 135)
+
+    @testset "fixture A: step-loop descent through the E = 0 plateau (seed 424261)" begin
+        iters, emaxs, npars, logts, live = pin_step_run(424261, pin_counts_a, 6.0, 60, 120)
+        @test iters == collect(1:120)
+        @test issorted(emaxs, rev=true)
+        @test npars == PIN_A_NPAR
+        @test logts == log.(PIN_A_LC_NUM ./ PIN_A_LC_DEN)
+        @test all(isapprox.(emaxs, PIN_A_EMAX; rtol=1e-12, atol=0.0))
+        @test all(isapprox.(live, PIN_A_LIVE; rtol=1e-12, atol=0.0))
+    end
+
+    @testset "fixture B: denser step-loop, brief plateau (seed 424262)" begin
+        iters, emaxs, npars, logts, live = pin_step_run(424262, pin_counts_b, 12.0, 40, 80)
+        @test iters == collect(1:80)
+        @test issorted(emaxs, rev=true)
+        @test npars == PIN_B_NPAR
+        @test logts == log.(PIN_B_LC_NUM ./ PIN_B_LC_DEN)
+        @test all(isapprox.(emaxs, PIN_B_EMAX; rtol=1e-12, atol=0.0))
+        @test all(isapprox.(live, PIN_B_LIVE; rtol=1e-12, atol=0.0))
+    end
+
+    @testset "kernel counters on the zero-interaction fixture (seed 424253)" begin
+        accept, rate, n_final, stats = pin_kernel_run(424253)
+        @test accept === true
+        @test rate == 448 / 500
+        @test n_final == 0
+        for (k, v) in pairs(PIN_K_STATS)
+            @test getproperty(stats, k) == v
+        end
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-gcns.jl
@@ -753,3 +753,97 @@ end
         @test length(fls.walkers) >= 2
     end
 end
+
+@testset "bounded-support construction (n_max)" begin
+    using Random
+    # Calibration ledger:
+    # - Truncated initializer moments at K = 200, z0V = 3, n_max = 2, seeds
+    #   {1,2,3,52551}: exact conditional-Poisson mean 24/17 = 1.41176 and
+    #   variance 138/289 = 0.47751; max devs mean 0.0732, var 0.0657 (both at
+    #   the shipped seed); gates ship at >= 3x (0.22 and 0.20).
+    # - The stream-identity and guard testsets are deterministic contracts and
+    #   need no calibration.
+    bb_box = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+    bb_pbc = (true, true, true)
+    bb_seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], bb_box, bb_pbc))
+    bb_mkempty() = FastSystem(cell_vectors(bb_seed_at), periodicity(bb_seed_at),
+                              empty(position(bb_seed_at, :)), empty(species(bb_seed_at, :)),
+                              empty(mass(bb_seed_at, :)))
+    bb_V = 1728.0
+    bb_lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+    bb_save(tag) = SaveEveryN(df_filename="_igref_bb_$(tag).csv",
+                              wk_filename="_igref_bb_$(tag).traj.extxyz",
+                              ls_filename="_igref_bb_$(tag).ls.extxyz",
+                              n_traj=10^7, n_snap=10^7, n_info=10^7)
+    bb_clean(tag) = for f in ["_igref_bb_$(tag).csv", "_igref_bb_$(tag).traj.extxyz",
+                              "_igref_bb_$(tag).ls.extxyz"]
+        rm(f, force=true)
+    end
+    function bb_run(seed, n_max; n_steps=120)
+        Random.seed!(seed)
+        ls = GenericAtomWalkers([AtomWalker{1}(bb_mkempty()) for _ in 1:16], bb_lj)
+        params = AtomisticIGRefGCNSParameters(mc_steps=60,
+            reference_activity=(6.0 / bb_V)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000, n_max=n_max)
+        df, lso, pout = ideal_gas_referenced_nested_sampling(
+            ls, params, n_steps, MCAtomGrandCanonicalMoves(), bb_save("r"))
+        bb_clean("r")
+        live_e = [ustrip(u"eV", w.energy) for w in lso.walkers]
+        live_n = [w.list_num_par[1] for w in lso.walkers]
+        return df, live_e, live_n, pout
+    end
+
+    @testset "constructor validation and default" begin
+        @test_throws ArgumentError AtomisticIGRefGCNSParameters(n_max=0)
+        @test_throws ArgumentError AtomisticIGRefGCNSParameters(n_max=-3)
+        @test AtomisticIGRefGCNSParameters(n_max=5).n_max == 5
+        @test AtomisticIGRefGCNSParameters().n_max == typemax(Int64)
+    end
+
+    @testset "workable-mass guard on the truncated reference" begin
+        # P(Poisson(60) <= 1) ~ 5e-25: the conditional-Poisson rejection
+        # sampler would loop essentially forever, so validation rejects it
+        params = AtomisticIGRefGCNSParameters(reference_activity=(60.0 / bb_V)u"Å^-3",
+                                              species=:Ar, n_max=1)
+        ls = GenericAtomWalkers([AtomWalker{1}(bb_mkempty())], bb_lj)
+        @test_throws ArgumentError FreeBird.SamplingSchemes._atomistic_igref_z0V(ls, params)
+        # a workable truncation at the same cap passes validation
+        params_ok = AtomisticIGRefGCNSParameters(reference_activity=(1.0 / bb_V)u"Å^-3",
+                                                 species=:Ar, n_max=1)
+        @test FreeBird.SamplingSchemes._atomistic_igref_z0V(ls, params_ok) ≈ 1.0 atol=1e-12
+    end
+
+    @testset "truncated initializer law (seeded, calibrated)" begin
+        Random.seed!(52551)
+        ls = GenericAtomWalkers([AtomWalker{1}(bb_mkempty()) for _ in 1:200],
+                                LJParameters(epsilon=0.0))
+        params = AtomisticIGRefGCNSParameters(reference_activity=(3.0 / bb_V)u"Å^-3",
+                                              species=:Ar, n_max=2)
+        z0V = FreeBird.SamplingSchemes._atomistic_igref_z0V(ls, params)
+        FreeBird.SamplingSchemes._init_atomistic_igref_walkers!(ls, params, z0V)
+        ns = [w.list_num_par[1] for w in ls.walkers]
+        # conditional Poisson(3) on {0, 1, 2}: masses prop. to (1, 3, 4.5),
+        # mean 24/17, variance 0.477508...
+        @test all(0 .<= ns .<= 2)
+        @test abs(mean(ns) - 24 / 17) < 0.22
+        @test abs(var(ns) - (42 / 17 - (24 / 17)^2)) < 0.20
+        @test all(length(w.configuration) == w.list_num_par[1] for w in ls.walkers)
+    end
+
+    @testset "bounded-vs-unbounded stream identity when the cap is unhit" begin
+        df_u, live_eu, live_nu, _ = bb_run(52552, typemax(Int64))
+        df_b, live_eb, live_nb, _ = bb_run(52552, 10^6)
+        @test df_u == df_b
+        @test live_eu == live_eb
+        @test live_nu == live_nb
+    end
+
+    @testset "binding cap: the ledger and live set respect n_max end to end" begin
+        df, live_e, live_n, pout = bb_run(52553, 4)
+        @test maximum(df.num_particles) <= 4
+        @test maximum(live_n) <= 4
+        @test nrow(df) > 0
+        @test issorted(df.emax, rev=true)
+        @test pout.n_max == 4
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-stats.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-stats.jl
@@ -330,3 +330,198 @@ end
         end
     end
 end
+@testset "bounded-support normalization (truncated reference)" begin
+    using Random
+    # Calibration ledger:
+    # - Bounded cross-route agreement (bounded igref reduction vs fixed-N
+    #   stitching over N = 0..4, dilute LJ gas, K = 24, z0V = 6, n_max = 4,
+    #   per-T mu grids solved from target zV in {4, 6}; igref seeds
+    #   {1,2,3,62622} against fixed-N seeds {1001,1002,1003,63622}): max devs
+    #   logXi 0.245, mean_N 0.530, N_eff floor observed 28.3 (binding on the
+    #   T = 400 K reduction of the seed-3 calibration pair); gates ship at
+    #   >= 3x (0.75 and 1.6) with an N_eff floor assertion at 10.
+    # - Every other testset here is an exact identity (constructed ledgers or
+    #   the same-input constant-shift contract) and needs no calibration.
+    kb = 8.617333262e-5
+    Vq = 1000.0u"Å^3"
+    V = 1000.0
+    mass_ar = 39.948u"u"
+    lam(T) = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass_ar, T * u"K"))
+    mu_for(zV, T) = (kb * T * (log(zV / V) + 3 * log(lam(T)))) * u"eV"
+    logfact(n) = n == 0 ? 0.0 : sum(log, 1:n)
+    lpps = FreeBird.AnalysisTools._log_poisson_partial_sum
+
+    # A compression ledger that ENCODES the truncated (conditional) Poisson
+    # prior on 0:nmax exactly: shells carry the conditional masses of
+    # N = 0..nmax-1 at energy zero, the tail walker carries N = nmax
+    function trunc_poisson_ledger(z0V, nmax)
+        logq = [n * log(z0V) - logfact(n) for n in 0:nmax]
+        Q = sum(exp, logq)
+        pi_n = exp.(logq) ./ Q
+        X = reverse(cumsum(reverse(pi_n)))
+        lc = [log(X[j+1] / X[j]) for j in 1:nmax]
+        df = DataFrame(iter=collect(1:nmax), emax=zeros(nmax),
+                       num_particles=collect(0:nmax-1), log_compression=lc)
+        return df, [0.0], [nmax]
+    end
+
+    @testset "_log_poisson_partial_sum identities" begin
+        @test lpps(3.0, 0) == 0.0
+        @test abs(lpps(3.0, 60) - 3.0) < 1e-12
+        @test abs(lpps(1.0, 1) - log(2.0)) < 1e-14
+        @test lpps(3.0, 5) < lpps(3.0, 6) < lpps(3.0, 60)
+        @test_throws ArgumentError lpps(3.0, -1)
+    end
+
+    @testset "exact closure of the bounded assembly" begin
+        z0V = 3.0
+        nmax = 5
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = trunc_poisson_ledger(z0V, nmax)
+        T = 300.0
+        zVs = [1.0, 3.0, 7.0]
+        mus = [mu_for(zV, T) for zV in zVs]
+        stats = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, [T]u"K";
+                                                 live_emax=live_e, live_numbers=live_n,
+                                                 n_max=nmax)
+        for (i, zV) in enumerate(zVs)
+            # the truncated model's exact grand potential: logXi = log sum_{N<=nmax} (zV)^N/N!
+            @test abs(stats.logXi[i, 1] - lpps(zV, nmax)) < 1e-11 * max(lpps(zV, nmax), 1.0)
+            # exact conditional-Poisson occupancy at the target activity
+            logq = [n * log(zV) - logfact(n) for n in 0:nmax]
+            q = exp.(logq) ./ sum(exp, logq)
+            m1 = sum(q .* (0:nmax))
+            @test abs(stats.mean_N[i, 1] - m1) < 1e-11 * max(m1, 1.0)
+            for n in 0:nmax
+                @test abs(stats.p_N[i, 1, n + 1] - q[n + 1]) < 1e-11
+            end
+            @test abs(sum(stats.p_N[i, 1, :]) - 1.0) < 1e-12
+        end
+    end
+
+    @testset "constant-shift contract against the unbounded normalization" begin
+        z0V = 3.0
+        nmax = 5
+        z0 = (z0V / V)u"Å^-3"
+        df, live_e, live_n = trunc_poisson_ledger(z0V, nmax)
+        T = 300.0
+        mus = [mu_for(2.0, T), mu_for(5.0, T)]
+        b = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, [T]u"K";
+                                             live_emax=live_e, live_numbers=live_n,
+                                             n_max=nmax)
+        u = gc_thermodynamic_stats_ideal_ref(df, Vq, mass_ar, z0, mus, [T]u"K";
+                                             live_emax=live_e, live_numbers=live_n)
+        # logXi differs by exactly the reference-mass swap; everything that the
+        # reference mass cancels from is bitwise identical
+        @test all(abs.((b.logXi .- u.logXi) .- (lpps(z0V, nmax) - z0V)) .< 1e-12)
+        @test b.mean_N == u.mean_N
+        @test b.var_N == u.var_N
+        @test b.mean_U == u.mean_U
+        @test b.p_N == u.p_N
+        @test b.N_eff == u.N_eff
+        # the ESS reduction needs no n_max: same ledger, same N_eff, bitwise
+        ess = gc_effective_sample_size_ideal_ref(df, Vq, mass_ar, z0, mus, [T]u"K";
+                                                 live_emax=live_e, live_numbers=live_n)
+        @test ess == b.N_eff
+    end
+
+    @testset "bounded-run consistency validation" begin
+        z0 = (3.0 / V)u"Å^-3"
+        T = [300.0]u"K"
+        mus = [mu_for(3.0, 300.0)]
+        df, live_e, live_n = trunc_poisson_ledger(3.0, 5)
+        # a ledger row above the claimed cap is rejected
+        df_bad = copy(df)
+        df_bad.num_particles[end] = 9
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df_bad, Vq, mass_ar, z0, mus, T;
+            live_emax=live_e, live_numbers=live_n, n_max=5)
+        # a live-tail count above the claimed cap is rejected
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, Vq, mass_ar, z0, mus, T;
+            live_emax=live_e, live_numbers=[9], n_max=5)
+        # a negative cap is rejected
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, Vq, mass_ar, z0, mus, T;
+            live_emax=live_e, live_numbers=live_n, n_max=-1)
+        # the typemax sentinel of an unbounded run is rejected with a clear
+        # error instead of a runaway allocation
+        @test_throws ArgumentError gc_thermodynamic_stats_ideal_ref(
+            df, Vq, mass_ar, z0, mus, T;
+            live_emax=live_e, live_numbers=live_n, n_max=typemax(Int64))
+    end
+
+    @testset "bounded cross-route agreement (seed 62622)" begin
+        box = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+        pbc = (true, true, true)
+        seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        mkempty() = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                               empty(position(seed_at, :)), empty(species(seed_at, :)),
+                               empty(mass(seed_at, :)))
+        V12 = 1728.0
+        Vq12 = 1728.0u"Å^3"
+        lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+        z0 = (6.0 / V12)u"Å^-3"
+        n_cap = 4
+        mu12(zV, T) = (kb * T * (log(zV / V12) + 3 * log(lam(T)))) * u"eV"
+        Ts = [300.0, 400.0]
+        mugrids = [[mu12(4.0, T), mu12(6.0, T)] for T in Ts]
+        mksave(tag) = SaveEveryN(df_filename="_igbnd_$(tag).csv",
+                                 wk_filename="_igbnd_$(tag).traj.extxyz",
+                                 ls_filename="_igbnd_$(tag).ls.extxyz",
+                                 n_traj=10^7, n_snap=10^7, n_info=10^7)
+        clean(tag) = for f in ["_igbnd_$(tag).csv", "_igbnd_$(tag).traj.extxyz", "_igbnd_$(tag).ls.extxyz"]
+            rm(f, force=true)
+        end
+
+        Random.seed!(62622)
+        ls = GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:24], lj)
+        params = AtomisticIGRefGCNSParameters(mc_steps=60, reference_activity=z0,
+                                              species=:Ar, allowed_fail_count=100,
+                                              n_max=n_cap)
+        df, lso, _ = ideal_gas_referenced_nested_sampling(
+            ls, params, 300, MCAtomGrandCanonicalMoves(), mksave("ig"))
+        clean("ig")
+        live_e = [ustrip(u"eV", w.energy) for w in lso.walkers]
+        live_n = [w.list_num_par[1] for w in lso.walkers]
+        @test maximum(df.num_particles) <= n_cap
+        @test maximum(live_n) <= n_cap
+
+        Random.seed!(63622)
+        dfs = DataFrame[]
+        lives = Vector{Float64}[]
+        for N in 0:n_cap
+            if N == 0
+                push!(dfs, DataFrame(iter=Int[], emax=Float64[]))
+                push!(lives, zeros(8))
+                continue
+            end
+            walkers = AtomWalker{1}[]
+            for _ in 1:24
+                coords = [[rand() * 12.0, rand() * 12.0, rand() * 12.0] for _ in 1:N]
+                push!(walkers, AtomWalker{1}(FastSystem(atomic_system(
+                    [:Ar => SVector{3}(c)u"Å" for c in coords], box, pbc))))
+            end
+            lsN = GenericAtomWalkers(walkers, lj)
+            p = NestedSamplingParameters(mc_steps=60, initial_step_size=0.5, step_size=0.5,
+                                         step_size_lo=0.01, step_size_up=2.0,
+                                         allowed_fail_count=1000)
+            dfN, lsoN, _ = nested_sampling(lsN, p, 150, MCRandomWalkClone(), mksave("fx$N"))
+            clean("fx$N")
+            push!(dfs, dfN)
+            push!(lives, [ustrip(u"eV", w.energy) for w in lsoN.walkers])
+        end
+
+        for k in 1:2
+            ig = gc_thermodynamic_stats_ideal_ref(df, Vq12, mass_ar, z0, mugrids[k], [Ts[k]]u"K";
+                                                  live_emax=live_e, live_numbers=live_n,
+                                                  n_max=n_cap)
+            fx = gc_thermodynamic_stats_fixed_N(dfs, collect(0:n_cap), Vq12, mass_ar,
+                                                mugrids[k], [Ts[k]]u"K";
+                                                n_walkers=24, live_emax=lives)
+            @test maximum(abs.(ig.logXi .- fx.logXi)) < 0.75
+            @test maximum(abs.(ig.mean_N .- fx.mean_N)) < 1.6
+            @test minimum(ig.N_eff) > 10.0
+        end
+    end
+end


### PR DESCRIPTION
Implements #262. Stacked on #261's branch (`test/igref-driver-pins`); merge that PR first.

- `AtomisticIGRefGCNSParameters` gains `n_max::Int64` (appended last, default `typemax(Int64)`, constructor validates `n_max >= 1`): a finite cap selects the truncated reference measure, the conditional Poisson on `0:n_max`, exact when all three legs move together.
- Initialization draws the truncated law by rejection, stream-identical to the unbounded draw whenever no draw exceeds the cap; a workable-mass guard in the liveset validator rejects `P(Poisson(z0V) <= n_max) < 1e-8` so the rejection loop cannot degenerate.
- Both kernel call sites forward `params.n_max` to the kernel's pre-existing bounded-construction guard; the explicit `typemax` default equals the kernel default, a draw-for-draw no-op on the default path, gated by the #261 pins (replayed digit-identically at this PR's tip).
- `gc_thermodynamic_stats_ideal_ref` gains `n_max::Union{Nothing,Int}=nothing`: when set, the `e^{z0V}` reference mass becomes the truncated partial sum via the new log-space `_log_poisson_partial_sum`, ledger or live-tail counts above the cap are rejected as inconsistent with the claimed bounded run, and the `typemax` sentinel of an unbounded run is rejected with a clear error instead of a runaway allocation. Ratio observables, `p_N`, and `N_eff` are invariant by construction (the reference mass cancels), so the effective-sample-size reductions need no change; a capped run reduced with the unbounded normalization overstates logXi by exactly `-log P(Poisson(z0V) <= n_max)`, now stated in the parameter docstring as the pairing obligation.
- The particle-number-cap schema pin is rescoped inside the Add commit, with disclosure, to what is now true: the field exists and its default keeps the historical unbounded measure.
- Tests (70 new assertions): constructor and guard validation; the truncated initializer law against the exact conditional-Poisson moments (calibrated over four seeds at 3x the maximum deviation, both extremes at the shipped seed); bounded-vs-unbounded stream identity when the cap is unhit (digit-identical ledgers and live sets); a binding-cap end-to-end run; `_log_poisson_partial_sum` identities; exact closure of the bounded assembly on a constructed conditional-Poisson ledger at 1e-11 welds; the constant-shift contract (logXi moves by the reference-mass swap at 1e-12 while every ratio observable and `N_eff` is bitwise identical, and `gc_effective_sample_size_ideal_ref` output is unchanged); sentinel and above-cap rejection; and bounded cross-route agreement against fixed-N stitching over `N = 0..4` (calibrated over four seed pairs; the `N_eff` minimum binds on the T = 400 K reduction of the seed-3 calibration pair).

Adversarially reviewed pre-filing under three charters (issue-promise round-trip, independent oracle re-deriving the truncated-reference mathematics and confirming conditional-Poisson stationarity to zero residual, determinism and assertion accounting). Full suite green on the shipped bytes.
