### PR TITLE
Offset-stacked multilayer triangular lattices and layer-resolved order parameters

### DIFF
--- a/src/AbstractWalkers/AbstractWalkers.jl
+++ b/src/AbstractWalkers/AbstractWalkers.jl
@@ -32,6 +32,7 @@ export order_parameter_sqrt3
 export bragg_amplitude
 export order_parameter_stripe
 export order_parameter_p2x2
+export bragg_amplitude_layers, stacking_bragg_amplitude
 export site_layers, layer_coverage, occupancy_profile, layer_field
 export enumerate_motif_embeddings, motif_distances
 export view_structure

--- a/src/AbstractWalkers/lattice_walkers.jl
+++ b/src/AbstractWalkers/lattice_walkers.jl
@@ -331,7 +331,9 @@ Throws an `ArgumentError` if the number of components does not match `C`.
                                   cutoff_radii::Vector{Float64}=[1.1, 1.8],
                                   components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                   adsorptions::Union{Vector{Int},Symbol}=:full,
-                                  image_multiplicity::Bool=false)
+                                  image_multiplicity::Bool=false,
+                                  layer_offset::Union{Nothing,NTuple{2,Float64}}=nothing,
+                                  stacking::Symbol=:aligned)
 
 Constructs a square/triangular lattice with the specified parameters. The `components` and `adsorptions` arguments can be a vector of integers specifying
 the indices of the occupied sites, or a symbol. If `components` is `:equal`, the lattice is divided into `C` equal components when possible, or
@@ -372,6 +374,40 @@ cutoff-ladder validation and the empty-shell warning of
 with `image_multiplicity`; the third axis is non-periodic by default, so
 slabs gain no z-wrap images. Must be finite and strictly positive when given;
 violations throw an `ArgumentError`.
+
+The triangular constructor's `layer_offset` and `stacking` keywords set the
+in-plane displacement between successive layers, for layered hosts whose
+layers do not sit vertically above one another. The default
+(`layer_offset = nothing`, `stacking = :aligned`) keeps the vertical third
+lattice vector `[0, 0, c]`, so every existing call constructs the same
+object. An explicit `layer_offset = (Δx, Δy)`, an absolute in-plane
+displacement in the same length units as `lattice_constant` and
+`interlayer_spacing`, makes the third lattice vector `[Δx, Δy, c]`, so
+layer `k` sits at `(k − 1)·(Δx, Δy)` in-plane; `stacking = :aligned` with
+an explicit offset is accepted. `stacking = :abc` selects the
+triangle-centre offset `(a/2, √3·a/6)`: each layer sits over the triangle
+centres of the layer below and the site geometry repeats after three
+layers (`3·Δ = t₁ + t₂` is an in-plane lattice vector). It cannot be
+combined with an explicit `layer_offset`, and any other `stacking` value
+throws an `ArgumentError`. Both offset components must be finite. No
+layer-count condition applies with a periodic third axis: the supercell's
+third vector is `supercell_dimensions[3]` times the skewed `a₃`, itself a
+lattice vector of the stacked crystal, so every layer count gives a valid
+periodic crystal with the same ABC site geometry, and
+`supercell_dimensions[3]` is the period of the occupation pattern along
+the stacking direction: `1` constrains every layer to the same pattern in
+its own frame (a cell primitive along the stacking direction), while `3`
+or `6` admits the stacking sequences of an in-plane order (see
+[`stacking_bragg_amplitude`](@ref)). On an offset cell build with
+`image_multiplicity = true`: on one- and two-layer periodic cells the
+default once-per-pair minimum-image convention drops the interlayer shell
+entirely or by half, because the partners across the stacking direction
+are further images of in-plane neighbours (a warning fires), and on
+taller skewed cells it can still drop pairs from a long-cutoff shell,
+whereas the all-images convention enumerates every in-cutoff image and
+reproduces the bulk coordination of the stacked crystal. The skewed cell
+needs no other change: the layer
+helpers read the contiguous layer blocks of `lattice_positions`.
 
 ## Returns
 - `MLattice{C,G}`: A square/triangular lattice object with `C` components.
@@ -552,6 +588,44 @@ function _out_of_plane_spacing(lattice_constant::Float64, interlayer_spacing::Un
     return interlayer_spacing
 end
 
+"""
+    _layer_offset(lattice_constant, layer_offset, stacking)
+
+Resolve the in-plane offset between successive layers for the triangular
+keyword constructor: `stacking = :aligned` returns `layer_offset` (the zero
+offset when `nothing`), and `stacking = :abc` returns the triangle centre
+`(a/2, √3·a/6)` of the in-plane lattice, so that each layer sits over the
+triangle centres of the one below and the site geometry repeats after
+three layers. An explicit `layer_offset` together with `stacking = :abc`,
+an unknown `stacking`, or a non-finite offset throws an `ArgumentError`.
+No layer-count condition applies: the supercell's third vector is
+`supercell_dimensions[3]` times the skewed `a₃`, a lattice vector of the
+stacked crystal for every layer count, so every `supercell_dimensions[3]`
+is a valid periodic supercell with the same site geometry (see the
+[`MLattice`](@ref) docstring).
+"""
+function _layer_offset(lattice_constant::Float64,
+                       layer_offset::Union{Nothing,NTuple{2,Float64}},
+                       stacking::Symbol)
+    if stacking == :aligned
+        offset = layer_offset === nothing ? (0.0, 0.0) : layer_offset
+    elseif stacking == :abc
+        if layer_offset !== nothing
+            throw(ArgumentError(
+                "stacking=:abc fixes the layer offset to (a/2, √3·a/6); pass " *
+                "either stacking or layer_offset, not both, got " *
+                "layer_offset=$layer_offset"))
+        end
+        offset = (lattice_constant / 2, sqrt(3) * lattice_constant / 6)
+    else
+        throw(ArgumentError("stacking must be :aligned or :abc, got :$stacking"))
+    end
+    if !(isfinite(offset[1]) && isfinite(offset[2]))
+        throw(ArgumentError("layer_offset must be finite, got $offset"))
+    end
+    return offset
+end
+
 function MLattice{C,SquareLattice}(; lattice_constant::Float64=1.0,
                                     interlayer_spacing::Union{Nothing,Float64}=nothing,
                                     basis::Vector{Tuple{Float64,Float64,Float64}}=[(0.0, 0.0, 0.0)],
@@ -582,10 +656,13 @@ function MLattice{C,TriangularLattice}(; lattice_constant::Float64=1.0,
                                         components::Union{Vector{Vector{Int64}},Vector{Vector{Bool}},Symbol}=:equal,
                                         adsorptions::Union{Vector{Int},Symbol}=:full,
                                         image_multiplicity::Bool=false,
+                                        layer_offset::Union{Nothing,NTuple{2,Float64}}=nothing,
+                                        stacking::Symbol=:aligned,
                                     ) where C
 
     c = _out_of_plane_spacing(lattice_constant, interlayer_spacing)
-    lattice_vectors = [lattice_constant 0.0 0.0; 0.0 sqrt(3)*lattice_constant 0.0; 0.0 0.0 c]
+    dx, dy = _layer_offset(lattice_constant, layer_offset, stacking)
+    lattice_vectors = [lattice_constant 0.0 dx; 0.0 sqrt(3)*lattice_constant dy; 0.0 0.0 c]
     lattice_comp, lattice_adsorptions = mlattice_setup(C, basis, supercell_dimensions, components, adsorptions)
 
     return MLattice{C,TriangularLattice}(lattice_vectors, basis, supercell_dimensions, periodicity, cutoff_radii, lattice_comp, lattice_adsorptions;
@@ -712,7 +789,9 @@ strictly two-dimensional supercell (`supercell_dimensions[3] == 1`), and
 `supercell_dimensions[1]` divisible by 3 (the tripartition closes on the
 periodic cell iff the a₁ circumference is a multiple of 3; the a₂ dimension
 is unconstrained); violations throw an `ArgumentError`. Note the shipped
-default `supercell_dimensions = (4, 2, 1)` is *not* commensurate.
+default `supercell_dimensions = (4, 2, 1)` is *not* commensurate. For
+multilayer cells use the layer-indexed method
+`order_parameter_sqrt3(lattice, layer)`.
 """
 function order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice})
     if length(lattice.basis) != 2
@@ -759,6 +838,101 @@ function order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice})
     # integers; one final square root, no complex arithmetic.
     s2 = n[1]^2 + n[2]^2 + n[3]^2 - n[1] * n[2] - n[2] * n[3] - n[3] * n[1]
     return sqrt(Float64(s2)) / M
+end
+
+"""
+    _check_triangular_basis(caller::Symbol, lattice::MLattice{1,TriangularLattice})
+
+Shared guard for the layer-indexed triangular observables: throw an
+`ArgumentError`, naming the public entry point `caller`, unless the lattice
+carries the standard two-site centered-rectangular basis
+`[(0, 0, 0), (a/2, √3·a/2, 0)]` consistent with its lattice vectors, the
+convention under which the in-plane site decoders of the single-layer
+kernels apply.
+"""
+function _check_triangular_basis(caller::Symbol, lattice::MLattice{1,TriangularLattice})
+    if length(lattice.basis) != 2
+        throw(ArgumentError("$caller requires the two-site " *
+            "centered-rectangular triangular basis, got " *
+            "$(length(lattice.basis)) basis sites"))
+    end
+    ax, ay = lattice.lattice_vectors[1, 1], lattice.lattice_vectors[2, 2]
+    b1, b2 = lattice.basis
+    if !(isapprox(b1[1], 0.0, atol=1e-9) && isapprox(b1[2], 0.0, atol=1e-9) &&
+         isapprox(b2[1], ax / 2, atol=1e-9) && isapprox(b2[2], ay / 2, atol=1e-9))
+        throw(ArgumentError("$caller requires the standard " *
+            "triangular basis [(0, 0, 0), (a/2, √3·a/2, 0)] consistent with " *
+            "the lattice vectors, got $(lattice.basis)"))
+    end
+    return nothing
+end
+
+"""
+    _check_layer_index(caller::Symbol, d3::Int, layer::Int)
+
+Shared guard for the layer-indexed observables: throw an `ArgumentError`,
+naming the public entry point `caller`, unless `1 ≤ layer ≤ d3`, in the
+style of [`layer_coverage`](@ref).
+"""
+function _check_layer_index(caller::Symbol, d3::Int, layer::Int)
+    if !(1 <= layer <= d3)
+        throw(ArgumentError("$caller requires 1 <= layer <= $d3 " *
+            "(= supercell_dimensions[3]), got $layer"))
+    end
+    return nothing
+end
+
+"""
+    order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice}, layer::Int) -> Float64
+
+Layer-resolved form of [`order_parameter_sqrt3`](@ref) for multilayer
+triangular cells: the same three-sublattice modulus evaluated on the
+contiguous block of `B = 2·d₁·d₂` sites of layer `layer` (see
+[`site_layers`](@ref)) and normalized by `B`, so a perfect √3×√3
+arrangement in that layer gives `1/3` whatever the other layers hold.
+Because `lattice_positions` orders basis innermost, dimension 1 next and
+dimension 3 outermost, a layer block carries the site ordering of the
+two-dimensional cell and the tripartition arithmetic of the single-layer
+kernel applies verbatim, for aligned and for offset-stacked layers alike
+(the `layer_offset`/`stacking` keywords of the constructor): the sublattice
+labels are read from the block index, not from the Cartesian positions. At
+`d₃ == 1`, `layer = 1` returns exactly the zero-argument value (same loop,
+same reduction).
+
+Usable per configuration through the `observables` keyword of the
+nested-sampling loops, one callback per layer:
+
+    observables = [Symbol(:psi, k) => (cfg -> order_parameter_sqrt3(cfg, k)) for k in 1:d₃]
+
+Requires the standard two-site basis and `supercell_dimensions[1]`
+divisible by 3, as the zero-argument form, plus `1 ≤ layer ≤ d₃`; the
+two-dimensionality guard of the zero-argument form does not apply.
+Violations throw an `ArgumentError`.
+"""
+function order_parameter_sqrt3(lattice::MLattice{1,TriangularLattice}, layer::Int)
+    _check_triangular_basis(:order_parameter_sqrt3, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    _check_layer_index(:order_parameter_sqrt3, d3, layer)
+    if d1 % 3 != 0
+        throw(ArgumentError("order_parameter_sqrt3 requires " *
+            "supercell_dimensions[1] divisible by 3 so the three √3×√3 " *
+            "sublattices close on the periodic cell, got $d1"))
+    end
+    B = 2 * d1 * d2
+    occ = lattice.components[1]
+    s0 = (layer - 1) * B
+    # The single-layer sublattice decoder applied to the block-local index
+    # t = s − s0 (dimension 3 outermost, so the block is one layer)
+    n = zeros(Int, 3)
+    for t in 1:B
+        occ[s0 + t] || continue
+        b = (t - 1) % 2
+        ci = ((t - 1) ÷ 2) % d1
+        c = b == 0 ? ci % 3 : (ci + 2) % 3
+        n[c+1] += 1
+    end
+    s2 = n[1]^2 + n[2]^2 + n[3]^2 - n[1] * n[2] - n[2] * n[3] - n[3] * n[1]
+    return sqrt(Float64(s2)) / B
 end
 
 """
@@ -941,7 +1115,9 @@ must be evaluated on configurations (e.g. per culled walker, via the
 Requires the standard two-site centered-rectangular triangular basis
 `[(0, 0, 0), (a/2, √3·a/2, 0)]` consistent with the lattice vectors and a
 strictly two-dimensional supercell (`supercell_dimensions[3] == 1`);
-violations throw an `ArgumentError`.
+violations throw an `ArgumentError`. For multilayer cells use the
+layer-indexed method `bragg_amplitude(lattice, m, n, layer)` or
+[`bragg_amplitude_layers`](@ref).
 """
 function bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int)
     if length(lattice.basis) != 2
@@ -993,6 +1169,66 @@ function bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int)
 end
 
 """
+    bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int, layer::Int) -> Float64
+
+Layer-resolved form of the triangular [`bragg_amplitude`](@ref) for
+multilayer cells: `|ρ(k)|` of the occupation pattern in layer `layer`'s
+contiguous block of `B = 2·d₁·d₂` sites (see [`site_layers`](@ref)),
+normalized by `B`, at the same in-plane `k = 2π·(m/d₁, n/(√3·d₂))` of the
+conventional cell. The phase is read from the block-local site index, so
+the value is that of the layer's pattern in its own frame; a rigid in-plane
+offset of the whole layer (the `layer_offset`/`stacking` keywords of the
+constructor) multiplies ρ by a global phase that the modulus drops, so
+aligned and offset-stacked cells give the same value. The relative phases
+between layers, which carry the stacking sequence of an in-plane order, are
+available from [`bragg_amplitude_layers`](@ref). At `d₃ == 1`, `layer = 1`
+returns exactly the zero-argument value (same loop, same reduction).
+
+Requires the standard two-site basis and `1 ≤ layer ≤ d₃`; violations throw
+an `ArgumentError`.
+"""
+function bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int, layer::Int)
+    _check_triangular_basis(:bragg_amplitude, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    _check_layer_index(:bragg_amplitude, d3, layer)
+    colnum, rownum, twoM = _bragg_phase_tables(d1, d2, m, n)
+    z = _bragg_block_sum(lattice.components[1], d1, d2, colnum, rownum, twoM,
+                         (layer - 1) * twoM)
+    return abs(z) / twoM
+end
+
+# Own-frame phase tables of the single-layer triangular kernel for the
+# in-plane index (m, n): the reduced column and row numerators and the
+# modulus 2·d₁·d₂ (see the single-layer `bragg_amplitude` for the derivation)
+function _bragg_phase_tables(d1::Int, d2::Int, m::Int, n::Int)
+    twoM = 2 * d1 * d2
+    mr = mod(m, 2 * d1)
+    nr = mod(n, 2 * d2)
+    colnum = [mod(mr * u * d2, twoM) for u in 0:2*d1-1]
+    rownum = [mod(nr * v * d1, twoM) for v in 0:2*d2-1]
+    return colnum, rownum, twoM
+end
+
+# Unnormalized own-frame Bragg sum over the block of twoM sites following
+# site s0: the single-layer loop and reduction applied to the block-local
+# index t = s − s0 (dimension 3 outermost, so the block is one layer)
+function _bragg_block_sum(occ::Vector{Bool}, d1::Int, d2::Int,
+                          colnum::Vector{Int}, rownum::Vector{Int}, twoM::Int, s0::Int)
+    z = 0.0 + 0.0im
+    for t in 1:twoM
+        if occ[s0 + t]
+            b = (t - 1) % 2
+            ci0 = ((t - 1) ÷ 2) % d1
+            cj0 = (t - 1) ÷ (2 * d1)
+            num = colnum[2*ci0+b+1] + rownum[2*cj0+b+1]
+            num >= twoM && (num -= twoM)
+            z += cispi(num / (d1 * d2))
+        end
+    end
+    return z
+end
+
+"""
     order_parameter_p2x2(lattice::MLattice{1,TriangularLattice}) -> Float64
 
 Orientation-degenerate M-point order parameter for p(2×2) and p(2×1)/row
@@ -1035,7 +1271,8 @@ of the p(2×2) sublattice. A cell hosting this order parameter and
 [`order_parameter_sqrt3`](@ref) simultaneously needs
 `supercell_dimensions[1]` divisible by 6 with an even second dimension;
 the shipped default `(4, 2, 1)` satisfies this function's guards but not
-the √3×√3 one's.
+the √3×√3 one's. For multilayer cells use the layer-indexed method
+`order_parameter_p2x2(lattice, layer)`.
 """
 function order_parameter_p2x2(lattice::MLattice{1,TriangularLattice})
     if length(lattice.basis) != 2
@@ -1066,6 +1303,141 @@ function order_parameter_p2x2(lattice::MLattice{1,TriangularLattice})
     return sqrt(bragg_amplitude(lattice, d1 ÷ 2, -(d2 ÷ 2))^2 +
                 bragg_amplitude(lattice, 0, d2)^2 +
                 bragg_amplitude(lattice, d1 ÷ 2, d2 ÷ 2)^2)
+end
+
+"""
+    order_parameter_p2x2(lattice::MLattice{1,TriangularLattice}, layer::Int) -> Float64
+
+Layer-resolved form of [`order_parameter_p2x2`](@ref) for multilayer
+triangular cells: the quadrature of the three layer-indexed M-point
+amplitudes of [`bragg_amplitude`](@ref) for layer `layer`, so a perfect
+p(2×1) row phase in that layer gives `1/2` and a perfect p(2×2) arrangement
+`√3/4`, whatever the other layers hold and for aligned and offset-stacked
+layers alike. At `d₃ == 1`, `layer = 1` returns exactly the zero-argument
+value.
+
+Usable per configuration through the `observables` keyword of the
+nested-sampling loops, one callback per layer:
+
+    observables = [Symbol(:psi, k) => (cfg -> order_parameter_p2x2(cfg, k)) for k in 1:d₃]
+
+Requires the standard two-site basis and even in-plane supercell
+dimensions, as the zero-argument form, plus `1 ≤ layer ≤ d₃`; violations
+throw an `ArgumentError`.
+"""
+function order_parameter_p2x2(lattice::MLattice{1,TriangularLattice}, layer::Int)
+    _check_triangular_basis(:order_parameter_p2x2, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    _check_layer_index(:order_parameter_p2x2, d3, layer)
+    if d1 % 2 != 0 || d2 % 2 != 0
+        bad = d1 % 2 != 0 ? d1 : d2
+        throw(ArgumentError("order_parameter_p2x2 requires even in-plane " *
+            "supercell dimensions, since the M points sit at half-integer " *
+            "reciprocal indices and the p(2×2) sublattice closes on the " *
+            "periodic cell only for even circumferences; got $bad"))
+    end
+    return sqrt(bragg_amplitude(lattice, d1 ÷ 2, -(d2 ÷ 2), layer)^2 +
+                bragg_amplitude(lattice, 0, d2, layer)^2 +
+                bragg_amplitude(lattice, d1 ÷ 2, d2 ÷ 2, layer)^2)
+end
+
+"""
+    bragg_amplitude_layers(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int) -> Vector{ComplexF64}
+
+Complex per-layer Bragg amplitudes of the occupation pattern on a
+multilayer single-component triangular lattice, each layer in its own
+frame,
+
+    ρ_k = (1/B) Σ_{occupied sites s in layer k} e^{i k·r_s},   k = 1:d₃,
+
+with `B = 2·d₁·d₂` sites per layer, the in-plane wavevector
+`k = 2π·(m/d₁, n/(√3·d₂))` in inverse lattice constants (the convention of
+the triangular [`bragg_amplitude`](@ref)), and `r_s` the in-plane position
+of site `s` relative to its own layer's origin: the phase table of the
+layer-indexed [`bragg_amplitude`](@ref), read from the block-local site
+index, so `abs.(ρ)` equals that function's values and the relative phases
+between layers compare each layer's pattern in the layer's own frame. The
+rigid in-plane offset of an offset-stacked cell (the
+`layer_offset`/`stacking` keywords of the constructor) does not enter: it
+is absorbed in the skewed supercell whose reciprocal lattice
+[`stacking_bragg_amplitude`](@ref) samples, whereas a per-layer offset
+phase would make the layer transform depend on which layer is called
+layer 1 whenever `d₃·k·Δ` is not a whole number of turns. The vector is
+translation-covariant: an in-plane lattice translation multiplies every
+`ρ_k` by one common phase, and a translation by the third lattice vector
+relabels the layers cyclically.
+
+The return value is a `Vector`, not a scalar, so this function is not
+directly usable as an `observables` callback (callbacks must return a
+`Real`); record a component's modulus caller-side, e.g.
+`cfg -> abs(bragg_amplitude_layers(cfg, m, n)[k])`, or use
+[`stacking_bragg_amplitude`](@ref).
+
+Requires the standard two-site centered-rectangular triangular basis
+`[(0, 0, 0), (a/2, √3·a/2, 0)]` consistent with the lattice vectors;
+violations throw an `ArgumentError`. Any number of layers is accepted,
+`d₃ == 1` included.
+"""
+function bragg_amplitude_layers(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int)
+    _check_triangular_basis(:bragg_amplitude_layers, lattice)
+    d1, d2, d3 = lattice.supercell_dimensions
+    colnum, rownum, twoM = _bragg_phase_tables(d1, d2, m, n)
+    occ = lattice.components[1]
+    rho = zeros(ComplexF64, d3)
+    for k in 1:d3
+        rho[k] = _bragg_block_sum(occ, d1, d2, colnum, rownum, twoM, (k - 1) * twoM) / twoM
+    end
+    return rho
+end
+
+"""
+    stacking_bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int, l::Int) -> Float64
+
+Stacking-resolved Bragg amplitude of a multilayer single-component
+triangular lattice: the modulus of the discrete Fourier transform, along
+the layer index, of the own-frame per-layer amplitudes of
+[`bragg_amplitude_layers`](@ref),
+
+    |A_l| = |(1/d₃) Σ_{k=1}^{d₃} ρ_k e^{2πi·l·(k − 1)/d₃}|,   l ∈ 0:d₃−1.
+
+This is the three-dimensional structure factor of the periodic supercell,
+`|Σ_{occupied sites} e^{i K·r}| / M` with `M = 2·d₁·d₂·d₃`, at its own
+reciprocal-lattice point `K = 2π·A⁻ᵀ·(m, n, l)` (`A` the supercell
+matrix, so the skewed third vector of an offset-stacked cell is accounted
+for exactly). It is therefore invariant under every lattice translation
+of the configuration, in-plane or along the stacking direction, at every
+`(m, n, l)` on every cell, and the `l` labels do not depend on the sign or
+size of the layer offset. `l = 0` is the amplitude of the sequence in
+which every layer carries the same own-frame pattern, and `l ≥ 1` picks
+out the sequences whose own-frame phase advances by `−2π·l/d₃` per layer:
+on a three-layer cell at a K point, a √3×√3 sublattice held fixed across
+layers gives `l = 0` and one that rotates by one sublattice per layer
+gives `l = 1` or `l = 2` by its sense; at an M point, rows held fixed give
+`l = 0`, while rows shifted by one row per layer (an own-frame phase
+advance of π, a two-layer period) give a pure `l = d₃/2` component on an
+even layer count and spread over every `l`, `l = 0` included, on an odd
+one ((1/6, 1/3, 1/3) on three layers). The components
+obey the Parseval identity `Σ_l |A_l|² = (1/d₃) Σ_k |ρ_k|²`, and each lies
+in `[0, 1]`. The value is a scalar, so
+`cfg -> stacking_bragg_amplitude(cfg, m, n, l)` is directly usable as an
+`observables` callback in the nested-sampling loops.
+
+Requires the structural guard of [`bragg_amplitude_layers`](@ref) and
+`0 ≤ l ≤ d₃ − 1`; violations throw an `ArgumentError`.
+"""
+function stacking_bragg_amplitude(lattice::MLattice{1,TriangularLattice}, m::Int, n::Int, l::Int)
+    d3 = lattice.supercell_dimensions[3]
+    if !(0 <= l <= d3 - 1)
+        throw(ArgumentError("stacking_bragg_amplitude requires 0 <= l <= $(d3 - 1) " *
+            "(= supercell_dimensions[3] - 1), got $l"))
+    end
+    rho = bragg_amplitude_layers(lattice, m, n)
+    z = 0.0 + 0.0im
+    for k in 1:d3
+        # Layer phase reduced modulo one turn, so half turns are exactly ±1
+        z += rho[k] * cispi(2 * mod(l * (k - 1), d3) / d3)
+    end
+    return abs(z) / d3
 end
 
 """

--- a/test/test-AbstractWalkers.jl
+++ b/test/test-AbstractWalkers.jl
@@ -865,6 +865,209 @@
                 @test tri.lattice_vectors ≈ [1.0 0.0 0.0; 0.0 sqrt(3) 0.0; 0.0 0.0 1.25]
             end
 
+            @testset "Layer offset and stacking" begin
+                # Offset-stacked layers: interlayer spacing h in units of the
+                # in-plane lattice constant (the c/(3a) ratio of a
+                # representative O3-type layered host) and the triangle-centre
+                # offset Δ = (1/2, √3/6), for which 3Δ = t₁ + t₂ is an
+                # in-plane lattice vector, so three layers close the
+                # periodic repeat
+                h = 4.683 / 2.816
+                S3 = sqrt(3.0)
+                Δ = (0.5, S3 / 6)
+                tri_basis = [(0.0, 0.0, 0.0), (0.5, S3 / 2, 0.0)]
+                # Shipped-geometry reference: the positional inner
+                # constructor with an explicit third lattice vector (dx, dy, c)
+                function inner_tri(dims, dx, dy, c, per3, cutoffs)
+                    lv = [1.0 0.0 dx; 0.0 S3 dy; 0.0 0.0 c]
+                    M = 2 * prod(dims)
+                    MLattice{1,TriangularLattice}(lv, tri_basis, dims,
+                        (true, true, per3), cutoffs,
+                        [[false for _ in 1:M]], ones(Bool, M))
+                end
+                # Per-axis fractional wrap of the separation and its |Δz|:
+                # equal to the minimum image for every pair asserted here
+                # (|Δz| ≤ h dominates any in-plane ambiguity), not a general
+                # minimum-image routine on a skewed cell
+                function minimg(lat, i, j)
+                    dims = lat.supercell_dimensions
+                    scv = hcat([lat.lattice_vectors[:, k] .* dims[k] for k in 1:3]...)
+                    f = inv(scv) * (lat.positions[j, :] .- lat.positions[i, :])
+                    for k in 1:3
+                        lat.periodicity[k] && (f[k] -= round(f[k]))
+                    end
+                    d = scv * f
+                    return sqrt(sum(abs2, d)), abs(d[3])
+                end
+
+                # Default path unchanged: no stacking keyword, stacking=:aligned
+                # and layer_offset=(0.0, 0.0) all reproduce the shipped
+                # vertical-c geometry field for field, on the default single
+                # layer and on an aligned three-layer cell
+                for (dims, c, per3, cutoffs, kw) in [
+                        ((4, 2, 1), 1.0, false, [1.1], (;)),
+                        ((4, 4, 3), h, true, [1.05, 1.80], (; interlayer_spacing=h))]
+                    ref = inner_tri(dims, 0.0, 0.0, c, per3, cutoffs)
+                    for extra in ((;), (; stacking=:aligned), (; layer_offset=(0.0, 0.0)))
+                        lat = MLattice{1,TriangularLattice}(
+                            supercell_dimensions=dims,
+                            periodicity=(true, true, per3),
+                            cutoff_radii=cutoffs,
+                            components=[[false for _ in 1:2*prod(dims)]];
+                            kw..., extra...)
+                        @test lat.lattice_vectors == ref.lattice_vectors
+                        @test lat.positions == ref.positions
+                        @test lat.neighbors == ref.neighbors
+                    end
+                end
+
+                # stacking=:abc on (4, 4, 3) equals the inner-constructor
+                # build with the skewed third vector (Δx, Δy, h) field for
+                # field; the ladder [1.05, 1.745, 1.80] isolates the in-plane
+                # first and second shells and the adjacent-layer shell at
+                # √(1/3 + h²) ≈ 1.760, and construction is silent
+                ref = inner_tri((4, 4, 3), Δ[1], Δ[2], h, true, [1.05, 1.745, 1.80])
+                abc = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,TriangularLattice}(
+                    interlayer_spacing=h,
+                    supercell_dimensions=(4, 4, 3),
+                    periodicity=(true, true, true),
+                    cutoff_radii=[1.05, 1.745, 1.80],
+                    components=[[false for _ in 1:96]],
+                    stacking=:abc)
+                for field in fieldnames(typeof(abc))
+                    @test getfield(abc, field) == getfield(ref, field)
+                end
+                # An explicit layer_offset=Δ, with or without stacking=:aligned
+                # spelled out, is the same object
+                for extra in ((; layer_offset=Δ), (; layer_offset=Δ, stacking=:aligned))
+                    expl = MLattice{1,TriangularLattice}(
+                        interlayer_spacing=h,
+                        supercell_dimensions=(4, 4, 3),
+                        periodicity=(true, true, true),
+                        cutoff_radii=[1.05, 1.745, 1.80],
+                        components=[[false for _ in 1:96]];
+                        extra...)
+                    @test expl.lattice_vectors == abc.lattice_vectors
+                    @test expl.positions == abc.positions
+                    @test expl.neighbors == abc.neighbors
+                end
+                # lattice_constant scales the :abc offset with the cell
+                a2 = MLattice{1,TriangularLattice}(
+                    lattice_constant=2.0,
+                    interlayer_spacing=2h,
+                    supercell_dimensions=(4, 4, 3),
+                    periodicity=(true, true, true),
+                    cutoff_radii=[2.1],
+                    components=[[false for _ in 1:96]],
+                    stacking=:abc)
+                @test a2.lattice_vectors ≈ [2.0 0.0 1.0; 0.0 2S3 S3/3; 0.0 0.0 2h]
+
+                # No layer-count condition: the supercell's third vector is
+                # d3 times the skewed a₃, a lattice vector of the stacked
+                # crystal for every d3, so every layer count is a valid
+                # periodic supercell with the same site geometry. Under the
+                # all-images convention the (4, 4, 2) and (4, 4, 1) :abc
+                # cells with a periodic third axis reproduce the bulk
+                # coordination [6, 6, 6] of the three-rung ladder; on the
+                # one-layer (rhombohedral primitive) cell the adjacent-layer
+                # partners include the site's own images
+                for (d3, expect_self) in ((2, false), (1, true))
+                    per = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,TriangularLattice}(
+                        interlayer_spacing=h,
+                        supercell_dimensions=(4, 4, d3),
+                        periodicity=(true, true, true),
+                        cutoff_radii=[1.05, 1.745, 1.80],
+                        components=[[false for _ in 1:32*d3]],
+                        stacking=:abc,
+                        image_multiplicity=true)
+                    @test all(length.(per.neighbors[s]) == [6, 6, 6] for s in 1:32*d3)
+                    @test all((s in per.neighbors[s][3]) == expect_self for s in 1:32*d3)
+                    @test !any(s in per.neighbors[s][shell] for s in 1:32*d3 for shell in 1:2)
+                end
+                six = MLattice{1,TriangularLattice}(
+                    interlayer_spacing=h,
+                    supercell_dimensions=(4, 4, 6),
+                    periodicity=(true, true, true),
+                    cutoff_radii=[1.05],
+                    components=[[false for _ in 1:192]],
+                    stacking=:abc)
+                @test six.lattice_vectors[:, 3] == [Δ[1], Δ[2], h]
+                @test six.positions[:, 3] == vcat([fill((k - 1) * h, 32) for k in 1:6]...)
+                open2 = MLattice{1,TriangularLattice}(
+                    interlayer_spacing=h,
+                    supercell_dimensions=(4, 4, 2),
+                    periodicity=(true, true, false),
+                    cutoff_radii=[1.05],
+                    components=[[false for _ in 1:64]],
+                    stacking=:abc)
+                @test open2.lattice_vectors[:, 3] == [Δ[1], Δ[2], h]
+                @test open2.positions[33:64, 1:2] ≈ open2.positions[1:32, 1:2] .+ [Δ[1] Δ[2]]
+                # A generic explicit offset is accepted at any layer count
+                for d3 in (2, 3)
+                    @test MLattice{1,TriangularLattice}(
+                        interlayer_spacing=h,
+                        supercell_dimensions=(4, 4, d3),
+                        periodicity=(true, true, true),
+                        cutoff_radii=[1.05],
+                        components=[[false for _ in 1:32*d3]],
+                        layer_offset=(0.5, 0.0)).lattice_vectors[:, 3] == [0.5, 0.0, h]
+                end
+                # Keyword validation: finite offsets, known stacking, and
+                # not both at once
+                @test_throws ArgumentError MLattice{1,TriangularLattice}(
+                    layer_offset=(NaN, 0.0), components=[[false for _ in 1:16]])
+                @test_throws ArgumentError MLattice{1,TriangularLattice}(
+                    layer_offset=(0.0, Inf), components=[[false for _ in 1:16]])
+                @test_throws ArgumentError MLattice{1,TriangularLattice}(
+                    stacking=:abab, components=[[false for _ in 1:16]])
+                @test_throws ArgumentError MLattice{1,TriangularLattice}(
+                    stacking=:abc, layer_offset=Δ, components=[[false for _ in 1:16]])
+
+                # Positions on the :abc (4, 4, 3) cell: layer k at (k − 1)·Δ
+                # in-plane and (k − 1)·h out of plane
+                @test abc.positions[33:64, 1:2] ≈ abc.positions[1:32, 1:2] .+ [Δ[1] Δ[2]]
+                @test abc.positions[65:96, 1:2] ≈ abc.positions[1:32, 1:2] .+ 2 .* [Δ[1] Δ[2]]
+                @test abc.positions[:, 3] == vcat(zeros(32), fill(h, 32), fill(2h, 32))
+                # Third-axis minimum image: shell 3 is the adjacent-layer
+                # shell, six partners per site at √(1/3 + h²) with |Δz| = h;
+                # the in-plane shells have |Δz| = 0
+                d_I1 = sqrt(1 / 3 + h^2)
+                @test all(length(abc.neighbors[s][3]) == 6 for s in 1:96)
+                @test all(isapprox(minimg(abc, s, j)[1], d_I1; atol=1e-12)
+                          for s in 1:96 for j in abc.neighbors[s][3])
+                @test all(isapprox(minimg(abc, s, j)[2], h; atol=1e-12)
+                          for s in 1:96 for j in abc.neighbors[s][3])
+                @test all(isapprox(minimg(abc, s, j)[2], 0.0; atol=1e-12)
+                          for s in 1:96 for shell in 1:2 for j in abc.neighbors[s][shell])
+                # The nearest layer-2 and layer-3 sites of a layer-1 site are
+                # both adjacent-layer partners (the periodic image of layer 3
+                # sits one layer below layer 1), and the wrapped |Δz| of every
+                # pair is 0 or h (the third-axis wrap alone decides it)
+                @test minimum(minimg(abc, 1, j)[1] for j in 33:64) ≈ d_I1 atol = 1e-12
+                @test minimum(minimg(abc, 1, j)[1] for j in 65:96) ≈ d_I1 atol = 1e-12
+                dz = sort(unique(round.([minimg(abc, i, j)[2] for i in 1:96, j in 1:96]; digits=9)))
+                @test dz ≈ [0.0, h] atol = 1e-8
+
+                # Bulk coordination on the :abc (6, 6, 3) cell under the
+                # image-multiplicity convention: a fourteen-rung ladder that
+                # isolates the six in-plane shells (1, √3, 2, √7, 3, 2√3) and
+                # the eight interlayer shells between them reproduces the
+                # bulk counts on every site, with no self-image entries
+                ladder = [1.05, 1.745, 1.80, 2.012, 2.10, 2.40, 2.655, 2.75,
+                          2.90, 3.008, 3.06, 3.35, 3.40, 3.470]
+                bulk = [6, 6, 6, 6, 6, 12, 12, 12, 6, 6, 12, 6, 6, 6]
+                big = @test_logs min_level = Base.CoreLogging.Warn MLattice{1,TriangularLattice}(
+                    interlayer_spacing=h,
+                    supercell_dimensions=(6, 6, 3),
+                    periodicity=(true, true, true),
+                    cutoff_radii=ladder,
+                    components=[[false for _ in 1:216]],
+                    stacking=:abc,
+                    image_multiplicity=true)
+                @test all(length.(big.neighbors[s]) == bulk for s in 1:216)
+                @test !any(s in vcat(big.neighbors[s]...) for s in 1:216)
+            end
+
             @testset "Error handling" begin
                 # Test wrong number of components
                 @test_throws ArgumentError MLattice{2,SquareLattice}(

--- a/test/test-SamplingSchemes/test-ns-observables.jl
+++ b/test/test-SamplingSchemes/test-ns-observables.jl
@@ -589,6 +589,316 @@
         @test all(isapprox.(df.psi4, df.psi .^ 4; rtol=1e-12))
     end
 
+    @testset "layer-indexed order parameters and stacking amplitudes on multilayer triangular cells" begin
+        # Triangular cells, offset-stacked (:abc) and aligned, interlayer
+        # spacing h in units of the in-plane lattice constant
+        h = 4.683 / 2.816
+        S3 = sqrt(3.0)
+        function obs_tri_layers(d1, d2, d3; stacking=:aligned)
+            MLattice{1,TriangularLattice}(
+                lattice_constant=1.0,
+                interlayer_spacing=h,
+                supercell_dimensions=(d1, d2, d3),
+                periodicity=(true, true, true),
+                cutoff_radii=[1.05],
+                components=[[false for _ in 1:2*d1*d2*d3]],
+                adsorptions=:full,
+                stacking=stacking)
+        end
+        # Site decoder of lattice_positions (basis innermost, dimension 1,
+        # dimension 2, dimension 3 outermost) -> zero-based (ci, cj, b, k),
+        # and its inverse
+        function site_index(lat, s)
+            d1, d2, _ = lat.supercell_dimensions
+            cell = (s - 1) ÷ 2
+            return cell % d1, (cell ÷ d1) % d2, (s - 1) % 2, cell ÷ (d1 * d2)
+        end
+        function site_of(lat, ci, cj, b, k)
+            d1, d2, _ = lat.supercell_dimensions
+            return ((k * d2 + cj) * d1 + ci) * 2 + b + 1
+        end
+        function set_state!(lat, rule)
+            for s in eachindex(lat.components[1])
+                lat.components[1][s] = rule(site_index(lat, s)...)
+            end
+            return lat
+        end
+        # p(2×1) rows along t₂, identical in every layer's own frame or
+        # shifted by one row per layer
+        row_rule(ci, cj, b, k) = iseven(ci - cj)
+        row_rule_shift(ci, cj, b, k) = iseven(ci - cj + k)
+        # √3×√3 states built from explicit coordinates: the primitive
+        # coordinates (p, q) of each site's own-frame position,
+        # r = p·t₁ + q·t₂ with t₁ = (1, 0) and t₂ = (1/2, √3/2), label the
+        # tripartition c = (p − q) mod 3, and `sublattice(k)` picks the
+        # occupied sublattice of (zero-based) layer k
+        function sqrt3_state!(lat, sublattice)
+            d1, d2, d3 = lat.supercell_dimensions
+            B = 2 * d1 * d2
+            a3 = lat.lattice_vectors[:, 3]
+            for s in eachindex(lat.components[1])
+                k = (s - 1) ÷ B
+                x = lat.positions[s, 1] - k * a3[1]
+                y = lat.positions[s, 2] - k * a3[2]
+                q = round(Int, y / (S3 / 2))
+                p = round(Int, x - q / 2)
+                lat.components[1][s] = mod(p - q, 3) == sublattice(k)
+            end
+            return lat
+        end
+        sqrt3_fixed!(lat) = sqrt3_state!(lat, k -> 0)
+        sqrt3_rot_plus!(lat) = sqrt3_state!(lat, k -> mod(k, 3))
+        sqrt3_rot_minus!(lat) = sqrt3_state!(lat, k -> mod(-k, 3))
+        # Lattice translations of an occupation `occ` on `lat`: by the third
+        # lattice vector (a cyclic relabelling of the layers), by t₁, and
+        # by t₂ (basis site 0 -> 1, basis site 1 -> 0 of the next cell)
+        function translate_a3(lat, occ)
+            B = 2 * lat.supercell_dimensions[1] * lat.supercell_dimensions[2]
+            return vcat(occ[(end - B + 1):end], occ[1:(end - B)])
+        end
+        function translate_t1(lat, occ)
+            d1 = lat.supercell_dimensions[1]
+            new = similar(occ)
+            for s in eachindex(occ)
+                ci, cj, b, k = site_index(lat, s)
+                new[site_of(lat, mod(ci + 1, d1), cj, b, k)] = occ[s]
+            end
+            return new
+        end
+        function translate_t2(lat, occ)
+            d1, d2, _ = lat.supercell_dimensions
+            new = similar(occ)
+            for s in eachindex(occ)
+                ci, cj, b, k = site_index(lat, s)
+                if b == 0
+                    new[site_of(lat, ci, cj, 1, k)] = occ[s]
+                else
+                    new[site_of(lat, mod(ci + 1, d1), mod(cj + 1, d2), 0, k)] = occ[s]
+                end
+            end
+            return new
+        end
+        # Three-dimensional structure factor of the periodic supercell at
+        # its reciprocal-lattice point K = 2π·A⁻ᵀ·(m, n, l), on the true
+        # positions
+        function structure_factor(lat, m, n, l)
+            dims = lat.supercell_dimensions
+            A = hcat([lat.lattice_vectors[:, k] .* dims[k] for k in 1:3]...)
+            K = 2 * pi .* (transpose(inv(A)) * [m, n, l])
+            occ = lat.components[1]
+            z = sum(cis(K[1] * lat.positions[s, 1] + K[2] * lat.positions[s, 2] +
+                        K[3] * lat.positions[s, 3])
+                    for s in eachindex(occ) if occ[s])
+            return abs(z) / length(occ)
+        end
+
+        abc = obs_tri_layers(6, 6, 3; stacking=:abc)
+        aligned = obs_tri_layers(6, 6, 3)
+        flat = obs_tri_lattice(6, 6)
+        B = 72
+        # Zero-argument value of one layer's contiguous block projected
+        # onto the (6, 6, 1) cell
+        function projected(lat, k, f)
+            flat.components[1] .= lat.components[1][((k - 1) * B + 1):(k * B)]
+            return f(flat)
+        end
+
+        for lat in (abc, aligned)
+            # Row states: 1/2 on the M-point quadrature and exactly 0 on the
+            # three-sublattice modulus in every layer, each equal to the
+            # projected zero-argument value
+            for rule in (row_rule, row_rule_shift)
+                set_state!(lat, rule)
+                for k in 1:3
+                    @test order_parameter_p2x2(lat, k) ≈ 1 / 2 atol = 1e-12
+                    @test order_parameter_sqrt3(lat, k) == 0.0
+                    @test order_parameter_p2x2(lat, k) == projected(lat, k, order_parameter_p2x2)
+                    @test order_parameter_sqrt3(lat, k) == projected(lat, k, order_parameter_sqrt3)
+                    @test bragg_amplitude(lat, 3, -3, k) ==
+                          projected(lat, k, l -> bragg_amplitude(l, 3, -3))
+                end
+            end
+            # √3×√3 states (fixed and both rotating sublattice sequences):
+            # exactly 1/3 and exactly 0
+            for build! in (sqrt3_fixed!, sqrt3_rot_plus!, sqrt3_rot_minus!)
+                build!(lat)
+                for k in 1:3
+                    @test order_parameter_sqrt3(lat, k) == 1 / 3
+                    @test order_parameter_p2x2(lat, k) == 0.0
+                    @test order_parameter_p2x2(lat, k) == projected(lat, k, order_parameter_p2x2)
+                    @test order_parameter_sqrt3(lat, k) == projected(lat, k, order_parameter_sqrt3)
+                    @test bragg_amplitude(lat, 3, -3, k) ==
+                          projected(lat, k, l -> bragg_amplitude(l, 3, -3))
+                end
+            end
+        end
+
+        # At d3 == 1, layer = 1 is the zero-argument form bit for bit, and
+        # the own-frame amplitudes agree to roundoff
+        Random.seed!(4167)
+        for _ in 1:10
+            flat.components[1] .= rand(Bool, 72)
+            @test order_parameter_sqrt3(flat, 1) == order_parameter_sqrt3(flat)
+            @test order_parameter_p2x2(flat, 1) == order_parameter_p2x2(flat)
+            @test bragg_amplitude(flat, 1, 2, 1) == bragg_amplitude(flat, 1, 2)
+            @test bragg_amplitude(flat, 3, -3, 1) == bragg_amplitude(flat, 3, -3)
+            @test abs(bragg_amplitude_layers(flat, 1, 2)[1]) ≈ bragg_amplitude(flat, 1, 2) atol = 1e-12
+            @test stacking_bragg_amplitude(flat, 1, 2, 0) ≈ bragg_amplitude(flat, 1, 2) atol = 1e-12
+        end
+
+        # Guards: layer out of range; the zero-argument forms still reject
+        # the multilayer cell; the in-plane commensurability guards and the
+        # basis guard survive in the layer-indexed forms; l out of range
+        for bad in (0, 4)
+            @test_throws ArgumentError order_parameter_sqrt3(abc, bad)
+            @test_throws ArgumentError bragg_amplitude(abc, 3, -3, bad)
+            @test_throws ArgumentError order_parameter_p2x2(abc, bad)
+        end
+        @test_throws ArgumentError order_parameter_sqrt3(abc)
+        @test_throws ArgumentError bragg_amplitude(abc, 3, -3)
+        @test_throws ArgumentError order_parameter_p2x2(abc)
+        @test_throws ArgumentError order_parameter_p2x2(flat, 2)
+        odd = obs_tri_layers(3, 3, 3; stacking=:abc)    # d1 = 3: √3×√3 closes, the M points do not
+        @test_throws ArgumentError order_parameter_p2x2(odd, 1)
+        odd.components[1][1] = true
+        @test order_parameter_sqrt3(odd, 1) == 1 / 18
+        @test order_parameter_sqrt3(odd, 2) == 0.0
+        four = obs_tri_layers(4, 4, 3; stacking=:abc)   # d1 = 4: the converse
+        @test_throws ArgumentError order_parameter_sqrt3(four, 1)
+        four.components[1][33] = true                    # one particle in layer 2
+        @test order_parameter_p2x2(four, 2) ≈ sqrt(3) / 32 rtol = 1e-12
+        @test order_parameter_p2x2(four, 1) == 0.0
+        @test bragg_amplitude(four, 0, 4, 2) == 1 / 32
+        @test_throws ArgumentError stacking_bragg_amplitude(abc, 3, -3, -1)
+        @test_throws ArgumentError stacking_bragg_amplitude(abc, 3, -3, 3)
+        latnb = MLattice{1,TriangularLattice}(
+            lattice_constant=1.0,
+            basis=[(0.0, 0.0, 0.0), (0.5, 0.5, 0.0)],
+            supercell_dimensions=(4, 4, 2),
+            periodicity=(true, true, false),
+            cutoff_radii=[1.1],
+            components=[[false for _ in 1:64]],
+            adsorptions=:full)
+        @test_throws ArgumentError bragg_amplitude_layers(latnb, 1, 0)
+        @test_throws ArgumentError bragg_amplitude(latnb, 1, 0, 1)
+        @test_throws ArgumentError order_parameter_sqrt3(latnb, 1)
+        @test_throws ArgumentError order_parameter_p2x2(latnb, 1)
+
+        # Stacking amplitudes at the ordering M point (3, −3) of the row
+        # states, own-frame convention, on the offset and the aligned cell
+        # alike: rows held fixed across layers carry the same own-frame
+        # phase in every layer, a pure l = 0 component of 1/2; rows shifted
+        # by one row per layer flip the own-frame phase each layer (a
+        # two-layer period), which a three-layer cell spreads as
+        # (1/6, 1/3, 1/3); the per-layer moduli are 1/2 in both
+        for lat in (abc, aligned)
+            set_state!(lat, row_rule)
+            ρu = bragg_amplitude_layers(lat, 3, -3)
+            @test abs.(ρu) ≈ [0.5, 0.5, 0.5] atol = 1e-12
+            @test ρu[2] ≈ ρu[1] atol = 1e-12
+            @test ρu[3] ≈ ρu[1] atol = 1e-12
+            @test [stacking_bragg_amplitude(lat, 3, -3, l) for l in 0:2] ≈ [1 / 2, 0.0, 0.0] atol = 1e-12
+            set_state!(lat, row_rule_shift)
+            ρs = bragg_amplitude_layers(lat, 3, -3)
+            @test abs.(ρs) ≈ [0.5, 0.5, 0.5] atol = 1e-12
+            @test ρs[2] ≈ -ρs[1] atol = 1e-12
+            @test ρs[3] ≈ ρs[1] atol = 1e-12
+            @test [stacking_bragg_amplitude(lat, 3, -3, l) for l in 0:2] ≈ [1 / 6, 1 / 3, 1 / 3] atol = 1e-12
+        end
+        # On a six-layer :abc cell the two-layer period is commensurate:
+        # shifted rows give a pure l = 3 component of 1/2 with l = 0 zero,
+        # rows held fixed a pure l = 0 component
+        six = obs_tri_layers(6, 6, 6; stacking=:abc)
+        set_state!(six, row_rule)
+        @test abs.(bragg_amplitude_layers(six, 3, -3)) ≈ fill(0.5, 6) atol = 1e-12
+        @test [stacking_bragg_amplitude(six, 3, -3, l) for l in 0:5] ≈ [1 / 2, 0, 0, 0, 0, 0] atol = 1e-12
+        set_state!(six, row_rule_shift)
+        @test abs.(bragg_amplitude_layers(six, 3, -3)) ≈ fill(0.5, 6) atol = 1e-12
+        @test [stacking_bragg_amplitude(six, 3, -3, l) for l in 0:5] ≈ [0, 0, 0, 1 / 2, 0, 0] atol = 1e-12
+        # √3×√3 stackings at the K point (4, 0) on the three-layer cells: a
+        # sublattice held fixed across layers is l = 0, one that rotates by
+        # one sublattice per layer is l = 1 or l = 2 by its sense, each with
+        # the full per-layer weight 1/3 and the same labels on the offset
+        # and the aligned cell
+        for lat in (abc, aligned)
+            for (build!, expect) in ((sqrt3_fixed!, [1 / 3, 0, 0]),
+                                     (sqrt3_rot_plus!, [0, 1 / 3, 0]),
+                                     (sqrt3_rot_minus!, [0, 0, 1 / 3]))
+                build!(lat)
+                @test abs.(bragg_amplitude_layers(lat, 4, 0)) ≈ fill(1 / 3, 3) atol = 1e-12
+                @test [stacking_bragg_amplitude(lat, 4, 0, l) for l in 0:2] ≈ expect atol = 1e-12
+            end
+        end
+
+        # Random occupations on both three-layer cells: the moduli equal
+        # the layer-indexed amplitudes, Parseval closes, and every component
+        # is the three-dimensional structure factor of the periodic
+        # supercell at its reciprocal-lattice point (m, n, l), evaluated on
+        # the true positions
+        Random.seed!(4168)
+        for lat in (abc, aligned), _ in 1:5
+            lat.components[1] .= rand(Bool, 216)
+            for (m, n) in [(3, -3), (0, 6), (1, 2)]
+                ρ = bragg_amplitude_layers(lat, m, n)
+                for k in 1:3
+                    @test abs(ρ[k]) ≈ bragg_amplitude(lat, m, n, k) atol = 1e-12
+                end
+                @test sum(stacking_bragg_amplitude(lat, m, n, l)^2 for l in 0:2) ≈
+                      sum(abs2, ρ) / 3 atol = 1e-12
+                for l in 0:2
+                    @test stacking_bragg_amplitude(lat, m, n, l) ≈
+                          structure_factor(lat, m, n, l) atol = 1e-12
+                end
+            end
+        end
+
+        # Lattice translations of a random occupation, by a₃ (a cyclic
+        # relabelling of the layers), by t₁ and by t₂, leave every stacking
+        # amplitude unchanged on the three- and the six-layer :abc cells,
+        # at in-plane indices whose offset phase d3·k·Δ is and is not a
+        # whole number of turns alike
+        Random.seed!(4170)
+        for lat in (abc, six), _ in 1:2
+            orig = rand(Bool, length(lat.components[1]))
+            d3 = lat.supercell_dimensions[3]
+            for (m, n) in [(3, -3), (0, 6), (1, 2), (5, -1)]
+                lat.components[1] .= orig
+                ref = [stacking_bragg_amplitude(lat, m, n, l) for l in 0:d3-1]
+                for translate in (translate_a3, translate_t1, translate_t2)
+                    lat.components[1] .= translate(lat, orig)
+                    for l in 0:d3-1
+                        @test stacking_bragg_amplitude(lat, m, n, l) ≈ ref[l + 1] atol = 1e-12
+                    end
+                end
+            end
+        end
+
+        # A short seeded fixed-N run on the :abc cell records a layer-indexed
+        # order parameter and a stacking amplitude through the observables
+        # hook
+        Random.seed!(4169)
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        walkers = [LatticeWalker(obs_tri_layers(6, 6, 3; stacking=:abc),
+                                 energy=0.0u"eV", iter=0) for _ in 1:20]
+        for w in walkers
+            occ = vcat(fill(true, 72), fill(false, 144))
+            shuffle!(occ)
+            w.configuration.components[1] .= occ
+        end
+        ls = LatticeGasWalkers(walkers, ham; perturb_energy=1e-9)
+        params = LatticeNestedSamplingParameters(mc_steps=30,
+            energy_perturbation=1e-9, allowed_fail_count=100000)
+        df, _, _ = nested_sampling(ls, params, Int64(200),
+            MCRandomWalkClone(), obs_save;
+            observables=[:p1 => (cfg -> order_parameter_p2x2(cfg, 1)),
+                         :s0 => (cfg -> stacking_bragg_amplitude(cfg, 3, 3, 0))])
+        obs_cleanup()
+        @test names(df) == ["iter", "emax", "p1", "s0"]
+        @test nrow(df) > 0
+        @test all(0.0 .<= df.p1 .<= 1 / 2)
+        @test all(0.0 .<= df.s0 .<= 1.0)
+    end
+
     @testset "observable hook: validation" begin
         lat = obs_square_lattice(4, 4)
         walkers = [LatticeWalker(deepcopy(lat), energy=0.0u"eV", iter=0) for _ in 1:8]


### PR DESCRIPTION
Implements #273.

- `MLattice{C,TriangularLattice}` gains `layer_offset` (an absolute in-plane displacement, in the length units of `lattice_constant` and `interlayer_spacing`, that becomes the in-plane part of the third lattice vector) and `stacking = :abc` (the triangle-centre offset of a layered intercalation host); `nothing` and `:aligned` construct byte-identical objects to the shipped call (cross-process digests of every field agree on ten cells). The layer count is the period of the occupation pattern along the stacking direction, documented rather than guarded: every periodic layer count is a valid crystal with the same site geometry.
- Layer-indexed `order_parameter_sqrt3(lat, layer)`, `bragg_amplitude(lat, m, n, layer)` and `order_parameter_p2x2(lat, layer)` reuse the single-layer kernels on the contiguous layer block; at one layer they equal the zero-argument forms bit for bit, whose bodies and guards are unchanged.
- `bragg_amplitude_layers(lat, m, n)` returns the per-layer complex amplitudes in each layer's own frame and `stacking_bragg_amplitude(lat, m, n, l)` their discrete Fourier transform along the layer index, which equals the three-dimensional structure factor of the periodic supercell at its reciprocal points and is invariant under every lattice translation (verified independently to 1e-15 at twelve wavevectors on seven cells); per-layer magnitudes are stacking-blind, the complex amplitudes are not.
- Docstrings state the structure-factor identity, the layer-count convention, and that offset cells must be built with `image_multiplicity = true` (the default per-axis minimum image drops interlayer bonds on one- and two-layer skewed cells and can drop long-cutoff pairs on taller ones; pre-existing neighbour-list behaviour).
- Tests (761 new assertions): constructor identity and guards, positions and the c minimum image, bulk coordination under a fourteen-rung ladder, layer-indexed order parameters on hand-built row and sqrt3 states with uniform and per-layer-shifted stackings on offset and aligned cells, the stacking amplitudes on three- and six-layer fixtures (pure components for commensurate sequences, the K-point sqrt3 rotations), a brute-force structure factor, translation invariance, Parseval, and a seeded fixed-N run recording both observables through the `observables` hook.

Adversarially reviewed pre-filing under three charters (issue-promise round-trip, independent oracle rederiving positions, shells, order parameters and the structure factor, determinism and assertion accounting) plus a second independent oracle after the fix round, which moved the stacking amplitudes to own-frame phases and removed the closure guard. Full suite green on the shipped bytes.
