### PR TITLE
Incremental energy deltas in the fixed-N lattice walk

### DIFF
--- a/src/AbstractHamiltonians/AbstractHamiltonians.jl
+++ b/src/AbstractHamiltonians/AbstractHamiltonians.jl
@@ -207,10 +207,25 @@ Throws `ArgumentError` on `K < 3`, a non-finite coupling, an embedding that
 is not strictly increasing or contains a non-positive index, or a duplicate
 embedding; warns on an empty embedding list (which contributes exactly
 zero energy).
+
+# Fields
+- `coupling::U`: The figure's coupling (energy per fully occupied embedding).
+- `embeddings::Vector{NTuple{K,Int}}`: The canonical embedding list.
+- `incidence::Vector{Vector{Int}}`: Per-site incidence lists, built once by
+  the constructor: `incidence[s]` holds the indices into `embeddings` of
+  every embedding containing site `s`, in embedding order. The vector is
+  sized to the largest site index present (canonical form makes each
+  tuple's last entry its maximum); an empty embedding list gives an empty
+  vector. The lists make the exact single-site flip delta of
+  `site_flip_delta` a scan over the embeddings incident to the flipped
+  site instead of a sweep over every embedding. They are derived once at
+  construction, so `embeddings` must not be mutated afterwards (the energy
+  and the delta would silently disagree); build a new interaction instead.
 """
 struct ClusterInteraction{K,U}
     coupling::U
     embeddings::Vector{NTuple{K,Int}}
+    incidence::Vector{Vector{Int}}
 
     function ClusterInteraction{K,U}(coupling::U, embeddings::Vector{NTuple{K,Int}}) where {K,U}
         if K < 3
@@ -243,7 +258,16 @@ struct ClusterInteraction{K,U}
             end
             push!(seen, e)
         end
-        return new(coupling, embeddings)
+        # Site-to-embedding incidence, sized to the largest site index
+        # (canonical form: each tuple's last entry is its maximum).
+        max_site = isempty(embeddings) ? 0 : maximum(e[end] for e in embeddings)
+        incidence = [Int[] for _ in 1:max_site]
+        for (idx, e) in enumerate(embeddings)
+            for s in e
+                push!(incidence[s], idx)
+            end
+        end
+        return new(coupling, embeddings, incidence)
     end
 end
 
@@ -472,14 +496,19 @@ Opt-in trait: whether an exact O(z) single-site occupancy-flip energy delta
 
 The `false` fallback is a contract, not a failure: consumers fall back to
 full recomputation instead of silently mis-evaluating. `ClusterLatticeHamiltonian`
-deliberately stays `false` (an exact cluster delta needs precomputed
-site-to-embedding incidence lists that do not exist yet), and the site-field
-wrapper delegates to its base. New `ClassicalHamiltonian` types opt in by
+opts in through the per-site incidence lists its `ClusterInteraction`s
+carry (each figure's delta is a scan over the embeddings incident to the
+flipped site), and the site-field wrapper delegates to its base. The
+grand-canonical lattice kernel reads the same trait behind its own
+`incremental` flag, so an `incremental = true` grand-canonical walk under a
+`ClusterLatticeHamiltonian` takes the delta path too; the default of every
+kernel stays the full recompute. New `ClassicalHamiltonian` types opt in by
 adding a method alongside their `site_flip_delta` method.
 """
 supports_site_deltas(::ClassicalHamiltonian) = false
 supports_site_deltas(::GenericLatticeHamiltonian) = true
 supports_site_deltas(::MLatticeHamiltonian) = true
+supports_site_deltas(::ClusterLatticeHamiltonian) = true
 supports_site_deltas(h::SiteFieldLatticeHamiltonian) = supports_site_deltas(h.base)
 
 end # module Hamiltonians

--- a/src/EnergyEval/lattice_energies.jl
+++ b/src/EnergyEval/lattice_energies.jl
@@ -264,6 +264,58 @@ function site_flip_delta(lattice::SLattice, h::SiteFieldLatticeHamiltonian{H,U},
 end
 
 """
+    cluster_flip_count(occupations::Vector{Bool}, c::ClusterInteraction{K,U}, site::Int)
+
+Number of embeddings of one cluster figure that contain `site` and whose
+other `K - 1` sites are all occupied: the embeddings whose occupancy count
+changes when `site` flips, read from the figure's per-site `incidence`
+list. A site beyond the incidence vector (no embedding contains it)
+contributes zero. The per-figure function barrier keeps the scan
+type-stable across the heterogeneous cluster orders of a
+`ClusterLatticeHamiltonian`, as in `cluster_energy`.
+"""
+function cluster_flip_count(occupations::Vector{Bool}, c::ClusterInteraction{K,U},
+                            site::Int) where {K,U}
+    site <= length(c.incidence) || return 0
+    n = 0
+    for idx in c.incidence[site]
+        others_occupied = true
+        for s in c.embeddings[idx]
+            if s != site && !occupations[s]
+                others_occupied = false
+                break
+            end
+        end
+        n += others_occupied ? 1 : 0
+    end
+    return n
+end
+
+"""
+    site_flip_delta(lattice::SLattice, h::ClusterLatticeHamiltonian{N,U}, site::Int) where {N,U}
+
+Exact energy change from flipping the occupancy of `site` under a
+multi-body lattice Hamiltonian: the wrapped pair part's delta (the
+`GenericLatticeHamiltonian` method, with its neighbor-convention rules)
+plus, per cluster figure, the coupling times the number of embeddings
+containing `site` whose other sites are all occupied
+([`cluster_flip_count`](@ref)), with the flip sign (positive when the site
+fills, negative when it empties). Mirrors the `interacting_energy` method
+for the cluster Hamiltonian term by term, so the two agree to the
+single-flip rounding class.
+"""
+function site_flip_delta(lattice::SLattice, h::ClusterLatticeHamiltonian{N,U},
+                         site::Int) where {N,U}
+    occ = lattice.components[1]
+    sgn = occ[site] ? -1 : 1
+    acc::U = zero(U)
+    for c in h.clusters
+        acc += cluster_flip_count(occ, c, site) * c.coupling
+    end
+    return site_flip_delta(lattice, h.pair_ham, site) + sgn * acc
+end
+
+"""
     interacting_energy(lattice::MLattice{C,G}, h::MLatticeHamiltonian{C,N,U})
 
 Compute the interaction energy of a multi-component lattice configuration using the Hamiltonian parameters.

--- a/src/MonteCarloMoves/random_walks.jl
+++ b/src/MonteCarloMoves/random_walks.jl
@@ -311,7 +311,7 @@ function MC_random_walk_2D!(
 end
 
 """
-    MC_random_walk!(n_steps::Int, lattice::LatticeWalker, h::ClassicalHamiltonian, emax::Float64; energy_perturb::Float64=0.0)
+    MC_random_walk!(n_steps::Int, lattice::LatticeWalker, h::ClassicalHamiltonian, emax::Float64; energy_perturb::Float64=0.0, incremental::Bool=false)
 
 Perform a Monte Carlo random walk on the lattice system.
 
@@ -321,6 +321,21 @@ Perform a Monte Carlo random walk on the lattice system.
 - `h::ClassicalHamiltonian`: The lattice gas Hamiltonian.
 - `emax::Float64`: The maximum energy allowed for accepting a move.
 - `energy_perturb::Float64=0.0`: The energy perturbation used to make degenerate configurations distinguishable.
+- `incremental::Bool=false`: Opt-in incremental energy evaluation (default
+  `false` = the shipped full-recompute arithmetic, draw-count and digit
+  identical). When `true`, a single-component walk under a Hamiltonian with
+  `supports_site_deltas` anchors the unperturbed energy once at entry and
+  advances it per proposal by exact O(z) `site_flip_delta` sums: a hop pair
+  is two sequentially composed site flips, the second delta evaluated on the
+  intermediate configuration, and an equal-occupancy pair contributes
+  exactly zero. The pair draws are those of the default path in the same
+  order, the perturbation is added on top as on the default path, and a
+  rejected pair is reverted by the same replay. Multi-component walkers and
+  Hamiltonians without the trait fall back to the full recompute inside the
+  same walk. The delta path accumulates energy in a different floating-point
+  order, so same-seed trajectories are not digit-identical to the default
+  and accept/reject decisions near the ceiling can differ; flipping the
+  default is deliberately out of scope.
 
 # Returns
 - `accept_this_walker::Bool`: Whether the walker is accepted or not.
@@ -333,28 +348,68 @@ function MC_random_walk!(n_steps::Int,
                          h::ClassicalHamiltonian,
                          emax::Float64;
                          energy_perturb::Float64=0.0,
+                         incremental::Bool=false,
                          ) where C
 
     n_accept = 0
     accept_this_walker = false
     emax = emax * unit(lattice.energy)
 
+    # Opt-in incremental energy path (single-component walkers only): anchor
+    # the unperturbed energy once per walk and advance it by exact
+    # site_flip_delta sums, the pattern of MC_grand_canonical_walk!. The
+    # default path below is the shipped arithmetic in the shipped order with
+    # the shipped random draws; the anchor is not evaluated on it.
+    use_deltas = incremental && C == 1 && supports_site_deltas(h)
+    zero_e = 0.0 * unit(lattice.energy)
+    raw = use_deltas ? interacting_energy(lattice.configuration, h) : zero_e
+    step_delta = zero_e
+    hop_from = 0
+    hop_to = 0
+    was_null = false
+
     for i_mc_step in 1:n_steps
         config = lattice.configuration
 
-        # In-place proposal: the hop-pair walk mutates the live configuration
-        # and returns the drawn pair; a rejected proposal is reverted by
-        # replaying the pair (involution). No random draw changes.
-        hop_from, hop_to = _lattice_walk_draw!(config)
+        if use_deltas
+            # Inlined draws in lockstep with _lattice_walk_draw!(::SLattice)
+            # (identical order, identical count). A non-null pair composes
+            # two flips with the second delta evaluated on the intermediate
+            # state; an equal-occupancy pair performs no flips and
+            # contributes exactly zero, as under _lattice_walk_apply!.
+            hop_from = rand(eachindex(config.components[1]))
+            hop_to = rand(eachindex(config.components[1]))
+            was_null = config.components[1][hop_from] == config.components[1][hop_to]
+            if !was_null
+                step_delta = site_flip_delta(config, h, hop_from)
+                config.components[1][hop_from] = !config.components[1][hop_from]
+                step_delta += site_flip_delta(config, h, hop_to)
+                config.components[1][hop_to] = !config.components[1][hop_to]
+            end
+        else
+            # In-place proposal: the hop-pair walk mutates the live configuration
+            # and returns the drawn pair; a rejected proposal is reverted by
+            # replaying the pair (involution). No random draw changes.
+            hop_from, hop_to = _lattice_walk_draw!(config)
+        end
 
         perturbation_energy = energy_perturb * (rand() - 0.5) * unit(lattice.energy)
-        proposed_energy = interacting_energy(config, h) + perturbation_energy
+        if use_deltas
+            proposed_raw = was_null ? raw : raw + step_delta
+            proposed_energy = proposed_raw + perturbation_energy
+        else
+            proposed_raw = zero_e
+            proposed_energy = interacting_energy(config, h) + perturbation_energy
+        end
 
         @debug "proposed_energy = $proposed_energy, perturbed_energy = $(perturbation_energy), emax = $(emax)), accept = $(proposed_energy < emax)"
         if proposed_energy >= emax
             _lattice_walk_apply!(config, hop_from, hop_to)
             continue
         else
+            # On accept the anchor advances to the unperturbed proposal and
+            # the stored walker energy keeps the perturbed value, as before
+            raw = proposed_raw
             lattice.energy = proposed_energy
             n_accept += 1
             accept_this_walker = true

--- a/src/SamplingSchemes/nested_sampling.jl
+++ b/src/SamplingSchemes/nested_sampling.jl
@@ -209,6 +209,19 @@ For lattice systems, `walks_freq` and `clusters_freq` control the ratio of local
 - `cluster_adjust_interval::Int`: Number of NS iterations between cluster p adjustments (default 50).
 - `cluster_p_floor::Float64`: Lower bound for adaptive cluster p (default 0.01).
 - `cluster_p_ceiling::Float64`: Upper bound for adaptive cluster p (default 1.0).
+- `incremental::Bool`: Opt-in incremental energy evaluation in the lattice
+  local-swap kernel (default `false` = the shipped full-recompute
+  arithmetic, draw-count and digit identical). When `true`, the lattice
+  mixed step passes it to `MC_random_walk!`, which under a Hamiltonian with
+  `supports_site_deltas` advances a per-walk raw-energy anchor by exact
+  O(z) `site_flip_delta` sums; cluster proposals (`MC_cluster_walk!`),
+  multi-component walkers, and unsupported Hamiltonians keep the full
+  recompute. The delta path accumulates energy in a different
+  floating-point order, so same-seed trajectories are not digit-identical
+  to the default; flipping the default is deliberately out of scope. A
+  swap-only incremental walk is
+  `MCMixedMoves(walks_freq=1, clusters_freq=0, incremental=true)`.
+  Atomistic systems ignore the field.
 """
 mutable struct MCMixedMoves <: MCRoutine
     walks_freq::Int
@@ -219,6 +232,18 @@ mutable struct MCMixedMoves <: MCRoutine
     cluster_adjust_interval::Int
     cluster_p_floor::Float64
     cluster_p_ceiling::Float64
+    incremental::Bool
+end
+
+# Eight-positional constructor (the field set before `incremental` was
+# appended): keeps every shipped positional call working with the default.
+function MCMixedMoves(walks_freq::Int, swaps_freq::Int, clusters_freq::Int,
+                      initial_cluster_p::Float64, target_cluster_accept::Float64,
+                      cluster_adjust_interval::Int, cluster_p_floor::Float64,
+                      cluster_p_ceiling::Float64)
+    MCMixedMoves(walks_freq, swaps_freq, clusters_freq,
+                 initial_cluster_p, target_cluster_accept, cluster_adjust_interval,
+                 cluster_p_floor, cluster_p_ceiling, false)
 end
 
 # Backward-compatible constructor: MCMixedMoves(5, 1)
@@ -236,10 +261,11 @@ function MCMixedMoves(;
     cluster_adjust_interval::Int=50,
     cluster_p_floor::Float64=0.01,
     cluster_p_ceiling::Float64=1.0,
+    incremental::Bool=false,
 )
     MCMixedMoves(walks_freq, swaps_freq, clusters_freq,
                  initial_cluster_p, target_cluster_accept, cluster_adjust_interval,
-                 cluster_p_floor, cluster_p_ceiling)
+                 cluster_p_floor, cluster_p_ceiling, incremental)
 end
 
 """
@@ -1137,7 +1163,8 @@ function nested_sampling_step!(liveset::LatticeGasWalkers,
     if n_local > 0
         local_accepted, local_rate, to_walk = MC_random_walk!(
             n_local, to_walk, h, emax;
-            energy_perturb=ns_params.energy_perturbation)
+            energy_perturb=ns_params.energy_perturbation,
+            incremental=mc_routine.incremental)
     end
 
     accept = cluster_accepted || local_accepted

--- a/test/test-EnergyEval-clusters.jl
+++ b/test/test-EnergyEval-clusters.jl
@@ -265,6 +265,68 @@
     end
 
     # ================================================================
+    @testset "incidence lists" begin
+        # Each site's incidence list indexes exactly the embeddings that
+        # contain it, in embedding order (brute-force cross-check against a
+        # scan of the embedding vector), the vector is sized to the largest
+        # site index, and a figure whose embedding spans layers is reached
+        # from every one of its sites.
+        function check_incidence(c, M)
+            @test length(c.incidence) == M
+            for s in 1:M
+                @test c.incidence[s] == findall(e -> s in e, c.embeddings)
+            end
+        end
+
+        sq4 = cluster_square(4)
+        t_sq = ClusterInteraction(0.1u"eV", enumerate_motif_embeddings(sq4,
+            motif_distances([(0, 0), (1, 0), (0, 1)]); expected_count=64))
+        check_incidence(t_sq, 16)
+        q_sq = ClusterInteraction(-0.1u"eV", enumerate_motif_embeddings(sq4,
+            [(0, 0), (1, 0), (0, 1), (1, 1)]; expected_count=16))
+        check_incidence(q_sq, 16)
+
+        # Offset-stacked three-layer triangular cell (layer k shifted by
+        # k (1/2, sqrt(3)/6) in plane): a trio of two in-plane neighbors
+        # plus the adjacent-layer site above their bond. Three layers under
+        # a periodic third axis are not a faithful quotient for a figure
+        # spanning two layers, so the enumeration warns and follows the
+        # torus convention; 18 embeddings meet every site.
+        h = 1.0
+        M3 = 2 * 4 * 4 * 3
+        tri3 = MLattice{1,TriangularLattice}(
+            [1.0 0.0 0.5; 0.0 sqrt(3) sqrt(3)/6; 0.0 0.0 h],
+            [(0.0, 0.0, 0.0), (0.5, sqrt(3)/2, 0.0)],
+            (4, 4, 3), (true, true, true), [1.05, 1.2],
+            [zeros(Bool, M3)], ones(Bool, M3); image_multiplicity=true)
+        embs3 = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+            tri3, [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.5, sqrt(3)/6, h)];
+            expected_count=576)
+        t_3 = ClusterInteraction(0.02u"eV", embs3)
+        check_incidence(t_3, M3)
+        @test all(==(18), length.(t_3.incidence))
+
+        # Sizing and gaps: sites beyond the largest index have no entry,
+        # sites inside the range with no embedding have an empty list
+        gap = ClusterInteraction(0.1u"eV", [(1, 2, 5)])
+        @test length(gap.incidence) == 5
+        @test gap.incidence[1] == [1]
+        @test gap.incidence[2] == [1]
+        @test gap.incidence[5] == [1]
+        @test all(isempty, gap.incidence[[3, 4]])
+        shared = ClusterInteraction(0.1u"eV", [(1, 2, 3), (2, 3, 4)])
+        @test shared.incidence[1] == [1]
+        @test shared.incidence[2] == [1, 2]
+        @test shared.incidence[3] == [1, 2]
+        @test shared.incidence[4] == [2]
+
+        # An empty embedding list has empty incidence
+        empty_c = @test_logs (:warn, r"empty embedding list") ClusterInteraction(
+            0.1u"eV", NTuple{3,Int}[])
+        @test isempty(empty_c.incidence)
+    end
+
+    # ================================================================
     @testset "Zhang O-Pd(100) m = 9 expansion: counts, adlayers, sampling" begin
         # Figure geometry transcribed from Zhang, Blum & Reuter, PRB 75,
         # 235406 (2007), Fig. 1 (arXiv:cond-mat/0701549). In the paper's own

--- a/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
+++ b/test/test-SamplingSchemes/test-ideal-gas-ref-gcns.jl
@@ -840,9 +840,16 @@
         @test abs(ustrip(u"eV", null_wk.energy -
                   interacting_energy(null_wk.configuration, inc_ham))) <= 1e-12
 
-        # Trait fallback: an unsupported Hamiltonian under incremental =
-        # true recomputes fully each step and stays digit-identical to the
-        # same-seed default
+        # Cluster Hamiltonian under incremental = true. Originally the trait
+        # fallback fixture (digit identity with the same-seed default);
+        # ClusterLatticeHamiltonian now supports site deltas, so the walk
+        # takes the delta path and the energy agrees with the full recompute
+        # to the accumulation class instead of digit for digit. Every
+        # proposal is accepted under this ceiling, so the configuration
+        # stream, the count, and the rate stay exact. The fallback contract
+        # itself is covered with a trait-less fixture in
+        # test-lattice-site-deltas.jl (a runtests-level file, which can
+        # define the fixture type).
         cl_ham = ClusterLatticeHamiltonian(inc_ham,
             [ClusterInteraction(0.1u"eV", [(1, 2, 5)])])
         function inc_cl(inc)
@@ -859,7 +866,7 @@
         end
         eT, nT, rT = inc_cl(true)
         eF, nF, rF = inc_cl(false)
-        @test eT == eF
+        @test isapprox(eT, eF; rtol=1e-12)
         @test nT == nF
         @test rT == rF
 

--- a/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
+++ b/test/test-SamplingSchemes/test-lattice-gcns-fixed-n.jl
@@ -186,59 +186,120 @@
             ls_filename="test_lfn.ls.extxyz",
             n_traj=1_000_000, n_snap=1_000_000, n_info=1_000_000)
 
-        dfs = Vector{DataFrame}(undef, M + 1)
-        live = Vector{Vector{Float64}}(undef, M + 1)
-
-        # N = 0: empty lattice, handled internally (DataFrame ignored).
-        dfs[1] = DataFrame(iter=Int[], emax=Float64[])
-        live[1] = Float64[]
-
-        for N in 1:(M - 1)
-            walkers = [
-                begin
-                    lat = lattice_at(N)
-                    generate_random_new_lattice_sample!(lat)
-                    LatticeWalker(lat)
-                end for _ in 1:K]
-            liveset = LatticeGasWalkers(walkers, ham, perturb_energy=1e-12)
-            ns_params = LatticeNestedSamplingParameters(
-                mc_steps=60,
-                allowed_fail_count=100_000)
-            df, final_ls, _ = nested_sampling(
-                liveset, ns_params, n_iters, MCRandomWalkClone(), save_strategy)
-            dfs[N + 1] = df
-            live[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
-        end
-
-        # N = M: a single configuration, so NS cannot progress; the live-set
-        # tail carries the whole sector (empty DataFrame + K copies of E_full).
-        dfs[M + 1] = DataFrame(iter=Int[], emax=Float64[])
-        live[M + 1] = fill(only(exact_E[M]), K)
-
-        rm("test_lfn_df.csv", force=true)
-        rm("test_lfn.traj.extxyz", force=true)
-        rm("test_lfn.ls.extxyz", force=true)
-
         μ_grid = [-0.10, -0.06, -0.03] .* u"eV"
         T_grid = [300.0, 500.0] .* u"K"
 
-        stats = gc_thermodynamic_stats_fixed_N(dfs, collect(0:M), M,
-            μ_grid, T_grid;
-            n_walkers=K, n_cull=1, ω0=(K + 1) / K, live_emax=live)
+        # The ladder as a function of the routine so the incremental swap
+        # walk below runs the identical protocol; the shipped run keeps its
+        # RNG sequence (the function consumes no draws before the loop).
+        function run_ladder(routine)
+            dfs = Vector{DataFrame}(undef, M + 1)
+            live = Vector{Vector{Float64}}(undef, M + 1)
 
-        for (j, T) in enumerate(T_grid), (k, μ) in enumerate(μ_grid)
-            ref_logXi, ref_mean_N, ref_var_N, ref_mean_U = exact_stats(
-                ustrip(u"eV", μ), ustrip(u"K", T))
-            @test isapprox(stats.logXi[k, j], ref_logXi, atol=0.1)
-            @test isapprox(stats.mean_N[k, j], ref_mean_N, rtol=0.05, atol=0.1)
-            @test isapprox(stats.var_N[k, j], ref_var_N, rtol=0.25, atol=0.2)
-            @test isapprox(stats.mean_U[k, j], ref_mean_U, rtol=0.05, atol=0.02)
+            # N = 0: empty lattice, handled internally (DataFrame ignored).
+            dfs[1] = DataFrame(iter=Int[], emax=Float64[])
+            live[1] = Float64[]
+
+            for N in 1:(M - 1)
+                walkers = [
+                    begin
+                        lat = lattice_at(N)
+                        generate_random_new_lattice_sample!(lat)
+                        LatticeWalker(lat)
+                    end for _ in 1:K]
+                liveset = LatticeGasWalkers(walkers, ham, perturb_energy=1e-12)
+                ns_params = LatticeNestedSamplingParameters(
+                    mc_steps=60,
+                    allowed_fail_count=100_000)
+                df, final_ls, _ = nested_sampling(
+                    liveset, ns_params, n_iters, routine, save_strategy)
+                dfs[N + 1] = df
+                live[N + 1] = [ustrip(u"eV", w.energy) for w in final_ls.walkers]
+            end
+
+            # N = M: a single configuration, so NS cannot progress; the live-set
+            # tail carries the whole sector (empty DataFrame + K copies of E_full).
+            dfs[M + 1] = DataFrame(iter=Int[], emax=Float64[])
+            live[M + 1] = fill(only(exact_E[M]), K)
+
+            rm("test_lfn_df.csv", force=true)
+            rm("test_lfn.traj.extxyz", force=true)
+            rm("test_lfn.ls.extxyz", force=true)
+
+            return gc_thermodynamic_stats_fixed_N(dfs, collect(0:M), M,
+                μ_grid, T_grid;
+                n_walkers=K, n_cull=1, ω0=(K + 1) / K, live_emax=live)
         end
 
-        # Monotonicity: ⟨N⟩ increases with μ at fixed T.
-        for j in eachindex(T_grid)
-            @test issorted(stats.mean_N[:, j])
+        function check_stats(stats)
+            for (j, T) in enumerate(T_grid), (k, μ) in enumerate(μ_grid)
+                ref_logXi, ref_mean_N, ref_var_N, ref_mean_U = exact_stats(
+                    ustrip(u"eV", μ), ustrip(u"K", T))
+                @test isapprox(stats.logXi[k, j], ref_logXi, atol=0.1)
+                @test isapprox(stats.mean_N[k, j], ref_mean_N, rtol=0.05, atol=0.1)
+                @test isapprox(stats.var_N[k, j], ref_var_N, rtol=0.25, atol=0.2)
+                @test isapprox(stats.mean_U[k, j], ref_mean_U, rtol=0.05, atol=0.02)
+            end
+
+            # Monotonicity: ⟨N⟩ increases with μ at fixed T.
+            for j in eachindex(T_grid)
+                @test issorted(stats.mean_N[:, j])
+            end
         end
+
+        stats = run_ladder(MCRandomWalkClone())
+        check_stats(stats)
+
+        # The same ladder through the swap-only incremental walk (the
+        # lattice mixed step with no cluster moves, delta-path energies),
+        # against the same exact reference at the same gates
+        Random.seed!(1001)
+        stats_inc = run_ladder(MCMixedMoves(walks_freq=1, clusters_freq=0,
+                                            incremental=true))
+        check_stats(stats_inc)
+    end
+
+    # ================================================================
+    @testset "incremental routine: constructor and default neutrality" begin
+        using Random
+        # The appended field defaults to false through every shipped
+        # constructor form
+        @test MCMixedMoves(5, 1).incremental == false
+        @test MCMixedMoves(1, 0, 0, 0.3, 0.3, 50, 0.01, 1.0).incremental == false
+        @test MCMixedMoves(walks_freq=1, clusters_freq=0, incremental=true).incremental == true
+
+        # Same-seed driver A/B: a routine that never mentions `incremental`
+        # against `incremental = false`, identical ledger and live set
+        ham = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
+        function ab_run(routine, tag)
+            Random.seed!(1002)
+            walkers = [begin
+                lat = MLattice{1,SquareLattice}(lattice_constant=1.0,
+                    basis=[(0.0, 0.0, 0.0)], supercell_dimensions=(4, 4, 1),
+                    periodicity=(true, true, false), cutoff_radii=[1.1],
+                    components=[[false for _ in 1:16]], adsorptions=:full)
+                lat.components[1][1:8] .= true
+                generate_random_new_lattice_sample!(lat)
+                LatticeWalker(lat)
+            end for _ in 1:20]
+            ls = LatticeGasWalkers(walkers, ham, perturb_energy=1e-9)
+            params = LatticeNestedSamplingParameters(mc_steps=30,
+                                                     allowed_fail_count=100_000)
+            save = SaveEveryN("t_ab_$(tag).csv", "t_ab_$(tag).traj",
+                              "t_ab_$(tag).ls", 1000000, 1000000, 1000000)
+            df, lsf, _ = nested_sampling(ls, params, Int64(100), routine, save)
+            rm.(["t_ab_$(tag).csv", "t_ab_$(tag).traj", "t_ab_$(tag).ls"],
+                force=true)
+            return df, lsf
+        end
+        df_a, ls_a = ab_run(MCMixedMoves(walks_freq=1, clusters_freq=0), "a")
+        df_b, ls_b = ab_run(MCMixedMoves(walks_freq=1, clusters_freq=0,
+                                         incremental=false), "b")
+        @test df_a.iter == df_b.iter
+        @test df_a.emax == df_b.emax
+        @test [w.energy for w in ls_a.walkers] == [w.energy for w in ls_b.walkers]
+        @test [w.configuration.components[1] for w in ls_a.walkers] ==
+              [w.configuration.components[1] for w in ls_b.walkers]
     end
 
 end

--- a/test/test-lattice-site-deltas.jl
+++ b/test/test-lattice-site-deltas.jl
@@ -9,6 +9,17 @@
 # safe).
 struct SFDMinimalHam <: FreeBird.AbstractHamiltonians.ClassicalHamiltonian end
 
+# Trait-less evaluable fixture: a pair Hamiltonian wrapper that evaluates
+# exactly as its base but does not declare `supports_site_deltas`, so an
+# incremental walk under it must fall back to the full recompute. Every
+# shipped single-component lattice Hamiltonian type now carries the trait,
+# so the fallback path is reachable only through a fixture like this one.
+struct SFDNoDeltaHam{H} <: FreeBird.AbstractHamiltonians.ClassicalHamiltonian
+    base::H
+end
+FreeBird.EnergyEval.interacting_energy(lat::SLattice, h::SFDNoDeltaHam) =
+    interacting_energy(lat, h.base)
+
 @testset "Lattice site-flip deltas" begin
     using Random
     using Unitful
@@ -48,6 +59,81 @@ struct SFDMinimalHam <: FreeBird.AbstractHamiltonians.ClassicalHamiltonian end
 
     h1 = GenericLatticeHamiltonian(-0.04, [-0.01], u"eV")
     h2 = GenericLatticeHamiltonian(-0.04, [-0.01, -0.0025], u"eV")
+
+    # Swap counterpart of sfd_maxdev: two sequentially composed flips, the
+    # second delta on the intermediate configuration, against the full
+    # energy difference of the swap (non-null pairs only)
+    function sfd_swap_maxdev(lat, h, seed; nswaps=200)
+        Random.seed!(seed)
+        maxdev = 0.0
+        occ = lat.components[1]
+        M = length(occ)
+        done = 0
+        while done < nswaps
+            i = rand(1:M)
+            j = rand(1:M)
+            occ[i] == occ[j] && continue
+            e0 = interacting_energy(lat, h)
+            d = site_flip_delta(lat, h, i)
+            occ[i] = !occ[i]
+            d += site_flip_delta(lat, h, j)
+            occ[j] = !occ[j]
+            e1 = interacting_energy(lat, h)
+            occ[j] = !occ[j]
+            occ[i] = !occ[i]
+            maxdev = max(maxdev, abs(ustrip(u"eV", (e1 - e0) - d)))
+            done += 1
+        end
+        return maxdev
+    end
+
+    # Two-site triangular cell, one layer: three trio figures (face,
+    # linear, obtuse) over two pair shells. The linear trio's K d_max equals
+    # the a1 circumference, so its enumeration warns and follows the torus
+    # convention.
+    function sfd_tri(nx, ny)
+        MLattice{1,TriangularLattice}(supercell_dimensions=(nx, ny, 1),
+            periodicity=(true, true, false), cutoff_radii=[1.1, 1.8],
+            components=[[false for _ in 1:2*nx*ny]], adsorptions=:full)
+    end
+    tri_cell = sfd_tri(6, 4)
+    tri_face = enumerate_motif_embeddings(tri_cell, [1.0, 1.0, 1.0];
+                                          expected_count=96)
+    tri_lin = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+        tri_cell, [1.0, 1.0, 2.0]; expected_count=144)
+    tri_obt = enumerate_motif_embeddings(tri_cell, [1.0, 1.0, sqrt(3)];
+                                         expected_count=288)
+    hc_tri = ClusterLatticeHamiltonian(h2,
+        [ClusterInteraction(0.012u"eV", tri_face),
+         ClusterInteraction(-0.007u"eV", tri_lin),
+         ClusterInteraction(0.004u"eV", tri_obt)])
+
+    # Offset-stacked three-layer triangular cell (layer k shifted by
+    # k (1/2, sqrt(3)/6) in plane, spacing h, periodic third axis): shell 1
+    # is the six in-plane neighbors, shell 2 the six adjacent-layer
+    # neighbors at sqrt(1/3 + h^2). Two figures spanning two layers: a bond
+    # with the adjacent-layer site above it, and a second-neighbor pair
+    # with the adjacent-layer site above their midpoint. Three layers are
+    # not a faithful quotient for either, so both enumerations warn.
+    function sfd_offset(nx, ny, nz; h=1.0, image_multiplicity=true)
+        M = 2 * nx * ny * nz
+        MLattice{1,TriangularLattice}(
+            [1.0 0.0 0.5; 0.0 sqrt(3) sqrt(3)/6; 0.0 0.0 h],
+            [(0.0, 0.0, 0.0), (0.5, sqrt(3)/2, 0.0)],
+            (nx, ny, nz), (true, true, true), [1.05, 1.2],
+            [zeros(Bool, M)], ones(Bool, M);
+            image_multiplicity=image_multiplicity)
+    end
+    hl = GenericLatticeHamiltonian(-0.04, [-0.01, -0.006], u"eV")
+    off_cell = sfd_offset(4, 4, 3)
+    off_bond = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+        off_cell, [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.5, sqrt(3)/6, 1.0)];
+        expected_count=576)
+    off_second = @test_logs (:warn, r"faithful quotient") match_mode = :any enumerate_motif_embeddings(
+        off_cell, [(0.0, 0.0, 0.0), (0.0, sqrt(3), 0.0), (0.0, 2 * sqrt(3) / 3, 1.0)])
+    hc_off = ClusterLatticeHamiltonian(hl,
+        [ClusterInteraction(0.012u"eV", off_bond),
+         ClusterInteraction(-0.007u"eV", off_second)])
 
     @testset "exactness against full-energy differences" begin
         # square, one shell, full adsorption
@@ -130,11 +216,148 @@ struct SFDMinimalHam <: FreeBird.AbstractHamiltonians.ClassicalHamiltonian end
         @test supports_site_deltas(MLatticeHamiltonian(1, [h1]))
         @test supports_site_deltas(SiteFieldLatticeHamiltonian(h1, fld))
         @test !supports_site_deltas(SFDMinimalHam())
-        @test !supports_site_deltas(clham)
+        @test !supports_site_deltas(SFDNoDeltaHam(h1))
+        # The cluster Hamiltonian opted in when ClusterInteraction gained
+        # its incidence lists (these two asserts were the negative case)
+        @test supports_site_deltas(clham)
         # the wrapper delegates to its base
-        @test !supports_site_deltas(SiteFieldLatticeHamiltonian(clham, fld))
+        @test supports_site_deltas(SiteFieldLatticeHamiltonian(clham, fld))
         # the delta enforces the same shell-count rule as the full sweep
         lat1 = sfd_square(4)
         @test_throws ArgumentError site_flip_delta(lat1, h2, 1)
+    end
+
+    @testset "cluster and multilayer deltas" begin
+        # Cluster Hamiltonian: 200 random single flips and 200 random swaps
+        # against interacting_energy differences, on the single-layer
+        # two-site cell with three trio figures and on the offset
+        # three-layer cell with two-layer figures (a figure spanning layers
+        # is counted from every one of its sites)
+        @test sfd_maxdev(sfd_fill!(tri_cell, 92_010, 0.5), hc_tri,
+                         93_010) <= 1e-12
+        @test sfd_swap_maxdev(tri_cell, hc_tri, 93_011) <= 1e-12
+        @test sfd_maxdev(sfd_fill!(off_cell, 92_012, 0.5), hc_off,
+                         93_012) <= 1e-12
+        @test sfd_swap_maxdev(off_cell, hc_off, 93_013) <= 1e-12
+
+        # Pair Hamiltonian on the multilayer cell under both neighbor
+        # conventions
+        @test sfd_maxdev(off_cell, hl, 93_014) <= 1e-12
+        @test sfd_swap_maxdev(off_cell, hl, 93_015) <= 1e-12
+        off_min = sfd_fill!(sfd_offset(4, 4, 3; image_multiplicity=false),
+                            92_016, 0.5)
+        @test sfd_maxdev(off_min, hl, 93_016) <= 1e-12
+        @test sfd_swap_maxdev(off_min, hl, 93_017) <= 1e-12
+
+        # A one-cell-wide multilayer cell under image_multiplicity = true:
+        # the a1 circumference (1.0) lies inside shell 1, so every site
+        # carries two self-image entries at half weight per image
+        off_self = sfd_fill!(sfd_offset(1, 2, 3), 92_018, 0.5)
+        @test all(count(==(s), off_self.neighbors[s][1]) == 2
+                  for s in eachindex(off_self.components[1]))
+        @test sfd_maxdev(off_self, hl, 93_018) <= 1e-12
+        @test sfd_swap_maxdev(off_self, hl, 93_019) <= 1e-12
+    end
+
+    @testset "incremental fixed-N walk" begin
+        # Same-seed kernel A/B: a call that never mentions `incremental`
+        # against `incremental = false`, digit for digit
+        function sfd_walk(lat, h, seed, emax, inc; n=500, perturb=1e-9)
+            Random.seed!(seed)
+            l = deepcopy(lat)
+            w = LatticeWalker(l, energy=interacting_energy(l, h), iter=0)
+            _, r, _ = inc === nothing ?
+                MC_random_walk!(n, w, h, emax; energy_perturb=perturb) :
+                MC_random_walk!(n, w, h, emax; energy_perturb=perturb,
+                                incremental=inc)
+            return w.energy.val, r, copy(w.configuration.components[1])
+        end
+        sq = sfd_fill!(sfd_square(6; cutoffs=[1.1, 1.5]), 92_020, 0.5)
+        e_sq = ustrip(u"eV", interacting_energy(sq, h2))
+        for (lat, h, emax) in ((sq, h2, e_sq + 0.01),
+                               (tri_cell, hc_tri,
+                                ustrip(u"eV", interacting_energy(tri_cell, hc_tri)) + 0.01))
+            a = sfd_walk(lat, h, 93_020, emax, nothing)
+            b = sfd_walk(lat, h, 93_020, emax, false)
+            @test a[1] == b[1]
+            @test a[2] == b[2]
+            @test a[3] == b[3]
+        end
+
+        # Anchor-drift weld: after a 10^4-step seeded incremental walk with
+        # a zero perturbation the stored walker energy IS the raw anchor,
+        # so it must agree with a from-scratch recompute to 1e-12 eV. The
+        # ceiling sits above every energy so every proposal is accepted and
+        # the anchor advances 10^4 times.
+        function sfd_weld(lat, h, seed; n=10_000, emax=10.0, perturb=0.0)
+            Random.seed!(seed)
+            l = deepcopy(lat)
+            w = LatticeWalker(l, energy=interacting_energy(l, h), iter=0)
+            _, r, _ = MC_random_walk!(n, w, h, emax; energy_perturb=perturb,
+                                      incremental=true)
+            drift = abs(ustrip(u"eV", w.energy -
+                               interacting_energy(w.configuration, h)))
+            return drift, r
+        end
+        fld_off = collect(0.001 .* (1:96)) .* u"eV"
+        @test sfd_weld(off_cell, hl, 93_021)[1] <= 1e-12
+        @test sfd_weld(off_cell, hc_off, 93_022)[1] <= 1e-12
+        @test sfd_weld(off_cell, SiteFieldLatticeHamiltonian(hc_off, fld_off),
+                       93_023)[1] <= 1e-12
+        # With a perturbation the stored energy carries the last accepted
+        # perturbation, bounded by half its width
+        @test sfd_weld(off_cell, hc_off, 93_024; perturb=1e-9)[1] <=
+              0.5e-9 + 1e-12
+        # A ceiling near the start energy exercises the revert path inside
+        # the same weld
+        e_off = ustrip(u"eV", interacting_energy(off_cell, hc_off))
+        drift_cold, rate_cold = sfd_weld(off_cell, hc_off, 93_025;
+                                         emax=e_off + 0.02)
+        @test drift_cold <= 1e-12
+        @test 0.0 < rate_cold < 1.0
+        # Null-pair dominance: a nearly full lattice proposes mostly
+        # equal-occupancy pairs, which must contribute exactly zero
+        full_cell = sfd_offset(4, 4, 3)
+        full_cell.components[1] .= true
+        full_cell.components[1][7] = false
+        @test sfd_weld(full_cell, hc_off, 93_026; n=2000)[1] <= 1e-12
+
+        # Trait fallback: an incremental = true walk under a Hamiltonian
+        # without the trait matches the same-seed default digit for digit,
+        # in the fixed-N kernel and in the grand-canonical kernel (whose
+        # shipped fallback test used the cluster Hamiltonian before it
+        # opted in)
+        hnd = SFDNoDeltaHam(h2)
+        a = sfd_walk(sq, hnd, 93_027, e_sq + 0.01, true)
+        b = sfd_walk(sq, hnd, 93_027, e_sq + 0.01, false)
+        @test a[1] == b[1]
+        @test a[2] == b[2]
+        @test a[3] == b[3]
+        function sfd_gc_walk(inc)
+            Random.seed!(93_028)
+            l = deepcopy(sq)
+            w = LatticeWalker(l, energy=interacting_energy(l, hnd), iter=0)
+            _, r, _, _, _, _ = MC_grand_canonical_walk!(500, w, hnd, 1.0e3,
+                0.0; p_move=0.4, p_insert=0.3, z0=1.0, energy_perturb=1e-9,
+                incremental=inc)
+            return w.energy.val, sum(w.configuration.components[1]), r
+        end
+        @test sfd_gc_walk(true) == sfd_gc_walk(false)
+
+        # Multi-component walkers keep the full recompute: same-seed
+        # identity under incremental = true
+        ml = MLattice{2,SquareLattice}(supercell_dimensions=(4, 4, 1),
+            components=[[1, 3, 6, 8, 11], [2, 4, 9, 13]])
+        mlh = MLatticeHamiltonian(2, [h1, GenericLatticeHamiltonian(-0.02, [-0.005], u"eV"),
+                                      GenericLatticeHamiltonian(-0.03, [-0.008], u"eV")])
+        function sfd_ml_walk(inc)
+            Random.seed!(93_029)
+            l = deepcopy(ml)
+            w = LatticeWalker(l, energy=interacting_energy(l, mlh), iter=0)
+            _, r, _ = MC_random_walk!(300, w, mlh, 0.0; energy_perturb=1e-9,
+                                      incremental=inc)
+            return w.energy.val, r, deepcopy(w.configuration.components)
+        end
+        @test sfd_ml_walk(true) == sfd_ml_walk(false)
     end
 end


### PR DESCRIPTION
Implements #275. Merge the fixed-N pins PR filed alongside first; this change cites those pins as its bit-identity gate.

- `MC_random_walk!` gains `incremental::Bool = false`. With `incremental` and `supports_site_deltas(h)` on a single-component walker, the walk anchors the raw energy once at entry and advances it per proposal by two sequentially composed site flips (the second delta on the intermediate configuration, so pairs that are neighbours or share an embedding are exact); equal-occupancy pairs are no-ops; the pair draws, their order, and the perturbation are the shipped ones; on reject the pair is replayed. The default path is the shipped statements with no draw or floating-point operation added, removed, or reordered: the fixed-N pins (29) and the lattice grand-canonical pins (67) replay digit for digit, and a same-seed A/B against the shipped source over nine kernel fixtures and six driver ladders is byte-identical.
- `MCMixedMoves` gains `incremental` (appended; the positional and two-argument constructors keep their defaults) and the lattice mixed step threads it; cluster proposals and multi-component walkers keep the full recompute.
- `ClusterInteraction` gains per-site incidence lists built once in the constructor (`embeddings` must not be mutated afterwards); `site_flip_delta` for `ClusterLatticeHamiltonian` is the pair delta plus, per figure, the coupling times the incident embeddings whose other sites are occupied; `supports_site_deltas` is now true for it, so the grand-canonical kernel's own `incremental` flag also takes the delta path under a cluster Hamiltonian (every kernel's default stays the full recompute). The shipped grand-canonical trait-fallback check used the cluster Hamiltonian as its trait-less fixture; its digit-identity assert becomes rtol 1e-12 inside the `Add` commit with a disclosure comment, and the fallback contract moves to a wrapper Hamiltonian defined at the top level of the site-delta test file.
- Exactness, measured: cluster and pair deltas within 2.2e-15 eV of full recomputes under both neighbour conventions on single-layer and offset three-layer cells; a 10^4-step anchored walk drifts by 4.9e-15 eV. Per-move cost on a three-layer offset cell with twelve pair shells and seven trio figures, fixed-N nested sampling with swaps: 75.4 to 5.0 us on 216 sites and 146.6 to 5.7 us on 384 sites (default to incremental); 10.7 to 2.4 us on a two-site 144-site cell. Timings are reported, not asserted.
- Tests (210 new assertions): incidence lists against a brute-force cross-check, deltas against full recomputes at 1e-12 on both cells including two-layer figures and self-image entries, the anchor-drift weld with zero and finite perturbations and the revert path, the default-neutrality A/B, the trait fallback in both kernels and the multi-component identity, and a seeded incremental fixed-N ladder against the exact-enumeration reference at its calibrated gates (worst deviation 0.14 of the logXi gate over three seeds).

Adversarially reviewed pre-filing under the issue-promise round-trip and independent-oracle charters (the oracle rederived every delta from its own energy function and confirmed stationarity against an exact enumeration over six seeds); the determinism and assertion-accounting charter was completed in-session (assertion delta reconciled per testset by two parties, exact float equalities confined to same-path identities, added suite time under four seconds). Full suite green on the shipped bytes.
