### PR TITLE
Cross-construction regression coverage for the chemical-potential-ordered atomistic route

### DIFF
--- a/src/AnalysisTools/AnalysisTools.jl
+++ b/src/AnalysisTools/AnalysisTools.jl
@@ -18,6 +18,7 @@ export transition_convergence
 export gc_thermodynamic_stats_ideal_ref
 export kish_effective_sample_size
 export gc_effective_sample_size_ideal_ref
+export reference_activity_temperature
 
 """
     read_output(filename::String)
@@ -1259,6 +1260,33 @@ Internal helper for `gc_thermodynamic_stats_fixed_N`.
 """
 function _thermal_wavelength(atomic_mass::typeof(1.0u"u"), T::Unitful.Temperature)
     return uconvert(u"Å", Unitful.h / sqrt(2π * atomic_mass * Unitful.k * T))
+end
+
+"""
+    reference_activity_temperature(reference_activity::typeof(1.0u"Å^-3"),
+                                   atomic_mass::typeof(1.0u"u")) -> typeof(1.0u"K")
+
+The temperature at which the reference activity equals the inverse cubed thermal de
+Broglie wavelength, `z0 Λ(T)^3 = 1`, that is `k_B T = h^2 z0^(2/3) / (2π m)`. It is the
+zero of the ideal-gas-referenced window centre `μ_ref(T) = k_B T ln(z0 Λ(T)^3)` and, for
+a run ordered by Ω = E − μN at its own μ (the `chemical_potential` field of
+`AtomisticIGRefGCNSParameters`), the temperature at which the reweighting factor of
+`gc_thermodynamic_stats_ideal_ref` depends on a shell through Ω alone, the residual
+`(z0 Λ(T)^3)^{-N}` being identically one, so that pooling the particle-number sectors
+is exact there. For any target temperature T the factor is a function of Ω alone along
+the line `μ' = μ + k_B T ln(z0 Λ(T)^3)`; at fixed μ' = μ the residual is
+`(z0 Λ(T)^3)^{-N}` per shell, of order `(1e5)^N` for argon-mass particles at z0V of order
+unity and room temperature, where this temperature itself is sub-kelvin. Report it
+alongside every such run. Evaluated through `_thermal_wavelength`, so it shares the
+reductions' constants digit for digit.
+"""
+function reference_activity_temperature(reference_activity::typeof(1.0u"Å^-3"),
+                                        atomic_mass::typeof(1.0u"u"))
+    reference_activity > 0.0u"Å^-3" || throw(ArgumentError("reference_activity must be positive"))
+    T0 = 1.0u"K"
+    r = ustrip(Unitful.NoUnits, reference_activity * _thermal_wavelength(atomic_mass, T0)^3)
+    # Λ(T)^3 scales as T^(-3/2): z0 Λ(T)^3 = r (T0/T)^(3/2) equals one at T = T0 r^(2/3)
+    return T0 * r^(2 / 3)
 end
 
 """

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -1331,10 +1331,12 @@ gc_delete_acceptance_ratio(z0V::Float64, n::Int, p_insert::Float64, p_delete::Fl
 """
     MC_grand_canonical_walk!(n_steps::Int, at::AtomWalker{1}, pot::SingleComponentPotential{Pairwise}, emax::typeof(0.0u"eV");
                              z0V::Float64, species, p_move::Float64=0.5, p_insert::Float64=0.25,
-                             step_size::Float64=0.5, n_max::Int=typemax(Int))
+                             step_size::Float64=0.5, n_max::Int=typemax(Int),
+                             mu::typeof(0.0u"eV")=0.0u"eV")
 
 Perform a grand-canonical Monte Carlo walk on a continuous-space `AtomWalker{1}` below a
-nested-sampling energy ceiling: single-atom displacements mixed with uniform-in-cell
+nested-sampling ceiling on the ordering scalar `E - mu*N` (the energy ceiling at the
+default `mu = 0`): single-atom displacements mixed with uniform-in-cell
 insertions and uniform-among-particles deletions, under the Metropolis corrections that
 preserve the activity-z0-weighted reference measure. The continuous counterpart
 of the lattice `MC_grand_canonical_walk!` above; the site-counting acceptance ratios of the
@@ -1349,8 +1351,8 @@ draws one particle index and the three walk displacements; an insertion draws th
 uniforms (x, y, z) plus the Metropolis uniform only when its ratio is below one; a deletion
 draws one particle index plus the conditional Metropolis uniform. Guard skips (a
 displacement or deletion proposed at N = 0, an insertion proposed above `n_max`) consume
-only the channel draw and are not counted as attempts. The energy ceiling is checked before
-the Metropolis ratio, so ceiling rejections draw no Metropolis uniform. Energies are updated
+only the channel draw and are not counted as attempts. The ceiling is checked before the
+Metropolis ratio, so ceiling rejections draw no Metropolis uniform. Energies are updated
 incrementally through `single_site_energy` on the same audited path the displacement walks
 use, with insertions evaluated by insert-then-revert.
 
@@ -1358,7 +1360,8 @@ use, with insertions evaluated by insert-then-revert.
 - `n_steps::Int`: The number of Monte Carlo steps to perform.
 - `at::AtomWalker{1}`: The walker to evolve; a single unfrozen component.
 - `pot::SingleComponentPotential{Pairwise}`: The pairwise potential.
-- `emax::typeof(0.0u"eV")`: The nested-sampling energy ceiling (strict-below acceptance).
+- `emax::typeof(0.0u"eV")`: The nested-sampling ceiling on the ordering scalar `E - mu*N`
+  (strict-below acceptance); the energy ceiling at the default `mu = 0`.
 - `z0V::Float64`: Dimensionless product of the reference activity and the cell volume.
 - `species`: Chemical identity (a `Symbol` or `ChemicalSpecies`) of inserted particles;
   passed explicitly because the configuration may be empty.
@@ -1368,6 +1371,10 @@ use, with insertions evaluated by insert-then-revert.
 - `n_max::Int=typemax(Int)`: Upper bound on the particle count, for bounded constructions
   only. A finite cap truncates the unbounded particle-number support of the reference
   measure and biases the evidence; production callers must leave it inactive.
+- `mu::typeof(0.0u"eV")=0.0u"eV"`: Chemical potential of the ordering scalar. It enters
+  only the ceiling indicator, evaluated on the proposal's own particle count (`n`,
+  `n + 1`, `n - 1` per channel), never the acceptance ratios; at the default the added
+  term is an exact zero and the random-number stream is unchanged.
 
 # Returns
 - `accept_this_walker::Bool`: Whether at least one move was accepted.
@@ -1389,7 +1396,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   n_max::Int=typemax(Int),
                                   p_bias::Float64=0.0,
                                   bias_radius::Float64=0.0,
-                                  bias_grid::Int=0)
+                                  bias_grid::Int=0,
+                                  mu::typeof(0.0u"eV")=0.0u"eV")
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
     end
@@ -1444,7 +1452,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
             config.position[i_at] = pos
             postwalk_energy = single_site_energy(i_at, config, pot, at.list_num_par)
             proposed_energy = at.energy + (postwalk_energy - prewalk_energy)
-            if proposed_energy >= emax
+            if proposed_energy - mu * n >= emax
                 config.position[i_at] = orig_pos
             else
                 at.energy = proposed_energy
@@ -1481,7 +1489,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
             e_site = single_site_energy(n + 1, config, pot, at.list_num_par)
             proposed_energy = at.energy + e_site
             accept = true
-            if proposed_energy >= emax
+            if proposed_energy - mu * (n + 1) >= emax
                 accept = false
             else
                 if p_bias > 0.0
@@ -1510,7 +1518,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
             e_site = single_site_energy(i_at, config, pot, at.list_num_par)
             proposed_energy = at.energy - e_site
             accept = true
-            if proposed_energy >= emax
+            if proposed_energy - mu * (n - 1) >= emax
                 accept = false
             else
                 if p_bias > 0.0
@@ -1558,7 +1566,7 @@ end
                              surface::AtomWalker{CS};
                              z0V::Float64, species, p_move::Float64=0.5,
                              p_insert::Float64=0.25, step_size::Float64=0.5,
-                             n_max::Int=typemax(Int))
+                             n_max::Int=typemax(Int), mu::typeof(0.0u"eV")=0.0u"eV")
 
 Surface-aware method of the continuous grand-canonical kernel: identical moves,
 acceptance ratios, and random-number stream contract as the plain method above, with
@@ -1570,7 +1578,9 @@ automatically. Insertions propose uniformly in the FULL cell, keeping the librar
 reference-measure convention: the substrate region is excluded by the energy ceiling,
 never by the proposal support, so `z0V` folds the full cell volume. The walker's
 `energy` carries `energy_frozen_part` as a constant offset, exactly as in the
-surface method of `MC_random_walk!`; incremental updates are unaffected by it.
+surface method of `MC_random_walk!`; incremental updates are unaffected by it. The
+`mu` keyword has the plain method's meaning: `emax` is the ceiling on `E - mu*N`,
+evaluated on the proposal's own particle count, the energy ceiling at the default.
 
 The cavity-biased insertion channel and the Galilean burst are not surface-aware, so
 this method takes no `p_bias`/`bias_radius`/`bias_grid` kwargs — passing one is a loud
@@ -1594,7 +1604,8 @@ function MC_grand_canonical_walk!(n_steps::Int,
                                   p_move::Float64=0.5,
                                   p_insert::Float64=0.25,
                                   step_size::Float64=0.5,
-                                  n_max::Int=typemax(Int)
+                                  n_max::Int=typemax(Int),
+                                  mu::typeof(0.0u"eV")=0.0u"eV"
                                   ) where {C, CS, P<:SingleComponentPotential{Pairwise}}
     if p_move < 0.0 || p_insert < 0.0 || p_move + p_insert > 1.0
         throw(ArgumentError("p_move and p_insert must satisfy 0 <= p_move + p_insert <= 1"))
@@ -1645,7 +1656,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
             config.position[i_at] = pos
             postwalk_energy = single_site_energy(i_at, config, cps, at.list_num_par, surface.configuration)
             proposed_energy = at.energy + (postwalk_energy - prewalk_energy)
-            if proposed_energy >= emax
+            if proposed_energy - mu * n >= emax
                 config.position[i_at] = orig_pos
             else
                 at.energy = proposed_energy
@@ -1662,7 +1673,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
             e_site = single_site_energy(n + 1, config, cps, at.list_num_par, surface.configuration)
             proposed_energy = at.energy + e_site
             accept = true
-            if proposed_energy >= emax
+            if proposed_energy - mu * (n + 1) >= emax
                 accept = false
             else
                 ratio = gc_insert_acceptance_ratio(z0V, n, p_insert, p_delete)
@@ -1686,7 +1697,7 @@ function MC_grand_canonical_walk!(n_steps::Int,
             e_site = single_site_energy(i_at, config, cps, at.list_num_par, surface.configuration)
             proposed_energy = at.energy - e_site
             accept = true
-            if proposed_energy >= emax
+            if proposed_energy - mu * (n - 1) >= emax
                 accept = false
             else
                 ratio = gc_delete_acceptance_ratio(z0V, n, p_insert, p_delete)

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -2448,11 +2448,52 @@ function _gc_walk_length(params::SamplingParameters, mc_routine::MCAtomGrandCano
 end
 
 """
+    _grand_potential(walker::AtomWalker{1}, mu::typeof(0.0u"eV")) -> typeof(0.0u"eV")
+
+Compute the ordering scalar Ω = E − μN of an atomistic walker, the continuous
+counterpart of the lattice method (`N = walker.list_num_par[1]`). At
+`mu = 0.0u"eV"` the product `mu * N` is an exact `+0.0 eV` and the subtraction
+returns `walker.energy` bit-for-bit, for every finite energy including `-0.0`.
+"""
+function _grand_potential(walker::AtomWalker{1}, mu::typeof(0.0u"eV"))
+    return walker.energy - mu * walker.list_num_par[1]
+end
+
+"""
+    _sort_by_grand_potential!(liveset::AtomWalkers, mu::typeof(0.0u"eV"))
+
+Sort the walkers by Ω = E − μN in descending order through the same `sort!` call,
+algorithm, and stability as `sort_by_energy!`, so at `mu = 0.0u"eV"` the comparator
+values, the resulting order, and the tie order are identical.
+"""
+function _sort_by_grand_potential!(liveset::AtomWalkers, mu::typeof(0.0u"eV"))
+    sort!(liveset.walkers, by = w -> _grand_potential(w, mu), rev=true)
+    return liveset
+end
+
+"""
+    _tie_block_length(walkers, mu::typeof(0.0u"eV"))
+
+Length of the leading block of walkers whose Ω = E − μN equals the first walker's
+bit-exactly (the sorted-by-Ω analogue of the one-argument method).
+"""
+function _tie_block_length(walkers, mu::typeof(0.0u"eV"))
+    k1 = _grand_potential(walkers[1], mu)
+    n = 1
+    while n < length(walkers) && _grand_potential(walkers[n+1], mu) == k1
+        n += 1
+    end
+    return n
+end
+
+"""
     mutable struct AtomisticIGRefGCNSParameters <: SamplingParameters
 
-Parameters for atomistic energy-sorted ideal-gas-referenced grand-canonical nested
-sampling. The sampler is athermal: the chemical potential and the temperature never
-enter a run; both enter only in the post-run reduction to Ξ(μ, T).
+Parameters for atomistic ideal-gas-referenced grand-canonical nested sampling. The
+sampler is athermal: the temperature never enters a run, and the chemical potential
+enters only through the ordering scalar when `chemical_potential` is nonzero (the
+default keeps the energy-sorted construction); both enter the post-run reduction to
+Ξ(μ, T), which reweights the recorded (E, N) record to any target.
 
 # Fields
 - `mc_steps::Int64`: MCMC steps per replacement walker.
@@ -2473,7 +2514,9 @@ enter a run; both enter only in the post-run reduction to Ξ(μ, T).
   matching the canonical atomistic loop) suits interacting descents, where a run of
   failed replacements is an ordinary sampling hiccup rather than a terminal state.
 - `plateau_refill_target::Int64`: Live-set size to restore after a plateau eviction
-  block (mutable runtime state; reset at driver entry).
+  block (mutable runtime state; reset at driver entry when `initialize=true` and
+  carried across `initialize=false` continuations, which own it: a chunked driver
+  restores it from its own checkpoint).
 - `refill_fail_budget::Int64`: Failure budget for one plateau-refill loop. The default
   0 keeps the historical behavior of charging refill failures against
   `allowed_fail_count` cumulatively; a positive value gives each refill loop its own
@@ -2494,6 +2537,32 @@ enter a run; both enter only in the post-run reduction to Ξ(μ, T).
   same `n_max` to `gc_thermodynamic_stats_ideal_ref`; mixing a capped run with the
   unbounded `e^{z0V}` normalization overstates logXi by exactly
   `-log P(Poisson(z0V) <= n_max)` (the surplus reference mass above the cap).
+- `chemical_potential::typeof(0.0u"eV")`: Chemical potential of the ORDERING scalar.
+  The step sorts, detects plateaus, selects parents, and accepts on
+  Ω = E − μN (the grand potential of the lattice grand-canonical construction,
+  `GrandCanonicalNestedSamplingParameters`), never through the acceptance ratios or
+  the reference measure: insertions and deletions keep the z0-weighted Metropolis
+  factors, and the ceiling indicator is evaluated on the proposal's own Ω, so a
+  particle-number move faces the per-sector energy ceiling Ω* + μ N_after. The
+  default `0.0u"eV"` keeps the energy-sorted construction bit-for-bit: every added
+  term is an exact zero addend, no random draw is added or reordered, and the ledger
+  schema is unchanged. A nonzero μ orders the descent toward the grand ground state of
+  that μ and adds an `:omega` column recording the culled walker's Ω; `:emax` still
+  records its energy, so `gc_thermodynamic_stats_ideal_ref` consumes the ledger
+  unchanged (its reweighting factor is a function of the recorded (E, N) alone and it
+  never assumes `:emax` is monotone) and any target (μ', T') remains reachable by the
+  same post-run reweighting. The reweighting exponent is `-β(E - μ'N) - N ln(z0 Λ(T)^3)`,
+  so for a target temperature T the factor depends on a shell through Ω alone along the
+  line `μ' = μ + k_B T ln(z0 Λ(T)^3)`, and at the run's own μ exactly where
+  `z0 Λ(T)^3 = 1` (`reference_activity_temperature` in `AnalysisTools`), the situation
+  in which pooling the particle-number sectors is exact; at the run's own μ elsewhere
+  the residual `(z0 Λ(T)^3)^{-N}` is carried per recorded shell at a weight-concentration
+  cost measured by the returned `N_eff` (of order `(1e5)^N` per shell for argon-mass
+  particles at z0V of order unity and room temperature, where that temperature is
+  sub-kelvin). A continued block (`initialize=false`) must use the same μ as its
+  predecessor. Under a nonzero μ the descent may end at an atom of the ordering
+  scalar's law rather than at the ground-state sector; see the stall contract of
+  `ideal_gas_referenced_nested_sampling`.
 
 Two fields carried by sibling parameter structs are deliberately absent. No
 `energy_perturbation`: exact energy ties are handled by the plateau-aware eviction
@@ -2517,6 +2586,7 @@ mutable struct AtomisticIGRefGCNSParameters <: SamplingParameters
     refill_fail_budget::Int64
     move_stats::Dict{Symbol,Int}
     n_max::Int64
+    chemical_potential::typeof(0.0u"eV")
 end
 
 """
@@ -2525,14 +2595,16 @@ end
         initial_step_size=0.5, step_size=0.5, step_size_lo=0.01, step_size_up=2.0,
         accept_range=(0.25, 0.75), fail_count=0, allowed_fail_count=100,
         plateau_refill_target=0, refill_fail_budget=0, move_stats=Dict{Symbol,Int}(),
-        n_max=typemax(Int64))
+        n_max=typemax(Int64), chemical_potential=0.0u"eV")
 
 Convenience constructor for `AtomisticIGRefGCNSParameters`. `reference_activity` (z0)
 must be positive; choose it so z0V sits near the particle-number range of interest, as
 post-run reweighting to a target (μ, T) carries a factor `(z/z0)^N` per sample whose
 effective sample size degrades away from the reference. A finite `n_max` selects the
 bounded construction (see the field docstring); it must be at least 1, and the same
-`n_max` must be passed to `gc_thermodynamic_stats_ideal_ref`.
+`n_max` must be passed to `gc_thermodynamic_stats_ideal_ref`. `chemical_potential`
+selects the ordering scalar Ω = E − μN (Unitful, eV; see the field docstring); the
+default keeps the energy ordering bit-for-bit.
 """
 function AtomisticIGRefGCNSParameters(;
     mc_steps::Int64=100,
@@ -2549,6 +2621,7 @@ function AtomisticIGRefGCNSParameters(;
     refill_fail_budget::Int64=0,
     move_stats::Dict{Symbol,Int}=Dict{Symbol,Int}(),
     n_max::Int64=typemax(Int64),
+    chemical_potential::typeof(0.0u"eV")=0.0u"eV",
 )
     if reference_activity <= 0.0u"Å^-3"
         throw(ArgumentError("reference_activity must be positive"))
@@ -2559,11 +2632,16 @@ function AtomisticIGRefGCNSParameters(;
     if n_max < 1
         throw(ArgumentError("n_max must be at least 1 (typemax(Int64) selects the unbounded construction)"))
     end
+    isfinite(ustrip(chemical_potential)) ||
+        throw(ArgumentError("chemical_potential must be finite (a NaN makes every ceiling comparison false)"))
+    # a negative zero would map -0.0 energies to +0.0 inside the Ω arithmetic:
+    # normalize it to the default's exact +0.0 so the default path is unique
+    chemical_potential = iszero(chemical_potential) ? zero(chemical_potential) : chemical_potential
     AtomisticIGRefGCNSParameters(
         mc_steps, reference_activity, species,
         initial_step_size, step_size, step_size_lo, step_size_up, accept_range,
         fail_count, allowed_fail_count, plateau_refill_target, refill_fail_budget, move_stats,
-        n_max,
+        n_max, chemical_potential,
     )
 end
 
@@ -2795,8 +2873,9 @@ end
                           mc_routine::MCAtomGrandCanonicalMoves;
                           ns_iteration::Int=0, z0V::Union{Nothing,Float64}=nothing)
 
-Perform one step of atomistic energy-sorted ideal-gas-referenced grand-canonical nested
-sampling: sort by energy (descending), handle exact ceiling ties with the plateau-aware
+Perform one step of atomistic ideal-gas-referenced grand-canonical nested sampling: sort
+by the ordering scalar Ω = E − μN (descending; the energy at the default
+`chemical_potential = 0.0u"eV"`), handle exact ceiling ties with the plateau-aware
 eviction machinery of the canonical atomistic steps (refill walks run the grand-canonical
 kernel, so refilled clones may re-enter at a different particle count; the compression
 bookkeeping counts walkers, not particle-number sectors), otherwise cull the worst walker
@@ -2809,7 +2888,9 @@ sub-levels and admit clones whose true energy sits on, not below, the ceiling.
 
 # Returns
 - `iter`: Iteration number (or `missing` if the step failed).
-- `emax`: The energy of the culled walker (with units; `missing` on failure).
+- `emax`: The energy of the culled walker (with units; `missing` on failure). Under a
+  nonzero μ the ceiling the step enforced is the walker's Ω = emax − μ num_particles,
+  not this energy.
 - `num_particles`: The particle count of the culled walker (`missing` on failure).
 - `liveset`: The updated liveset.
 - `params`: The updated parameters.
@@ -2821,15 +2902,19 @@ function nested_sampling_step!(liveset::AtomWalkers,
                                ns_iteration::Int=0,
                                z0V::Union{Nothing,Float64}=nothing)
     z0V === nothing && (z0V = _atomistic_igref_z0V(liveset, params))
-    sort_by_energy!(liveset)
+    mu = params.chemical_potential
+    _sort_by_grand_potential!(liveset, mu)
     ats = liveset.walkers
     pot = liveset.potential
     iter::Union{Missing,Int} = missing
+    # The record is (E, N) of the culled walker; the ceiling the step enforces is
+    # its Ω = E − μN (the energy at the default mu = 0)
     emax::Union{Missing,typeof(0.0u"eV")} = ats[1].energy
     num_particles::Union{Missing,Int} = ats[1].list_num_par[1]
+    omega_max::typeof(0.0u"eV") = _grand_potential(ats[1], mu)
     log_t::Union{Missing,Float64} = missing
     n_live = length(ats)
-    n_tied = _tie_block_length(ats)
+    n_tied = _tie_block_length(ats, mu)
     if (n_tied >= 2 || params.plateau_refill_target != 0) && n_tied < n_live
         # Plateau block: evict the worst tied walker without replacement
         # (Fowlie-Handley-Su), charging (n_live - 1)/n_live with the shrinking
@@ -2850,17 +2935,22 @@ function nested_sampling_step!(liveset::AtomWalkers,
             while length(ats) < params.plateau_refill_target && refill_fails < refill_budget
                 at_r = deepcopy(rand(ats))
                 accept_r, _, at_r, _ = MC_grand_canonical_walk!(
-                    _gc_walk_length(params, mc_routine, at_r.list_num_par[1]), at_r, pot, emax;
+                    _gc_walk_length(params, mc_routine, at_r.list_num_par[1]), at_r, pot, omega_max;
                     z0V=z0V, species=params.species,
                     p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
                     step_size=params.step_size, n_max=params.n_max,
                     p_bias=mc_routine.p_bias, bias_radius=mc_routine.bias_radius,
-                    bias_grid=mc_routine.bias_grid)
+                    bias_grid=mc_routine.bias_grid, mu=mu)
                 if accept_r && mc_routine.galilean_steps > 0 && at_r.list_num_par[1] > 0
                     # Optional reflective decorrelation burst at the clone's
                     # current particle count; measure-preserving at fixed N, so
                     # the composition preserves the constrained reference
-                    MC_galilean_walk!(mc_routine.galilean_steps, at_r, pot, emax;
+                    # N is fixed inside a burst, so the Ω ceiling is the per-sector
+                    # energy ceiling Ω* + μN (an exact zero addend at mu = 0; the sum
+                    # can sit an ulp from the culled energy, and the re-anchor check
+                    # on Ω below remains the authoritative gate)
+                    MC_galilean_walk!(mc_routine.galilean_steps, at_r, pot,
+                                      omega_max + mu * at_r.list_num_par[1];
                                       step_size=mc_routine.galilean_step_size,
                                       n_refresh=mc_routine.galilean_n_refresh)
                 end
@@ -2870,7 +2960,7 @@ function nested_sampling_step!(liveset::AtomWalkers,
                     # bit-exact plateaus and admit sub-ceiling dust crossings
                     at_r.energy = interacting_energy(at_r.configuration, pot,
                         at_r.list_num_par, at_r.frozen) + at_r.energy_frozen_part
-                    accept_r = at_r.energy < emax
+                    accept_r = _grand_potential(at_r, mu) < omega_max
                 end
                 if accept_r
                     push!(ats, at_r)
@@ -2887,17 +2977,31 @@ function nested_sampling_step!(liveset::AtomWalkers,
         return iter, emax, num_particles, liveset, params, log_t
     end
     # Ordinary cull: strictly-below-ceiling parent selection, mirroring the
-    # lattice ideal-gas-referenced step
-    eligible = [k for k in 2:n_live if ats[k].energy < emax]
+    # lattice ideal-gas-referenced step. Two terminal shapes count a failed
+    # replacement without a walk, so the stall contract fires: a live set
+    # reduced to one walker by refill failures has no parent to clone (the
+    # shipped code drew a parent from an empty range); and, under a nonzero
+    # chemical potential, a live set tied in its entirety on one Ω (an atom of
+    # the ordering scalar's law, the empty configuration over a substrate),
+    # whose interior below carries at most a fraction of order 1/K of the
+    # atom's mass. Ordinary culls through such an atom would charge K/(K+1)
+    # per empty and misstate the mass below by up to a factor of order K; the
+    # mass is charged to the atom instead (the reduction's live tail). At the
+    # default mu = 0 the branch is off and the shipped walk is attempted.
+    if n_live < 2 || (n_tied == n_live && !iszero(mu))
+        params.fail_count += 1
+        return iter, missing, missing, liveset, params, log_t
+    end
+    eligible = [k for k in 2:n_live if _grand_potential(ats[k], mu) < omega_max]
     parent_idx = isempty(eligible) ? rand(2:n_live) : rand(eligible)
     to_walk = deepcopy(ats[parent_idx])
     accept, rate, to_walk, move_stats = MC_grand_canonical_walk!(
-        _gc_walk_length(params, mc_routine, to_walk.list_num_par[1]), to_walk, pot, emax;
+        _gc_walk_length(params, mc_routine, to_walk.list_num_par[1]), to_walk, pot, omega_max;
         z0V=z0V, species=params.species,
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
         step_size=params.step_size, n_max=params.n_max,
         p_bias=mc_routine.p_bias, bias_radius=mc_routine.bias_radius,
-        bias_grid=mc_routine.bias_grid)
+        bias_grid=mc_routine.bias_grid, mu=mu)
     if accept && mc_routine.galilean_steps > 0 && to_walk.list_num_par[1] > 0
         # Optional reflective decorrelation burst (see the refill branch).
         # Its counters accumulate immediately, unconditionally on the
@@ -2905,8 +3009,9 @@ function nested_sampling_step!(liveset::AtomWalkers,
         # and the delta ledger's fold-forward semantics keep the per-column
         # closure against the run totals exact. Refill-branch bursts stay
         # unaccumulated, per the plateau contract.
+        # per-sector energy ceiling Ω* + μN (see the refill branch)
         _, _, _, gal_stats = MC_galilean_walk!(mc_routine.galilean_steps,
-                          to_walk, pot, emax;
+                          to_walk, pot, omega_max + mu * to_walk.list_num_par[1];
                           step_size=mc_routine.galilean_step_size,
                           n_refresh=mc_routine.galilean_n_refresh)
         _accumulate_move_stats!(params, gal_stats)
@@ -2915,7 +3020,7 @@ function nested_sampling_step!(liveset::AtomWalkers,
         # Re-anchor the clone's energy from scratch (see the refill branch)
         to_walk.energy = interacting_energy(to_walk.configuration, pot,
             to_walk.list_num_par, to_walk.frozen) + to_walk.energy_frozen_part
-        accept = to_walk.energy < emax
+        accept = _grand_potential(to_walk, mu) < omega_max
     end
     if accept
         push!(ats, to_walk)
@@ -2966,16 +3071,20 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers,
     mc_routine.p_bias > 0 && throw(ArgumentError("the cavity-biased insertion channel is not surface-aware; use p_bias = 0 with LJSurfaceWalkers"))
     mc_routine.galilean_steps > 0 && throw(ArgumentError("the Galilean burst is not surface-aware; use galilean_steps = 0 with LJSurfaceWalkers"))
     z0V === nothing && (z0V = _atomistic_igref_z0V(liveset, params))
-    sort_by_energy!(liveset)
+    mu = params.chemical_potential
+    _sort_by_grand_potential!(liveset, mu)
     ats = liveset.walkers
     pot = liveset.potential
     surface = liveset.surface
     iter::Union{Missing,Int} = missing
+    # The record is (E, N) of the culled walker; the ceiling the step enforces is
+    # its Ω = E − μN (the energy at the default mu = 0)
     emax::Union{Missing,typeof(0.0u"eV")} = ats[1].energy
     num_particles::Union{Missing,Int} = ats[1].list_num_par[1]
+    omega_max::typeof(0.0u"eV") = _grand_potential(ats[1], mu)
     log_t::Union{Missing,Float64} = missing
     n_live = length(ats)
-    n_tied = _tie_block_length(ats)
+    n_tied = _tie_block_length(ats, mu)
     if (n_tied >= 2 || params.plateau_refill_target != 0) && n_tied < n_live
         # Plateau block: evict the worst tied walker without replacement
         # (Fowlie-Handley-Su), charging (n_live - 1)/n_live with the shrinking
@@ -2996,16 +3105,16 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers,
             while length(ats) < params.plateau_refill_target && refill_fails < refill_budget
                 at_r = deepcopy(rand(ats))
                 accept_r, _, at_r, _ = MC_grand_canonical_walk!(
-                    _gc_walk_length(params, mc_routine, at_r.list_num_par[1]), at_r, pot, emax, surface;
+                    _gc_walk_length(params, mc_routine, at_r.list_num_par[1]), at_r, pot, omega_max, surface;
                     z0V=z0V, species=params.species,
                     p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
-                    step_size=params.step_size, n_max=params.n_max)
+                    step_size=params.step_size, n_max=params.n_max, mu=mu)
                 if accept_r
                     # Re-anchor the clone's energy from scratch (see the
                     # AtomWalkers method), against the surface
                     at_r.energy = interacting_energy(at_r.configuration, pot,
                         at_r.list_num_par, at_r.frozen, surface.configuration) + at_r.energy_frozen_part
-                    accept_r = at_r.energy < emax
+                    accept_r = _grand_potential(at_r, mu) < omega_max
                 end
                 if accept_r
                     push!(ats, at_r)
@@ -3022,21 +3131,35 @@ function nested_sampling_step!(liveset::LJSurfaceWalkers,
         return iter, emax, num_particles, liveset, params, log_t
     end
     # Ordinary cull: strictly-below-ceiling parent selection, mirroring the
-    # lattice ideal-gas-referenced step
-    eligible = [k for k in 2:n_live if ats[k].energy < emax]
+    # lattice ideal-gas-referenced step. Two terminal shapes count a failed
+    # replacement without a walk, so the stall contract fires: a live set
+    # reduced to one walker by refill failures has no parent to clone (the
+    # shipped code drew a parent from an empty range); and, under a nonzero
+    # chemical potential, a live set tied in its entirety on one Ω (an atom of
+    # the ordering scalar's law, the empty configuration over a substrate),
+    # whose interior below carries at most a fraction of order 1/K of the
+    # atom's mass. Ordinary culls through such an atom would charge K/(K+1)
+    # per empty and misstate the mass below by up to a factor of order K; the
+    # mass is charged to the atom instead (the reduction's live tail). At the
+    # default mu = 0 the branch is off and the shipped walk is attempted.
+    if n_live < 2 || (n_tied == n_live && !iszero(mu))
+        params.fail_count += 1
+        return iter, missing, missing, liveset, params, log_t
+    end
+    eligible = [k for k in 2:n_live if _grand_potential(ats[k], mu) < omega_max]
     parent_idx = isempty(eligible) ? rand(2:n_live) : rand(eligible)
     to_walk = deepcopy(ats[parent_idx])
     accept, rate, to_walk, move_stats = MC_grand_canonical_walk!(
-        _gc_walk_length(params, mc_routine, to_walk.list_num_par[1]), to_walk, pot, emax, surface;
+        _gc_walk_length(params, mc_routine, to_walk.list_num_par[1]), to_walk, pot, omega_max, surface;
         z0V=z0V, species=params.species,
         p_move=mc_routine.p_move, p_insert=mc_routine.p_insert,
-        step_size=params.step_size, n_max=params.n_max)
+        step_size=params.step_size, n_max=params.n_max, mu=mu)
     if accept
         # Re-anchor the clone's energy from scratch (see the AtomWalkers
         # method), against the surface
         to_walk.energy = interacting_energy(to_walk.configuration, pot,
             to_walk.list_num_par, to_walk.frozen, surface.configuration) + to_walk.energy_frozen_part
-        accept = to_walk.energy < emax
+        accept = _grand_potential(to_walk, mu) < omega_max
     end
     if accept
         push!(ats, to_walk)
@@ -3106,21 +3229,48 @@ end
                                          record_move_rates::Bool=false,
                                          initialize::Bool=true)
 
-Run the atomistic energy-sorted ideal-gas-referenced grand-canonical nested sampling
-loop. Walkers are initialized as exact i.i.d. draws from the continuous ideal-gas prior
-at the reference activity (particle counts Poisson(z0V), positions uniform in the cell),
-then the loop iterates: remove the highest-energy walker, record (E, N, log-compression),
-replace with a strictly-below-ceiling clone decorrelated by the grand-canonical kernel
-under the z0-weighted prior. Exact ceiling ties are handled by the plateau-aware
-eviction machinery. Neither the chemical potential nor the temperature enters the run.
+Run the atomistic ideal-gas-referenced grand-canonical nested sampling loop. Walkers
+are initialized as exact i.i.d. draws from the continuous ideal-gas prior at the
+reference activity (particle counts Poisson(z0V), positions uniform in the cell), then
+the loop iterates: remove the walker of highest ordering scalar Ω = E − μN (the energy
+at the default `chemical_potential = 0.0u"eV"`), record (E, N, log-compression) and,
+under a nonzero μ, Ω, replace with a strictly-below-ceiling clone decorrelated by the
+grand-canonical kernel under the z0-weighted prior. Exact ceiling ties are handled by
+the plateau-aware eviction machinery. The temperature never enters the run; the
+chemical potential enters only the ordering scalar, never the acceptance ratios or the
+reference measure, so the recorded (E, N) ledger reduces with
+`gc_thermodynamic_stats_ideal_ref` to any target (μ', T') exactly as an energy-sorted
+ledger does (see the `chemical_potential` field docstring of
+`AtomisticIGRefGCNSParameters`).
 
 Stall contract: when `params.fail_count` reaches `params.allowed_fail_count`, the driver
 warns once and, with `stop_on_stall=true` (the default), returns the partial ledger and
 the intact live set instead of consuming the remaining iteration budget on proposals
 that cannot be accepted. A fully degenerate live set (every configuration at exactly one
 energy, the zero-interaction limit) is a legitimate terminal state whose entire prior
-mass sits in the live set; the subsequent ledger reduction is then exact. With
-`stop_on_stall=false` the driver keeps the warn-and-continue contract of the sibling
+mass sits in the live set; the subsequent ledger reduction is then exact. Under a
+nonzero `chemical_potential` the descent ends either in the ground-state sector of that
+μ or at an atom of the ordering scalar's law, most commonly the empty configuration
+over a frozen substrate (every empty walker carries the identical Ω, its
+`energy_frozen_part`): once every walker sits on that atom no proposal can go strictly
+below it, the stall fires, and the returned record is complete with the atom's
+reference mass in the live tail. That stall does not certify that the ground-state
+sector of that μ was reached: when the region below the atom carries far less prior
+mass than the atom itself, the live set reaches the atom before any walker lands in
+that region, and its mass is charged to the atom: under a nonzero μ a live set tied in
+its entirety on one Ω never attempts a replacement walk (the interior below such an
+atom carries at most a fraction of order 1/K of its mass, which ordinary culls charging
+K/(K+1) per walker would misstate by up to a factor of order K), so the stall fires
+after `allowed_fail_count` counted failures. A plateau whose survivors all sit on
+such an atom cannot be refilled (isolated particles of a truncated pair potential share
+one exact energy, so at a nonzero μ every N = 1 walker sits on one Ω, and the refill
+clones the survivors below it, which are the empties): such a clone stays strictly below
+the plateau only by accepting no move, which the refill counts as a failure, whatever
+bound clusters of negligible prior mass also lie below; the refill exhausts its budget,
+the live set shrinks to the survivors, and a live set reduced to a single walker counts
+every subsequent replacement as failed rather than drawing a parent from an empty range,
+so the stall contract fires there too.
+With `stop_on_stall=false` the driver keeps the warn-and-continue contract of the sibling
 loops (the failure counter is reset, the step size is reset to
 `params.initial_step_size` following the canonical loop's contract, and the loop
 continues).
@@ -3165,16 +3315,22 @@ from scratch on entry (surface livesets also re-inherit the surface's
 loop consistent with the run's potential. Under a finite `n_max` the restored counts
 must respect the cap; a violating walker is rejected with an `ArgumentError`. The
 continuation contract the caller owns: the same `reference_activity`, potential,
-`species`, and `n_max` as the first block (none of these can be validated against a
-bare live set, and a mismatch produces a chimera ledger whose blocks sample different
-constrained reference measures); and a run stopped mid-plateau-eviction resumes with
-its refill target re-derived from the current, possibly reduced, live count (the
+`species`, `n_max`, and `chemical_potential` as the first block (none of these can be
+validated against a bare live set, and a mismatch produces a chimera ledger whose
+blocks sample different constrained reference measures, or, for μ, the same measure
+under two different ceilings); and a run stopped mid-plateau-eviction resumes the
+eviction with the refill target the parameters carry (`plateau_refill_target` is kept
+on entry when `initialize=false`; a driver that rebuilds its parameters from a
+checkpoint must restore it there), so the walkers evicted before the boundary are
+refilled once the plateau is exhausted; a continuation entered with a zero target
+re-derives it from the current, reduced live count and never refills them (the
 compression bookkeeping stays exact either way, since every charge uses the actual
 live count).
 
 # Returns
-- `df::DataFrame`: Columns `[:iter, :emax, :num_particles, :log_compression]`, plus the
-  acceptance columns when requested, plus one column per requested observable.
+- `df::DataFrame`: Columns `[:iter, :emax, :num_particles, :log_compression]`, plus
+  `:omega` (the culled walker's Ω = E − μN) under a nonzero `chemical_potential`, plus
+  the acceptance columns when requested, plus one column per requested observable.
   Zero-accept runs return the schema with no rows.
 - `liveset::AtomWalkers`: The final liveset (surviving walkers).
 - `params::AtomisticIGRefGCNSParameters`: Updated parameters.
@@ -3201,12 +3357,22 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
         _reanchor_igref_energies!(liveset)
     end
 
-    # Parameter-reuse hazards: runtime state never leaks between runs
-    params.plateau_refill_target = 0
+    # Parameter-reuse hazards: runtime state never leaks between runs. The
+    # plateau refill target is the one runtime field a CONTINUATION owns: a
+    # chunked driver that re-enters mid-eviction (initialize=false) must carry
+    # it, or the target is re-derived from the reduced live count and the
+    # walkers evicted before the boundary are never refilled (a permanent
+    # shrink of the live set with exact but coarser compression)
+    initialize && (params.plateau_refill_target = 0)
     params.fail_count = 0
     empty!(params.move_stats)
 
+    mu = params.chemical_potential
+    # A nonzero chemical potential adds the :omega column (the culled walker's
+    # Ω = E − μN, the ordering scalar); the default schema is unchanged
+    omega_active = !iszero(mu)
     df = DataFrame(iter=Int[], emax=Float64[], num_particles=Int[], log_compression=Float64[])
+    omega_active && (df[!, :omega] = Float64[])
     rate_cols = _move_rate_columns(mc_routine)
     if record_move_rates
         for name in rate_cols
@@ -3237,9 +3403,10 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
         end
 
         if observables !== nothing || dead_point_callback !== nothing
-            # Pre-sort with the step's own comparator (energy, descending)
-            # and hold the walker the step will cull; see `nested_sampling`.
-            sort_by_energy!(liveset)
+            # Pre-sort with the step's own comparator (Ω = E − μN, descending;
+            # the energy at mu = 0) and hold the walker the step will cull;
+            # see `nested_sampling`.
+            _sort_by_grand_potential!(liveset, mu)
             culled = liveset.walkers[1]
         end
 
@@ -3261,10 +3428,11 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
 
         if !(iter isa typeof(missing))
             if culled !== nothing
-                emax == culled.energy || error(
+                (emax == culled.energy && n_par == culled.list_num_par[1]) || error(
                     "Atomistic IG-ref GC-NS observable recording: dead-point/observable " *
-                    "pairing lost (step culled a walker with energy $emax, " *
-                    "but the pre-sorted worst walker had $(culled.energy))")
+                    "pairing lost (step culled a walker with energy $emax and " *
+                    "N = $n_par, but the pre-sorted worst walker had $(culled.energy) " *
+                    "and N = $(culled.list_num_par[1]))")
             end
             if record_move_rates
                 snap = _move_stats_snapshot(params, rate_cols)
@@ -3275,10 +3443,13 @@ function ideal_gas_referenced_nested_sampling(liveset::AtomWalkers,
             else
                 rate_row = ()
             end
+            # The recorded Ω is formed by the step's own expression on the same
+            # values, so it equals the ceiling the step enforced bit-for-bit
+            omega_row = omega_active ? ((emax - mu * n_par).val,) : ()
             if observables === nothing
-                push!(df, (iter, emax.val, n_par, log_t, rate_row...))
+                push!(df, (iter, emax.val, n_par, log_t, omega_row..., rate_row...))
             else
-                push!(df, (iter, emax.val, n_par, log_t, rate_row...,
+                push!(df, (iter, emax.val, n_par, log_t, omega_row..., rate_row...,
                            (Float64(f(culled.configuration)) for (_, f) in observables)...))
             end
             dead_point_callback === nothing || dead_point_callback(iter, culled)

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -30,6 +30,8 @@ include("test-atomistic-gc-interacting-regressions.jl")
     include("test-atomistic-igref-surface.jl")
     # test the chemical-potential ordering of the atomistic ideal-gas-referenced route
     include("test-atomistic-igref-omega.jl")
+    # cross-construction regressions for the chemical-potential-ordered route
+    include("test-atomistic-igref-omega-regressions.jl")
     # test the ideal-gas-referenced effective-sample-size reductions
     include("test-igref-ess.jl")
     # regression coverage for the continuous-space grand-canonical route

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -28,6 +28,8 @@ include("test-atomistic-gc-interacting-regressions.jl")
     include("test-atomistic-igref-stats.jl")
     # test the surface-aware ideal-gas-referenced route
     include("test-atomistic-igref-surface.jl")
+    # test the chemical-potential ordering of the atomistic ideal-gas-referenced route
+    include("test-atomistic-igref-omega.jl")
     # test the ideal-gas-referenced effective-sample-size reductions
     include("test-igref-ess.jl")
     # regression coverage for the continuous-space grand-canonical route

--- a/test/test-SamplingSchemes/test-SamplingSchemes.jl
+++ b/test/test-SamplingSchemes/test-SamplingSchemes.jl
@@ -22,6 +22,8 @@ include("test-atomistic-gc-interacting-regressions.jl")
     include("test-atomistic-igref-gcns.jl")
     # absolute seeded pins for the atomistic ideal-gas-referenced driver
     include("test-atomistic-igref-driver-pins.jl")
+    # absolute seeded pins for the surface, Galilean, and driver paths of the same route
+    include("test-atomistic-igref-path-pins.jl")
     # test the atomistic ideal-gas-referenced ledger assembly
     include("test-atomistic-igref-stats.jl")
     # test the surface-aware ideal-gas-referenced route

--- a/test/test-SamplingSchemes/test-atomistic-igref-omega-regressions.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-omega-regressions.jl
@@ -1,0 +1,239 @@
+# Cross-construction regression coverage for the chemical-potential-ordered
+# atomistic ideal-gas-referenced route: an Omega-ordered run at its own mu,
+# reduced over a temperature interval, against the energy-ordered run and the
+# fixed-N stitch of canonical ladders (the independent oracle), plus the
+# exactness identity at the residual-free temperature and the bitwise
+# agreement of the effective-sample-size reduction on an Omega ledger.
+#
+# Calibration ledger (gates ship at >= 3x the maximum deviation over the seed
+# pairs, per statistic; N_eff floors sit below the smallest observed value):
+# - Surface three-way weld (the bounded surface fixture of the surface-route
+#   testsets: z0V = 4, n_max = 4, K = 16; the Omega-ordered run at mu_run, the
+#   chemical potential at which the ideal occupancy is 2 at 300 K, for 300
+#   steps; the energy-ordered run for 200 steps; fixed-N ladders over N = 0..4
+#   at K = 16 for 120 steps; targets (mu_run, T) for T in {250, 300, 400} K;
+#   Omega-ordered igref seeds {1,2,3,86621}, energy-ordered igref seeds
+#   {101,102,103,86721}, fixed-N seeds {1001,1002,1003,87621}). Every
+#   Omega-ordered run ends on the empty-configuration atom (its live set all
+#   empty), which at mu_run is the ground-state sector. Omega-ordered run
+#   against the stitch: max devs logXi 0.672 (the shipped pair, 400 K) and
+#   mean_N 0.417 (the seed-2 pair, 300 K; the shipped pair's largest is 0.329
+#   at 300 K), N_eff floor observed 2.9 at 400 K; gates 2.1 and 1.3, floor 2.5.
+#   Energy-ordered run against the stitch at 300 and 400 K: max devs logXi
+#   0.480, mean_N 0.525 (400 K of the shipped pair, 300 K of the seed-2 pair),
+#   N_eff floor observed 10.0; gates 1.5 and 1.6, floor 9. The energy-ordered
+#   run's 250 K target lies outside its trust window (N_eff 1.2 to 4.3,
+#   deviations up to 2.8 nats) and is deliberately not gated: at a fixed mu the
+#   ideal occupancy falls to about 0.13 there, far from that run's reference
+#   activity, whereas the Omega-ordered run, ordered at that mu, keeps N_eff
+#   18 to 23 at 250 K. The residual-free temperature of this fixture's
+#   reference activity is 0.1467 K (argon mass), where the exactness identity
+#   below is evaluated.
+# - Plain three-way weld (the 12 A periodic box of the ledger-assembly
+#   testsets: z0V = 6, K = 24, 300 igref steps, fixed-N ladders over N = 0..12
+#   at K = 24 for 150 steps; mu_run the chemical potential of ideal occupancy 4
+#   at 300 K; Omega-ordered igref seeds {1,2,3,86631}, energy-ordered igref
+#   seeds {101,102,103,86731}, fixed-N seeds {1001,1002,1003,87631}). At 300 K:
+#   Omega-ordered run max devs logXi 0.211 (seed 3), mean_N 0.480 (seed 1),
+#   N_eff floor observed 75.4; gates 0.65 and 1.5, floor 60. Energy-ordered run
+#   max devs logXi 0.385 (the shipped seed), mean_N 0.792 (seed 1); gates 1.2
+#   and 2.4. A 400 K target at this mu (ideal occupancy about 110, far above
+#   the ladder's top at N = 12) lies outside the coverage of every construction
+#   (deviations of 1 to 20 nats, N_eff 1 to 2) and is not part of the fixture.
+# - The exactness identity and the effective-sample-size weld are floating-point
+#   contracts and need no calibration.
+@testset "cross-construction regressions for the chemical-potential-ordered route" begin
+    using Random
+
+    kb = 8.617333262e-5
+    mass_ar = 39.948u"u"
+    lam(T) = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(mass_ar, T * u"K"))
+    orsave(tag) = SaveEveryN(df_filename="_igoreg_$(tag).csv",
+                             wk_filename="_igoreg_$(tag).traj.extxyz",
+                             ls_filename="_igoreg_$(tag).ls.extxyz",
+                             n_traj=10^7, n_snap=10^7, n_info=10^7)
+    orclean(tag) = for f in ["_igoreg_$(tag).csv", "_igoreg_$(tag).traj.extxyz",
+                             "_igoreg_$(tag).ls.extxyz"]
+        rm(f, force=true)
+    end
+
+    # the surface fixture of the surface-route testsets
+    sbox = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 15.0]]u"Å"
+    spbc = (true, true, false)
+    sV = 1500.0
+    sVq = 1500.0u"Å^3"
+    surf_sys = FastSystem(atomic_system(
+        [:H => [2.5, 2.5, 2.0]u"Å", :H => [7.5, 2.5, 2.0]u"Å",
+         :H => [2.5, 7.5, 2.0]u"Å", :H => [7.5, 7.5, 2.0]u"Å"], sbox, spbc))
+    mksurf() = AtomWalker(deepcopy(surf_sys); freeze_species=[:H])
+    smkempty() = FastSystem(cell_vectors(surf_sys), periodicity(surf_sys),
+                            empty(position(surf_sys, :)), empty(species(surf_sys, :)),
+                            empty(mass(surf_sys, :)))
+    cps = CompositeParameterSets(2, [LJParameters(epsilon=0.001, sigma=2.5, cutoff=1.8, shift=true),
+                                     LJParameters(epsilon=0.003, sigma=2.5, cutoff=1.8, shift=true),
+                                     LJParameters(epsilon=0.01, sigma=2.5, cutoff=1.8, shift=true)])
+    sliveset(K) = LJSurfaceWalkers([AtomWalker{1}(smkempty()) for _ in 1:K], cps, mksurf();
+                                   assign_energy=true)
+    muS(zV, T) = (kb * T * (log(zV / sV) + 3 * log(lam(T)))) * u"eV"
+    function surface_igref(seed, mu, n_steps; z0V=4.0, n_max=4, K=16)
+        Random.seed!(seed)
+        p = AtomisticIGRefGCNSParameters(mc_steps=40, reference_activity=(z0V / sV)u"Å^-3",
+                                         species=:H, allowed_fail_count=1000, n_max=n_max,
+                                         chemical_potential=mu)
+        df, lso, _ = ideal_gas_referenced_nested_sampling(
+            sliveset(K), p, n_steps, MCAtomGrandCanonicalMoves(), orsave("s"))
+        orclean("s")
+        return df, [ustrip(u"eV", w.energy) for w in lso.walkers], [w.list_num_par[1] for w in lso.walkers]
+    end
+    function surface_fixedN(seed; n_cap=4, K=16, n_steps=120)
+        Random.seed!(seed)
+        dfs = DataFrame[]
+        lives = Vector{Float64}[]
+        for N in 0:n_cap
+            if N == 0
+                # the N = 0 sector at zero energy: the four frozen H atoms sit 5 A
+                # apart, beyond the 4.5 A cutoff, so the surface's own
+                # energy_frozen_part is exactly zero and the empties of the igref
+                # runs carry the same energy (a fixture with a nonzero frozen
+                # part would shift this sector by e^{-beta E_frozen})
+                push!(dfs, DataFrame(iter=Int[], emax=Float64[]))
+                push!(lives, zeros(8))
+                continue
+            end
+            walkers = AtomWalker{1}[]
+            for _ in 1:K
+                coords = [[rand() * 10.0, rand() * 10.0, rand() * 15.0] for _ in 1:N]
+                push!(walkers, AtomWalker{1}(FastSystem(atomic_system(
+                    [:H => SVector{3}(c)u"Å" for c in coords], sbox, spbc))))
+            end
+            lsN = LJSurfaceWalkers(walkers, cps, mksurf(); assign_energy=true)
+            pN = NestedSamplingParameters(mc_steps=40, initial_step_size=0.5, step_size=0.5,
+                                          step_size_lo=0.01, step_size_up=2.0,
+                                          allowed_fail_count=1000)
+            dfN, lsoN, _ = nested_sampling(lsN, pN, n_steps, MCRandomWalkClone(), orsave("fx$N"))
+            orclean("fx$N")
+            push!(dfs, dfN)
+            push!(lives, [ustrip(u"eV", w.energy) for w in lsoN.walkers])
+        end
+        return dfs, lives
+    end
+
+    @testset "surface three-way weld over a temperature interval (seeds 86621, 86721, 87621)" begin
+        z0s = (4.0 / sV)u"Å^-3"
+        n_cap = 4
+        Ts = [250.0, 300.0, 400.0]
+        mu_run = muS(2.0, 300.0)
+        df3, e3, n3 = surface_igref(86621, mu_run, 300)
+        df2, e2, n2 = surface_igref(86721, 0.0u"eV", 200)
+        dfs, lives = surface_fixedN(87621)
+        # the Omega-ordered run ends on the empty-configuration atom, the
+        # ground-state sector at this mu
+        @test nrow(df3) > 0
+        @test all(iszero, n3)
+        @test issorted(df3.omega, rev=true)
+        st3 = gc_thermodynamic_stats_ideal_ref(df3, sVq, mass_ar, z0s, [mu_run], Ts .* u"K";
+                                               live_emax=e3, live_numbers=n3, n_max=n_cap)
+        st2 = gc_thermodynamic_stats_ideal_ref(df2, sVq, mass_ar, z0s, [mu_run], Ts .* u"K";
+                                               live_emax=e2, live_numbers=n2, n_max=n_cap)
+        fx = gc_thermodynamic_stats_fixed_N(dfs, collect(0:n_cap), sVq, mass_ar, [mu_run], Ts .* u"K";
+                                            n_walkers=16, live_emax=lives)
+        # Omega-ordered run against the independent oracle at every target
+        @test maximum(abs.(st3.logXi .- fx.logXi)) < 2.1
+        @test maximum(abs.(st3.mean_N .- fx.mean_N)) < 1.3
+        @test minimum(st3.N_eff) > 2.5
+        # energy-ordered run against the oracle inside its own trust window
+        @test maximum(abs.(st2.logXi[1, 2:3] .- fx.logXi[1, 2:3])) < 1.5
+        @test maximum(abs.(st2.mean_N[1, 2:3] .- fx.mean_N[1, 2:3])) < 1.6
+        @test minimum(st2.N_eff[1, 2:3]) > 9.0
+        # at the residual-free temperature the reweighting factor at the run's
+        # own mu is a function of Omega alone: a hand assembly on the :omega
+        # column reproduces the reduction's logXi
+        TL = reference_activity_temperature(z0s, mass_ar)
+        stL = gc_thermodynamic_stats_ideal_ref(df3, sVq, mass_ar, z0s, [mu_run], [TL];
+                                               live_emax=e3, live_numbers=n3, n_max=n_cap)
+        beta = 1 / (kb * ustrip(u"K", TL))
+        muv = ustrip(u"eV", mu_run)
+        lc = Vector{Float64}(df3.log_compression)
+        cs = cumsum(lc)
+        log_w0 = vcat(0.0, cs[1:end-1]) .+ log.(-expm1.(lc))
+        log_tail = cs[end] - log(length(e3))
+        lw = vcat(log_w0 .- beta .* df3.omega,
+                  fill(log_tail, length(e3)) .- beta .* (e3 .- muv .* n3))
+        m = maximum(lw)
+        hand = FreeBird.AnalysisTools._log_poisson_partial_sum(4.0, n_cap) + m + log(sum(exp.(lw .- m)))
+        @test isapprox(hand, stL.logXi[1, 1]; rtol=1e-10)
+        # the effective-sample-size reduction on an Omega ledger is the stats
+        # N_eff, bitwise, and its relative form is finite over the interval
+        ess = gc_effective_sample_size_ideal_ref(df3, sVq, mass_ar, z0s, [mu_run], Ts .* u"K";
+                                                 live_emax=e3, live_numbers=n3)
+        @test ess == st3.N_eff
+        essr = gc_effective_sample_size_ideal_ref(df3, sVq, mass_ar, z0s, [mu_run], Ts .* u"K";
+                                                  live_emax=e3, live_numbers=n3, relative=true)
+        @test all(isfinite, essr)
+    end
+
+    @testset "plain three-way weld at 300 K (seeds 86631, 86731, 87631)" begin
+        box = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+        pbc = (true, true, true)
+        seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], box, pbc))
+        mkempty() = FastSystem(cell_vectors(seed_at), periodicity(seed_at),
+                               empty(position(seed_at, :)), empty(species(seed_at, :)),
+                               empty(mass(seed_at, :)))
+        V12 = 1728.0
+        Vq12 = 1728.0u"Å^3"
+        lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+        z0 = (6.0 / V12)u"Å^-3"
+        mu12(zV, T) = (kb * T * (log(zV / V12) + 3 * log(lam(T)))) * u"eV"
+        mu_run = mu12(4.0, 300.0)
+        Ts = [300.0]
+        function plain_igref(seed, mu, n_steps)
+            Random.seed!(seed)
+            p = AtomisticIGRefGCNSParameters(mc_steps=60, reference_activity=z0, species=:Ar,
+                                             allowed_fail_count=100, chemical_potential=mu)
+            df, lso, _ = ideal_gas_referenced_nested_sampling(
+                GenericAtomWalkers([AtomWalker{1}(mkempty()) for _ in 1:24], lj), p, n_steps,
+                MCAtomGrandCanonicalMoves(), orsave("p"))
+            orclean("p")
+            return df, [ustrip(u"eV", w.energy) for w in lso.walkers], [w.list_num_par[1] for w in lso.walkers]
+        end
+        df3, e3, n3 = plain_igref(86631, mu_run, 300)
+        df2, e2, n2 = plain_igref(86731, 0.0u"eV", 300)
+        Random.seed!(87631)
+        Nmax = 12
+        dfs = DataFrame[]
+        lives = Vector{Float64}[]
+        for N in 0:Nmax
+            if N == 0
+                push!(dfs, DataFrame(iter=Int[], emax=Float64[]))
+                push!(lives, zeros(8))
+                continue
+            end
+            walkers = AtomWalker{1}[]
+            for _ in 1:24
+                coords = [[rand() * 12.0, rand() * 12.0, rand() * 12.0] for _ in 1:N]
+                push!(walkers, AtomWalker{1}(FastSystem(atomic_system(
+                    [:Ar => SVector{3}(c)u"Å" for c in coords], box, pbc))))
+            end
+            pN = NestedSamplingParameters(mc_steps=60, initial_step_size=0.5, step_size=0.5,
+                                          step_size_lo=0.01, step_size_up=2.0,
+                                          allowed_fail_count=1000)
+            dfN, lsoN, _ = nested_sampling(GenericAtomWalkers(walkers, lj), pN, 150,
+                                           MCRandomWalkClone(), orsave("px$N"))
+            orclean("px$N")
+            push!(dfs, dfN)
+            push!(lives, [ustrip(u"eV", w.energy) for w in lsoN.walkers])
+        end
+        st3 = gc_thermodynamic_stats_ideal_ref(df3, Vq12, mass_ar, z0, [mu_run], Ts .* u"K";
+                                               live_emax=e3, live_numbers=n3)
+        st2 = gc_thermodynamic_stats_ideal_ref(df2, Vq12, mass_ar, z0, [mu_run], Ts .* u"K";
+                                               live_emax=e2, live_numbers=n2)
+        fx = gc_thermodynamic_stats_fixed_N(dfs, collect(0:Nmax), Vq12, mass_ar, [mu_run], Ts .* u"K";
+                                            n_walkers=24, live_emax=lives)
+        @test issorted(df3.omega, rev=true)
+        @test abs(st3.logXi[1, 1] - fx.logXi[1, 1]) < 0.65
+        @test abs(st3.mean_N[1, 1] - fx.mean_N[1, 1]) < 1.5
+        @test st3.N_eff[1, 1] > 60.0
+        @test abs(st2.logXi[1, 1] - fx.logXi[1, 1]) < 1.2
+        @test abs(st2.mean_N[1, 1] - fx.mean_N[1, 1]) < 2.4
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-omega.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-omega.jl
@@ -1,0 +1,623 @@
+# Chemical-potential ordering of the atomistic ideal-gas-referenced route
+# (the `chemical_potential` field of `AtomisticIGRefGCNSParameters`; the step
+# sorts, detects plateaus, selects parents, and accepts on Ω = E − μN, the
+# ledger gains an :omega column, and the reduction is unchanged).
+#
+# Calibration ledger (protocol identical to the shipped testsets: gates ship at
+# >= 3x the maximum three-seed deviation, stated per statistic):
+# - Kernel stationarity under the Ω ceiling (150 independent walkers x 400
+#   steps, ideal gas, z0V = 3, mu = -1 eV, ceiling 3.5 eV, so the stationary
+#   law is Poisson(3) conditioned on N <= 3 with mean 51/26 and variance
+#   0.88314; seeds {1,2,3,86001}): max devs mean 0.128 (at the shipped seed),
+#   var 0.137 (seed 3); gates ship at >= 3x (0.39 and 0.42).
+#   Under mu = +1 eV, ceiling -2.5 eV, n_max = 6 (Poisson(3) conditioned on
+#   3 <= N <= 6, mean 3.9588, variance 0.9674; seeds {1,2,3,86002}): max devs
+#   mean 0.175, var 0.196 (both at the shipped seed); gates ship at >= 3x
+#   (0.53 and 0.59).
+# - Ideal-gas descent under Ω ordering (K = 256, z0V = 4, mu = -0.02 eV,
+#   unbounded; the reduction at the reference activity is exact, and the
+#   activity-linearity, occupancy-moment, and p_N gates are calibrated over
+#   seeds {1,2,3,86003}): max devs logXi 0.077 (seed 2), mean_N 0.413 (seed 2),
+#   var_N 1.58 and total variation 0.0933 (both at the shipped seed; the
+#   total-variation gate clears 3x by 2e-5); gates ship at >= 3x (0.24, 1.25,
+#   4.8, 0.28) and also bound the bounded (n_max = 6) and
+#   the mu > 0 (n_max = 8) descents, whose shipped-seed deviations are below
+#   0.031.
+# - Every other testset is an exact contract (bit-identity, closed forms,
+#   ordering invariants, schema) and needs no calibration.
+@testset "chemical-potential ordering of the atomistic ideal-gas-referenced route" begin
+    using Random
+
+    om_box = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+    om_pbc = (true, true, true)
+    om_seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], om_box, om_pbc))
+    om_mkempty() = FastSystem(cell_vectors(om_seed_at), periodicity(om_seed_at),
+                              empty(position(om_seed_at, :)), empty(species(om_seed_at, :)),
+                              empty(mass(om_seed_at, :)))
+    om_V = 1728.0
+    om_Vq = 1728.0u"Å^3"
+    # cutoff 2.0 sigma = 5 A stays inside the half cell, so the driver's
+    # minimum-image warning stays silent
+    om_lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.0)
+    om_lj0 = LJParameters(epsilon=0.0)
+    om_kb = 8.617333262e-5
+    om_mass = 39.948u"u"
+    om_lam(T) = ustrip(u"Å", FreeBird.AnalysisTools._thermal_wavelength(om_mass, T * u"K"))
+    om_mu_for(zV, T) = (om_kb * T * (log(zV / om_V) + 3 * log(om_lam(T)))) * u"eV"
+    om_logfact(n) = n == 0 ? 0.0 : sum(log, 1:n)
+    om_lpps = FreeBird.AnalysisTools._log_poisson_partial_sum
+    om_save(tag) = SaveEveryN(df_filename="_igomega_$(tag).csv",
+                              wk_filename="_igomega_$(tag).traj.extxyz",
+                              ls_filename="_igomega_$(tag).ls.extxyz",
+                              n_traj=10^7, n_snap=10^7, n_info=10^7)
+    om_clean(tag) = for f in ["_igomega_$(tag).csv", "_igomega_$(tag).traj.extxyz",
+                              "_igomega_$(tag).ls.extxyz"]
+        rm(f, force=true)
+    end
+    function om_walker(n; species=:Ar, box=(12.0, 12.0, 12.0), mk=om_mkempty)
+        w = AtomWalker{1}(mk())
+        for _ in 1:n
+            pos = SVector(rand() * box[1], rand() * box[2], rand() * box[3])u"Å"
+            FreeBird.AbstractWalkers.insert_particle!(w, pos, species)
+        end
+        return w
+    end
+
+    # surface fixture of the surface-route testsets
+    om_sbox = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 15.0]]u"Å"
+    om_spbc = (true, true, false)
+    om_sV = 1500.0
+    om_surf_sys = FastSystem(atomic_system(
+        [:H => [2.5, 2.5, 2.0]u"Å", :H => [7.5, 2.5, 2.0]u"Å",
+         :H => [2.5, 7.5, 2.0]u"Å", :H => [7.5, 7.5, 2.0]u"Å"], om_sbox, om_spbc))
+    om_mksurf() = AtomWalker(deepcopy(om_surf_sys); freeze_species=[:H])
+    om_smkempty() = FastSystem(cell_vectors(om_surf_sys), periodicity(om_surf_sys),
+                               empty(position(om_surf_sys, :)), empty(species(om_surf_sys, :)),
+                               empty(mass(om_surf_sys, :)))
+    om_cps = CompositeParameterSets(2, [LJParameters(epsilon=0.001, sigma=2.5, cutoff=1.8, shift=true),
+                                        LJParameters(epsilon=0.003, sigma=2.5, cutoff=1.8, shift=true),
+                                        LJParameters(epsilon=0.01, sigma=2.5, cutoff=1.8, shift=true)])
+    om_cps0 = CompositeParameterSets(2, [om_lj0, om_lj0, om_lj0])
+    om_sliveset(K) = LJSurfaceWalkers([AtomWalker{1}(om_smkempty()) for _ in 1:K], om_cps, om_mksurf();
+                                      assign_energy=true)
+
+    @testset "constructor, field, and ledger schema" begin
+        @test AtomisticIGRefGCNSParameters().chemical_potential == 0.0u"eV"
+        @test AtomisticIGRefGCNSParameters(chemical_potential=-0.02u"eV").chemical_potential == -0.02u"eV"
+        @test AtomisticIGRefGCNSParameters(chemical_potential=0.5u"eV").chemical_potential == 0.5u"eV"
+        # a unitless chemical potential is a loud type error, never a silent eV
+        @test_throws TypeError AtomisticIGRefGCNSParameters(chemical_potential=0.01)
+        # a NaN would make every ceiling comparison false; a negative zero is
+        # normalized to the default's exact +0.0
+        @test_throws ArgumentError AtomisticIGRefGCNSParameters(chemical_potential=NaN * u"eV")
+        @test !signbit(ustrip(u"eV", AtomisticIGRefGCNSParameters(chemical_potential=-0.0u"eV").chemical_potential))
+        # the :omega column is reserved
+        Random.seed!(86010)
+        ls = GenericAtomWalkers([AtomWalker{1}(om_mkempty()) for _ in 1:4], om_lj)
+        p = AtomisticIGRefGCNSParameters(mc_steps=10, reference_activity=(2.0 / om_V)u"Å^-3",
+                                         species=:Ar, allowed_fail_count=20,
+                                         chemical_potential=-0.01u"eV")
+        @test_throws ArgumentError ideal_gas_referenced_nested_sampling(
+            ls, p, 2, MCAtomGrandCanonicalMoves(), om_save("res");
+            observables=[:omega => cfg -> 0.0])
+        om_clean("res")
+        # schema: default unchanged, nonzero mu appends :omega after the compression
+        # column and before the acceptance columns and observables
+        function schema_run(mu; record=false, obs=nothing)
+            Random.seed!(86011)
+            lsr = GenericAtomWalkers([AtomWalker{1}(om_mkempty()) for _ in 1:8], om_lj)
+            pr = AtomisticIGRefGCNSParameters(mc_steps=20, reference_activity=(3.0 / om_V)u"Å^-3",
+                                              species=:Ar, allowed_fail_count=50,
+                                              chemical_potential=mu)
+            df, _, _ = ideal_gas_referenced_nested_sampling(
+                lsr, pr, 12, MCAtomGrandCanonicalMoves(), om_save("sch");
+                record_move_rates=record, observables=obs)
+            om_clean("sch")
+            return df
+        end
+        @test names(schema_run(0.0u"eV")) == ["iter", "emax", "num_particles", "log_compression"]
+        @test names(schema_run(-0.01u"eV")) == ["iter", "emax", "num_particles", "log_compression", "omega"]
+        @test names(schema_run(-0.01u"eV"; record=true)) ==
+              ["iter", "emax", "num_particles", "log_compression", "omega",
+               "move_attempted", "move_accepted", "insert_attempted", "insert_accepted",
+               "delete_attempted", "delete_accepted", "step_size"]
+        @test names(schema_run(-0.01u"eV"; obs=[:n_obs => cfg -> Float64(length(cfg))])) ==
+              ["iter", "emax", "num_particles", "log_compression", "omega", "n_obs"]
+    end
+
+    @testset "_grand_potential closed form and the exact-zero addend" begin
+        Random.seed!(86012)
+        w = om_walker(3)
+        w.energy = -0.5u"eV"
+        # binary-exact values: -0.5 - (-0.25 * 3) = 0.25
+        @test FreeBird.SamplingSchemes._grand_potential(w, -0.25u"eV") == 0.25u"eV"
+        @test FreeBird.SamplingSchemes._grand_potential(w, 0.25u"eV") == -1.25u"eV"
+        @test FreeBird.SamplingSchemes._grand_potential(w, 0.0u"eV") == w.energy
+        # the sign of a negative zero survives the default's exact-zero addend
+        w.energy = -0.0u"eV"
+        @test signbit(ustrip(u"eV", FreeBird.SamplingSchemes._grand_potential(w, 0.0u"eV")))
+        # the two-argument tie block agrees with the one-argument one at mu = 0 and
+        # splits an energy plateau by particle number at mu != 0
+        ws = [om_walker(n) for n in (2, 2, 3, 3)]
+        for x in ws
+            x.energy = 0.0u"eV"
+        end
+        @test FreeBird.SamplingSchemes._tie_block_length(ws) == 4
+        @test FreeBird.SamplingSchemes._tie_block_length(ws, 0.0u"eV") == 4
+        sort!(ws, by = x -> FreeBird.SamplingSchemes._grand_potential(x, -0.1u"eV"), rev=true)
+        @test FreeBird.SamplingSchemes._tie_block_length(ws, -0.1u"eV") == 2
+        @test ws[1].list_num_par[1] == 3
+    end
+
+    @testset "kernel: the Ω ceiling is a per-sector energy ceiling (eps = 0)" begin
+        function three_particle_walker(mk, species, box)
+            w = om_walker(0; mk=mk)
+            for pos in ([2.0, 2.0, 2.0], [7.0, 7.0, 7.0], [2.0, 7.0, 2.0])
+                FreeBird.AbstractWalkers.insert_particle!(w, SVector{3}(pos)u"Å", species)
+            end
+            w.energy = 0.0u"eV"
+            return w
+        end
+        # Ensembles of short walks from N = 3 locate the boundary exactly: under
+        # mu = -1 eV and a 3.5 eV ceiling the admissible sectors are N <= 3 (an
+        # indicator evaluated on n instead of n + 1 would admit N = 4), under
+        # mu = +1 eV and a -2.5 eV ceiling they are N >= 3 (an indicator on n
+        # instead of n - 1 would admit N = 2); the mu = 0 controls show the same
+        # ceilings admit both crossings when the sector shift is absent
+        function ensemble(mu, ceiling; surface=false, n_walkers=200, steps=50)
+            finals = Int[]
+            ins = 0
+            del = 0
+            for _ in 1:n_walkers
+                if surface
+                    w = three_particle_walker(om_smkempty, :H, (10.0, 10.0, 15.0))
+                    _, _, w, st = MC_grand_canonical_walk!(steps, w, om_cps0, ceiling, om_mksurf();
+                        z0V=4.0, species=:H, p_move=0.4, p_insert=0.3, mu=mu)
+                else
+                    w = three_particle_walker(om_mkempty, :Ar, (12.0, 12.0, 12.0))
+                    _, _, w, st = MC_grand_canonical_walk!(steps, w, om_lj0, ceiling;
+                        z0V=4.0, species=:Ar, p_move=0.4, p_insert=0.3, step_size=0.8, mu=mu)
+                end
+                push!(finals, w.list_num_par[1])
+                ins += st.insert_accepted
+                del += st.delete_accepted
+            end
+            return finals, ins, del
+        end
+        Random.seed!(86020)
+        f, ins, del = ensemble(-1.0u"eV", 3.5u"eV")
+        @test maximum(f) == 3
+        @test minimum(f) < 3
+        @test ins > 0
+        @test del > 0
+        Random.seed!(86020)
+        f0, _, _ = ensemble(0.0u"eV", 3.5u"eV")
+        @test maximum(f0) > 3
+        Random.seed!(86021)
+        f, ins, del = ensemble(1.0u"eV", -2.5u"eV")
+        @test minimum(f) == 3
+        @test maximum(f) > 3
+        @test ins > 0
+        @test del > 0
+        Random.seed!(86021)
+        f0, _, _ = ensemble(0.0u"eV", 1.0e9u"eV")
+        @test minimum(f0) < 3
+        # the same four contracts through the surface-aware method
+        Random.seed!(86022)
+        f, _, _ = ensemble(-1.0u"eV", 3.5u"eV"; surface=true)
+        @test maximum(f) == 3
+        @test minimum(f) < 3
+        Random.seed!(86022)
+        f0, _, _ = ensemble(0.0u"eV", 3.5u"eV"; surface=true)
+        @test maximum(f0) > 3
+        Random.seed!(86023)
+        f, _, _ = ensemble(1.0u"eV", -2.5u"eV"; surface=true)
+        @test minimum(f) == 3
+        @test maximum(f) > 3
+        Random.seed!(86023)
+        f0, _, _ = ensemble(0.0u"eV", 1.0e9u"eV"; surface=true)
+        @test minimum(f0) < 3
+        # an explicit mu = 0 is the shipped kernel draw for draw
+        function kernel_pair(mu_kw)
+            Random.seed!(86024)
+            wk = three_particle_walker(om_mkempty, :Ar, (12.0, 12.0, 12.0))
+            r = MC_grand_canonical_walk!(500, wk, om_lj0, 1.0u"eV";
+                z0V=4.0, species=:Ar, p_move=0.4, p_insert=0.3, step_size=0.8, mu_kw...)
+            return r[1], r[2], wk.list_num_par[1], wk.configuration.position, r[4]
+        end
+        a = kernel_pair(NamedTuple())
+        b = kernel_pair((mu=0.0u"eV",))
+        @test a[1] === b[1]
+        @test a[2] == b[2]
+        @test a[3] == b[3]
+        @test a[4] == b[4]
+        @test a[5] == b[5]
+        # with a ceiling that never binds, a nonzero mu changes nothing either
+        function loose_pair(mu)
+            Random.seed!(86025)
+            wk = three_particle_walker(om_mkempty, :Ar, (12.0, 12.0, 12.0))
+            r = MC_grand_canonical_walk!(500, wk, om_lj0, 1.0e9u"eV";
+                z0V=4.0, species=:Ar, p_move=0.4, p_insert=0.3, step_size=0.8, mu=mu)
+            return wk.list_num_par[1], wk.configuration.position, r[4]
+        end
+        c = loose_pair(0.0u"eV")
+        d = loose_pair(-1.0u"eV")
+        @test c[1] == d[1]
+        @test c[2] == d[2]
+        @test c[3] == d[3]
+    end
+
+    @testset "kernel stationarity under the Ω ceiling (seeded, calibrated)" begin
+        # ideal gas at z0V = 3, mu = -1 eV, ceiling 3.5 eV: the reference measure
+        # conditioned on N <= 3, masses proportional to (1, 3, 4.5, 4.5)
+        Random.seed!(86001)
+        ns = Int[]
+        for _ in 1:150
+            w = om_walker(0)
+            w.energy = 0.0u"eV"
+            MC_grand_canonical_walk!(400, w, om_lj0, 3.5u"eV"; z0V=3.0, species=:Ar, mu=-1.0u"eV")
+            push!(ns, w.list_num_par[1])
+        end
+        @test all(0 .<= ns .<= 3)
+        @test abs(mean(ns) - 51 / 26) < 0.39
+        @test abs(var(ns) - (123 / 26 - (51 / 26)^2)) < 0.42
+        # mu = +1 eV, ceiling -2.5 eV, n_max = 6: conditioned on 3 <= N <= 6,
+        # masses proportional to (4.5, 3.375, 2.025, 1.0125); walkers start at N = 3
+        Random.seed!(86002)
+        ns = Int[]
+        for _ in 1:150
+            w = om_walker(3)
+            w.energy = 0.0u"eV"
+            MC_grand_canonical_walk!(400, w, om_lj0, -2.5u"eV"; z0V=3.0, species=:Ar,
+                                     n_max=6, mu=1.0u"eV")
+            push!(ns, w.list_num_par[1])
+        end
+        q = [4.5, 3.375, 2.025, 1.0125] ./ 10.9125
+        m1 = sum(q .* (3:6))
+        v1 = sum(q .* (3:6) .^ 2) - m1^2
+        @test all(3 .<= ns .<= 6)
+        @test abs(mean(ns) - m1) < 0.53
+        @test abs(var(ns) - v1) < 0.59
+    end
+
+    function om_run(seed, mu; K=16, z0V=6.0, mc_steps=60, n_steps=120, n_max=typemax(Int64),
+                    tag="r", obs=nothing, callback=nothing, ls=nothing, initialize=true,
+                    potential=om_lj, allowed_fail_count=100_000)
+        Random.seed!(seed)
+        lsr = ls === nothing ? GenericAtomWalkers([AtomWalker{1}(om_mkempty()) for _ in 1:K], potential) : ls
+        p = AtomisticIGRefGCNSParameters(mc_steps=mc_steps, reference_activity=(z0V / om_V)u"Å^-3",
+                                         species=:Ar, allowed_fail_count=allowed_fail_count,
+                                         n_max=n_max, chemical_potential=mu)
+        df, lso, pout = ideal_gas_referenced_nested_sampling(
+            lsr, p, n_steps, MCAtomGrandCanonicalMoves(), om_save(tag);
+            observables=obs, dead_point_callback=callback, initialize=initialize)
+        om_clean(tag)
+        live_e = [ustrip(u"eV", w.energy) for w in lso.walkers]
+        live_n = [w.list_num_par[1] for w in lso.walkers]
+        return df, live_e, live_n, lso, pout
+    end
+
+    @testset "driver stream identity: an explicit zero is the default" begin
+        df_d, e_d, n_d, _, _ = om_run(52552, 0.0u"eV")
+        Random.seed!(52552)
+        ls = GenericAtomWalkers([AtomWalker{1}(om_mkempty()) for _ in 1:16], om_lj)
+        p = AtomisticIGRefGCNSParameters(mc_steps=60, reference_activity=(6.0 / om_V)u"Å^-3",
+                                         species=:Ar, allowed_fail_count=100_000)
+        df_0, lso_0, _ = ideal_gas_referenced_nested_sampling(
+            ls, p, 120, MCAtomGrandCanonicalMoves(), om_save("z"))
+        om_clean("z")
+        @test df_d == df_0
+        @test e_d == [ustrip(u"eV", w.energy) for w in lso_0.walkers]
+        @test n_d == [w.list_num_par[1] for w in lso_0.walkers]
+        # the surface path likewise
+        function sf_pair(mu_kw)
+            Random.seed!(84004)
+            lss = om_sliveset(8)
+            ps = AtomisticIGRefGCNSParameters(; mc_steps=40, reference_activity=(4.0 / om_sV)u"Å^-3",
+                                              species=:H, allowed_fail_count=1000, n_max=6, mu_kw...)
+            dfs, lsos, _ = ideal_gas_referenced_nested_sampling(
+                lss, ps, 60, MCAtomGrandCanonicalMoves(), om_save("s"))
+            om_clean("s")
+            return dfs, [ustrip(u"eV", w.energy) for w in lsos.walkers]
+        end
+        sa = sf_pair(NamedTuple())
+        sb = sf_pair((chemical_potential=0.0u"eV",))
+        @test sa[1] == sb[1]
+        @test sa[2] == sb[2]
+    end
+
+    @testset "ordering contract at mu != 0 on the dilute interacting gas (seed 86030)" begin
+        # mu = -0.002 eV: bound pairs (E about -0.01 eV) sit below the exact
+        # N = 1 plateau at Ω = 0.002 eV, so the descent has an interior to refill
+        # from and every step records a row
+        mu = -0.002u"eV"
+        df1, e1, n1, _, _ = om_run(86030, mu)
+        df2, e2, n2, _, _ = om_run(86030, mu)
+        @test df1 == df2
+        @test e1 == e2
+        @test n1 == n2
+        @test nrow(df1) >= 60
+        @test length(unique(df1.iter)) == nrow(df1)
+        @test issorted(df1.omega, rev=true)
+        # the energy column is not the ordering scalar any more
+        @test !issorted(df1.emax, rev=true)
+        # the recorded Ω is the step's own expression on the recorded (E, N)
+        @test df1.omega == df1.emax .- ustrip(u"eV", mu) .* df1.num_particles
+        @test all(df1.log_compression .< 0.0)
+    end
+
+    @testset "observable pre-sort and dead-point pairing at mu != 0 (seed 86031)" begin
+        seen = Int[]
+        df, _, _, _, _ = om_run(86031, -0.002u"eV"; K=8, z0V=4.0, mc_steps=40, n_steps=40,
+                                obs=[:n_obs => cfg -> Float64(length(cfg))],
+                                callback=(iter, walker) -> push!(seen, walker.list_num_par[1]))
+        @test names(df) == ["iter", "emax", "num_particles", "log_compression", "omega", "n_obs"]
+        @test df.n_obs == Float64.(df.num_particles)
+        @test seen == df.num_particles
+        @test issorted(df.omega, rev=true)
+    end
+
+    @testset "atoms of the ordering scalar end the dilute descent in a stall, never a throw (seed 86032)" begin
+        # mu = -0.02 eV on the dilute gas at K = 8: the exact N = 1 level
+        # (Ω = 0.02 eV, every isolated particle) and the empty configuration
+        # (Ω = 0) are atoms of Ω. When the N = 1 level is the top block, its
+        # survivors are empties, whose clones stay below it only by accepting
+        # no move, so the refill exhausts its budget and the live set shrinks;
+        # when either atom holds the whole live set, the step attempts no walk.
+        # Either way the driver stalls on an all-tied live set and never draws
+        # a parent from an empty range (the shipped code threw there).
+        df, live_e, live_n, lso, pout = @test_logs (:warn, r"stop_on_stall") match_mode=:any begin
+            om_run(86032, -0.02u"eV"; K=8, z0V=4.0, mc_steps=40, n_steps=400, allowed_fail_count=20)
+        end
+        @test pout.fail_count == 20
+        @test 1 <= length(lso.walkers) <= 8
+        omegas = [FreeBird.SamplingSchemes._grand_potential(w, -0.02u"eV") for w in lso.walkers]
+        @test all(==(omegas[1]), omegas)
+        @test all(n -> n <= 1, live_n)
+        @test issorted(df.omega, rev=true)
+        @test df.omega == df.emax .- (-0.02) .* df.num_particles
+    end
+
+    @testset "ideal-gas descent under Ω ordering closes against the Poisson closed forms (seed 86003)" begin
+        # U = 0 everywhere, so Ω = -μN: at mu < 0 the descent evicts the particle-number
+        # plateaus from the top down and ends on K empties (the terminal atom); the
+        # compression ledger then encodes the reference law's N-marginal
+        z0V = 4.0
+        z0 = (z0V / om_V)u"Å^-3"
+        T = 300.0
+        mu = -0.02u"eV"
+        df, live_e, live_n, _, _ = @test_logs (:warn, r"stop_on_stall") match_mode=:any begin
+            om_run(86003, mu; K=256, z0V=z0V, mc_steps=20, n_steps=4000, potential=IdealGasParameters(),
+                   allowed_fail_count=10, tag="ig")
+        end
+        @test nrow(df) > 256
+        @test all(df.emax .== 0.0)
+        @test issorted(df.omega, rev=true)
+        @test issorted(df.num_particles, rev=true)
+        @test df.omega == -ustrip(u"eV", mu) .* df.num_particles
+        @test all(iszero, live_n)
+        @test all(iszero, live_e)
+        mus = [om_mu_for(0.7 * z0V, T), om_mu_for(z0V, T), om_mu_for(1.3 * z0V, T)]
+        st = gc_thermodynamic_stats_ideal_ref(df, om_Vq, om_mass, z0, mus, [T]u"K";
+                                              live_emax=live_e, live_numbers=live_n)
+        # at the reference activity the shells and the tail telescope to the full
+        # reference mass, whatever ordering produced them
+        @test abs(st.logXi[2, 1] - z0V) < 1e-10
+        @test all(st.mean_U .== 0.0)
+        # the Ω-ordered compression reproduces the Poisson N-marginal: activity
+        # linearity and the occupancy moments at every grid point (calibrated)
+        @test abs(st.logXi[1, 1] - 0.7 * z0V) < 0.24
+        @test abs(st.logXi[3, 1] - 1.3 * z0V) < 0.24
+        for (i, zV) in enumerate((0.7 * z0V, z0V, 1.3 * z0V))
+            @test abs(st.mean_N[i, 1] - zV) < 1.25
+            @test abs(st.var_N[i, 1] - zV) < 4.8
+            pois = [exp(n * log(zV) - zV - om_logfact(n)) for n in st.N_support]
+            @test 0.5 * sum(abs.(st.p_N[i, 1, :] .- pois)) < 0.28
+        end
+        # the bounded construction: the same descent on the conditional Poisson
+        n_cap = 6
+        dfb, live_eb, live_nb, _, _ = @test_logs (:warn, r"stop_on_stall") match_mode=:any begin
+            om_run(86004, mu; K=256, z0V=z0V, mc_steps=20, n_steps=4000, potential=IdealGasParameters(),
+                   allowed_fail_count=10, n_max=n_cap, tag="igb")
+        end
+        @test maximum(dfb.num_particles) <= n_cap
+        @test issorted(dfb.num_particles, rev=true)
+        @test all(iszero, live_nb)
+        stb = gc_thermodynamic_stats_ideal_ref(dfb, om_Vq, om_mass, z0, mus, [T]u"K";
+                                               live_emax=live_eb, live_numbers=live_nb, n_max=n_cap)
+        @test abs(stb.logXi[2, 1] - om_lpps(z0V, n_cap)) < 1e-10
+        @test abs(stb.logXi[1, 1] - om_lpps(0.7 * z0V, n_cap)) < 0.24
+        @test abs(stb.logXi[3, 1] - om_lpps(1.3 * z0V, n_cap)) < 0.24
+        # mu > 0 under a cap: the descent climbs the plateaus and ends on the cap
+        n_cap_p = 8
+        dfp, live_ep, live_np, _, _ = @test_logs (:warn, r"stop_on_stall") match_mode=:any begin
+            om_run(86005, -mu; K=256, z0V=z0V, mc_steps=20, n_steps=4000, potential=IdealGasParameters(),
+                   allowed_fail_count=10, n_max=n_cap_p, tag="igp")
+        end
+        @test all(dfp.emax .== 0.0)
+        @test issorted(dfp.omega, rev=true)
+        @test issorted(dfp.num_particles)
+        @test all(==(n_cap_p), live_np)
+        stp = gc_thermodynamic_stats_ideal_ref(dfp, om_Vq, om_mass, z0, mus, [T]u"K";
+                                               live_emax=live_ep, live_numbers=live_np, n_max=n_cap_p)
+        @test abs(stp.logXi[2, 1] - om_lpps(z0V, n_cap_p)) < 1e-10
+        @test abs(stp.logXi[1, 1] - om_lpps(0.7 * z0V, n_cap_p)) < 0.24
+        @test abs(stp.logXi[3, 1] - om_lpps(1.3 * z0V, n_cap_p)) < 0.24
+    end
+
+    @testset "terminal-atom stall over a frozen substrate (seed 86040)" begin
+        # |mu| far above every interaction energy: the Ω order is the particle-number
+        # order, the descent empties every walker, and the empty configuration is an
+        # atom of Ω (every empty walker carries exactly energy_frozen_part)
+        Random.seed!(86040)
+        walkers = AtomWalker{1}[]
+        for n in (0, 1, 1, 2, 2, 3, 3, 4)
+            push!(walkers, om_walker(n; species=:H, box=(10.0, 10.0, 15.0), mk=om_smkempty))
+        end
+        ls = LJSurfaceWalkers(walkers, om_cps, om_mksurf(); assign_energy=true)
+        e_frozen = ls.surface.energy_frozen_part
+        mu = -1.0u"eV"
+        p = AtomisticIGRefGCNSParameters(mc_steps=40, reference_activity=(4.0 / om_sV)u"Å^-3",
+                                         species=:H, allowed_fail_count=5, chemical_potential=mu)
+        df, lso, pout = @test_logs (:warn, r"stop_on_stall") match_mode=:any begin
+            ideal_gas_referenced_nested_sampling(ls, p, 500, MCAtomGrandCanonicalMoves(), om_save("atom");
+                                                 initialize=false)
+        end
+        om_clean("atom")
+        @test pout.fail_count == 5
+        @test nrow(df) >= 7
+        @test all(w.list_num_par[1] == 0 for w in lso.walkers)
+        @test all(w.energy == e_frozen for w in lso.walkers)
+        @test issorted(df.omega, rev=true)
+        @test issorted(df.num_particles, rev=true)
+        @test df.omega == df.emax .- ustrip(u"eV", mu) .* df.num_particles
+        live_e = [ustrip(u"eV", w.energy) for w in lso.walkers]
+        live_n = [w.list_num_par[1] for w in lso.walkers]
+        st = gc_thermodynamic_stats_ideal_ref(df, 1500.0u"Å^3", 1.008u"u", (4.0 / om_sV)u"Å^-3",
+                                              [mu], [300.0]u"K"; live_emax=live_e, live_numbers=live_n)
+        @test st.mean_N[1, 1] < 1e-10
+        @test abs(st.mean_U[1, 1] - ustrip(u"eV", e_frozen)) < 1e-12
+        # the vacuous effective sample size of an atom-dominated target: the K
+        # identical tail walkers share the weight
+        @test abs(st.N_eff[1, 1] - 8.0) < 1e-6
+        # a continuation of the stalled set stalls again without a recorded row
+        df2, lso2, _ = @test_logs (:warn, r"stop_on_stall") match_mode=:any begin
+            ideal_gas_referenced_nested_sampling(lso, p, 50, MCAtomGrandCanonicalMoves(), om_save("atom2");
+                                                 initialize=false)
+        end
+        om_clean("atom2")
+        @test nrow(df2) == 0
+        @test all(w.list_num_par[1] == 0 for w in lso2.walkers)
+    end
+
+    @testset "an all-tied live set is terminal under a nonzero mu (seed 86060)" begin
+        # K identical empties over the substrate sit on one Ω; bound single
+        # adsorbates lie below it at this mu (E_1 is about -0.01 eV against
+        # mu = -0.001 eV) and are easy to find from an empty parent. At mu = 0 the
+        # shipped path culls through the atom and records rows; under the
+        # nonzero mu the step attempts no walk and the stall fires with the
+        # live set intact, its mass charged to the atom.
+        function tied_run(mu)
+            Random.seed!(86060)
+            ls = om_sliveset(6)
+            p = AtomisticIGRefGCNSParameters(mc_steps=40, reference_activity=(4.0 / om_sV)u"Å^-3",
+                                             species=:H, allowed_fail_count=8,
+                                             chemical_potential=mu)
+            df, lso, pout = ideal_gas_referenced_nested_sampling(
+                ls, p, 30, MCAtomGrandCanonicalMoves(), om_save("tied"); initialize=false)
+            om_clean("tied")
+            return df, lso, pout
+        end
+        df0, lso0, _ = tied_run(0.0u"eV")
+        @test nrow(df0) > 0
+        @test any(w.list_num_par[1] > 0 for w in lso0.walkers)
+        dfm, lsom, poutm = @test_logs (:warn, r"stop_on_stall") match_mode=:any tied_run(-0.001u"eV")
+        @test nrow(dfm) == 0
+        @test poutm.fail_count == 8
+        @test all(w.list_num_par[1] == 0 for w in lsom.walkers)
+        @test length(lsom.walkers) == 6
+        # the same live set with one walker below the atom is an ordinary
+        # plateau: the evictions and the refill proceed and rows are recorded
+        Random.seed!(86061)
+        ls1 = om_sliveset(6)
+        # one adsorbate at the pair minimum 2^(1/6) sigma = 2.81 A above a
+        # surface atom (the other three sit 5 A away, beyond the cutoff)
+        w1 = AtomWalker{1}(om_smkempty())
+        FreeBird.AbstractWalkers.insert_particle!(w1, SVector(2.5, 2.5, 2.0 + 2.0^(1 / 6) * 2.5)u"Å", :H)
+        ls1.walkers[1] = w1
+        FreeBird.SamplingSchemes._reanchor_igref_energies!(ls1)
+        p1 = AtomisticIGRefGCNSParameters(mc_steps=40, reference_activity=(4.0 / om_sV)u"Å^-3",
+                                          species=:H, allowed_fail_count=8,
+                                          chemical_potential=-0.001u"eV")
+        @test FreeBird.SamplingSchemes._grand_potential(ls1.walkers[1], -0.001u"eV") < 0.0u"eV"
+        df1, lso1, _ = ideal_gas_referenced_nested_sampling(
+            ls1, p1, 30, MCAtomGrandCanonicalMoves(), om_save("tied1"); initialize=false)
+        om_clean("tied1")
+        @test nrow(df1) >= 5
+        @test count(==(0), df1.num_particles) == 5
+    end
+
+    @testset "a continuation carries the plateau refill target across a chunk boundary (seed 86070)" begin
+        # K = 8 over the substrate: four empties on the atom Ω = 0 (the top block
+        # under mu = -0.001 eV) above four bound adsorbates with distinct heights.
+        # A chunked driver that re-enters mid-eviction with the parameters it
+        # carried keeps the target 8 and refills to 8 once the plateau is
+        # exhausted; a re-entry with fresh parameters re-derives the target from
+        # the reduced live count and never refills the walkers evicted before
+        # the boundary
+        function mid_eviction_liveset()
+            ls = om_sliveset(8)
+            for (i, z) in enumerate((4.80, 4.86, 4.92, 4.98))
+                w = AtomWalker{1}(om_smkempty())
+                FreeBird.AbstractWalkers.insert_particle!(w, SVector(2.5, 2.5, z)u"Å", :H)
+                ls.walkers[4 + i] = w
+            end
+            FreeBird.SamplingSchemes._reanchor_igref_energies!(ls)
+            return ls
+        end
+        mu = -0.001u"eV"
+        mkp() = AtomisticIGRefGCNSParameters(mc_steps=40, reference_activity=(4.0 / om_sV)u"Å^-3",
+                                             species=:H, allowed_fail_count=200,
+                                             chemical_potential=mu)
+        Random.seed!(86070)
+        ls = mid_eviction_liveset()
+        p = mkp()
+        df1, lso1, p1 = ideal_gas_referenced_nested_sampling(ls, p, 2, MCAtomGrandCanonicalMoves(), om_save("pt1");
+                                                             initialize=false)
+        om_clean("pt1")
+        @test nrow(df1) == 2
+        @test all(==(0), df1.num_particles)
+        @test length(lso1.walkers) == 6
+        @test p1.plateau_refill_target == 8
+        # carried parameters: the two remaining empties are evicted, then the
+        # refill restores the live set to 8
+        df2, lso2, p2 = ideal_gas_referenced_nested_sampling(lso1, p1, 6, MCAtomGrandCanonicalMoves(), om_save("pt2");
+                                                             initialize=false)
+        om_clean("pt2")
+        @test length(lso2.walkers) == 8
+        @test p2.plateau_refill_target == 0
+        # fresh parameters at the same boundary: the target is re-derived as 6
+        Random.seed!(86070)
+        lsb = mid_eviction_liveset()
+        dfb1, lsob1, _ = ideal_gas_referenced_nested_sampling(lsb, mkp(), 2, MCAtomGrandCanonicalMoves(), om_save("pt3");
+                                                              initialize=false)
+        om_clean("pt3")
+        dfb2, lsob2, _ = ideal_gas_referenced_nested_sampling(lsob1, mkp(), 6, MCAtomGrandCanonicalMoves(), om_save("pt4");
+                                                              initialize=false)
+        om_clean("pt4")
+        @test length(lsob2.walkers) == 6
+    end
+
+    @testset "block continuation carries mu (seed 86050)" begin
+        Random.seed!(86050)
+        ls = om_sliveset(8)
+        mu = -0.005u"eV"
+        p = AtomisticIGRefGCNSParameters(mc_steps=40, reference_activity=(4.0 / om_sV)u"Å^-3",
+                                         species=:H, allowed_fail_count=1000, n_max=6,
+                                         chemical_potential=mu)
+        df1, lso1, _ = ideal_gas_referenced_nested_sampling(ls, p, 60, MCAtomGrandCanonicalMoves(), om_save("c1"))
+        om_clean("c1")
+        df2, lso2, _ = ideal_gas_referenced_nested_sampling(lso1, p, 40, MCAtomGrandCanonicalMoves(), om_save("c2");
+                                                            initialize=false)
+        om_clean("c2")
+        @test nrow(df2) > 0
+        @test df2.iter[1] == df1.iter[end] + 1
+        @test df2.omega[1] <= df1.omega[end]
+        @test issorted(vcat(df1.omega, df2.omega), rev=true)
+        @test df2.omega == df2.emax .- ustrip(u"eV", mu) .* df2.num_particles
+    end
+
+    @testset "reference_activity_temperature" begin
+        for (z0V, Vc) in ((16.0, 2091.124), (4.0, 2091.124), (3.0, 1000.0))
+            z0 = (z0V / Vc)u"Å^-3"
+            TL = reference_activity_temperature(z0, om_mass)
+            @test unit(TL) == u"K"
+            lam3 = FreeBird.AnalysisTools._thermal_wavelength(om_mass, TL)^3
+            @test abs(ustrip(Unitful.NoUnits, z0 * lam3) - 1.0) < 1e-12
+            # Λ^3 scales as T^(-3/2): eight times the activity quadruples the temperature
+            @test isapprox(reference_activity_temperature(8 * z0, om_mass), 4 * TL; rtol=1e-12)
+        end
+        @test_throws ArgumentError reference_activity_temperature(0.0u"Å^-3", om_mass)
+        @test_throws ArgumentError reference_activity_temperature(-1.0u"Å^-3", om_mass)
+    end
+end

--- a/test/test-SamplingSchemes/test-atomistic-igref-path-pins.jl
+++ b/test/test-SamplingSchemes/test-atomistic-igref-path-pins.jl
@@ -1,0 +1,308 @@
+# Absolute seeded pins for the paths the driver pins of
+# test-atomistic-igref-driver-pins.jl leave uncovered, captured at dev 8bdd7556
+# (the shipped SHA at the close of the bounded-support and surface rounds) and
+# reproduced digit-identically across two separate Julia processes before
+# recording: the SURFACE-aware ideal-gas-referenced step loop, the plain step
+# loop with the Galilean burst enabled, and a DRIVER-level run entered through
+# initialize=false with an observable and a dead-point callback, so the ledger
+# assembly, the observable pre-sort, and the pairing check are pinned without
+# routing through the reference-law initializer. Those paths had same-process
+# A/B coverage only (two runs of one seed compared inside one process), so a
+# stream-neutral change touching their comparator or ceiling could pass every
+# shipped testset while shifting the stream.
+#
+# Julia-version policy (observed on the PR's CI legs at filing, which run
+# Julia {lts, 1, pre} x {ubuntu-x64, macos-aarch64}): on Julia 1.10 every
+# vector reproduces digit-identically on the x64 lts leg and on the aarch64
+# development machine, so architecture is not what moves these fixtures. Julia
+# 1.12 flips one accept/reject decision after 10 to 13 steps in each of the
+# three fixtures (the same flipped trajectory on x64 and aarch64) and the
+# pre-release leg flips fixture G, so the trajectory vectors (num_particles,
+# emax, the sorted live-set energies, the Galilean counters) are asserted under
+# VERSION < v"1.11" only. On every version the file asserts the content the
+# flips leave unchanged: the iteration sequences, nonincreasing emax, the
+# compression charges as same-process logs of integer ratios (the plateau entry
+# and exit steps of fixtures S and D are the same on every leg), the ledger
+# schema and welds, and a same-process replay identity of each fixture (two
+# runs of one seed, every vector equal under ==). Within a version the vectors
+# follow the scoping of the driver pins: live sets are built deterministically
+# (fixed particle counts, positions from raw Random-stdlib uniforms; the
+# Distributions Poisson initializer is never drawn), the pinned stream consumes
+# only rand()/rand(1:n) draws, emax and live-set energies are smooth
+# Lennard-Jones accumulations pinned elementwise at rtol 1e-12 (a real stream
+# change moves them by orders of magnitude), num_particles and iteration
+# sequences are exact integers, and the Galilean counters are exact integers
+# accumulated from the burst's segment outcomes.
+#
+# Fixture S (seed 424271): the 10 x 10 x 15 A slab cell of the surface-route
+# testsets, four frozen H, K = 12 with two empty walkers, 60 steps (the descent
+# traverses the exact empty-configuration plateau: six eviction charges).
+# Fixture G (seed 424272): the 12 A periodic box, K = 12 with counts 1..12,
+# galilean_steps = 2, 80 steps, no plateau. Fixture D (seed 424273): the
+# driver at K = 12 with counts 1..6 doubled, cutoff 2.0 sigma (inside the half
+# cell, so the minimum-image warning stays silent), 60 steps.
+@testset "atomistic igref surface, Galilean, and driver-path pins (absolute, captured at 8bdd7556)" begin
+    using Random
+    pin3_box = [[12.0, 0.0, 0.0], [0.0, 12.0, 0.0], [0.0, 0.0, 12.0]]u"Å"
+    pin3_pbc = (true, true, true)
+    pin3_seed_at = FastSystem(atomic_system([:Ar => [1.0, 1.0, 1.0]u"Å"], pin3_box, pin3_pbc))
+    pin3_mkempty() = FastSystem(cell_vectors(pin3_seed_at), periodicity(pin3_seed_at),
+                                empty(position(pin3_seed_at, :)), empty(species(pin3_seed_at, :)),
+                                empty(mass(pin3_seed_at, :)))
+    pin3_V = 1728.0
+    pin3_lj = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.5)
+    # driver fixture: cutoff 2.0 sigma = 5 A stays inside the half cell (6 A), so the
+    # driver-level minimum-image warning never fires
+    pin3_lj_d = LJParameters(epsilon=0.01, sigma=2.5, cutoff=2.0)
+
+    function pin3_liveset(counts; lj=pin3_lj)
+        walkers = AtomWalker{1}[]
+        for n in counts
+            w = AtomWalker{1}(pin3_mkempty())
+            for _ in 1:n
+                pos = SVector(rand() * 12.0, rand() * 12.0, rand() * 12.0)u"Å"
+                FreeBird.AbstractWalkers.insert_particle!(w, pos, :Ar)
+            end
+            push!(walkers, w)
+        end
+        return GenericAtomWalkers(walkers, lj)
+    end
+
+    # surface fixture: the 10 x 10 x 15 A slab cell of the surface-route testsets
+    pin3_sbox = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 15.0]]u"Å"
+    pin3_spbc = (true, true, false)
+    pin3_sV = 1500.0
+    pin3_surf_sys = FastSystem(atomic_system(
+        [:H => [2.5, 2.5, 2.0]u"Å", :H => [7.5, 2.5, 2.0]u"Å",
+         :H => [2.5, 7.5, 2.0]u"Å", :H => [7.5, 7.5, 2.0]u"Å"], pin3_sbox, pin3_spbc))
+    pin3_mksurf() = AtomWalker(deepcopy(pin3_surf_sys); freeze_species=[:H])
+    pin3_smkempty() = FastSystem(cell_vectors(pin3_surf_sys), periodicity(pin3_surf_sys),
+                                 empty(position(pin3_surf_sys, :)), empty(species(pin3_surf_sys, :)),
+                                 empty(mass(pin3_surf_sys, :)))
+    pin3_cps = CompositeParameterSets(2, [LJParameters(epsilon=0.001, sigma=2.5, cutoff=1.8, shift=true),
+                                          LJParameters(epsilon=0.003, sigma=2.5, cutoff=1.8, shift=true),
+                                          LJParameters(epsilon=0.01, sigma=2.5, cutoff=1.8, shift=true)])
+
+    function pin3_surface_liveset(counts)
+        walkers = AtomWalker{1}[]
+        for n in counts
+            w = AtomWalker{1}(pin3_smkempty())
+            for _ in 1:n
+                pos = SVector(rand() * 10.0, rand() * 10.0, rand() * 15.0)u"Å"
+                FreeBird.AbstractWalkers.insert_particle!(w, pos, :H)
+            end
+            push!(walkers, w)
+        end
+        return LJSurfaceWalkers(walkers, pin3_cps, pin3_mksurf(); assign_energy=true)
+    end
+
+    function pin3_step_run(seed::Int, ls, z0V::Float64, mc_steps::Int, n_steps::Int,
+                           species::Symbol, routine)
+        Random.seed!(seed)
+        params = AtomisticIGRefGCNSParameters(mc_steps=mc_steps,
+            reference_activity=(z0V / (species == :H ? pin3_sV : pin3_V))u"Å^-3", species=species,
+            allowed_fail_count=100_000)
+        iters = Int[]
+        emaxs = Float64[]
+        npars = Int[]
+        logts = Float64[]
+        for k in 1:n_steps
+            iter, emax, n_par, ls, params, log_t = FreeBird.SamplingSchemes.nested_sampling_step!(
+                ls, params, routine; ns_iteration=k, z0V=z0V)
+            if !(iter isa Missing)
+                push!(iters, iter)
+                push!(emaxs, ustrip(u"eV", emax))
+                push!(npars, n_par)
+                push!(logts, log_t)
+            end
+        end
+        live = sort([ustrip(u"eV", w.energy) for w in ls.walkers])
+        return iters, emaxs, npars, logts, live, params
+    end
+
+    function pin3_driver_run(seed::Int, counts, z0V::Float64, mc_steps::Int, n_steps::Int)
+        Random.seed!(seed)
+        ls = pin3_liveset(counts; lj=pin3_lj_d)
+        params = AtomisticIGRefGCNSParameters(mc_steps=mc_steps,
+            reference_activity=(z0V / pin3_V)u"Å^-3", species=:Ar,
+            allowed_fail_count=100_000)
+        save = SaveEveryN(df_filename="_igpin3_d.csv", wk_filename="_igpin3_d.traj.extxyz",
+                          ls_filename="_igpin3_d.ls.extxyz", n_traj=10^7, n_snap=10^7, n_info=10^7)
+        seen = Int[]
+        df, lso, pout = ideal_gas_referenced_nested_sampling(
+            ls, params, n_steps, MCAtomGrandCanonicalMoves(), save;
+            observables=[:n_obs => cfg -> Float64(length(cfg))],
+            dead_point_callback=(iter, walker) -> push!(seen, walker.list_num_par[1]),
+            initialize=false)
+        for f in ["_igpin3_d.csv", "_igpin3_d.traj.extxyz", "_igpin3_d.ls.extxyz"]
+            rm(f, force=true)
+        end
+        live = sort([ustrip(u"eV", w.energy) for w in lso.walkers])
+        return df, seen, live
+    end
+
+    pin3_counts_s = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 6]
+    pin3_counts_g = collect(1:12)
+    pin3_counts_d = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6]
+
+    PIN_S_LC_NUM = [12, 12, 12, 12, 12, 12, 12, 12, 11, 10, 9, 8, 7, 6, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12]
+    PIN_S_LC_DEN = [13, 13, 13, 13, 13, 13, 13, 13, 12, 11, 10, 9, 8, 7, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13]
+    PIN_S_EMAX = [
+        4419.129797462226, 1010.5537403793226, 85.63218407922264, 3.0163181736208453,
+        2.3476913169078686, 0.11304809321577121, 0.05878582739650565, 0.002627620932742753,
+        0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, -5.441923076881155e-5, -6.871164967922444e-5,
+        -0.0003406155365023688, -0.0004956350901303653, -0.0005382278315483823, -0.0005499439184449129,
+        -0.0008148414203291925, -0.0023859551644023506, -0.0025833274219798797, -0.002730482668209874,
+        -0.002861228693387175, -0.0038088447900542386, -0.0038353622008285146, -0.003910989504662127,
+        -0.003928601246190308, -0.0039793192138034405, -0.004065028055560342, -0.004068628577770526,
+        -0.004132363973788921, -0.004387253004923683, -0.004404960263507768, -0.004519053612516182,
+        -0.0045475355557148545, -0.004618143320768944, -0.004679206712934623, -0.005275838551975641,
+        -0.005523001474009049, -0.005661567362651757, -0.005835726044533011, -0.005886186642191259,
+        -0.006316594270489362, -0.00659960352876567, -0.007305007236287267, -0.00733737908859124,
+        -0.007356128212885969, -0.007392573418900009, -0.007412815636501858, -0.007456064595922726,
+        -0.007551570801007557, -0.007577477907205688, -0.00760547936811748, -0.007869436107156166,
+        -0.007997165956837693, -0.008368042409748571, -0.008386160148814305, -0.008605823929848922,
+    ]
+    PIN_S_NPAR = [5, 3, 6, 3, 2, 5, 5, 2, 0, 0, 1, 2, 0, 0, 4, 2, 2, 4, 1, 3, 4, 1, 2, 2, 6, 4, 3, 4, 5, 4, 4, 6, 2, 3, 4, 4, 2, 3, 3, 5, 6, 5, 4, 4, 8, 4, 7, 5, 3, 5, 4, 5, 7, 3, 4, 4, 5, 4, 5, 4]
+    PIN_S_LIVE = [
+        -0.01273728915228397, -0.012397731251003045, -0.010812381037838537, -0.01042208585836983,
+        -0.010201130479888194, -0.010187948491559028, -0.010042644350024199, -0.009845398115053144,
+        -0.00903952910411551, -0.008919187994820547, -0.008863258219377767, -0.008855509136200321,
+    ]
+    PIN_G_LC_NUM = [12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12]
+    PIN_G_LC_DEN = [13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13]
+    PIN_G_EMAX = [
+        3144.2884568710397, 2302.4143293077777, 392.5971503756005, 115.29551252503245,
+        1.1140972574803694, 0.21647293549669352, 0.20634030197749, 0.12544620921434657,
+        0.03191805811958175, 0.0, -1.0405478849798388e-5, -0.000711188684746097,
+        -0.0035533214781051157, -0.004795511737167576, -0.004814838855556114, -0.005242624365113564,
+        -0.005787482246932602, -0.006133187535164323, -0.008596611938561198, -0.01258731466310189,
+        -0.013218932602700219, -0.015513513622867917, -0.020059509308067432, -0.02426690897259415,
+        -0.02475790706388038, -0.031037054452576568, -0.03217565968972192, -0.034192245985379295,
+        -0.037648036595296266, -0.03786350996042457, -0.04249446372871251, -0.04383553852707076,
+        -0.04740597612998426, -0.04772182804126908, -0.048592096206524264, -0.04996145323480243,
+        -0.05248632251053338, -0.053911225852430494, -0.05725050234709659, -0.05774939308789473,
+        -0.0577587381231814, -0.06268916944763968, -0.06452808170782498, -0.06652815979244109,
+        -0.06666585161212202, -0.06848562695298296, -0.06871125543920967, -0.0709576345379536,
+        -0.07121060025500044, -0.07174746949392585, -0.07233952329767018, -0.07289241505201287,
+        -0.07615416064121418, -0.07641064148494951, -0.07904787190406168, -0.07933428695796324,
+        -0.07959637166385172, -0.08055405598336417, -0.0815415774411034, -0.08155880396102999,
+        -0.08589333463247362, -0.08650752766420201, -0.08850080877962133, -0.08906807135780583,
+        -0.0894783158964076, -0.09236073486731246, -0.09450805987317386, -0.09577578262897105,
+        -0.09846266299325436, -0.10128499772779555, -0.10191221395572513, -0.1022010913403918,
+        -0.10247972832643418, -0.10623961178250028, -0.10713418261444885, -0.11124146877709745,
+        -0.11274791611074315, -0.11355742382232921, -0.11428135674495542, -0.11439020714004836,
+    ]
+    PIN_G_NPAR = [11, 10, 8, 12, 10, 7, 7, 7, 8, 1, 2, 3, 6, 3, 5, 5, 4, 8, 7, 5, 8, 6, 6, 9, 8, 9, 7, 9, 9, 8, 12, 9, 12, 10, 7, 7, 9, 14, 11, 10, 10, 14, 10, 12, 13, 14, 12, 13, 10, 12, 13, 13, 14, 14, 11, 11, 11, 15, 13, 14, 14, 16, 14, 17, 17, 11, 14, 15, 15, 14, 14, 13, 16, 14, 16, 15, 18, 13, 14, 16]
+    PIN_G_LIVE = [
+        -0.1592523598599889, -0.15022961846025504, -0.14055521156268097, -0.1334233199212144,
+        -0.12931001478363915, -0.12729476378264942, -0.12392331361457364, -0.1224483880701329,
+        -0.1221661065068472, -0.12027109753967548, -0.11897824010905407, -0.11645089682921181,
+    ]
+    PIN_G_STATS = (galilean_attempted = 640, galilean_accepted = 619, galilean_reflect_attempted = 121, galilean_reflect_evals = 121, galilean_reflect_accepted = 100)
+    PIN_D_LC_NUM = [12, 12, 11, 10, 9, 8, 7, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12]
+    PIN_D_LC_DEN = [13, 13, 12, 11, 10, 9, 8, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13]
+    PIN_D_EMAX = [
+        0.5683032610215084, 0.04085402446129616, 0.0, 0.0,
+        0.0, 0.0, 0.0, -0.0002415774487922488,
+        -0.0004619323185189282, -0.0014413214393594253, -0.0026588419367326215, -0.0033412393551947826,
+        -0.003610632599490484, -0.0038022863894361545, -0.005395378550775143, -0.006823931352110592,
+        -0.006889445857491823, -0.009254923968391053, -0.009481858767731981, -0.011110679570031153,
+        -0.012033701958010592, -0.012781277332849115, -0.015120124003479292, -0.015660710979635856,
+        -0.015889455197580567, -0.016368455210328436, -0.016813215495566344, -0.017121019549627376,
+        -0.018989232854541682, -0.02173716977503926, -0.02281788067358222, -0.023257434242204715,
+        -0.023264271601147413, -0.023421062981890763, -0.024419145414096427, -0.0248688525864012,
+        -0.02489509438718094, -0.02561903931868135, -0.02650766531827569, -0.0269615687328806,
+        -0.028451202388155596, -0.029167500052373035, -0.029326768596927878, -0.02971251281006961,
+        -0.030007476995403997, -0.030745653042293628, -0.031410690717822834, -0.0316169620840196,
+        -0.03176555521577647, -0.03190513953104817, -0.0328335182977063, -0.03359010249234158,
+        -0.03363846885340897, -0.0342850545199016, -0.035160225722636024, -0.0352934784406423,
+        -0.036366085579350886, -0.03826528737529982, -0.03861222019746885, -0.03865195399157628,
+    ]
+    PIN_D_NPAR = [6, 4, 1, 1, 2, 2, 4, 3, 6, 6, 4, 3, 4, 5, 5, 6, 5, 3, 5, 7, 4, 7, 6, 6, 6, 7, 6, 9, 9, 8, 7, 6, 9, 8, 9, 8, 7, 5, 8, 8, 8, 7, 5, 6, 8, 8, 9, 9, 9, 8, 6, 6, 9, 7, 7, 8, 7, 6, 10, 8]
+    PIN_D_LIVE = [
+        -0.06807237923919043, -0.054164644627748615, -0.04796606078869758, -0.0446797791601345,
+        -0.04457319055415465, -0.04373742360162495, -0.04257064966474083, -0.04174472546941582,
+        -0.0409156328602522, -0.04087820938898697, -0.039766124292473684, -0.039181799166424246,
+    ]
+
+    # the trajectory vectors are asserted on Julia 1.10 only (header); the
+    # replay identity and the charge, order, and weld asserts run on every version
+    pin3_assert_trajectory = VERSION < v"1.11"
+
+    @testset "fixture S: surface-aware step loop through the empty plateau (seed 424271)" begin
+        Random.seed!(424271)
+        ls_s = pin3_surface_liveset(pin3_counts_s)
+        iters, emaxs, npars, logts, live, _ = pin3_step_run(424271, ls_s, 4.0, 40, 60, :H,
+                                                            MCAtomGrandCanonicalMoves())
+        @test iters == collect(1:60)
+        @test issorted(emaxs, rev=true)
+        @test logts == log.(PIN_S_LC_NUM ./ PIN_S_LC_DEN)
+        if pin3_assert_trajectory
+            @test npars == PIN_S_NPAR
+            @test all(isapprox.(emaxs, PIN_S_EMAX; rtol=1e-12, atol=0.0))
+            @test all(isapprox.(live, PIN_S_LIVE; rtol=1e-12, atol=0.0))
+        end
+        # same-process replay of the fixture
+        Random.seed!(424271)
+        ls_s2 = pin3_surface_liveset(pin3_counts_s)
+        iters2, emaxs2, npars2, logts2, live2, _ = pin3_step_run(424271, ls_s2, 4.0, 40, 60, :H,
+                                                                 MCAtomGrandCanonicalMoves())
+        @test iters2 == iters
+        @test npars2 == npars
+        @test logts2 == logts
+        @test emaxs2 == emaxs
+        @test live2 == live
+    end
+
+    @testset "fixture G: plain step loop with the Galilean burst (seed 424272)" begin
+        Random.seed!(424272)
+        ls_g = pin3_liveset(pin3_counts_g)
+        iters, emaxs, npars, logts, live, params = pin3_step_run(424272, ls_g, 12.0, 40, 80, :Ar,
+            MCAtomGrandCanonicalMoves(galilean_steps=2, galilean_n_refresh=4, galilean_step_size=0.5))
+        @test iters == collect(1:80)
+        @test issorted(emaxs, rev=true)
+        @test logts == log.(PIN_G_LC_NUM ./ PIN_G_LC_DEN)
+        if pin3_assert_trajectory
+            @test npars == PIN_G_NPAR
+            @test all(isapprox.(emaxs, PIN_G_EMAX; rtol=1e-12, atol=0.0))
+            @test all(isapprox.(live, PIN_G_LIVE; rtol=1e-12, atol=0.0))
+            for (k, v) in pairs(PIN_G_STATS)
+                @test params.move_stats[k] == v
+            end
+        end
+        # same-process replay of the fixture
+        Random.seed!(424272)
+        ls_g2 = pin3_liveset(pin3_counts_g)
+        iters2, emaxs2, npars2, logts2, live2, params2 = pin3_step_run(424272, ls_g2, 12.0, 40, 80, :Ar,
+            MCAtomGrandCanonicalMoves(galilean_steps=2, galilean_n_refresh=4, galilean_step_size=0.5))
+        @test iters2 == iters
+        @test npars2 == npars
+        @test logts2 == logts
+        @test emaxs2 == emaxs
+        @test live2 == live
+        @test all(params2.move_stats[k] == params.move_stats[k] for k in keys(PIN_G_STATS))
+    end
+
+    @testset "fixture D: driver entered through initialize=false with an observable (seed 424273)" begin
+        df, seen, live = pin3_driver_run(424273, pin3_counts_d, 6.0, 40, 60)
+        @test nrow(df) == 60
+        @test names(df) == ["iter", "emax", "num_particles", "log_compression", "n_obs"]
+        @test df.iter == collect(1:60)
+        @test issorted(df.emax, rev=true)
+        @test df.log_compression == log.(PIN_D_LC_NUM ./ PIN_D_LC_DEN)
+        if pin3_assert_trajectory
+            @test df.num_particles == PIN_D_NPAR
+            @test all(isapprox.(df.emax, PIN_D_EMAX; rtol=1e-12, atol=0.0))
+            @test all(isapprox.(live, PIN_D_LIVE; rtol=1e-12, atol=0.0))
+        end
+        @test df.n_obs == Float64.(df.num_particles)
+        @test seen == df.num_particles
+        # same-process replay of the fixture
+        df2, seen2, live2 = pin3_driver_run(424273, pin3_counts_d, 6.0, 40, 60)
+        @test df2 == df
+        @test seen2 == seen
+        @test live2 == live
+    end
+end


### PR DESCRIPTION
Implements #269. Stacked on #271's branch (`feature/igref-omega-ordering`); merge that PR first.

- Adds `test/test-SamplingSchemes/test-atomistic-igref-omega-regressions.jl` (18 assertions, no source changes).
- Surface three-way weld over a temperature interval (the bounded surface fixture, z0V = 4, n_max = 4, K = 16; the Omega-ordered run at the chemical potential of ideal occupancy 2 at 300 K, reduced at 250, 300, and 400 K, and the energy-ordered run, each against the fixed-N stitch over N = 0 to 4; calibrated over Omega-ordered igref seeds {1, 2, 3, 86621}, energy-ordered igref seeds {101, 102, 103, 86721}, and fixed-N seeds {1001, 1002, 1003, 87621}): Omega-ordered run against the stitch, maximum deviations logXi 0.672 (the shipped pair, 400 K) and mean_N 0.417 (the seed-2 pair, 300 K; the shipped pair's largest is 0.329 at 300 K), N_eff floor observed 2.9 at 400 K, gates 2.1 and 1.3 with floor 2.5; energy-ordered run against the stitch at 300 and 400 K, maximum deviations logXi 0.480 and mean_N 0.525, N_eff floor observed 10.0, gates 1.5 and 1.6 with floor 9. Every Omega-ordered run of the calibration ends on the empty-configuration atom, the ground-state sector at this mu. The fixture's residual-free temperature is 0.1467 K (argon mass).
- Verified here, recorded rather than gated: the energy-ordered run's 250 K target at this mu, where the ideal occupancy falls to about 0.13, lies outside its trust window (N_eff 1.2 to 4.3 over the seed pairs, deviations up to 2.8 nats), while the Omega-ordered run keeps N_eff 18 to 23 there; the two constructions cover different windows around a fixed chemical potential, as the ordering's docstring states.
- Exactness identity at the residual-free temperature: a hand assembly on the `:omega` column reproduces the reduction's logXi at the run's own mu to rtol 10<sup>−10</sup> (measured relative difference 0.0). The effective-sample-size reduction on the Omega ledger equals the `N_eff` returned by `gc_thermodynamic_stats_ideal_ref` bitwise; its relative form is finite over the interval.
- Plain-box three-way weld at 300 K (the 12 Å periodic fixture, z0V = 6, K = 24, ladders over N = 0 to 12, each run against the stitch; Omega-ordered igref seeds {1, 2, 3, 86631}, energy-ordered igref seeds {101, 102, 103, 86731}, fixed-N seeds {1001, 1002, 1003, 87631}): Omega-ordered run maximum deviations logXi 0.211 (seed 3) and mean_N 0.480 (seed 1), N_eff floor observed 75.4, gates 0.65 and 1.5 with floor 60; energy-ordered run maximum deviations logXi 0.385 (the shipped seed) and mean_N 0.792 (seed 1), gates 1.2 and 2.4. The fixture's 400 K target, at an ideal occupancy of about 110, far above the ladder's top at N = 12, lies outside every construction's coverage (deviations of 1 to 20 nats, N_eff 1 to 2) and is recorded in the file header, not gated.
- One test-only commit.

Adversarially reviewed pre-filing under three charters (issue-promise round-trip, independent oracle, determinism and assertion accounting). Full suite green on the shipped bytes.
